### PR TITLE
chore: add --active-arch-only to android scripts

### DIFF
--- a/apps/fabric-example/package.json
+++ b/apps/fabric-example/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "cd ios && bundle install && bundle exec pod update --no-repo-update",
-    "android": "react-native run-android",
+    "android": "react-native run-android --active-arch-only",
     "ios": "react-native run-ios",
     "start": "react-native start",
     "format": "yarn run --top-level oxfmt .",

--- a/apps/tvos-example/package.json
+++ b/apps/tvos-example/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "cd ios && bundle install && bundle exec pod update --no-repo-update",
-    "android": "react-native run-android",
+    "android": "react-native run-android --active-arch-only",
     "ios": "react-native run-ios",
     "lint": "eslint . --max-warnings 0",
     "format": "yarn run --top-level oxfmt .",


### PR DESCRIPTION
## Summary

Agents supposed to test android apps tend to use scripts inside `package.json` to do it, in particular running `yarn android` which triggers compilation of all architectures, lagging my machine horribly. Adding `--active-arch-only` to the command to avoid this pitfall.

## Test plan

🚀 
