### PR TITLE
fix(Example): recover SectionList scroll failures

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/ScrollToExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/ScrollToExample.tsx
@@ -198,14 +198,23 @@ const AnimatedSectionList = Animated.createAnimatedComponent(
 
 const SectionListExample = ({ animated, ref }: ExampleProps) => {
   const aref = useAnimatedRef<typeof AnimatedSectionList>();
+  const scrollLocationRef = useRef({ sectionIndex: 0, itemIndex: 0 });
+
+  const scrollToLocation = useCallback(() => {
+    aref.current?.scrollToLocation({
+      ...scrollLocationRef.current,
+      animated,
+    });
+  }, [animated, aref]);
 
   useImperativeHandle(ref, () => ({
     scrollFromJS() {
       console.log(getRuntimeKind());
-      aref.current?.scrollToLocation({
+      scrollLocationRef.current = {
         sectionIndex: Math.floor((Math.random() * DATA.length) / 10),
         itemIndex: Math.floor((Math.random() * DATA.length) / 10),
-      });
+      };
+      scrollToLocation();
     },
     scrollFromUI() {
       scheduleOnUI(() => {
@@ -239,6 +248,13 @@ const SectionListExample = ({ animated, ref }: ExampleProps) => {
       renderSectionHeader={({ section: { title } }) => (
         <Text style={styles.header}>{title}</Text>
       )}
+      onScrollToIndexFailed={({ averageItemLength, index }) => {
+        aref.current?.getScrollResponder()?.scrollTo({
+          y: averageItemLength * index,
+          animated: false,
+        });
+        setTimeout(scrollToLocation, 100);
+      }}
       stickySectionHeadersEnabled={false}
     />
   );


### PR DESCRIPTION
## Summary

Fixes the ScrollTo example app's JS-thread SectionList scroll: random offscreen targets could throw because the list had no onScrollToIndexFailed handler. The example now estimates an offset and retries the requested location.

## Test plan

1. Run the common app on Android and open Reanimated > scrollTo > SectionList.
2. Tap Scroll from JS repeatedly.
3. Verify scrolling completes without the scrollToIndex invariant violation.