### PR TITLE
chore: set contentInsetAdjustmentBehavior in example app's main FlatList

### DIFF
--- a/apps/common-app/src/apps/reanimated/App.tsx
+++ b/apps/common-app/src/apps/reanimated/App.tsx
@@ -94,6 +94,7 @@ function HomeScreen({ navigation }: HomeScreenProps) {
       renderScrollComponent={(props) => <ScrollView {...props} />}
       ItemSeparatorComponent={ItemSeparator}
       style={styles.list}
+      contentInsetAdjustmentBehavior="automatic"
     />
   );
 }


### PR DESCRIPTION
## Summary

In the example app on the main screen we are using React Navigation's search bar that on iOS is absolutely positioned on the bottom of the screen. Because of that the last element from the list of examples was not reachable.

This fixes it by adding `contentInsetAdjustmentBehavior="automatic"` to the flat list with examples

## Test plan

Tested on the example app on both platforms by scrolling down and seeing that the last element is clickable
