### PR TITLE
chore(Worklets): remove stale getModules hunk from metro-runtime patches

### DIFF
--- a/packages/react-native-worklets/bundleMode/patches/__testers__/npm/patches/metro-runtime+0.84.4.patch
+++ b/packages/react-native-worklets/bundleMode/patches/__testers__/npm/patches/metro-runtime+0.84.4.patch
@@ -12,25 +12,3 @@ index 534ac87..5773985 100644
    if (global.globalEvalWithSourceUrl) {
      global.globalEvalWithSourceUrl(code, sourceURL);
    } else {
-diff --git a/node_modules/metro-runtime/src/polyfills/require.js b/node_modules/metro-runtime/src/polyfills/require.js
-index c46fb7c..2ba29ab 100644
---- a/node_modules/metro-runtime/src/polyfills/require.js
-+++ b/node_modules/metro-runtime/src/polyfills/require.js
-@@ -334,14 +334,14 @@ function unknownModuleError(id) {
-   }
-   return Error(message);
- }
-+metroRequire.getModules = () => {
-+  return modules;
-+};
- if (__DEV__) {
-   metroRequire.Systrace = {
-     beginEvent: () => {},
-     endEvent: () => {},
-   };
--  metroRequire.getModules = () => {
--    return modules;
--  };
-   var createHotReloadingObject = function () {
-     const hot = {
-       _acceptCallback: null,

--- a/packages/react-native-worklets/bundleMode/patches/patch-package/metro-runtime/metro-runtime+0.84.4.patch
+++ b/packages/react-native-worklets/bundleMode/patches/patch-package/metro-runtime/metro-runtime+0.84.4.patch
@@ -12,25 +12,3 @@ index 534ac87..5773985 100644
    if (global.globalEvalWithSourceUrl) {
      global.globalEvalWithSourceUrl(code, sourceURL);
    } else {
-diff --git a/node_modules/metro-runtime/src/polyfills/require.js b/node_modules/metro-runtime/src/polyfills/require.js
-index c46fb7c..2ba29ab 100644
---- a/node_modules/metro-runtime/src/polyfills/require.js
-+++ b/node_modules/metro-runtime/src/polyfills/require.js
-@@ -334,14 +334,14 @@ function unknownModuleError(id) {
-   }
-   return Error(message);
- }
-+metroRequire.getModules = () => {
-+  return modules;
-+};
- if (__DEV__) {
-   metroRequire.Systrace = {
-     beginEvent: () => {},
-     endEvent: () => {},
-   };
--  metroRequire.getModules = () => {
--    return modules;
--  };
-   var createHotReloadingObject = function () {
-     const hot = {
-       _acceptCallback: null,


### PR DESCRIPTION
## Summary

Removing discrepancy between patch files for Bundle Mode - patch-package version contained code that was unnecessary and was already removed in yarn version in https://github.com/software-mansion/react-native-reanimated/pull/9640/changes

## Test plan

I tested it on a npm based project.
