### PR TITLE
Avoid exception-based nativeID parsing

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.cpp
@@ -21,6 +21,22 @@ std::optional<facebook::react::SurfaceId> LayoutAnimationsProxyCommon::onGesture
 
 void LayoutAnimationsProxyCommon::startSurface(const SurfaceId surfaceId) {}
 
+void LayoutAnimationsProxyCommon::transferConfigFromNativeID(const std::string &nativeIdString, const int tag) const {
+  if (nativeIdString.empty() || nativeIdString.length() > 9) {
+    return;
+  }
+
+  auto nativeId = 0;
+  for (const auto character : nativeIdString) {
+    if (character < '0' || character > '9') {
+      return;
+    }
+    nativeId = nativeId * 10 + character - '0';
+  }
+
+  layoutAnimationsManager_->transferConfigFromNativeID(nativeId, tag);
+}
+
 #ifdef ANDROID
 
 const facebook::react::ShadowNode *findInShadowTreeByTag(const facebook::react::ShadowNode &node, Tag tag) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.h
@@ -91,6 +91,8 @@ class LayoutAnimationsProxyCommon : public facebook::react::MountingOverrideDele
   virtual void startSurface(const SurfaceId surfaceId);
 
  protected:
+  void transferConfigFromNativeID(const std::string &nativeId, const int tag) const;
+
   mutable std::unordered_set<Tag> maybeSettledAnimationTags_;
   mutable std::unordered_map<Tag, LayoutAnimation> layoutAnimations_;
   std::shared_ptr<LayoutAnimationsManager> layoutAnimationsManager_;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
@@ -568,23 +568,6 @@ void LayoutAnimationsProxy_Experimental::maybeCancelAnimation(const int tag) con
   });
 }
 
-void LayoutAnimationsProxy_Experimental::transferConfigFromNativeID(const std::string &nativeIdString, const int tag)
-    const {
-  if (nativeIdString.empty() || nativeIdString.length() > 9) {
-    return;
-  }
-  auto nativeId = 0;
-  for (int i = 0; i < nativeIdString.length(); i++) {
-    if (nativeIdString[i] < '0' || nativeIdString[i] > '9') {
-      return;
-    }
-    nativeId *= 10;
-    nativeId += nativeIdString[i] - '0';
-  }
-
-  layoutAnimationsManager_->transferConfigFromNativeID(nativeId, tag);
-}
-
 // When entering animations start, we temporarily set opacity to 0
 // so that we can immediately insert the view at the right position
 // and schedule the animation on the UI thread

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.h
@@ -137,7 +137,6 @@ struct LayoutAnimationsProxy_Experimental : public LayoutAnimationsProxyCommon,
       ShadowViewMutationList &filteredMutations,
       const PropsParserContext &propsParserContext) const;
 
-  void transferConfigFromNativeID(const std::string &nativeId, const int tag) const;
   std::optional<SurfaceId> progressLayoutAnimation(int tag, const jsi::Object &newStyle) override;
   std::optional<SurfaceId> endLayoutAnimation(int tag, bool shouldRemove) override;
   std::optional<SurfaceId> onTransitionProgress(int tag, double progress, bool isClosing, bool isGoingForward) override;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
@@ -859,17 +859,6 @@ void LayoutAnimationsProxy_Legacy::maybeCancelAnimation(const int tag) const {
   });
 }
 
-void LayoutAnimationsProxy_Legacy::transferConfigFromNativeID(const std::string &nativeIdString, const int tag) const {
-  if (nativeIdString.empty()) {
-    return;
-  }
-  try {
-    auto nativeId = stoi(nativeIdString);
-    layoutAnimationsManager_->transferConfigFromNativeID(nativeId, tag);
-  } catch (std::invalid_argument) {
-  } catch (std::out_of_range) {}
-}
-
 // When entering animations start, we temporarily set opacity to 0
 // so that we can immediately insert the view at the right position
 // and schedule the animation on the UI thread

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.h
@@ -143,7 +143,6 @@ struct LayoutAnimationsProxy_Legacy : public LayoutAnimationsProxyCommon,
   void startExitingAnimation(const int tag, ShadowViewMutation &mutation) const;
   void startLayoutAnimation(const int tag, const ShadowViewMutation &mutation) const;
 
-  void transferConfigFromNativeID(const std::string &nativeId, const int tag) const;
   std::optional<SurfaceId> progressLayoutAnimation(int tag, const jsi::Object &newStyle) override;
   std::optional<SurfaceId> endLayoutAnimation(int tag, bool shouldRemove) override;
   void maybeCancelAnimation(const int tag) const;


### PR DESCRIPTION
## Summary

Follow-up to #7163.

React Native exposes `nativeID` as a string and uses non-numeric values internally. The legacy layout animation proxy currently parses every non-empty `nativeID` with `stoi` and relies on exceptions to reject unrelated IDs. In iOS applications whose native link graph contains code compiled with `-fno-exceptions`, that invalid parse can terminate the process instead of reaching the catch block.

This change moves `nativeID` parsing into `LayoutAnimationsProxyCommon` and uses the existing non-throwing digit validation from the experimental proxy. Both layout animation proxies now share one parser, non-numeric IDs are ignored, and numeric Reanimated IDs continue transferring their animation configuration.

## Test plan

Formatting and common C++ validation:

```sh
clang-format --dry-run --Werror \
  packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.{cpp,h} \
  packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.{cpp,h} \
  packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.{cpp,h}

cd packages/react-native-reanimated
../../scripts/validate-common.sh
```

Physical iOS reproduction uses React Native 0.86, Fabric, Hermes, and a native dependency graph containing `-fno-exceptions`. Mounting a view with a non-numeric `nativeID` while Reanimated processes layout insertions previously aborted in `LayoutAnimationsProxy_Legacy::transferConfigFromNativeID` through `std::__1::stoi`.

Minimal affected view:

```tsx
import Animated, { FadeIn } from 'react-native-reanimated';

export default function App() {
  return <Animated.View entering={FadeIn} nativeID="profile-avatar" />;
}
```

After this change, the non-numeric ID is ignored without throwing. Numeric IDs still reach `LayoutAnimationsManager::transferConfigFromNativeID`.
