### PR TITLE
ci: fix react-native types resolution in type tests

### DIFF
--- a/scripts/test-ts.sh
+++ b/scripts/test-ts.sh
@@ -25,7 +25,7 @@ STATUS=0
 
 check_types() {
   local suffixes="$1"
-  yarn tsc --noEmit --target es6 --module ESNext --jsx react-native --skipLibCheck true --allowSyntheticDefaultImports true --moduleResolution node --esModuleInterop true --strict true --forceConsistentCasingInFileNames true --moduleSuffixes "$suffixes" --resolveJsonModule "${FILES[@]}" || STATUS=1
+  yarn tsc --noEmit --target es6 --module ESNext --jsx react-native --skipLibCheck true --allowSyntheticDefaultImports true --moduleResolution bundler --customConditions react-native-legacy-deep-imports --esModuleInterop true --strict true --forceConsistentCasingInFileNames true --moduleSuffixes "$suffixes" --resolveJsonModule "${FILES[@]}" || STATUS=1
 }
 
 if [ ${#FILES[@]} -gt 0 ]; then


### PR DESCRIPTION
> [!NOTE]
> **This PR description is AI-generated.**

## Summary

The nightly TypeScript compatibility job started failing on `yarn type:check:tests`: https://github.com/software-mansion/react-native-reanimated/actions/runs/29364040423/job/87191082893

Since `0.88.0-nightly-20260711` react-native ships no top-level `types` field — its declarations are only reachable through the `exports` map, which the `--moduleResolution node` mode used in `scripts/test-ts.sh` cannot read. `react-native` would degrade to `any` and the type tests failed with `TS7016` and dozens of unused `@ts-expect-error` directives. The step was broken since that nightly, but the compatibility action would stop on the earlier `type:check:app` failure until #9938 fixed it.

I switched the script to `--moduleResolution bundler`, matching the root `tsconfig.json`, and pinned the legacy type surface with `--customConditions react-native-legacy-deep-imports`. The type tests assert legacy API patterns (e.g. `useRef<Image>`) that are invalid under the Strict API types nightlies now serve by default, while on stable releases the condition is absent from the `exports` map and changes nothing. Rewriting the type tests for the Strict API is a follow-up.

## Test plan

`type:check:tests` passes for both `react-native-reanimated` and `react-native-worklets` on `react-native@0.86.0` and `react-native@0.88.0-nightly-20260714-a016e94b5`.

passing CI run: https://github.com/software-mansion/react-native-reanimated/actions/runs/29406583934
