### PR TITLE
[automated runtime tests][5/11] refactor(ReJest): Decouple the test framework from Reanimated

### DIFF
--- a/apps/common-app/runtime-tests/ReJest/RuntimeTestsRunner.tsx
+++ b/apps/common-app/runtime-tests/ReJest/RuntimeTestsRunner.tsx
@@ -1,5 +1,10 @@
 import type { ReactNode } from 'react';
-import React, { useEffect, useRef, useState } from 'react';
+import React, {
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { FlatList } from 'react-native-gesture-handler';
 
@@ -33,6 +38,27 @@ export class ErrorBoundary extends React.Component<
 
 let renderLock: RenderLock = new RenderLock();
 
+export type RunnerId = 'Reanimated' | 'Worklets' | 'SelfTests';
+
+let sessionOwner: RunnerId | null = null;
+const sessionOwnerListeners = new Set<() => void>();
+
+function claimSession(runnerId: RunnerId) {
+  sessionOwner = runnerId;
+  sessionOwnerListeners.forEach((listener) => listener());
+}
+
+function subscribeToSessionOwner(listener: () => void) {
+  sessionOwnerListeners.add(listener);
+  return () => {
+    sessionOwnerListeners.delete(listener);
+  };
+}
+
+function getSessionOwner() {
+  return sessionOwner;
+}
+
 interface TestData {
   testSuiteName: string;
   importTest: () => void;
@@ -42,9 +68,13 @@ interface TestData {
 
 interface RuntimeTestRunnerProps {
   tests: TestData[];
+  runnerId: RunnerId;
 }
 
-export default function RuntimeTestsRunner({ tests }: RuntimeTestRunnerProps) {
+export default function RuntimeTestsRunner({
+  tests,
+  runnerId,
+}: RuntimeTestRunnerProps) {
   const [component, setComponent] = useState<ReactNode | null>(null);
   const [started, setStarted] = useState<boolean>(false);
   const [finished, setFinished] = useState<boolean>(false);
@@ -70,11 +100,32 @@ export default function RuntimeTestsRunner({ tests }: RuntimeTestRunnerProps) {
     setFinished(true);
   }
 
+  const currentSessionOwner = useSyncExternalStore(
+    subscribeToSessionOwner,
+    getSessionOwner
+  );
+
   function handleStartClick() {
+    if (getSessionOwner() !== null) {
+      return;
+    }
+    claimSession(runnerId);
     testSelectionCallbacks.current.forEach((callback) => callback());
     setStarted(true);
     // eslint-disable-next-line no-void
     void run();
+  }
+
+  if (currentSessionOwner !== null && !started) {
+    return (
+      <View style={styles.flexOne}>
+        <Text style={navyText}>
+          {currentSessionOwner === runnerId
+            ? `${runnerId} tests already started in this session. Reload the app to run them again.`
+            : `${currentSessionOwner} tests already started in this session. Reload the app to run ${runnerId} tests.`}
+        </Text>
+      </View>
+    );
   }
 
   return (

--- a/apps/common-app/runtime-tests/ReJest/TestRunner/CallTrackerRegistry.ts
+++ b/apps/common-app/runtime-tests/ReJest/TestRunner/CallTrackerRegistry.ts
@@ -1,9 +1,11 @@
-import { makeMutable } from 'react-native-reanimated';
+import { createSynchronizable } from 'react-native-worklets';
 
 import type { TrackerCallCount } from '../types';
 
 let callCallTrackerRegistryJS: Record<string, number> = {};
-const callCallTrackerRegistryUI = makeMutable<Record<string, number>>({});
+const callCallTrackerRegistryUI = createSynchronizable<
+  Record<string, number>
+>({});
 function callTrackerJS(name: string) {
   if (!callCallTrackerRegistryJS[name]) {
     callCallTrackerRegistryJS[name] = 0;
@@ -15,11 +17,9 @@ export class CallTrackerRegistry {
   public callTracker(name: string) {
     'worklet';
     if (_WORKLET) {
-      if (!callCallTrackerRegistryUI.value[name]) {
-        callCallTrackerRegistryUI.value[name] = 0;
-      }
-      callCallTrackerRegistryUI.value[name]++;
-      callCallTrackerRegistryUI.value = { ...callCallTrackerRegistryUI.value };
+      callCallTrackerRegistryUI.setBlocking((prev) => {
+        return { ...prev, [name]: (prev[name] ?? 0) + 1 };
+      });
     } else {
       callTrackerJS(name);
     }
@@ -29,12 +29,12 @@ export class CallTrackerRegistry {
     return {
       name,
       onJS: callCallTrackerRegistryJS[name] ?? 0,
-      onUI: callCallTrackerRegistryUI.value[name] ?? 0,
+      onUI: callCallTrackerRegistryUI.getBlocking()[name] ?? 0,
     };
   }
 
   public resetRegistry() {
-    callCallTrackerRegistryUI.value = {};
+    callCallTrackerRegistryUI.setBlocking({});
     callCallTrackerRegistryJS = {};
   }
 }

--- a/apps/common-app/runtime-tests/ReJest/matchers/Comparators.ts
+++ b/apps/common-app/runtime-tests/ReJest/matchers/Comparators.ts
@@ -1,4 +1,4 @@
-import { isColor, processColor } from 'react-native-reanimated';
+import { isColor, processColorNumber } from '../utils/colorUtils';
 
 import type { TestValue, ValidPropNames } from '../types';
 import { ComparisonMode, isValidPropName } from '../types';
@@ -40,7 +40,7 @@ const COMPARATORS: {
     if (!isColor(expected) || !isColor(value)) {
       return false;
     }
-    return processColor(expected) === processColor(value);
+    return processColorNumber(expected) === processColorNumber(value);
   },
 
   [ComparisonMode.PIXEL]: (expected, value) => {

--- a/apps/common-app/runtime-tests/ReJest/matchers/rawMatchers.ts
+++ b/apps/common-app/runtime-tests/ReJest/matchers/rawMatchers.ts
@@ -1,11 +1,13 @@
-import { makeMutable } from 'react-native-reanimated';
-
 import type { TestValue, TrackerCallCount } from '../types';
 import { ComparisonMode } from '../types';
 import { cyan, green, red, yellow } from '../utils/stringFormatUtils';
 import { SyncUIRunner } from '../utils/SyncUIRunner';
 import { getComparator } from './Comparators';
-import { getRuntimeKind, RuntimeKind } from 'react-native-worklets';
+import {
+  createSynchronizable,
+  getRuntimeKind,
+  RuntimeKind,
+} from 'react-native-worklets';
 
 type ToBeArgs = [TestValue, ComparisonMode?];
 export type ToThrowArgs = [string?];
@@ -240,8 +242,8 @@ async function mockConsole(): Promise<
   const syncUIRunner = new SyncUIRunner();
   let counterJS = 0;
 
-  const counterUI = makeMutable(0);
-  const recordedMessage = makeMutable('');
+  const counterUI = createSynchronizable(0);
+  const recordedMessage = createSynchronizable('');
 
   const originalError = console.error;
   const originalWarning = console.warn;
@@ -254,12 +256,16 @@ async function mockConsole(): Promise<
     if (getRuntimeKind() === RuntimeKind.ReactNative) {
       incrementJS();
     } else {
-      counterUI.value++;
+      counterUI.setBlocking((prev) => {
+        return prev + 1;
+      });
     }
     if (typeof message === 'object' && 'message' in message) {
-      recordedMessage.value = message.message;
+      recordedMessage.setBlocking(message.message);
     } else {
-      recordedMessage.value = message.split('\n\nThis error is located at:')[0];
+      recordedMessage.setBlocking(
+        message.split('\n\nThis error is located at:')[0]
+      );
     }
   };
   console.error = mockedConsoleFunction;
@@ -289,10 +295,10 @@ async function mockConsole(): Promise<
   };
 
   const getCapturedConsoleErrors = () => {
-    const count = counterUI.value + counterJS;
+    const count = counterUI.getBlocking() + counterJS;
     return {
       consoleErrorCount: count,
-      consoleErrorMessage: recordedMessage.value,
+      consoleErrorMessage: recordedMessage.getBlocking(),
     };
   };
 

--- a/apps/common-app/runtime-tests/ReJest/utils/colorUtils.ts
+++ b/apps/common-app/runtime-tests/ReJest/utils/colorUtils.ts
@@ -1,0 +1,9 @@
+import { processColor } from 'react-native';
+
+export function isColor(value: unknown): value is string {
+  return typeof value === 'string' && processColor(value) != null;
+}
+
+export function processColorNumber(value: string): number {
+  return (processColor(value) as number) ?? 0;
+}

--- a/apps/common-app/runtime-tests/ReJest/utils/drawSnapshotTable.ts
+++ b/apps/common-app/runtime-tests/ReJest/utils/drawSnapshotTable.ts
@@ -1,4 +1,4 @@
-import { isColor } from 'react-native-reanimated';
+import { isColor } from './colorUtils';
 
 import {
   getComparator,

--- a/apps/common-app/runtime-tests/ReJest/utils/stringFormatUtils.ts
+++ b/apps/common-app/runtime-tests/ReJest/utils/stringFormatUtils.ts
@@ -1,4 +1,4 @@
-import { isColor, processColor } from 'react-native-reanimated';
+import { isColor, processColorNumber } from './colorUtils';
 
 import type { TestValue } from '../types';
 
@@ -94,7 +94,7 @@ export function getColorSquare(color: string) {
   if (!isColor(color)) {
     return '??';
   }
-  const colorNumber = processColor(color);
+  const colorNumber = processColorNumber(color);
   /* eslint-disable no-bitwise */
   const red = (colorNumber >> 16) & 255;
   const green = (colorNumber >> 8) & 255;

--- a/apps/common-app/src/apps/runtime-tests/App.tsx
+++ b/apps/common-app/src/apps/runtime-tests/App.tsx
@@ -7,6 +7,7 @@ import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { BackButton, DrawerButton } from '@/components';
 import { createStack, IS_MACOS } from '@/utils';
 
+import type { RunnerId } from '../../../runtime-tests/ReJest/RuntimeTestsRunner';
 import type { RuntimeTestSuite } from '../../../runtime-tests/types';
 
 type RootStackParamList = {
@@ -47,40 +48,53 @@ function HomeScreen({ navigation }: HomeScreenProps) {
 function ReanimatedTestsScreen() {
   const RuntimeTestsRunner = (
     require('../../../runtime-tests/ReJest/RuntimeTestsRunner') as {
-      default: React.ComponentType<{ tests: Array<RuntimeTestSuite> }>;
+      default: React.ComponentType<{
+        tests: Array<RuntimeTestSuite>;
+        runnerId: RunnerId;
+      }>;
     }
   ).default;
   const { REANIMATED_TEST_SUITES } =
     require('../../../runtime-tests/reanimated/suites') as {
       REANIMATED_TEST_SUITES: Array<RuntimeTestSuite>;
     };
-  return <RuntimeTestsRunner tests={REANIMATED_TEST_SUITES} />;
+  return (
+    <RuntimeTestsRunner runnerId="Reanimated" tests={REANIMATED_TEST_SUITES} />
+  );
 }
 
 function WorkletsTestsScreen() {
   const RuntimeTestsRunner = (
     require('../../../runtime-tests/ReJest/RuntimeTestsRunner') as {
-      default: React.ComponentType<{ tests: Array<RuntimeTestSuite> }>;
+      default: React.ComponentType<{
+        tests: Array<RuntimeTestSuite>;
+        runnerId: RunnerId;
+      }>;
     }
   ).default;
   const { WORKLETS_TEST_SUITES } =
     require('../../../runtime-tests/worklets/suites') as {
       WORKLETS_TEST_SUITES: Array<RuntimeTestSuite>;
     };
-  return <RuntimeTestsRunner tests={WORKLETS_TEST_SUITES} />;
+  return (
+    <RuntimeTestsRunner runnerId="Worklets" tests={WORKLETS_TEST_SUITES} />
+  );
 }
 
 function SelfTestsScreen() {
   const RuntimeTestsRunner = (
     require('../../../runtime-tests/ReJest/RuntimeTestsRunner') as {
-      default: React.ComponentType<{ tests: Array<RuntimeTestSuite> }>;
+      default: React.ComponentType<{
+        tests: Array<RuntimeTestSuite>;
+        runnerId: RunnerId;
+      }>;
     }
   ).default;
   const { SELF_TEST_SUITES } =
     require('../../../runtime-tests/self-tests/suites') as {
       SELF_TEST_SUITES: Array<RuntimeTestSuite>;
     };
-  return <RuntimeTestsRunner tests={SELF_TEST_SUITES} />;
+  return <RuntimeTestsRunner runnerId="SelfTests" tests={SELF_TEST_SUITES} />;
 }
 
 const Stack = createStack<RootStackParamList>();


### PR DESCRIPTION
## Summary

ReJest used react-native-reanimated in ways that execute at module-initialization time, so any app hosting the test framework loaded Reanimated with it. That blocks the one-library-at-a-time flows: a Worklets run can only prove Reanimated was never loaded if the framework itself does not load it.

I removed the initialization-time dependencies. Worklet-captured state moved from `makeMutable` to `createSynchronizable` from `react-native-worklets` (`CallTrackerRegistry`, the `mockConsole` counters in `rawMatchers`), and formatting helpers use a new `colorUtils` built on React Native's `processColor` instead of Reanimated's color parser.

## Test plan

Runtime tests pass for all three libraries; a Worklets auto-run session later in this stack asserts that Reanimated is never loaded.
