### PR TITLE
fix: patch react-native-screens web Screen typing for RN Strict API compatibility

### DIFF
--- a/.yarn/patches/react-native-screens-npm-4.24.0-c572d01561.patch
+++ b/.yarn/patches/react-native-screens-npm-4.24.0-c572d01561.patch
@@ -1,0 +1,20 @@
+diff --git a/lib/typescript/components/Screen.web.d.ts b/lib/typescript/components/Screen.web.d.ts
+index fdb5fe9302936eccc917fceba35524e13b41b42c..86c7c79c4c7a8c02dc8a37ae26ecf99d79633e42 100644
+--- a/lib/typescript/components/Screen.web.d.ts
++++ b/lib/typescript/components/Screen.web.d.ts
+@@ -1,11 +1,11 @@
+ import { ScreenProps } from '../types';
+-import { Animated, View } from 'react-native';
++import { View } from 'react-native';
+ import React from 'react';
+ export declare const InnerScreen: typeof View;
+ export declare class NativeScreen extends React.Component<ScreenProps> {
+     render(): React.JSX.Element;
+ }
+-declare const Screen: Animated.AnimatedComponent<typeof NativeScreen>;
+-export declare const ScreenContext: React.Context<Animated.AnimatedComponent<typeof NativeScreen>>;
++declare const Screen: React.ComponentType<ScreenProps & React.RefAttributes<View>>;
++export declare const ScreenContext: React.Context<React.ComponentType<ScreenProps & React.RefAttributes<View>>>;
+ export default Screen;
+ //# sourceMappingURL=Screen.web.d.ts.map
+\ No newline at end of file

--- a/apps/common-app/package.json
+++ b/apps/common-app/package.json
@@ -40,7 +40,7 @@
     "react-native-nitro-modules": "patch:react-native-nitro-modules@npm%3A0.35.2#~/.yarn/patches/react-native-nitro-modules-npm-0.35.2-717188fdb0.patch",
     "react-native-reanimated": "workspace:*",
     "react-native-safe-area-context": "patch:react-native-safe-area-context@npm%3A5.7.0#~/.yarn/patches/react-native-safe-area-context-npm-5.7.0-fcff6bf187.patch",
-    "react-native-screens": "4.24.0",
+    "react-native-screens": "patch:react-native-screens@npm%3A4.24.0#~/.yarn/patches/react-native-screens-npm-4.24.0-c572d01561.patch",
     "react-native-svg": "15.15.4",
     "react-native-worklets": "workspace:*",
     "react-strict-dom": "0.0.55"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14172,7 +14172,7 @@ __metadata:
     react-native-nitro-modules: "patch:react-native-nitro-modules@npm%3A0.35.2#~/.yarn/patches/react-native-nitro-modules-npm-0.35.2-717188fdb0.patch"
     react-native-reanimated: "workspace:*"
     react-native-safe-area-context: "patch:react-native-safe-area-context@npm%3A5.7.0#~/.yarn/patches/react-native-safe-area-context-npm-5.7.0-fcff6bf187.patch"
-    react-native-screens: "npm:4.24.0"
+    react-native-screens: "patch:react-native-screens@npm%3A4.24.0#~/.yarn/patches/react-native-screens-npm-4.24.0-c572d01561.patch"
     react-native-svg: "npm:15.15.4"
     react-native-worklets: "workspace:*"
     react-strict-dom: "npm:0.0.55"
@@ -28735,6 +28735,19 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: 10/1ac705f7c0c37f62f0c29c5bf477b4a2360c37dec6b689e7fa9a768cc8a08d828ac7260d168a60638d207e0be21ae22bb3f170d55f0ae97837c2053ba8e38aff
+  languageName: node
+  linkType: hard
+
+"react-native-screens@patch:react-native-screens@npm%3A4.24.0#~/.yarn/patches/react-native-screens-npm-4.24.0-c572d01561.patch":
+  version: 4.24.0
+  resolution: "react-native-screens@patch:react-native-screens@npm%3A4.24.0#~/.yarn/patches/react-native-screens-npm-4.24.0-c572d01561.patch::version=4.24.0&hash=6a1c83"
+  dependencies:
+    react-freeze: "npm:^1.0.0"
+    warn-once: "npm:^0.1.0"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 10/89f66b07665af12ac0672ac0efe635afad9d9df7f7dde3c5dc8b953b5f3909af1688c94974dbfdede2a83ba0fbac74222d6a7a640fed601cf50b412e66247a7e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

Fixes failing nightly CI https://github.com/software-mansion/react-native-reanimated/actions/runs/29206873570

Based on react-native-screens submitted fix https://github.com/software-mansion/react-native-screens/pull/4320
