### PR TITLE
fix: peer-validation script exit status

### DIFF
--- a/scripts/validate-compatibility-peer-dependencies.js
+++ b/scripts/validate-compatibility-peer-dependencies.js
@@ -53,6 +53,8 @@ function main() {
       compatibilityWorkletsRange
     );
   }
+
+  process.exit(status);
 }
 
 /**


### PR DESCRIPTION
## Summary

Turns out the script didn't exit with the error code if it failed.

## Test plan

Found it when releasing Reanimated 4.5.2 and not updating peer-deps - CI didn't report a failure but logged an error.
