### PR TITLE
[automated runtime tests][4/11] feat: Manual runtime test runs, one library at a time

### DIFF
--- a/apps/common-app/runtime-tests/ReJest/RuntimeTestsRunner.tsx
+++ b/apps/common-app/runtime-tests/ReJest/RuntimeTestsRunner.tsx
@@ -1,5 +1,10 @@
 import type { ReactNode } from 'react';
-import React, { useEffect, useRef, useState } from 'react';
+import React, {
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { FlatList } from 'react-native-gesture-handler';
 
@@ -33,6 +38,27 @@ export class ErrorBoundary extends React.Component<
 
 let renderLock: RenderLock = new RenderLock();
 
+export type RunnerId = 'Reanimated' | 'Worklets' | 'SelfTests';
+
+let sessionOwner: RunnerId | null = null;
+const sessionOwnerListeners = new Set<() => void>();
+
+function claimSession(runnerId: RunnerId) {
+  sessionOwner = runnerId;
+  sessionOwnerListeners.forEach((listener) => listener());
+}
+
+function subscribeToSessionOwner(listener: () => void) {
+  sessionOwnerListeners.add(listener);
+  return () => {
+    sessionOwnerListeners.delete(listener);
+  };
+}
+
+function getSessionOwner() {
+  return sessionOwner;
+}
+
 interface TestData {
   testSuiteName: string;
   importTest: () => void;
@@ -42,9 +68,13 @@ interface TestData {
 
 interface RuntimeTestRunnerProps {
   tests: TestData[];
+  runnerId: RunnerId;
 }
 
-export default function RuntimeTestsRunner({ tests }: RuntimeTestRunnerProps) {
+export default function RuntimeTestsRunner({
+  tests,
+  runnerId,
+}: RuntimeTestRunnerProps) {
   const [component, setComponent] = useState<ReactNode | null>(null);
   const [started, setStarted] = useState<boolean>(false);
   const [finished, setFinished] = useState<boolean>(false);
@@ -70,11 +100,32 @@ export default function RuntimeTestsRunner({ tests }: RuntimeTestRunnerProps) {
     setFinished(true);
   }
 
+  const currentSessionOwner = useSyncExternalStore(
+    subscribeToSessionOwner,
+    getSessionOwner
+  );
+
   function handleStartClick() {
+    if (getSessionOwner() !== null) {
+      return;
+    }
+    claimSession(runnerId);
     testSelectionCallbacks.current.forEach((callback) => callback());
     setStarted(true);
     // eslint-disable-next-line no-void
     void run();
+  }
+
+  if (currentSessionOwner !== null && !started) {
+    return (
+      <View style={styles.flexOne}>
+        <Text style={navyText}>
+          {currentSessionOwner === runnerId
+            ? `${runnerId} tests already started in this session. Reload the app to run them again.`
+            : `${currentSessionOwner} tests already started in this session. Reload the app to run ${runnerId} tests.`}
+        </Text>
+      </View>
+    );
   }
 
   return (

--- a/apps/common-app/src/apps/runtime-tests/App.tsx
+++ b/apps/common-app/src/apps/runtime-tests/App.tsx
@@ -7,6 +7,7 @@ import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { BackButton, DrawerButton } from '@/components';
 import { createStack, IS_MACOS } from '@/utils';
 
+import type { RunnerId } from '../../../runtime-tests/ReJest/RuntimeTestsRunner';
 import type { RuntimeTestSuite } from '../../../runtime-tests/types';
 
 type RootStackParamList = {
@@ -47,40 +48,53 @@ function HomeScreen({ navigation }: HomeScreenProps) {
 function ReanimatedTestsScreen() {
   const RuntimeTestsRunner = (
     require('../../../runtime-tests/ReJest/RuntimeTestsRunner') as {
-      default: React.ComponentType<{ tests: Array<RuntimeTestSuite> }>;
+      default: React.ComponentType<{
+        tests: Array<RuntimeTestSuite>;
+        runnerId: RunnerId;
+      }>;
     }
   ).default;
   const { REANIMATED_TEST_SUITES } =
     require('../../../runtime-tests/reanimated/suites') as {
       REANIMATED_TEST_SUITES: Array<RuntimeTestSuite>;
     };
-  return <RuntimeTestsRunner tests={REANIMATED_TEST_SUITES} />;
+  return (
+    <RuntimeTestsRunner runnerId="Reanimated" tests={REANIMATED_TEST_SUITES} />
+  );
 }
 
 function WorkletsTestsScreen() {
   const RuntimeTestsRunner = (
     require('../../../runtime-tests/ReJest/RuntimeTestsRunner') as {
-      default: React.ComponentType<{ tests: Array<RuntimeTestSuite> }>;
+      default: React.ComponentType<{
+        tests: Array<RuntimeTestSuite>;
+        runnerId: RunnerId;
+      }>;
     }
   ).default;
   const { WORKLETS_TEST_SUITES } =
     require('../../../runtime-tests/worklets/suites') as {
       WORKLETS_TEST_SUITES: Array<RuntimeTestSuite>;
     };
-  return <RuntimeTestsRunner tests={WORKLETS_TEST_SUITES} />;
+  return (
+    <RuntimeTestsRunner runnerId="Worklets" tests={WORKLETS_TEST_SUITES} />
+  );
 }
 
 function SelfTestsScreen() {
   const RuntimeTestsRunner = (
     require('../../../runtime-tests/ReJest/RuntimeTestsRunner') as {
-      default: React.ComponentType<{ tests: Array<RuntimeTestSuite> }>;
+      default: React.ComponentType<{
+        tests: Array<RuntimeTestSuite>;
+        runnerId: RunnerId;
+      }>;
     }
   ).default;
   const { SELF_TEST_SUITES } =
     require('../../../runtime-tests/self-tests/suites') as {
       SELF_TEST_SUITES: Array<RuntimeTestSuite>;
     };
-  return <RuntimeTestsRunner tests={SELF_TEST_SUITES} />;
+  return <RuntimeTestsRunner runnerId="SelfTests" tests={SELF_TEST_SUITES} />;
 }
 
 const Stack = createStack<RootStackParamList>();


### PR DESCRIPTION
## Summary

ReJest keeps its suites in an append-only module singleton — nothing ever resets it. Pressing Run a second time in one JS session, whether for the other library or the same one after re-opening its screen, re-runs the previously registered suites on top of the new ones and duplicates their test cases, so every run after the first produces corrupt results.

I made manual runs one-run-per-JS-session: `RuntimeTestsRunner` takes a required `runnerId` (`'Reanimated' | 'Worklets' | 'SelfTests'`), pressing Run claims the session, and any later mount of a test screen renders a reload prompt instead of a Run button.

## Test plan

Tests work
