### PR TITLE
release(Worklets): 0.11.0

### DIFF
--- a/apps/fabric-example/ios/Podfile.lock
+++ b/apps/fabric-example/ios/Podfile.lock
@@ -2198,7 +2198,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - RNWorklets (0.11.0-main):
+  - RNWorklets (0.11.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2220,10 +2220,10 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - RNWorklets/apple (= 0.11.0-main)
-    - RNWorklets/common (= 0.11.0-main)
+    - RNWorklets/apple (= 0.11.0)
+    - RNWorklets/common (= 0.11.0)
     - Yoga
-  - RNWorklets/apple (0.11.0-main):
+  - RNWorklets/apple (0.11.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2246,7 +2246,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - RNWorklets/common (0.11.0-main):
+  - RNWorklets/common (0.11.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2538,7 +2538,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: b3e7ad108f0d882e30445c5527d774e3fd432f3d
-  hermes-engine: 301bfc8256bbcac62de554fb504b160cb93b2d02
+  hermes-engine: c5355d3a55a7c79bd0541ed68d942b9f6d769214
   MMKVCore: 3d16ce9f7d411e135020915fde98a056859a1efa
   NitroMmkv: 3163b5e55ecaa9a2c90088fc76f4f4d5ec0fb3d8
   NitroModules: 2d92eeea80a5afdebe7b4fd2443b5bd4d7ba1a44
@@ -2621,7 +2621,7 @@ SPEC CHECKSUMS:
   RNReanimated: 27a2ac012e5795b0a6cf6dff64b0670baddad735
   RNScreens: 01b065ded2dfe7987bcce770ff3a196be417ff41
   RNSVG: 3fe8590403ac9f107b4d14591bc6e54da4894e5c
-  RNWorklets: ea172e0fe2b2354eb4bdf0e145665b3fd3fca61d
+  RNWorklets: 80e8185d2def201e6cd302a768cd599ddbc064cb
   Yoga: fe50ab299e578f397fef753cf309c6703a4db29b
 
 PODFILE CHECKSUM: 57bbab89b8d7e783d0fe0caf63c8ff8b06333f80

--- a/apps/tvos-example/ios/Podfile.lock
+++ b/apps/tvos-example/ios/Podfile.lock
@@ -1921,7 +1921,7 @@ PODS:
     - ReactNativeDependencies
     - RNWorklets
     - Yoga
-  - RNWorklets (0.11.0-main):
+  - RNWorklets (0.11.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1943,10 +1943,10 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - RNWorklets/apple (= 0.11.0-main)
-    - RNWorklets/common (= 0.11.0-main)
+    - RNWorklets/apple (= 0.11.0)
+    - RNWorklets/common (= 0.11.0)
     - Yoga
-  - RNWorklets/apple (0.11.0-main):
+  - RNWorklets/apple (0.11.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1969,7 +1969,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - RNWorklets/common (0.11.0-main):
+  - RNWorklets/common (0.11.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2233,7 +2233,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: 100e8b32d1fdc10711177c09562acc71be47bb05
-  hermes-engine: 92b7c0bc55cd63164170168e94ebe11fed5e8964
+  hermes-engine: a0b99e710e42de76a8f1fd87f4fb3b551844a158
   RCTDeprecation: ba1610d0889408090861cd2c23a2601825085b01
   RCTRequired: 1780932b53a72771e01d3ee3b3521271427c073d
   RCTSwiftUI: c05aab26e3da179ddaa83d478e23382203175d39
@@ -2307,7 +2307,7 @@ SPEC CHECKSUMS:
   ReactCommon: 6f4ba85738bbfcb7ff2c9f07d18ecf5b9ea70bcf
   ReactNativeDependencies: 623d00f77ed478f2c124086e59fb962e0923822a
   RNReanimated: 7b53821f346e241b123fb68cbe3baf587456fb1e
-  RNWorklets: 188075b3fbb6d27b3a5296c290b88ae193d6566b
+  RNWorklets: 5ad341af6751bde0a86c0b55d65f290fb50cbcf5
   Yoga: cd32a3bf945ae6b16cb7d32c8e3bb73fb150326d
 
 PODFILE CHECKSUM: 969564fe20813ed734d37b432240c1cd0480ae3a

--- a/packages/react-native-worklets/package.json
+++ b/packages/react-native-worklets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-worklets",
-  "version": "0.11.0-main",
+  "version": "0.11.0",
   "description": "The React Native multithreading library",
   "keywords": [
     "react-native",

--- a/packages/react-native-worklets/src/debug/jsVersion.ts
+++ b/packages/react-native-worklets/src/debug/jsVersion.ts
@@ -5,4 +5,4 @@
  * version used to build the native part of the library in runtime. Remember to
  * keep this in sync with the version declared in `package.json`
  */
-export const jsVersion = '0.11.0-main';
+export const jsVersion = '0.11.0';


### PR DESCRIPTION
## Summary

Releasing Worklets 0.11.0 with [experimental Hermes Bytecode](https://docs.swmansion.com/react-native-worklets/docs/worklets-babel-plugin/plugin-options#hermesbytecode) option

## Test plan

CI build job https://github.com/software-mansion/react-native-reanimated/actions/runs/29411004402
