### PR TITLE
fix: crash in handleRawEvent on stale EventTarget with null InstanceHandle

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -690,7 +690,18 @@ bool ReanimatedModuleProxy::handleRawEvent(const RawEvent &rawEvent, double curr
     return false;
   }
 
-  int tag = eventTarget->getTag();
+  const auto shadowNodeFamily = rawEvent.shadowNodeFamily.lock();
+  if (shadowNodeFamily == nullptr) {
+    // The component has already been unmounted and its ShadowNodeFamily
+    // destroyed, but a stale event still fired (e.g. react-native-svg emits
+    // onSvgLayout from a deferred drawRect: after the view unmounted). Don't
+    // read the tag from eventTarget here — EventTarget::getTag() dereferences
+    // its InstanceHandle which may be null for such events (see #9925). Drop
+    // the event, like UIManagerBinding::dispatchEventToJS does.
+    return false;
+  }
+
+  int tag = shadowNodeFamily->getTag();
   auto eventType = rawEvent.type;
   if (eventType.rfind("top", 0) == 0) {
     eventType = "on" + eventType.substr(3);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -692,8 +692,10 @@ bool ReanimatedModuleProxy::handleRawEvent(const RawEvent &rawEvent, double curr
 
   const auto shadowNodeFamily = rawEvent.shadowNodeFamily.lock();
   if (shadowNodeFamily == nullptr) {
-    // getTag() would dereference a null InstanceHandle on stale events dispatched
-    // during unmount (#9925, fixed in RN 0.87 by facebook/react-native#56763).
+    // This check is needed because a stale event dispatched during unmount may
+    // carry an EventTarget with a null InstanceHandle which getTag() would
+    // dereference (see #9925). Fixed in React Native 0.87 by
+    // https://github.com/facebook/react-native/pull/56763.
     return false;
   }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -691,7 +691,7 @@ bool ReanimatedModuleProxy::handleRawEvent(const RawEvent &rawEvent, double curr
   }
 
 #if REACT_NATIVE_VERSION_MINOR >= 87
-  int tag = eventTarget->getTag();
+  const auto tag = eventTarget->getTag();
 #else
   // A stale event dispatched during unmount may carry an EventTarget with a null
   // InstanceHandle which getTag() would dereference (see #9925).
@@ -700,7 +700,7 @@ bool ReanimatedModuleProxy::handleRawEvent(const RawEvent &rawEvent, double curr
   if (shadowNodeFamily == nullptr) {
     return false;
   }
-  int tag = shadowNodeFamily->getTag();
+  const auto tag = shadowNodeFamily->getTag();
 #endif
   auto eventType = rawEvent.type;
   if (eventType.rfind("top", 0) == 0) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -692,10 +692,9 @@ bool ReanimatedModuleProxy::handleRawEvent(const RawEvent &rawEvent, double curr
 
   const auto shadowNodeFamily = rawEvent.shadowNodeFamily.lock();
   if (shadowNodeFamily == nullptr) {
-    // This check is needed because a stale event dispatched during unmount may
-    // carry an EventTarget with a null InstanceHandle which getTag() would
-    // dereference (see #9925). Fixed in React Native 0.87 by
-    // https://github.com/facebook/react-native/pull/56763.
+    // A stale event dispatched during unmount may carry an EventTarget with a null
+    // InstanceHandle which getTag() would dereference (see #9925).
+    // Fixed in React Native 0.87 by https://github.com/facebook/react-native/pull/56763.
     return false;
   }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -690,15 +690,18 @@ bool ReanimatedModuleProxy::handleRawEvent(const RawEvent &rawEvent, double curr
     return false;
   }
 
+#if REACT_NATIVE_VERSION_MINOR < 87
+  // A stale event dispatched during unmount may carry an EventTarget with a null
+  // InstanceHandle which getTag() would dereference (see #9925).
+  // Fixed in React Native 0.87 by https://github.com/facebook/react-native/pull/56763.
   const auto shadowNodeFamily = rawEvent.shadowNodeFamily.lock();
   if (shadowNodeFamily == nullptr) {
-    // A stale event dispatched during unmount may carry an EventTarget with a null
-    // InstanceHandle which getTag() would dereference (see #9925).
-    // Fixed in React Native 0.87 by https://github.com/facebook/react-native/pull/56763.
     return false;
   }
-
   int tag = shadowNodeFamily->getTag();
+#else
+  int tag = eventTarget->getTag();
+#endif
   auto eventType = rawEvent.type;
   if (eventType.rfind("top", 0) == 0) {
     eventType = "on" + eventType.substr(3);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -690,7 +690,9 @@ bool ReanimatedModuleProxy::handleRawEvent(const RawEvent &rawEvent, double curr
     return false;
   }
 
-#if REACT_NATIVE_VERSION_MINOR < 87
+#if REACT_NATIVE_VERSION_MINOR >= 87
+  int tag = eventTarget->getTag();
+#else
   // A stale event dispatched during unmount may carry an EventTarget with a null
   // InstanceHandle which getTag() would dereference (see #9925).
   // Fixed in React Native 0.87 by https://github.com/facebook/react-native/pull/56763.
@@ -699,8 +701,6 @@ bool ReanimatedModuleProxy::handleRawEvent(const RawEvent &rawEvent, double curr
     return false;
   }
   int tag = shadowNodeFamily->getTag();
-#else
-  int tag = eventTarget->getTag();
 #endif
   auto eventType = rawEvent.type;
   if (eventType.rfind("top", 0) == 0) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -692,10 +692,8 @@ bool ReanimatedModuleProxy::handleRawEvent(const RawEvent &rawEvent, double curr
 
   const auto shadowNodeFamily = rawEvent.shadowNodeFamily.lock();
   if (shadowNodeFamily == nullptr) {
-    // This check is needed because a stale event dispatched during unmount may
-    // carry an EventTarget with a null InstanceHandle which getTag() would
-    // dereference (see #9925). Fixed in React Native 0.87 by
-    // https://github.com/facebook/react-native/pull/56763.
+    // getTag() would dereference a null InstanceHandle on stale events dispatched
+    // during unmount (#9925, fixed in RN 0.87 by facebook/react-native#56763).
     return false;
   }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -692,15 +692,10 @@ bool ReanimatedModuleProxy::handleRawEvent(const RawEvent &rawEvent, double curr
 
   const auto shadowNodeFamily = rawEvent.shadowNodeFamily.lock();
   if (shadowNodeFamily == nullptr) {
-    // This check is needed because a stale event dispatched while its
-    // component is being unmounted may carry an EventTarget whose
-    // InstanceHandle is null, and EventTarget::getTag() dereferences it
-    // unconditionally (see #9925). This stems from a data race in
-    // EventEmitter that will be fixed in React Native 0.87
-    // (https://github.com/facebook/react-native/pull/56763), but Reanimated
-    // also supports older versions. Read the tag from the ShadowNodeFamily
-    // instead and drop the event when the family is already destroyed, like
-    // UIManagerBinding::dispatchEventToJS does.
+    // This check is needed because a stale event dispatched during unmount may
+    // carry an EventTarget with a null InstanceHandle which getTag() would
+    // dereference (see #9925). Fixed in React Native 0.87 by
+    // https://github.com/facebook/react-native/pull/56763.
     return false;
   }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -692,12 +692,15 @@ bool ReanimatedModuleProxy::handleRawEvent(const RawEvent &rawEvent, double curr
 
   const auto shadowNodeFamily = rawEvent.shadowNodeFamily.lock();
   if (shadowNodeFamily == nullptr) {
-    // The component has already been unmounted and its ShadowNodeFamily
-    // destroyed, but a stale event still fired (e.g. react-native-svg emits
-    // onSvgLayout from a deferred drawRect: after the view unmounted). Don't
-    // read the tag from eventTarget here — EventTarget::getTag() dereferences
-    // its InstanceHandle which may be null for such events (see #9925). Drop
-    // the event, like UIManagerBinding::dispatchEventToJS does.
+    // This check is needed because a stale event dispatched while its
+    // component is being unmounted may carry an EventTarget whose
+    // InstanceHandle is null, and EventTarget::getTag() dereferences it
+    // unconditionally (see #9925). This stems from a data race in
+    // EventEmitter that will be fixed in React Native 0.87
+    // (https://github.com/facebook/react-native/pull/56763), but Reanimated
+    // also supports older versions. Read the tag from the ShadowNodeFamily
+    // instead and drop the event when the family is already destroyed, like
+    // UIManagerBinding::dispatchEventToJS does.
     return false;
   }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -702,6 +702,7 @@ bool ReanimatedModuleProxy::handleRawEvent(const RawEvent &rawEvent, double curr
   }
   const auto tag = shadowNodeFamily->getTag();
 #endif
+
   auto eventType = rawEvent.type;
   if (eventType.rfind("top", 0) == 0) {
     eventType = "on" + eventType.substr(3);


### PR DESCRIPTION
## Summary

Fixes #9925.

`ReanimatedModuleProxy::handleRawEvent` crashed when it received a stale event whose target component had already unmounted. The existing null check on `rawEvent.eventTarget` doesn't cover this case: the `EventTarget` object itself is non-null, but calling `getTag()` on it dereferences its internal `InstanceHandle` pointer, which can be null (`getTag()` is deprecated in RN core for exactly this reason). This state is produced by a use-after-free data race in `EventEmitter::dispatchEvent`, which copied `eventTarget_` without holding the dispatch mutex while unmount concurrently resets it — hit e.g. by react-native-svg emitting `onSvgLayout` from a deferred `drawRect:` pass against a recycled list item. The race is fixed upstream in React Native 0.87 (facebook/react-native#56763), but Reanimated also supports 0.83–0.86.

The issue suggests guarding with `eventTarget->getInstanceHandle(runtime).isUndefined()`, like `UIManagerBinding::dispatchEventToJS` does, but that's not applicable here: our listener runs in `willDispatchEvent` on the UI thread before React Native retains the target on the JS thread, so `getInstanceHandle` returns null for every event at that point, and we don't hold the React runtime on that thread anyway.

Instead, the fix reads the tag from `rawEvent.shadowNodeFamily` — same tag value, no `InstanceHandle` involved — and drops the event when the family is already destroyed, which matches how RN core drops such stale events on the JS dispatch path. Every `RawEvent` is created by `EventEmitter`, which always populates the family, so valid events are unaffected.

## Test plan

The race from the issue (rapid mount/unmount of SVG icons in a `FlatList` on a physical device) takes minutes to hit, so the crash was reproduced deterministically instead: a temporary snippet at the end of `installTurboModule` in `ReanimatedModule.mm` called `handleRawEvent` on the main queue with a crafted `RawEvent` carrying an `EventTarget` constructed with a null `InstanceHandle` and an expired `ShadowNodeFamily` — the exact state confirmed in the issue's debugger session.

```objc
// TEMP repro for issue #9925 (remove before merge): simulate RNSVG's stale
// onSvgLayout event — a non-null EventTarget whose InstanceHandle is null.
std::weak_ptr<ReanimatedModuleProxy> weakProxy = _reanimatedModuleProxy;
dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
  if (auto proxy = weakProxy.lock()) {
    auto staleTarget = std::make_shared<facebook::react::EventTarget>(nullptr, /* surfaceId */ 1);
    facebook::react::RawEvent rawEvent(
        "topSvgLayout", /* eventPayload */ nullptr, staleTarget, /* shadowNodeFamily */ {});
    NSLog(@"[Repro9925] dispatching stale RawEvent with null InstanceHandle");
    bool res = proxy->handleRawEvent(rawEvent, CACurrentMediaTime() * 1000);
    NSLog(@"[Repro9925] handleRawEvent returned %d - no crash", res);
  }
});
```

- Before this change: `EXC_BAD_ACCESS` in `InstanceHandle::getTag()` ← `EventTarget::getTag()` ← `handleRawEvent`, identical to the stack trace in the issue.
- After this change: the event is dropped, no crash.
- Regression check: the "Scroll event example" screen in the example app (scroll events driven through `useAnimatedScrollHandler`, i.e. this exact code path) still animates correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)