### PR TITLE
[automated runtime tests][6/11] feat(ReJest): test.failing for tests that are expected to fail

### DIFF
--- a/apps/common-app/runtime-tests/ReJest/RuntimeTestsApi.ts
+++ b/apps/common-app/runtime-tests/ReJest/RuntimeTestsApi.ts
@@ -73,13 +73,26 @@ const testOnly: DecoratedTestFunction = (
 testOnly.each = <T>(examples: Array<T>) => {
   return testSuiteBuilder.testEach(examples, TestDecorator.ONLY);
 };
+const testFailing: DecoratedTestFunction = (
+  name: string,
+  testCase: MaybeAsync<void>
+) => {
+  testSuiteBuilder.test(name, testCase, TestDecorator.FAILING);
+};
+testFailing.each = <T>(examples: Array<T>) => {
+  return testSuiteBuilder.testEach(examples, TestDecorator.FAILING);
+};
 
 type TestType = DecoratedTestFunction &
-  Record<TestDecorator.SKIP | TestDecorator.ONLY, DecoratedTestFunction>;
+  Record<
+    TestDecorator.SKIP | TestDecorator.ONLY | TestDecorator.FAILING,
+    DecoratedTestFunction
+  >;
 
 export const test = <TestType>testBasic;
 test.skip = testSkip;
 test.only = testOnly;
+test.failing = testFailing;
 
 export function beforeAll(job: MaybeAsync<void>) {
   testSuiteBuilder.beforeAll(job);

--- a/apps/common-app/runtime-tests/ReJest/RuntimeTestsRunner.tsx
+++ b/apps/common-app/runtime-tests/ReJest/RuntimeTestsRunner.tsx
@@ -1,5 +1,10 @@
 import type { ReactNode } from 'react';
-import React, { useEffect, useRef, useState } from 'react';
+import React, {
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { FlatList } from 'react-native-gesture-handler';
 
@@ -33,6 +38,27 @@ export class ErrorBoundary extends React.Component<
 
 let renderLock: RenderLock = new RenderLock();
 
+export type RunnerId = 'Reanimated' | 'Worklets' | 'SelfTests';
+
+let sessionOwner: RunnerId | null = null;
+const sessionOwnerListeners = new Set<() => void>();
+
+function claimSession(runnerId: RunnerId) {
+  sessionOwner = runnerId;
+  sessionOwnerListeners.forEach((listener) => listener());
+}
+
+function subscribeToSessionOwner(listener: () => void) {
+  sessionOwnerListeners.add(listener);
+  return () => {
+    sessionOwnerListeners.delete(listener);
+  };
+}
+
+function getSessionOwner() {
+  return sessionOwner;
+}
+
 interface TestData {
   testSuiteName: string;
   importTest: () => void;
@@ -42,9 +68,13 @@ interface TestData {
 
 interface RuntimeTestRunnerProps {
   tests: TestData[];
+  runnerId: RunnerId;
 }
 
-export default function RuntimeTestsRunner({ tests }: RuntimeTestRunnerProps) {
+export default function RuntimeTestsRunner({
+  tests,
+  runnerId,
+}: RuntimeTestRunnerProps) {
   const [component, setComponent] = useState<ReactNode | null>(null);
   const [started, setStarted] = useState<boolean>(false);
   const [finished, setFinished] = useState<boolean>(false);
@@ -70,11 +100,32 @@ export default function RuntimeTestsRunner({ tests }: RuntimeTestRunnerProps) {
     setFinished(true);
   }
 
+  const currentSessionOwner = useSyncExternalStore(
+    subscribeToSessionOwner,
+    getSessionOwner
+  );
+
   function handleStartClick() {
+    if (getSessionOwner() !== null) {
+      return;
+    }
+    claimSession(runnerId);
     testSelectionCallbacks.current.forEach((callback) => callback());
     setStarted(true);
     // eslint-disable-next-line no-void
     void run();
+  }
+
+  if (currentSessionOwner !== null && !started) {
+    return (
+      <View style={styles.flexOne}>
+        <Text style={navyText}>
+          {currentSessionOwner === runnerId
+            ? `${runnerId} tests already started in this session. Reload the app to run them again.`
+            : `${currentSessionOwner} tests already started in this session. Reload the app to run ${runnerId} tests.`}
+        </Text>
+      </View>
+    );
   }
 
   return (

--- a/apps/common-app/runtime-tests/ReJest/TestRunner/CallTrackerRegistry.ts
+++ b/apps/common-app/runtime-tests/ReJest/TestRunner/CallTrackerRegistry.ts
@@ -1,9 +1,11 @@
-import { makeMutable } from 'react-native-reanimated';
+import { createSynchronizable } from 'react-native-worklets';
 
 import type { TrackerCallCount } from '../types';
 
 let callCallTrackerRegistryJS: Record<string, number> = {};
-const callCallTrackerRegistryUI = makeMutable<Record<string, number>>({});
+const callCallTrackerRegistryUI = createSynchronizable<
+  Record<string, number>
+>({});
 function callTrackerJS(name: string) {
   if (!callCallTrackerRegistryJS[name]) {
     callCallTrackerRegistryJS[name] = 0;
@@ -15,11 +17,9 @@ export class CallTrackerRegistry {
   public callTracker(name: string) {
     'worklet';
     if (_WORKLET) {
-      if (!callCallTrackerRegistryUI.value[name]) {
-        callCallTrackerRegistryUI.value[name] = 0;
-      }
-      callCallTrackerRegistryUI.value[name]++;
-      callCallTrackerRegistryUI.value = { ...callCallTrackerRegistryUI.value };
+      callCallTrackerRegistryUI.setBlocking((prev) => {
+        return { ...prev, [name]: (prev[name] ?? 0) + 1 };
+      });
     } else {
       callTrackerJS(name);
     }
@@ -29,12 +29,12 @@ export class CallTrackerRegistry {
     return {
       name,
       onJS: callCallTrackerRegistryJS[name] ?? 0,
-      onUI: callCallTrackerRegistryUI.value[name] ?? 0,
+      onUI: callCallTrackerRegistryUI.getBlocking()[name] ?? 0,
     };
   }
 
   public resetRegistry() {
-    callCallTrackerRegistryUI.value = {};
+    callCallTrackerRegistryUI.setBlocking({});
     callCallTrackerRegistryJS = {};
   }
 }

--- a/apps/common-app/runtime-tests/ReJest/TestRunner/TestRunner.ts
+++ b/apps/common-app/runtime-tests/ReJest/TestRunner/TestRunner.ts
@@ -11,6 +11,7 @@ import type {
   TestSuite,
   TestValue,
 } from '../types';
+import { TestDecorator } from '../types';
 import { RenderLock } from '../utils/SyncUIRunner';
 import { AnimationUpdatesRecorder } from './AnimationUpdatesRecorder';
 import { assertTestCase } from './Asserts';
@@ -192,6 +193,14 @@ export class TestRunner {
       await testSuite.beforeEach();
     }
     await testCase.run();
+
+    if (testCase.decorator === TestDecorator.FAILING) {
+      if (testCase.errors.length > 0) {
+        testCase.errors.length = 0;
+      } else {
+        testCase.errors.push('Expected the test to fail, but it passed');
+      }
+    }
 
     this._testSummary.showTestCaseSummary(testCase, testSuite.nestingLevel);
 

--- a/apps/common-app/runtime-tests/ReJest/matchers/Comparators.ts
+++ b/apps/common-app/runtime-tests/ReJest/matchers/Comparators.ts
@@ -1,4 +1,4 @@
-import { isColor, processColor } from 'react-native-reanimated';
+import { isColor, processColorNumber } from '../utils/colorUtils';
 
 import type { TestValue, ValidPropNames } from '../types';
 import { ComparisonMode, isValidPropName } from '../types';
@@ -40,7 +40,7 @@ const COMPARATORS: {
     if (!isColor(expected) || !isColor(value)) {
       return false;
     }
-    return processColor(expected) === processColor(value);
+    return processColorNumber(expected) === processColorNumber(value);
   },
 
   [ComparisonMode.PIXEL]: (expected, value) => {

--- a/apps/common-app/runtime-tests/ReJest/matchers/rawMatchers.ts
+++ b/apps/common-app/runtime-tests/ReJest/matchers/rawMatchers.ts
@@ -1,11 +1,13 @@
-import { makeMutable } from 'react-native-reanimated';
-
 import type { TestValue, TrackerCallCount } from '../types';
 import { ComparisonMode } from '../types';
 import { cyan, green, red, yellow } from '../utils/stringFormatUtils';
 import { SyncUIRunner } from '../utils/SyncUIRunner';
 import { getComparator } from './Comparators';
-import { getRuntimeKind, RuntimeKind } from 'react-native-worklets';
+import {
+  createSynchronizable,
+  getRuntimeKind,
+  RuntimeKind,
+} from 'react-native-worklets';
 
 type ToBeArgs = [TestValue, ComparisonMode?];
 export type ToThrowArgs = [string?];
@@ -240,8 +242,8 @@ async function mockConsole(): Promise<
   const syncUIRunner = new SyncUIRunner();
   let counterJS = 0;
 
-  const counterUI = makeMutable(0);
-  const recordedMessage = makeMutable('');
+  const counterUI = createSynchronizable(0);
+  const recordedMessage = createSynchronizable('');
 
   const originalError = console.error;
   const originalWarning = console.warn;
@@ -254,12 +256,16 @@ async function mockConsole(): Promise<
     if (getRuntimeKind() === RuntimeKind.ReactNative) {
       incrementJS();
     } else {
-      counterUI.value++;
+      counterUI.setBlocking((prev) => {
+        return prev + 1;
+      });
     }
     if (typeof message === 'object' && 'message' in message) {
-      recordedMessage.value = message.message;
+      recordedMessage.setBlocking(message.message);
     } else {
-      recordedMessage.value = message.split('\n\nThis error is located at:')[0];
+      recordedMessage.setBlocking(
+        message.split('\n\nThis error is located at:')[0]
+      );
     }
   };
   console.error = mockedConsoleFunction;
@@ -289,10 +295,10 @@ async function mockConsole(): Promise<
   };
 
   const getCapturedConsoleErrors = () => {
-    const count = counterUI.value + counterJS;
+    const count = counterUI.getBlocking() + counterJS;
     return {
       consoleErrorCount: count,
-      consoleErrorMessage: recordedMessage.value,
+      consoleErrorMessage: recordedMessage.getBlocking(),
     };
   };
 

--- a/apps/common-app/runtime-tests/ReJest/types.ts
+++ b/apps/common-app/runtime-tests/ReJest/types.ts
@@ -44,6 +44,7 @@ export enum DescribeDecorator {
 export enum TestDecorator {
   ONLY = 'only',
   SKIP = 'skip',
+  FAILING = 'failing',
 }
 
 export type TestCase = {

--- a/apps/common-app/runtime-tests/ReJest/utils/colorUtils.ts
+++ b/apps/common-app/runtime-tests/ReJest/utils/colorUtils.ts
@@ -1,0 +1,9 @@
+import { processColor } from 'react-native';
+
+export function isColor(value: unknown): value is string {
+  return typeof value === 'string' && processColor(value) != null;
+}
+
+export function processColorNumber(value: string): number {
+  return (processColor(value) as number) ?? 0;
+}

--- a/apps/common-app/runtime-tests/ReJest/utils/drawSnapshotTable.ts
+++ b/apps/common-app/runtime-tests/ReJest/utils/drawSnapshotTable.ts
@@ -1,4 +1,4 @@
-import { isColor } from 'react-native-reanimated';
+import { isColor } from './colorUtils';
 
 import {
   getComparator,

--- a/apps/common-app/runtime-tests/ReJest/utils/stringFormatUtils.ts
+++ b/apps/common-app/runtime-tests/ReJest/utils/stringFormatUtils.ts
@@ -1,4 +1,4 @@
-import { isColor, processColor } from 'react-native-reanimated';
+import { isColor, processColorNumber } from './colorUtils';
 
 import type { TestValue } from '../types';
 
@@ -94,7 +94,7 @@ export function getColorSquare(color: string) {
   if (!isColor(color)) {
     return '??';
   }
-  const colorNumber = processColor(color);
+  const colorNumber = processColorNumber(color);
   /* eslint-disable no-bitwise */
   const red = (colorNumber >> 16) & 255;
   const green = (colorNumber >> 8) & 255;

--- a/apps/common-app/runtime-tests/self-tests/tests/TestsOfTestingFramework.test.tsx
+++ b/apps/common-app/runtime-tests/self-tests/tests/TestsOfTestingFramework.test.tsx
@@ -232,12 +232,12 @@ describe('Tests of Test Framework', () => {
     expect([]).not.toBeNullable();
     expect(0).not.toBeNullable();
   });
-  test('Test comparators - ❌', () => {
+  test.failing('Test comparators - ❌', () => {
     expect(0).toBeNullable();
     expect(2).not.toBeWithinRange(1.99999999, 2.0000001);
   });
 
-  test('withTiming - ❌', async () => {
+  test.failing('withTiming - ❌', async () => {
     await render(<AnimatedComponent />);
     const component = getTestComponent('BrownComponent');
     await wait(600);
@@ -247,7 +247,7 @@ describe('Tests of Test Framework', () => {
     );
   });
 
-  test('withTiming - ❌', async () => {
+  test.failing('withTiming - ❌', async () => {
     await render(<AnimatedComponent />);
     const component = getTestComponent('BrownComponent');
     await wait(600);
@@ -268,7 +268,7 @@ describe('Tests of Test Framework', () => {
     expect(await component.getAnimatedStyle('width')).toBe(100);
   });
 
-  test('withTiming - expect callback call - ❌', async () => {
+  test.failing('withTiming - expect callback call - ❌', async () => {
     await render(<AnimatedComponent />);
     await wait(600);
     expect(getTrackerCallCount('useAnimatedStyleTracker')).toBeCalled(4);
@@ -365,7 +365,7 @@ describe('Tests of Test Framework', () => {
       }).toThrow();
     });
 
-    test('Warn with no error message - ❌', async () => {
+    test.failing('Warn with no error message - ❌', async () => {
       await expect(() => {}).toThrow();
     });
 
@@ -373,13 +373,13 @@ describe('Tests of Test Framework', () => {
       await expect(() => {}).not.toThrow();
     });
 
-    test('Warn with with error message - ✅', async () => {
+    test('Warn with error message - ✅', async () => {
       await expect(() => {
         console.warn('OH, NO!');
       }).toThrow('OH, NO!');
     });
 
-    test('Warn with with error message - ❌', async () => {
+    test.failing('Warn with error message - ❌', async () => {
       await expect(() => {
         console.warn('OH, NO!');
       }).toThrow('OH, YES!');
@@ -391,13 +391,13 @@ describe('Tests of Test Framework', () => {
       }).toThrow();
     });
 
-    test('console.error  with with error message - ✅', async () => {
+    test('console.error with error message - ✅', async () => {
       await expect(() => {
         console.error('OH, NO!');
       }).toThrow('OH, NO!');
     });
 
-    test('console.error  with with error message - ❌', async () => {
+    test.failing('console.error with error message - ❌', async () => {
       await expect(() => {
         console.error('OH, NO!');
       }).toThrow('OH, YES!');
@@ -409,13 +409,13 @@ describe('Tests of Test Framework', () => {
       }).toThrow();
     });
 
-    test('Throw error with with error message - ✅', async () => {
+    test('Throw error with error message - ✅', async () => {
       await expect(() => {
         throw new Error('OH, NO!');
       }).toThrow('OH, NO!');
     });
 
-    test('Throw error with with error message - ❌', async () => {
+    test.failing('Throw error with error message - ❌', async () => {
       await expect(() => {
         throw new Error('OH, NO!');
       }).toThrow('OH, YES!');

--- a/apps/common-app/src/apps/runtime-tests/App.tsx
+++ b/apps/common-app/src/apps/runtime-tests/App.tsx
@@ -7,6 +7,7 @@ import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { BackButton, DrawerButton } from '@/components';
 import { createStack, IS_MACOS } from '@/utils';
 
+import type { RunnerId } from '../../../runtime-tests/ReJest/RuntimeTestsRunner';
 import type { RuntimeTestSuite } from '../../../runtime-tests/types';
 
 type RootStackParamList = {
@@ -47,40 +48,53 @@ function HomeScreen({ navigation }: HomeScreenProps) {
 function ReanimatedTestsScreen() {
   const RuntimeTestsRunner = (
     require('../../../runtime-tests/ReJest/RuntimeTestsRunner') as {
-      default: React.ComponentType<{ tests: Array<RuntimeTestSuite> }>;
+      default: React.ComponentType<{
+        tests: Array<RuntimeTestSuite>;
+        runnerId: RunnerId;
+      }>;
     }
   ).default;
   const { REANIMATED_TEST_SUITES } =
     require('../../../runtime-tests/reanimated/suites') as {
       REANIMATED_TEST_SUITES: Array<RuntimeTestSuite>;
     };
-  return <RuntimeTestsRunner tests={REANIMATED_TEST_SUITES} />;
+  return (
+    <RuntimeTestsRunner runnerId="Reanimated" tests={REANIMATED_TEST_SUITES} />
+  );
 }
 
 function WorkletsTestsScreen() {
   const RuntimeTestsRunner = (
     require('../../../runtime-tests/ReJest/RuntimeTestsRunner') as {
-      default: React.ComponentType<{ tests: Array<RuntimeTestSuite> }>;
+      default: React.ComponentType<{
+        tests: Array<RuntimeTestSuite>;
+        runnerId: RunnerId;
+      }>;
     }
   ).default;
   const { WORKLETS_TEST_SUITES } =
     require('../../../runtime-tests/worklets/suites') as {
       WORKLETS_TEST_SUITES: Array<RuntimeTestSuite>;
     };
-  return <RuntimeTestsRunner tests={WORKLETS_TEST_SUITES} />;
+  return (
+    <RuntimeTestsRunner runnerId="Worklets" tests={WORKLETS_TEST_SUITES} />
+  );
 }
 
 function SelfTestsScreen() {
   const RuntimeTestsRunner = (
     require('../../../runtime-tests/ReJest/RuntimeTestsRunner') as {
-      default: React.ComponentType<{ tests: Array<RuntimeTestSuite> }>;
+      default: React.ComponentType<{
+        tests: Array<RuntimeTestSuite>;
+        runnerId: RunnerId;
+      }>;
     }
   ).default;
   const { SELF_TEST_SUITES } =
     require('../../../runtime-tests/self-tests/suites') as {
       SELF_TEST_SUITES: Array<RuntimeTestSuite>;
     };
-  return <RuntimeTestsRunner tests={SELF_TEST_SUITES} />;
+  return <RuntimeTestsRunner runnerId="SelfTests" tests={SELF_TEST_SUITES} />;
 }
 
 const Stack = createStack<RootStackParamList>();


### PR DESCRIPTION
## Summary

Extracted from #9936

ReJest's framework self-tests contain eight tests that assert deliberately wrong expectations to prove that mismatch detection works — their names end with ❌. Under the plain `test` API they necessarily fail every run, which is why the whole self-tests suite used to be `skipByDefault` and never ran anywhere.

I added `test.failing` — the result is inverted: a test that records errors counts as passed, and a test that passes is reported with "Expected the test to fail, but it passed". The eight ❌ tests now use it, so the self-tests suite is green when detection works and goes red the moment it breaks.

## Test plan

The self-tests app runs green (28 passed, 0 failed) in both Bundle Mode and Legacy Eval, Debug and Release; deleting an `expect` from a ❌ test flips it to a failure.
