### PR TITLE
chore: remove onStartShouldSetResponder workaround from :active examples

### DIFF
--- a/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/Active.tsx
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/Active.tsx
@@ -54,7 +54,6 @@ export default function Active() {
                   transitionTimingFunction: 'ease-in-out',
                 },
               ]}
-              onStartShouldSetResponder={() => true}
             />
           </VerticalExampleCard>
 
@@ -84,7 +83,6 @@ export default function Active() {
                   transitionDuration: '150ms',
                 },
               ]}
-              onStartShouldSetResponder={() => true}
             />
           </VerticalExampleCard>
 
@@ -126,7 +124,6 @@ borderWidth: {
                   transitionDuration: '120ms',
                 },
               ]}
-              onStartShouldSetResponder={() => true}
             />
           </VerticalExampleCard>
 
@@ -157,7 +154,6 @@ borderWidth: {
                   transitionDuration: '120ms',
                 },
               ]}
-              onStartShouldSetResponder={() => true}
             />
           </VerticalExampleCard>
 
@@ -201,7 +197,6 @@ transform: {
                   transitionTimingFunction: 'ease-in-out',
                 },
               ]}
-              onStartShouldSetResponder={() => true}
             />
           </VerticalExampleCard>
 
@@ -302,7 +297,6 @@ transform: {
                   transitionDuration: '150ms',
                 },
               ]}
-              onStartShouldSetResponder={() => true}
             />
           </VerticalExampleCard>
 
@@ -331,7 +325,6 @@ transform: {
                   transitionDuration: '150ms',
                 },
               ]}
-              onStartShouldSetResponder={() => true}
             />
           </VerticalExampleCard>
         </Section>

--- a/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/Active.tsx
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/Active.tsx
@@ -211,7 +211,6 @@ transform: {
     fill: { default: colors.primary, ':active': colors.primaryDark },
     transitionDuration: '200ms',
   }}
-  onStartShouldSetResponder={() => true}
 />`}
             collapsedCode={`fill: {
   default: colors.primary,
@@ -230,7 +229,6 @@ transform: {
                   },
                   transitionDuration: '200ms',
                 }}
-                onStartShouldSetResponder={() => true}
               />
             </Svg>
           </VerticalExampleCard>
@@ -245,7 +243,6 @@ transform: {
     r: { default: 22, ':active': 12 },
     transitionDuration: '200ms',
   }}
-  onStartShouldSetResponder={() => true}
 />`}
             collapsedCode={`r: {
   default: 22,
@@ -261,7 +258,6 @@ transform: {
                   r: { ':active': sizes.md / 4, default: sizes.md / 2 - 2 },
                   transitionDuration: '200ms',
                 }}
-                onStartShouldSetResponder={() => true}
               />
             </Svg>
           </VerticalExampleCard>

--- a/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/Active.tsx
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/Active.tsx
@@ -211,6 +211,7 @@ transform: {
     fill: { default: colors.primary, ':active': colors.primaryDark },
     transitionDuration: '200ms',
   }}
+  onStartShouldSetResponder={() => true}
 />`}
             collapsedCode={`fill: {
   default: colors.primary,
@@ -229,6 +230,7 @@ transform: {
                   },
                   transitionDuration: '200ms',
                 }}
+                onStartShouldSetResponder={() => true}
               />
             </Svg>
           </VerticalExampleCard>
@@ -243,6 +245,7 @@ transform: {
     r: { default: 22, ':active': 12 },
     transitionDuration: '200ms',
   }}
+  onStartShouldSetResponder={() => true}
 />`}
             collapsedCode={`r: {
   default: 22,
@@ -258,6 +261,7 @@ transform: {
                   r: { ':active': sizes.md / 4, default: sizes.md / 2 - 2 },
                   transitionDuration: '200ms',
                 }}
+                onStartShouldSetResponder={() => true}
               />
             </Svg>
           </VerticalExampleCard>

--- a/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/ActiveBlocksRender.tsx
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/ActiveBlocksRender.tsx
@@ -40,7 +40,6 @@ export default function ActiveBlocksRender() {
     transitionDuration: '900ms',
     transitionTimingFunction: 'linear',
   }}
-  onStartShouldSetResponder={() => true}
 />`}
             collapsedCode={`backgroundColor: {
   default: renderColor,
@@ -58,7 +57,6 @@ export default function ActiveBlocksRender() {
                   transitionTimingFunction: 'linear',
                 },
               ]}
-              onStartShouldSetResponder={() => true}
             />
           </VerticalExampleCard>
         </Section>

--- a/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/ActiveDeepest.tsx
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/ActiveDeepest.tsx
@@ -97,8 +97,7 @@ transform: {
                         },
                         transitionDuration: '120ms',
                       },
-                    ]}
-                    onStartShouldSetResponder={() => true}>
+                    ]}>
                     <Text style={{ color: colors.white }} variant="label3">
                       Press me
                     </Text>
@@ -172,8 +171,7 @@ transform: {
                         },
                         transitionDuration: '120ms',
                       },
-                    ]}
-                    onStartShouldSetResponder={() => true}>
+                    ]}>
                     <Text style={{ color: colors.white }} variant="label3">
                       Press me
                     </Text>
@@ -267,8 +265,7 @@ transform: {
                           },
                           transitionDuration: '120ms',
                         },
-                      ]}
-                      onStartShouldSetResponder={() => true}>
+                      ]}>
                       <Text style={{ color: colors.white }} variant="label3">
                         Layer 4 (:active-deepest)
                       </Text>

--- a/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/Hover.tsx
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/Hover.tsx
@@ -290,6 +290,7 @@ shadowOpacity: {
       fill: { default: '#fca5a5', ':hover': '#dc2626' },
       transitionDuration: '150ms',
     }}
+    onStartShouldSetResponder={() => true}
   />
   {/* Front circle - drawn last, so it sits on top */}
   <AnimatedCircle
@@ -298,6 +299,7 @@ shadowOpacity: {
       fill: { default: '#93c5fd', ':hover': '#2563eb' },
       transitionDuration: '150ms',
     }}
+    onStartShouldSetResponder={() => true}
   />
 </Svg>`}
             collapsedCode={`fill: {
@@ -318,6 +320,7 @@ shadowOpacity: {
                     },
                     transitionDuration: '150ms',
                   }}
+                  onStartShouldSetResponder={() => true}
                 />
                 <AnimatedCircle
                   cx={145}
@@ -331,6 +334,7 @@ shadowOpacity: {
                     },
                     transitionDuration: '150ms',
                   }}
+                  onStartShouldSetResponder={() => true}
                 />
               </Svg>
             </View>

--- a/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/Hover.tsx
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/Hover.tsx
@@ -290,7 +290,6 @@ shadowOpacity: {
       fill: { default: '#fca5a5', ':hover': '#dc2626' },
       transitionDuration: '150ms',
     }}
-    onStartShouldSetResponder={() => true}
   />
   {/* Front circle - drawn last, so it sits on top */}
   <AnimatedCircle
@@ -299,7 +298,6 @@ shadowOpacity: {
       fill: { default: '#93c5fd', ':hover': '#2563eb' },
       transitionDuration: '150ms',
     }}
-    onStartShouldSetResponder={() => true}
   />
 </Svg>`}
             collapsedCode={`fill: {
@@ -320,7 +318,6 @@ shadowOpacity: {
                     },
                     transitionDuration: '150ms',
                   }}
-                  onStartShouldSetResponder={() => true}
                 />
                 <AnimatedCircle
                   cx={145}
@@ -334,7 +331,6 @@ shadowOpacity: {
                     },
                     transitionDuration: '150ms',
                   }}
-                  onStartShouldSetResponder={() => true}
                 />
               </Svg>
             </View>


### PR DESCRIPTION
Removes the `onStartShouldSetResponder={() => true}` workaround from the regular-View `:active` and `:active-deepest` examples.

The SVG examples keep it: react-native-svg only hit-tests an element marked `responsible`, on both Android and iOS, so there the prop is what makes the shape a touch target.
