### PR TITLE
chore: fix typo in Bundle Mode setup docs

### DIFF
--- a/docs/docs-worklets/docs/bundleMode/setup.mdx
+++ b/docs/docs-worklets/docs/bundleMode/setup.mdx
@@ -44,7 +44,7 @@ To use `react-native-worklets`'s Bundle Mode feature, you need to make the follo
     const { getDefaultConfig, mergeConfig } = require("expo/metro-config");
     const { getBundleModeMetroConfig } = require("react-native-worklets/bundleMode");
 
-    @type {import('expo/metro-config').MetroConfig} */
+    /** @type {import('expo/metro-config').MetroConfig} */
     let config = getDefaultConfig(__dirname);
 
     // Your modifications to the config


### PR DESCRIPTION
## Summary
Fixes a typo in the example code of the Bundle Mode setup docs. Stumbled across it while updating an Expo app to the latest SDK version, following their advice to avoid a memory consumption regression by enabling Bundle Mode. 

## Test plan

The example code now matches [this line](https://github.com/software-mansion/react-native-reanimated/blob/12a8d10454b20896c48443b6b5faa29b241e3f2f/apps/tvos-example/metro.config.js#L18) used by one of the example apps and also the [Expo metro.config.js docs](https://docs.expo.dev/versions/latest/config/metro/).