### PR TITLE
cherry-pick(4.3-stable): prevent animated views from reverting to stale values after app pause or re-animation (#9527)

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/AnimatedPropsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/AnimatedPropsRegistry.cpp
@@ -1,8 +1,10 @@
 #include <reanimated/Fabric/updates/AnimatedPropsRegistry.h>
 #include <reanimated/Tools/FeatureFlags.h>
 
+#include <functional>
 #include <memory>
 #include <utility>
+#include <vector>
 
 namespace reanimated {
 
@@ -25,25 +27,59 @@ void AnimatedPropsRegistry::update(jsi::Runtime &rt, const jsi::Value &operation
     addUpdatesToBatch(shadowNode, jsi::dynamicFromValue(rt, updates));
 
     if constexpr (StaticFeatureFlags::getFlag("FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS")) {
-      timestampMap_[shadowNode->getTag()] = timestamp;
+      const auto tag = shadowNode->getTag();
+      timestampMap_[tag] = timestamp;
+      // If JS already has a `settledProps` snapshot for this tag, it is now
+      // stale — schedule a refresh on the next `collectSettledUpdates`.
+      if (syncedTags_.erase(tag) > 0) {
+        invalidatedTags_.insert(tag);
+      }
     }
   }
 }
 
-jsi::Value AnimatedPropsRegistry::getUpdatesOlderThanTimestamp(
-    jsi::Runtime &rt,
-    const double timestamp,
-    const double cleanupTimestamp) {
+jsi::Value AnimatedPropsRegistry::collectSettledUpdates(jsi::Runtime &rt, const double settledTimestamp) {
   std::lock_guard<std::mutex> lock{mutex_};
-  removeUpdatesOlderThanTimestamp(cleanupTimestamp);
 
   std::vector<std::pair<Tag, std::reference_wrapper<const folly::dynamic>>> updates;
 
-  for (const auto &[viewTag, pair] : updatesRegistry_) {
-    auto it = timestampMap_.find(viewTag);
-    if (it != timestampMap_.end() && it->second < timestamp) {
-      updates.emplace_back(viewTag, std::cref(pair.second));
+  for (auto it = updatesRegistry_.begin(); it != updatesRegistry_.end();) {
+    const auto viewTag = it->first;
+
+    if (syncedTags_.contains(viewTag)) {
+      // React already has the latest value for this tag (synced on a previous
+      // call, so the `settledProps` state is committed by now) — the registry
+      // entry is redundant. `syncedTags_` is intentionally retained to detect
+      // re-animation staleness. Note that `syncedTags_` and `invalidatedTags_`
+      // are disjoint — `update()` moves tags from the former to the latter.
+      timestampMap_.erase(viewTag);
+      it = updatesRegistry_.erase(it);
+      continue;
     }
+
+    const auto timestampIt = timestampMap_.find(viewTag);
+    if (timestampIt == timestampMap_.end()) {
+      ++it;
+      continue;
+    }
+    const bool isSettled = timestampIt->second < settledTimestamp;
+    const auto invalidatedIt = invalidatedTags_.find(viewTag);
+    const bool isInvalidated = invalidatedIt != invalidatedTags_.end();
+    if (isSettled || isInvalidated) {
+      updates.emplace_back(viewTag, std::cref(it->second.second));
+      if (isSettled) {
+        // Only settled-path tags are tracked as "synced" so that an ongoing
+        // animation doesn't re-trigger an invalidation/sync on every GC tick.
+        syncedTags_.insert(viewTag);
+      }
+      if (isInvalidated) {
+        // Only erase serviced invalidations; if a tag was invalidated but the
+        // matching update batch hasn't been flushed into updatesRegistry_ yet,
+        // we leave the entry so the next sync picks it up.
+        invalidatedTags_.erase(invalidatedIt);
+      }
+    }
+    ++it;
   }
 
   const jsi::Array array(rt, updates.size());
@@ -58,22 +94,11 @@ jsi::Value AnimatedPropsRegistry::getUpdatesOlderThanTimestamp(
   return jsi::Value(rt, array);
 }
 
-void AnimatedPropsRegistry::removeUpdatesOlderThanTimestamp(const double timestamp) {
-  for (auto it = timestampMap_.begin(); it != timestampMap_.end();) {
-    const auto viewTag = it->first;
-    const auto viewTimestamp = it->second;
-    if (viewTimestamp < timestamp) {
-      it = timestampMap_.erase(it);
-      updatesRegistry_.erase(viewTag);
-    } else {
-      it++;
-    }
-  }
-}
-
 void AnimatedPropsRegistry::removeTag(const Tag tag) {
   updatesRegistry_.erase(tag);
   timestampMap_.erase(tag);
+  syncedTags_.erase(tag);
+  invalidatedTags_.erase(tag);
 }
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/AnimatedPropsRegistry.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/AnimatedPropsRegistry.h
@@ -4,10 +4,8 @@
 
 #include <react/renderer/uimanager/UIManager.h>
 
-#include <memory>
-#include <string>
 #include <unordered_map>
-#include <vector>
+#include <unordered_set>
 
 namespace reanimated {
 
@@ -15,13 +13,22 @@ class AnimatedPropsRegistry : public UpdatesRegistry {
  public:
   void update(jsi::Runtime &rt, const jsi::Value &operations, double timestamp);
 
-  /// Also removes updates older than `cleanupTimestamp` from the registry.
-  jsi::Value getUpdatesOlderThanTimestamp(jsi::Runtime &rt, double timestamp, double cleanupTimestamp);
+  /// Returns updates that settled (received no update since `settledTimestamp`)
+  /// or whose synced `settledProps` snapshot was invalidated by a fresh update.
+  /// Also evicts entries that have already been synced to React — by the time
+  /// of the next call, the corresponding `settledProps` state is guaranteed to
+  /// be committed, so the registry entries are redundant.
+  jsi::Value collectSettledUpdates(jsi::Runtime &rt, double settledTimestamp);
 
  private:
   std::unordered_map<Tag, double> timestampMap_; // viewTag -> timestamp, protected by `mutex_`
+  // Tags whose latest values have already been pushed to React `settledProps`.
+  // Intentionally retained after eviction to detect re-animation staleness.
+  std::unordered_set<Tag> syncedTags_;
+  // Tags that were synced to React but received a fresh worklet update since;
+  // their `settledProps` are stale and need to be refreshed on the next sync.
+  std::unordered_set<Tag> invalidatedTags_;
 
-  void removeUpdatesOlderThanTimestamp(double timestamp);
   void removeTag(Tag tag) override;
 };
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -524,15 +524,13 @@ jsi::Value ReanimatedModuleProxy::getSettledUpdates(jsi::Runtime &rt) {
       StaticFeatureFlags::getFlag("FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS") &&
       "getSettledUpdates requires FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS static feature flag to be enabled");
 
+  constexpr double SETTLED_ANIMATION_THRESHOLD_MS = 1000;
+
   // TODO(future): use unified timestamp
   const auto currentTimestamp = getAnimationTimestamp_();
 
-  // TODO: fix bug when threshold difference is smaller than 1 second
   // TODO(future): flush updates from CSS animations and CSS transitions registries
-  // TODO(future): find a better way to obtain timestamp for removing updates
-  // TODO(future): move removing old updates to separate method
-  return animatedPropsRegistry_->getUpdatesOlderThanTimestamp(
-      rt, currentTimestamp - 1000 /* 1 second */, currentTimestamp - 2000 /* 2 seconds */);
+  return animatedPropsRegistry_->collectSettledUpdates(rt, currentTimestamp - SETTLED_ANIMATION_THRESHOLD_MS);
 }
 
 bool ReanimatedModuleProxy::handleEvent(

--- a/packages/react-native-reanimated/src/PropsRegistryGarbageCollector.ts
+++ b/packages/react-native-reanimated/src/PropsRegistryGarbageCollector.ts
@@ -11,7 +11,6 @@ import { ReanimatedModule } from './ReanimatedModule';
 const FLUSH_INTERVAL_MS = 500;
 
 export const PropsRegistryGarbageCollector = {
-  viewsCount: 0,
   viewsMap: new Map<number, IAnimatedComponentInternal>(),
   intervalId: null as NodeJS.Timeout | null,
 
@@ -25,16 +24,14 @@ export const PropsRegistryGarbageCollector = {
       return;
     }
     this.viewsMap.set(viewTag, component);
-    this.viewsCount++;
-    if (this.viewsCount === 1) {
+    if (this.viewsMap.size === 1) {
       this.registerInterval();
     }
   },
 
   unregisterView(viewTag: number) {
-    this.viewsMap.delete(viewTag);
-    this.viewsCount--;
-    if (this.viewsCount === 0) {
+    const deleted = this.viewsMap.delete(viewTag);
+    if (deleted && this.viewsMap.size === 0) {
       this.unregisterInterval();
     }
   },


### PR DESCRIPTION
## Summary

Cherry-pick of #9527 for the next 4.3.x release.

Conflict resolutions (4.3-stable has diverged from main):
- Kept the internal `std::lock_guard{mutex_}` in `collectSettledUpdates` instead of `react_native_assert(UpdatesRegistryManager::isLockedByCurrentThread())` — 4.3-stable still uses per-registry locking and has no `isLockedByCurrentThread`.
- Dropped everything related to `USE_ANIMATION_BACKEND` (runtime guards, Gradle/`pod install` build-time validation, docs) — the flag doesn't exist on 4.3-stable, and `StaticFeatureFlags::getFlag` fails the build on unknown flags.
- `android/build.gradle.kts` doesn't exist on 4.3-stable (still Groovy) — the only hunk there was the dropped flag validation, so no Gradle change is needed.

The core fix is intact: sync-status-based eviction (`syncedTags_`/`invalidatedTags_`), removal of the 2-second wall-clock eviction, single sync per settled value, and the `PropsRegistryGarbageCollector` view-counter fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)