### PR TITLE
[automated runtime tests][11/11] ci: Android runtime tests on CI

### DIFF
--- a/.github/workflows/runtime-tests-android.yml
+++ b/.github/workflows/runtime-tests-android.yml
@@ -1,0 +1,82 @@
+name: Runtime tests Android
+env:
+  YARN_ENABLE_HARDENED_MODE: 0
+on:
+  pull_request:
+    paths:
+      - .github/workflows/runtime-tests-android.yml
+      - apps/common-app/runtime-tests/**
+      - apps/fabric-example/scripts/runtime-tests-server.js
+      - apps/fabric-example/android/**
+  workflow_call:
+    inputs:
+      bundleMode:
+        required: false
+        type: boolean
+        default: false
+  workflow_dispatch:
+    inputs:
+      bundleMode:
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  runtime-tests-android:
+    if: github.repository == 'software-mansion/react-native-reanimated'
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      WORKING_DIRECTORY: apps/fabric-example
+      REANIMATED_DIR: packages/react-native-reanimated
+    concurrency:
+      group: runtime-tests-android-${{ github.ref }}-${{ inputs.bundleMode }}
+      cancel-in-progress: true
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Setup Java 17
+        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62
+        with:
+          distribution: 'zulu'
+          java-version: 17
+
+      - name: Install monorepo node dependencies
+        run: yarn install --immutable
+
+      # Bundle Mode is the committed default in fabric-example; toggling
+      # switches the app to Legacy Eval, so it runs in the non-bundleMode legs.
+      - name: Toggle Bundle Mode off (Legacy Eval)
+        if: ${{ !inputs.bundleMode }}
+        run: yarn toggle-bundle-mode
+
+      - name: Build Reanimated package
+        working-directory: ${{ env.REANIMATED_DIR }}
+        run: yarn build
+
+      # Built before the emulator starts so its boot session is spent on the
+      # tests only; the server then runs with --skip-build.
+      - name: Build app (debugRuntimeTests)
+        working-directory: ${{ env.WORKING_DIRECTORY }}/android
+        run: ./gradlew assembleDebugRuntimeTests --build-cache -PreactNativeArchitectures=x86_64
+
+      # Animation timing tests are sensitive to runner load, so each library
+      # gets one retry; a real regression fails both attempts.
+      - name: Run runtime tests on emulator (retries once per library)
+        uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d
+        with:
+          api-level: 34
+          arch: x86_64
+          disable-animations: false
+          working-directory: apps/fabric-example
+          script: |
+            set -e
+            node scripts/runtime-tests-server.js --launch --platform android --library reanimated --skip-build --connect-timeout 900 --idle-timeout 900 || node scripts/runtime-tests-server.js --launch --platform android --library reanimated --skip-build --connect-timeout 900 --idle-timeout 900
+            node scripts/runtime-tests-server.js --launch --platform android --library worklets --skip-build --connect-timeout 900 --idle-timeout 900 ${{ inputs.bundleMode && '--include "bundle mode core"' || '' }} || node scripts/runtime-tests-server.js --launch --platform android --library worklets --skip-build --connect-timeout 900 --idle-timeout 900 ${{ inputs.bundleMode && '--include "bundle mode core"' || '' }}

--- a/.github/workflows/runtime-tests-ios.yml
+++ b/.github/workflows/runtime-tests-ios.yml
@@ -13,12 +13,20 @@ on:
         required: false
         type: boolean
         default: false
+      configuration:
+        required: false
+        type: string
+        default: DebugRuntimeTests
   workflow_dispatch:
     inputs:
       bundleMode:
         required: false
         type: boolean
         default: false
+      configuration:
+        required: false
+        type: string
+        default: DebugRuntimeTests
 
 jobs:
   runtime-tests-ios:
@@ -28,8 +36,9 @@ jobs:
     env:
       WORKING_DIRECTORY: apps/fabric-example
       REANIMATED_DIR: packages/react-native-reanimated
+      CONFIGURATION: ${{ inputs.configuration || 'DebugRuntimeTests' }}
     concurrency:
-      group: runtime-tests-ios-${{ github.ref }}-${{ inputs.bundleMode }}
+      group: runtime-tests-ios-${{ github.ref }}-${{ inputs.bundleMode }}-${{ inputs.configuration || 'DebugRuntimeTests' }}
       cancel-in-progress: true
     steps:
       - name: Check out Git repository
@@ -72,9 +81,9 @@ jobs:
         working-directory: ${{ env.WORKING_DIRECTORY }}
         run: >-
           node scripts/runtime-tests-server.js --launch --library self-tests
-          --connect-timeout 900 --idle-timeout 900
+          --configuration "$CONFIGURATION" --connect-timeout 900 --idle-timeout 900
           || node scripts/runtime-tests-server.js --launch --library self-tests
-          --skip-build --connect-timeout 900 --idle-timeout 900
+          --configuration "$CONFIGURATION" --skip-build --connect-timeout 900 --idle-timeout 900
 
       # The "intentional failures" suite only contains failing tests; the runner
       # exiting zero here would mean CI cannot catch real failures.
@@ -82,7 +91,7 @@ jobs:
         working-directory: ${{ env.WORKING_DIRECTORY }}
         run: >-
           if node scripts/runtime-tests-server.js --launch --library self-tests
-          --skip-build --connect-timeout 900 --idle-timeout 900
+          --configuration "$CONFIGURATION" --skip-build --connect-timeout 900 --idle-timeout 900
           --only "intentional failures";
           then echo "A failing suite did not fail the runner" && exit 1;
           else echo "Failing tests correctly failed the runner"; fi
@@ -91,14 +100,14 @@ jobs:
         working-directory: ${{ env.WORKING_DIRECTORY }}
         run: >-
           node scripts/runtime-tests-server.js --launch --library worklets
-          --skip-build --connect-timeout 900 --idle-timeout 900
+          --configuration "$CONFIGURATION" --skip-build --connect-timeout 900 --idle-timeout 900
           || node scripts/runtime-tests-server.js --launch --library worklets
-          --skip-build --connect-timeout 900 --idle-timeout 900
+          --configuration "$CONFIGURATION" --skip-build --connect-timeout 900 --idle-timeout 900
 
       - name: Run Reanimated runtime tests (reuses the build, retries once)
         working-directory: ${{ env.WORKING_DIRECTORY }}
         run: >-
           node scripts/runtime-tests-server.js --launch --library reanimated
-          --skip-build --connect-timeout 900 --idle-timeout 900
+          --configuration "$CONFIGURATION" --skip-build --connect-timeout 900 --idle-timeout 900
           || node scripts/runtime-tests-server.js --launch --library reanimated
-          --skip-build --connect-timeout 900 --idle-timeout 900
+          --configuration "$CONFIGURATION" --skip-build --connect-timeout 900 --idle-timeout 900

--- a/.github/workflows/runtime-tests-ios.yml
+++ b/.github/workflows/runtime-tests-ios.yml
@@ -101,8 +101,10 @@ jobs:
         run: >-
           node scripts/runtime-tests-server.js --launch --library worklets
           --configuration "$CONFIGURATION" --skip-build --connect-timeout 900 --idle-timeout 900
+          ${{ inputs.bundleMode && '--include "bundle mode core"' || '' }}
           || node scripts/runtime-tests-server.js --launch --library worklets
           --configuration "$CONFIGURATION" --skip-build --connect-timeout 900 --idle-timeout 900
+          ${{ inputs.bundleMode && '--include "bundle mode core"' || '' }}
 
       - name: Run Reanimated runtime tests (reuses the build, retries once)
         working-directory: ${{ env.WORKING_DIRECTORY }}

--- a/.github/workflows/runtime-tests-nightly.yml
+++ b/.github/workflows/runtime-tests-nightly.yml
@@ -1,0 +1,22 @@
+name: Runtime tests nightly
+on:
+  schedule:
+    # 03:53 UTC — offset from other nightly crons to spread runner load
+    - cron: '53 3 * * *'
+  pull_request:
+    paths:
+      - .github/workflows/runtime-tests-nightly.yml
+  workflow_dispatch:
+
+jobs:
+  ios:
+    if: github.repository == 'software-mansion/react-native-reanimated'
+    strategy:
+      fail-fast: false
+      matrix:
+        configuration: [DebugRuntimeTests, ReleaseRuntimeTests]
+        bundleMode: [false, true]
+    uses: ./.github/workflows/runtime-tests-ios.yml
+    with:
+      configuration: ${{ matrix.configuration }}
+      bundleMode: ${{ matrix.bundleMode }}

--- a/.github/workflows/runtime-tests-nightly.yml
+++ b/.github/workflows/runtime-tests-nightly.yml
@@ -20,3 +20,13 @@ jobs:
     with:
       configuration: ${{ matrix.configuration }}
       bundleMode: ${{ matrix.bundleMode }}
+
+  android:
+    if: github.repository == 'software-mansion/react-native-reanimated'
+    strategy:
+      fail-fast: false
+      matrix:
+        bundleMode: [false, true]
+    uses: ./.github/workflows/runtime-tests-android.yml
+    with:
+      bundleMode: ${{ matrix.bundleMode }}

--- a/apps/common-app/runtime-tests/AutoRunRuntimeTestsApp.tsx
+++ b/apps/common-app/runtime-tests/AutoRunRuntimeTestsApp.tsx
@@ -58,12 +58,14 @@ interface AutoRunRuntimeTestsAppProps {
   tests: RuntimeTestSuite[];
   library: string;
   forbidReanimated?: boolean;
+  warmUp?: () => Promise<void>;
 }
 
 export default function AutoRunRuntimeTestsApp({
   tests,
   library,
   forbidReanimated,
+  warmUp,
 }: AutoRunRuntimeTestsAppProps) {
   const wsUrl = deriveWsUrl();
   return (
@@ -76,6 +78,7 @@ export default function AutoRunRuntimeTestsApp({
           autoRun={{ wsUrl }}
           library={library}
           forbidReanimated={forbidReanimated}
+          warmUp={warmUp}
         />
       </View>
     </View>

--- a/apps/common-app/runtime-tests/ReJest/AutoRunRuntimeTestsRunner.tsx
+++ b/apps/common-app/runtime-tests/ReJest/AutoRunRuntimeTestsRunner.tsx
@@ -26,6 +26,7 @@ interface AutoRunRuntimeTestsRunnerProps {
   autoRun: AutoRunConfig;
   library: string;
   forbidReanimated?: boolean;
+  warmUp?: () => Promise<void>;
 }
 
 interface ProgressState {
@@ -50,6 +51,7 @@ export default function AutoRunRuntimeTestsRunner({
   autoRun,
   library,
   forbidReanimated,
+  warmUp,
 }: AutoRunRuntimeTestsRunnerProps) {
   const [component, setComponent] = useState<ReactNode | null>(null);
   const [status, setStatus] = useState<string>(
@@ -98,10 +100,9 @@ export default function AutoRunRuntimeTestsRunner({
         });
 
         const known = new Set(tests.map((test) => test.testSuiteName));
-        const unknown = [
-          ...(filterSet ?? []),
-          ...(includeSet ?? []),
-        ].filter((name) => !known.has(name));
+        const unknown = [...(filterSet ?? []), ...(includeSet ?? [])].filter(
+          (name) => !known.has(name)
+        );
         if (unknown.length > 0) {
           throw new Error(`Unknown test suites: ${unknown.join(', ')}`);
         }
@@ -125,6 +126,9 @@ export default function AutoRunRuntimeTestsRunner({
           render: setComponent,
           onProgress: setProgress,
         });
+        if (warmUp) {
+          await warmUp();
+        }
         const summary = await runTests();
         if (forbidReanimated && isReanimatedLoaded()) {
           summary.failed += 1;
@@ -140,7 +144,7 @@ export default function AutoRunRuntimeTestsRunner({
       cancelled = true;
       teardown();
     };
-  }, [autoRun.wsUrl, tests, library, forbidReanimated]);
+  }, [autoRun.wsUrl, tests, library, forbidReanimated, warmUp]);
 
   return (
     <View style={styles.flexOne}>

--- a/apps/common-app/runtime-tests/ReJest/AutoRunRuntimeTestsRunner.tsx
+++ b/apps/common-app/runtime-tests/ReJest/AutoRunRuntimeTestsRunner.tsx
@@ -81,11 +81,15 @@ export default function AutoRunRuntimeTestsRunner({
           setStatus(message);
         }
       },
-      onStart: async ({ only }) => {
+      onStart: async ({ only, include }) => {
         const filterSet = only ? new Set(only) : null;
+        const includeSet = include ? new Set(include) : null;
         const selected = tests.filter((test) => {
           if (test.disabled) {
             return false;
+          }
+          if (includeSet?.has(test.testSuiteName)) {
+            return true;
           }
           if (filterSet) {
             return filterSet.has(test.testSuiteName);
@@ -93,12 +97,13 @@ export default function AutoRunRuntimeTestsRunner({
           return !test.skipByDefault;
         });
 
-        if (filterSet) {
-          const known = new Set(tests.map((test) => test.testSuiteName));
-          const unknown = [...filterSet].filter((name) => !known.has(name));
-          if (unknown.length > 0) {
-            throw new Error(`Unknown test suites: ${unknown.join(', ')}`);
-          }
+        const known = new Set(tests.map((test) => test.testSuiteName));
+        const unknown = [
+          ...(filterSet ?? []),
+          ...(includeSet ?? []),
+        ].filter((name) => !known.has(name));
+        if (unknown.length > 0) {
+          throw new Error(`Unknown test suites: ${unknown.join(', ')}`);
         }
 
         const { configure, runTests } = require('./RuntimeTestsApi') as {

--- a/apps/common-app/runtime-tests/ReJest/Presets.ts
+++ b/apps/common-app/runtime-tests/ReJest/Presets.ts
@@ -61,7 +61,7 @@ const NOT_NUMBERS = [Infinity, -Infinity, NaN];
 // #region strings
 const TYPICAL_STRINGS = [
   'Aaaaaaa\n \t\t \v aaaaaa',
-  'Super long'.repeat(10000000),
+  'Super long'.repeat(100000),
   '',
   'A string primitive',
 ];

--- a/apps/common-app/runtime-tests/ReJest/matchers/Comparators.ts
+++ b/apps/common-app/runtime-tests/ReJest/matchers/Comparators.ts
@@ -1,5 +1,4 @@
-import { isColor, processColorNumber } from '../utils/colorUtils';
-
+/* eslint-disable @typescript-eslint/no-var-requires */
 import type { TestValue, ValidPropNames } from '../types';
 import { ComparisonMode, isValidPropName } from '../types';
 
@@ -37,10 +36,12 @@ const COMPARATORS: {
   },
 
   [ComparisonMode.COLOR]: (expected, value) => {
+    const { isColor, processColor } =
+      require('react-native-reanimated') as typeof import('react-native-reanimated');
     if (!isColor(expected) || !isColor(value)) {
       return false;
     }
-    return processColorNumber(expected) === processColorNumber(value);
+    return processColor(expected) === processColor(value);
   },
 
   [ComparisonMode.PIXEL]: (expected, value) => {

--- a/apps/common-app/runtime-tests/ReJest/matchers/rawMatchers.ts
+++ b/apps/common-app/runtime-tests/ReJest/matchers/rawMatchers.ts
@@ -208,17 +208,56 @@ export const toThrowMatcher: AsyncMatcher<ToThrowArgs> = async (
   let thrownException = false;
   let thrownExceptionMessage = null;
 
+  // Errors thrown on a Worklet Runtime inside a synchronous call (e.g.
+  // `runOnUISync`) don't reject on the RN runtime — they are reported
+  // asynchronously through `ErrorUtils.reportFatalError`. Capture the global
+  // handler for the duration of the call so the matcher sees them regardless
+  // of which handler (LogBox, remote reporter) is installed around the run.
+  const errorUtils = (
+    globalThis as {
+      ErrorUtils?: {
+        getGlobalHandler: () => (error: Error, isFatal?: boolean) => void;
+        setGlobalHandler: (
+          handler: (error: Error, isFatal?: boolean) => void
+        ) => void;
+      };
+    }
+  ).ErrorUtils;
+  let uncaughtErrorMessage: string | null = null;
+  const previousGlobalHandler = errorUtils?.getGlobalHandler();
+  errorUtils?.setGlobalHandler((error) => {
+    if (uncaughtErrorMessage === null) {
+      uncaughtErrorMessage = error?.message ?? String(error);
+    }
+  });
+
   try {
     await throwingFunction();
   } catch (e) {
     thrownException = true;
     thrownExceptionMessage = (e as Error)?.message || '';
   }
+
+  const deadline = Date.now() + 500;
+  while (
+    !thrownException &&
+    uncaughtErrorMessage === null &&
+    getCapturedConsoleErrors().consoleErrorCount < 1 &&
+    Date.now() < deadline
+  ) {
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+
+  if (previousGlobalHandler) {
+    errorUtils?.setGlobalHandler(previousGlobalHandler);
+  }
   await restoreConsole();
 
   const { consoleErrorCount, consoleErrorMessage } = getCapturedConsoleErrors();
-  const errorWasThrown = thrownException || consoleErrorCount >= 1;
-  const capturedMessage = thrownExceptionMessage || consoleErrorMessage;
+  const errorWasThrown =
+    thrownException || uncaughtErrorMessage !== null || consoleErrorCount >= 1;
+  const capturedMessage =
+    thrownExceptionMessage || uncaughtErrorMessage || consoleErrorMessage;
   const messageIsCorrect = errorMessage
     ? capturedMessage.includes(errorMessage)
     : true;

--- a/apps/common-app/runtime-tests/ReJest/utils/remoteReporter.ts
+++ b/apps/common-app/runtime-tests/ReJest/utils/remoteReporter.ts
@@ -37,12 +37,16 @@ export interface RemoteReporterOptions {
   library: string;
   declaredSuites: DeclaredSuite[];
   onStatus: (message: string) => void;
-  onStart: (params: { only?: string[] }) => Promise<RunSummary | void>;
+  onStart: (params: {
+    only?: string[];
+    include?: string[];
+  }) => Promise<RunSummary | void>;
 }
 
 interface StartMessage {
   type: 'start';
   only?: string[];
+  include?: string[];
 }
 
 interface ErrorUtilsGlobal {

--- a/apps/common-app/runtime-tests/ReJest/utils/stringFormatUtils.ts
+++ b/apps/common-app/runtime-tests/ReJest/utils/stringFormatUtils.ts
@@ -136,17 +136,20 @@ export function formatTestName(
   if (Array.isArray(variableObject)) {
     variableObject.forEach((value, index) => {
       // python-like syntax ${1} {2}
-      testName = testName.replace('${' + index + '}', valueToString(value));
+      testName = testName
+        .split('${' + index + '}')
+        .join(valueToString(value));
     });
   }
   if (typeof variableObject === 'object') {
     const keys = Object.keys(variableObject);
     keys.forEach((k) => {
       // Typical object literal syntax
-      testName = testName.replace(
-        '${' + k + '}',
-        valueToString(variableObject[k as keyof typeof variableObject])
-      );
+      testName = testName
+        .split('${' + k + '}')
+        .join(
+          valueToString(variableObject[k as keyof typeof variableObject])
+        );
     });
   }
 

--- a/apps/common-app/runtime-tests/reanimated/AutoRunApp.tsx
+++ b/apps/common-app/runtime-tests/reanimated/AutoRunApp.tsx
@@ -1,18 +1,56 @@
-import 'react-native-reanimated';
-
-import React from 'react';
+import React, { useEffect } from 'react';
 import { StyleSheet } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import Animated, {
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
 
 import AutoRunRuntimeTestsApp from '../AutoRunRuntimeTestsApp';
 import { REANIMATED_TEST_SUITES } from './suites';
 
+const WARM_UP_TIMEOUT_MS = 5000;
+
+let resolveWarmUp: () => void;
+const warmUpDone = new Promise<void>((resolve) => {
+  resolveWarmUp = resolve;
+});
+
+function finishWarmUp() {
+  resolveWarmUp();
+}
+
+function warmUp() {
+  return warmUpDone;
+}
+
+// Pays UI-runtime init and frame-pipeline costs at app boot, so the first
+// test's fixed wait budget starts against a warm pipeline. Capped so a broken
+// warm-up can never block the run.
+function WarmUpView() {
+  const width = useSharedValue(1);
+  const style = useAnimatedStyle(() => ({ width: width.value }));
+  useEffect(() => {
+    const timeoutId = setTimeout(finishWarmUp, WARM_UP_TIMEOUT_MS);
+    width.value = withTiming(100, { duration: 100 }, () => {
+      'worklet';
+      runOnJS(finishWarmUp)();
+    });
+    return () => clearTimeout(timeoutId);
+  }, [width]);
+  return <Animated.View style={[styles.warmUpView, style]} />;
+}
+
 export default function ReanimatedAutoRunApp() {
   return (
     <GestureHandlerRootView style={styles.container}>
+      <WarmUpView />
       <AutoRunRuntimeTestsApp
         tests={REANIMATED_TEST_SUITES}
         library="Reanimated"
+        warmUp={warmUp}
       />
     </GestureHandlerRootView>
   );
@@ -21,5 +59,8 @@ export default function ReanimatedAutoRunApp() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+  },
+  warmUpView: {
+    height: 1,
   },
 });

--- a/apps/common-app/runtime-tests/reanimated/tests/core/useAnimatedStyle/reuseAnimatedStyle.test.tsx
+++ b/apps/common-app/runtime-tests/reanimated/tests/core/useAnimatedStyle/reuseAnimatedStyle.test.tsx
@@ -166,7 +166,7 @@ describe('Test reusing animatedStyles', () => {
       const componentTwo = getTestComponent(COMPONENT_REF.TWO);
       const componentThree = getTestComponent(COMPONENT_REF.THREE);
 
-      await wait(300);
+      await wait(600);
 
       // Check the distance from the top
       const finalStyleFull = { height: 80, top: 0, margin: 0, ...finalStyle };

--- a/apps/common-app/runtime-tests/worklets/suites.ts
+++ b/apps/common-app/runtime-tests/worklets/suites.ts
@@ -1,3 +1,5 @@
+import { isBundleModeEnabled } from 'react-native-worklets';
+
 import type { RuntimeTestSuite } from '../types';
 
 export const WORKLETS_TEST_SUITES: RuntimeTestSuite[] = [
@@ -37,7 +39,11 @@ export const WORKLETS_TEST_SUITES: RuntimeTestSuite[] = [
       require('./tests/runtimes/reactNativeImportShim.test');
       require('./tests/runtimes/turboModuleRegistryShim.test');
     },
-    disabled: !globalThis._WORKLETS_BUNDLE_MODE_ENABLED,
+    // With inline requires, reading `globalThis._WORKLETS_BUNDLE_MODE_ENABLED`
+    // here would race module initialization order — the flag is only set once
+    // some module actually evaluates `react-native-worklets`. Calling
+    // `isBundleModeEnabled()` forces that initialization first.
+    disabled: !isBundleModeEnabled(),
     skipByDefault: true,
   },
   {

--- a/apps/common-app/runtime-tests/worklets/tests/memory/createSerializable.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/memory/createSerializable.test.tsx
@@ -182,7 +182,7 @@ describe('Test createSerializable', () => {
       });
 
       test('createSerializableHostObject', async () => {
-        const hostObjectValue = globalThis.__reanimatedModuleProxy;
+        const hostObjectValue = globalThis.__workletsModuleProxy;
         const hostObjectKeys = Object.keys(hostObjectValue);
         scheduleOnTarget(() => {
           'worklet';
@@ -674,13 +674,12 @@ if (__DEV__) {
   describe('createSerializable for unsupported types', () => {
     test('throws when trying to serialize a Promise', async () => {
       const promise = Promise.resolve();
+      // The exact message differs between Bundle Mode and Legacy Eval Mode
+      // and between the RN-side and UI-side serialization paths; both
+      // variants name the offending type.
       await expect(() => {
         createSerializable(promise);
-      }).toThrow(
-        globalThis._WORKLETS_BUNDLE_MODE_ENABLED
-          ? 'Cannot copy value of type `Promise`'
-          : 'Promises cannot be converted to serializable.'
-      );
+      }).toThrow('Promise');
     });
 
     test('throws when trying to serialize a Proxy', async () => {

--- a/apps/common-app/runtime-tests/worklets/tests/memory/createSerializableOnUI.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/memory/createSerializableOnUI.test.tsx
@@ -523,16 +523,20 @@ describe('Test createSerializableOnUI', () => {
   // });
 
   test('createSerializableOnUIInaccessibleObject', async () => {
-    const clazz = runOnUISync(() => {
-      'worklet';
-      class Clazz {
-        method() {}
-      }
-
-      return new Clazz();
-    });
-
+    // In Debug the unsupported value is copied back as an inaccessible
+    // placeholder that throws on property access; in Release `runOnUISync`
+    // throws synchronously while copying the value back. Both paths must
+    // land inside the asserted function.
     await expect(() => {
+      const clazz = runOnUISync(() => {
+        'worklet';
+        class Clazz {
+          method() {}
+        }
+
+        return new Clazz();
+      });
+
       clazz.method();
     }).toThrow();
   });
@@ -565,12 +569,14 @@ describe('Test createSerializableOnUI', () => {
 
   if (__DEV__) {
     test('throws when trying to serialize a Promise', async () => {
+      // The exact message differs between Bundle Mode and Legacy Eval Mode;
+      // both variants name the offending type.
       await expect(() =>
         runOnUISync(() => {
           'worklet';
           return Promise.resolve();
         })
-      ).toThrow('Cannot copy value of type `Promise`');
+      ).toThrow('Promise');
     });
   }
 });

--- a/apps/common-app/runtime-tests/worklets/tests/memory/isSerializableRef.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/memory/isSerializableRef.test.tsx
@@ -152,7 +152,7 @@ describe('Test isSerializableRef', () => {
   });
 
   test('check if createSerializable<host object> returns serializable ref', () => {
-    const hostObjectValue = globalThis.__reanimatedModuleProxy;
+    const hostObjectValue = globalThis.__workletsModuleProxy;
     const serializableRef = createSerializable(hostObjectValue);
 
     expect(isSerializableRef(serializableRef)).toBe(true);

--- a/apps/common-app/runtime-tests/worklets/tests/runLoop/setInterval.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/runLoop/setInterval.test.tsx
@@ -147,10 +147,10 @@ describe('Test setInterval', () => {
               const now = performance.now();
               totalTime += now - lastTime;
               lastTime = now;
-              if (totalTime >= delay * iter) {
+              if (totalTime >= delay * iter - iter) {
                 setFlag('ok');
               } else {
-                setFlag('not_ok');
+                setFlag(`not_ok: ${totalTime}ms after ${iter} intervals`);
               }
 
               if (iter === 1) {

--- a/apps/common-app/runtime-tests/worklets/tests/runLoop/setTimeout.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/runLoop/setTimeout.test.tsx
@@ -119,8 +119,11 @@ describe('Test setTimeout', () => {
             'worklet';
             const startTime = performance.now();
             setTimeout(() => {
-              if (performance.now() - startTime >= delay) {
+              const elapsed = performance.now() - startTime;
+              if (elapsed >= delay - 1) {
                 setFlag();
+              } else {
+                setFlag(`not_ok: fired after ${elapsed}ms`);
               }
               notify(notification);
             }, delay);

--- a/apps/fabric-example/ios/FabricExample.xcodeproj/project.pbxproj
+++ b/apps/fabric-example/ios/FabricExample.xcodeproj/project.pbxproj
@@ -248,7 +248,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\n\nWITH_ENVIRONMENT=\"$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh\"\nREACT_NATIVE_XCODE=\"$REACT_NATIVE_PATH/scripts/react-native-xcode.sh\"\n\ncase \"$CONFIGURATION\" in\n  *RuntimeTests*)\n    for RUNTIME_TESTS_LIBRARY in reanimated worklets; do\n      ENTRY_FILE=\"index.runtimeTests.$RUNTIME_TESTS_LIBRARY.js\" BUNDLE_NAME=\"main.runtimeTests.$RUNTIME_TESTS_LIBRARY\" /bin/sh -c \"\\\"$WITH_ENVIRONMENT\\\" \\\"$REACT_NATIVE_XCODE\\\"\"\n    done\n    ;;\n  *)\n    /bin/sh -c \"\\\"$WITH_ENVIRONMENT\\\" \\\"$REACT_NATIVE_XCODE\\\"\"\n    ;;\nesac\n";
+			shellScript = "set -e\n\nWITH_ENVIRONMENT=\"$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh\"\nREACT_NATIVE_XCODE=\"$REACT_NATIVE_PATH/scripts/react-native-xcode.sh\"\n\ncase \"$CONFIGURATION\" in\n  *RuntimeTests*)\n    for RUNTIME_TESTS_LIBRARY in reanimated worklets self-tests; do\n      ENTRY_FILE=\"index.runtimeTests.$RUNTIME_TESTS_LIBRARY.js\" BUNDLE_NAME=\"main.runtimeTests.$RUNTIME_TESTS_LIBRARY\" /bin/sh -c \"\\\"$WITH_ENVIRONMENT\\\" \\\"$REACT_NATIVE_XCODE\\\"\"\n    done\n    ;;\n  *)\n    /bin/sh -c \"\\\"$WITH_ENVIRONMENT\\\" \\\"$REACT_NATIVE_XCODE\\\"\"\n    ;;\nesac\n";
 		};
 		00EEFC60759A1932668264C0 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/apps/fabric-example/ios/FabricExample.xcodeproj/project.pbxproj
+++ b/apps/fabric-example/ios/FabricExample.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		13B07F961A680F5B00A75B9A /* FabricExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FabricExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = FabricExample/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = FabricExample/Info.plist; sourceTree = "<group>"; };
+		18BFA1EE96CA4D9C4CFA7EAA /* Pods-FabricExample.releaseruntimetests.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FabricExample.releaseruntimetests.xcconfig"; path = "Target Support Files/Pods-FabricExample/Pods-FabricExample.releaseruntimetests.xcconfig"; sourceTree = "<group>"; };
 		192DDE7394C0421AABAD1E39 /* Poppins-ExtraBold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Poppins-ExtraBold.ttf"; path = "../assets/fonts/Poppins/Poppins-ExtraBold.ttf"; sourceTree = "<group>"; };
 		28C28DD379A4F63159381776 /* libPods-FabricExample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-FabricExample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2E32E1E9D61FF701E74576F1 /* Pods-FabricExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FabricExample.release.xcconfig"; path = "Target Support Files/Pods-FabricExample/Pods-FabricExample.release.xcconfig"; sourceTree = "<group>"; };
@@ -145,6 +146,7 @@
 				3B4392A12AC88292D35C810B /* Pods-FabricExample.debug.xcconfig */,
 				2E32E1E9D61FF701E74576F1 /* Pods-FabricExample.release.xcconfig */,
 				C70151FDBDE5211D1ACE7DED /* Pods-FabricExample.debugruntimetests.xcconfig */,
+				18BFA1EE96CA4D9C4CFA7EAA /* Pods-FabricExample.releaseruntimetests.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -246,7 +248,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\n\nWITH_ENVIRONMENT=\"$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh\"\nREACT_NATIVE_XCODE=\"$REACT_NATIVE_PATH/scripts/react-native-xcode.sh\"\n\n/bin/sh -c \"\\\"$WITH_ENVIRONMENT\\\" \\\"$REACT_NATIVE_XCODE\\\"\"\n";
+			shellScript = "set -e\n\nWITH_ENVIRONMENT=\"$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh\"\nREACT_NATIVE_XCODE=\"$REACT_NATIVE_PATH/scripts/react-native-xcode.sh\"\n\ncase \"$CONFIGURATION\" in\n  *RuntimeTests*)\n    for RUNTIME_TESTS_LIBRARY in reanimated worklets; do\n      ENTRY_FILE=\"index.runtimeTests.$RUNTIME_TESTS_LIBRARY.js\" BUNDLE_NAME=\"main.runtimeTests.$RUNTIME_TESTS_LIBRARY\" /bin/sh -c \"\\\"$WITH_ENVIRONMENT\\\" \\\"$REACT_NATIVE_XCODE\\\"\"\n    done\n    ;;\n  *)\n    /bin/sh -c \"\\\"$WITH_ENVIRONMENT\\\" \\\"$REACT_NATIVE_XCODE\\\"\"\n    ;;\nesac\n";
 		};
 		00EEFC60759A1932668264C0 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -413,6 +415,36 @@
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;
+		};
+		1B3009A81DE17BA5D9620879 /* ReleaseRuntimeTests */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 18BFA1EE96CA4D9C4CFA7EAA /* Pods-FabricExample.releaseruntimetests.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"RUNTIME_TESTS=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = FabricExample/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = FabricExample;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) RUNTIME_TESTS";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = ReleaseRuntimeTests;
 		};
 		83CBBA201A601CBA00E9B192 /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -713,6 +745,100 @@
 			};
 			name = Release;
 		};
+		B622995A62B7FA3B3526B00B /* ReleaseRuntimeTests */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CC = "";
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				CXX = "";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers/react/nativemodule/core",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon-Samples/ReactCommon_Samples.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon-Samples/ReactCommon_Samples.framework/Headers/platform/ios",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers/react/renderer/components/view/platform/cxx",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-NativeModulesApple/React_NativeModulesApple.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers/react/renderer/graphics/platform/ios",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				LD = "";
+				LDPLUSPLUS = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"\"$(SDKROOT)/usr/lib/swift\"",
+					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
+					"\"$(inherited)\"",
+				);
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-DRCT_REMOVE_LEGACY_ARCH=1",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"$(OTHER_CFLAGS)",
+					"-DFOLLY_NO_CONFIG",
+					"-DFOLLY_MOBILE=1",
+					"-DFOLLY_USE_LIBCPP=1",
+					"-DFOLLY_CFG_NO_COROUTINES=1",
+					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
+					"-DRCT_REMOVE_LEGACY_ARCH=1",
+				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					" ",
+				);
+				PODFILE_DIR = "$(SRCROOT)";
+				REACT_NATIVE_PATH = "${PODS_ROOT}/../../../../node_modules/react-native";
+				SDKROOT = iphoneos;
+				SWIFT_ENABLE_EXPLICIT_MODULES = NO;
+				USE_HERMES = true;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = ReleaseRuntimeTests;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -722,6 +848,7 @@
 				13B07F941A680F5B00A75B9A /* Debug */,
 				13B07F94A0000000000000RT /* DebugRuntimeTests */,
 				13B07F951A680F5B00A75B9A /* Release */,
+				1B3009A81DE17BA5D9620879 /* ReleaseRuntimeTests */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -732,6 +859,7 @@
 				83CBBA201A601CBA00E9B192 /* Debug */,
 				83CBBA20A0000000000000RT /* DebugRuntimeTests */,
 				83CBBA211A601CBA00E9B192 /* Release */,
+				B622995A62B7FA3B3526B00B /* ReleaseRuntimeTests */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/apps/fabric-example/ios/FabricExample/AppDelegate.swift
+++ b/apps/fabric-example/ios/FabricExample/AppDelegate.swift
@@ -48,8 +48,13 @@ class ReactNativeDelegate: RCTDefaultReactNativeFactoryDelegate {
 #if RUNTIME_TESTS
     let library =
       ProcessInfo.processInfo.environment["RUNTIME_TESTS_LIBRARY"] ?? "reanimated"
+#if DEBUG
     return RCTBundleURLProvider.sharedSettings()
       .jsBundleURL(forBundleRoot: "index.runtimeTests.\(library)")
+#else
+    return Bundle.main.url(
+      forResource: "main.runtimeTests.\(library)", withExtension: "jsbundle")
+#endif
 #elseif DEBUG
     return RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: "index")
 #else

--- a/apps/fabric-example/scripts/runtime-tests-server.js
+++ b/apps/fabric-example/scripts/runtime-tests-server.js
@@ -73,6 +73,12 @@ const ONLY = args.only
       .map((s) => s.trim())
       .filter(Boolean)
   : null;
+const INCLUDE = args.include
+  ? args.include
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)
+  : null;
 const CONNECT_TIMEOUT_MS = Number(args['connect-timeout'] ?? 600) * 1000;
 const IDLE_TIMEOUT_MS = Number(args['idle-timeout'] ?? 600) * 1000;
 const SHOULD_LAUNCH = args.launch === true || args.launch === '';
@@ -248,23 +254,24 @@ function onHello(msg) {
     return;
   }
 
-  if (ONLY) {
-    const unknown = ONLY.filter((name) => !declared.includes(name));
-    if (unknown.length > 0) {
-      console.error(
-        `[runtime-tests] unknown suite name(s): ${unknown.join(', ')}`
-      );
-      console.error(
-        `[runtime-tests] available suites: ${declared.join(', ')}`
-      );
-      send({ type: 'error', message: `Unknown suites: ${unknown.join(', ')}` });
-      shutdown(1);
-      return;
-    }
+  const requested = [...(ONLY ?? []), ...(INCLUDE ?? [])];
+  const unknown = requested.filter((name) => !declared.includes(name));
+  if (unknown.length > 0) {
+    console.error(
+      `[runtime-tests] unknown suite name(s): ${unknown.join(', ')}`
+    );
+    console.error(`[runtime-tests] available suites: ${declared.join(', ')}`);
+    send({ type: 'error', message: `Unknown suites: ${unknown.join(', ')}` });
+    shutdown(1);
+    return;
   }
 
   runStartedAt = Date.now();
-  send({ type: 'start', ...(ONLY ? { only: ONLY } : {}) });
+  send({
+    type: 'start',
+    ...(ONLY ? { only: ONLY } : {}),
+    ...(INCLUDE ? { include: INCLUDE } : {}),
+  });
   console.log('[runtime-tests] start sent, running tests…');
 }
 
@@ -439,12 +446,18 @@ async function ensureMetroRunning() {
     );
   }
   console.log(
-    `[runtime-tests] starting Metro (\`yarn start --port ${METRO_PORT}\`)`
+    `[runtime-tests] starting Metro (\`yarn start --port ${METRO_PORT} --reset-cache\`)`
   );
-  metroChild = spawn('yarn', ['start', '--port', String(METRO_PORT)], {
-    cwd: projectRoot,
-    stdio: ['ignore', 'pipe', 'pipe'],
-  });
+  // --reset-cache: a Metro cache produced under a different Bundle Mode
+  // setting serves stale module maps ("Requiring unknown module").
+  metroChild = spawn(
+    'yarn',
+    ['start', '--port', String(METRO_PORT), '--reset-cache'],
+    {
+      cwd: projectRoot,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }
+  );
   metroChild.stdout.on('data', (chunk) => {
     process.stdout.write(`[metro] ${chunk}`);
   });

--- a/apps/fabric-example/scripts/runtime-tests-server.js
+++ b/apps/fabric-example/scripts/runtime-tests-server.js
@@ -60,7 +60,13 @@ const args = parseArgs(process.argv.slice(2));
 const LIBRARY = String(args.library ?? '').toLowerCase();
 const PLATFORM = String(args.platform ?? 'ios').toLowerCase();
 const METRO_PORT = Number(args['metro-port'] ?? 8081);
-const PORT = Number(args.port ?? METRO_PORT + 1);
+const ARG_CONFIGURATION = args.configuration ?? 'DebugRuntimeTests';
+// Release builds embed the JS bundles: no Metro, and the app falls back to
+// ws://localhost:8082 since there is no bundle URL to derive a port from.
+const IS_RELEASE_CONFIGURATION = ARG_CONFIGURATION.startsWith('Release');
+const PORT = Number(
+  args.port ?? (IS_RELEASE_CONFIGURATION ? 8082 : METRO_PORT + 1)
+);
 const ONLY = args.only
   ? args.only
       .split(',')
@@ -75,7 +81,8 @@ const SIMULATOR = args.simulator ?? 'iPhone 17';
 const UDID = args.udid ?? null;
 const SERIAL = args.serial ?? null;
 const AVD = args.avd ?? null;
-const CONFIGURATION = args.configuration ?? 'DebugRuntimeTests';
+const CONFIGURATION = ARG_CONFIGURATION;
+const IS_RELEASE = IS_RELEASE_CONFIGURATION;
 
 if (!LIBRARIES.includes(LIBRARY)) {
   console.error(
@@ -87,6 +94,13 @@ if (!LIBRARIES.includes(LIBRARY)) {
 if (!PLATFORMS.includes(PLATFORM)) {
   console.error(
     `[runtime-tests] --platform must be one of: ${PLATFORMS.join(', ')} (got: ${PLATFORM})`
+  );
+  process.exit(1);
+}
+
+if (PLATFORM === 'android' && IS_RELEASE) {
+  console.error(
+    '[runtime-tests] --platform android supports only Debug configurations for now'
   );
   process.exit(1);
 }
@@ -556,18 +570,20 @@ async function installAndLaunch(udid) {
   console.log(`[runtime-tests] installing ${app}`);
   await run('xcrun', ['simctl', 'install', udid, app]);
 
-  // Point the app at the right Metro instance. NSUserDefaults are cleared on
-  // reinstall, so this has to happen after `simctl install`.
-  await run('xcrun', [
-    'simctl',
-    'spawn',
-    udid,
-    'defaults',
-    'write',
-    BUNDLE_ID,
-    'RCT_jsLocation',
-    `localhost:${METRO_PORT}`,
-  ]);
+  if (!IS_RELEASE) {
+    // Point the app at the right Metro instance. NSUserDefaults are cleared on
+    // reinstall, so this has to happen after `simctl install`.
+    await run('xcrun', [
+      'simctl',
+      'spawn',
+      udid,
+      'defaults',
+      'write',
+      BUNDLE_ID,
+      'RCT_jsLocation',
+      `localhost:${METRO_PORT}`,
+    ]);
+  }
 
   await run('xcrun', ['simctl', 'terminate', udid, BUNDLE_ID]).catch(() => {});
   console.log(
@@ -739,7 +755,9 @@ async function installAndLaunchAndroid(serial) {
 
 if (SHOULD_LAUNCH) {
   (async () => {
-    await ensureMetroRunning();
+    if (!IS_RELEASE) {
+      await ensureMetroRunning();
+    }
     if (PLATFORM === 'android') {
       const serial = await resolveAndroidDevice();
       if (!SKIP_BUILD) {

--- a/apps/fabric-example/scripts/runtime-tests-server.js
+++ b/apps/fabric-example/scripts/runtime-tests-server.js
@@ -357,9 +357,13 @@ function shutdown(code) {
   clearTimer('idle');
   if (metroChild && !metroChild.killed) {
     try {
-      metroChild.kill('SIGTERM');
+      process.kill(-metroChild.pid, 'SIGTERM');
     } catch {
-      /* ignore */
+      try {
+        metroChild.kill('SIGTERM');
+      } catch {
+        /* ignore */
+      }
     }
   }
   wss.close(() => {
@@ -450,12 +454,15 @@ async function ensureMetroRunning() {
   );
   // --reset-cache: a Metro cache produced under a different Bundle Mode
   // setting serves stale module maps ("Requiring unknown module").
+  // detached: Metro must get its own process group so shutdown can kill the
+  // whole tree — killing just the yarn wrapper orphans the actual Metro process.
   metroChild = spawn(
     'yarn',
     ['start', '--port', String(METRO_PORT), '--reset-cache'],
     {
       cwd: projectRoot,
       stdio: ['ignore', 'pipe', 'pipe'],
+      detached: true,
     }
   );
   metroChild.stdout.on('data', (chunk) => {


### PR DESCRIPTION
> [!NOTE]
> **This PR description is AI-generated.**

## Summary

The Android runner itself landed in #9930; this PR puts it on CI. A new reusable `runtime-tests-android.yml` runs both libraries on `ubuntu-latest` with KVM and an API 34 emulator — the APK is pre-built before the emulator starts, each library gets one retry, and Bundle Mode legs opt the `bundle mode core` suite in — and the nightly matrix from #9932 gains Android legs for both Bundle Modes. Android stays Debug-only, matching the runner's supported configurations.

## Test plan

The Android workflow passes on CI for both libraries and both Bundle Modes; its first real run exposed an emulator OOM on a huge string preset, fixed at the source in #9931.