### PR TITLE
chore: add root .watchmanconfig to prevent watchman recrawl loops

### DIFF
--- a/.watchmanconfig
+++ b/.watchmanconfig
@@ -1,0 +1,22 @@
+{
+  "ignore_dirs": [
+    ".claude",
+    ".yarn/cache",
+    ".yarn/unprocessed",
+    "docs",
+    "apps/fabric-example/android/.gradle",
+    "apps/fabric-example/android/build",
+    "apps/fabric-example/android/app/build",
+    "apps/fabric-example/android/app/.cxx",
+    "apps/fabric-example/ios/Pods",
+    "apps/fabric-example/ios/build",
+    "apps/tvos-example/ios/Pods",
+    "apps/tvos-example/ios/build",
+    "apps/macos-example/macos/Pods",
+    "apps/macos-example/macos/build",
+    "packages/react-native-reanimated/android/build",
+    "packages/react-native-reanimated/android/.cxx",
+    "packages/react-native-worklets/android/build",
+    "packages/react-native-worklets/android/.cxx"
+  ]
+}


### PR DESCRIPTION
## Summary

The repo had no root `.watchmanconfig`, so watchman watched every generated tree in the monorepo — the docs sites' `node_modules`, the in-repo yarn cache, `ios/Pods`, Android build outputs. Bulk installs and native builds emit more FSEvents than watchman can drain, so macOS drops events and watchman falls back to minutes-long full recrawls (`Recrawled this watch N times ... MustScanSubDirs UserDropped`), during which Metro sync queries time out.

I added a root `.watchmanconfig` that ignores the generated directories while keeping everything Metro resolves through watched. It also collapses everything into a single root watch, since `watch-project` prefers the outermost `.watchmanconfig` — previously, starting Metro from an example app created a second watch nested in the root one.

## Test plan

After recreating the watch (`watchman watch-del` + `watch-project`), the ignored directories are invisible to queries and the recrawl warning is gone.
