### PR TITLE
[automated runtime tests][7/11] fix: Make runtime tests pass across the Debug/Release × BundleMode/LegacyEval matrix

### DIFF
--- a/apps/common-app/runtime-tests/ReJest/Presets.ts
+++ b/apps/common-app/runtime-tests/ReJest/Presets.ts
@@ -61,7 +61,7 @@ const NOT_NUMBERS = [Infinity, -Infinity, NaN];
 // #region strings
 const TYPICAL_STRINGS = [
   'Aaaaaaa\n \t\t \v aaaaaa',
-  'Super long'.repeat(10000000),
+  'Super long'.repeat(100000),
   '',
   'A string primitive',
 ];

--- a/apps/common-app/runtime-tests/ReJest/matchers/Comparators.ts
+++ b/apps/common-app/runtime-tests/ReJest/matchers/Comparators.ts
@@ -1,4 +1,4 @@
-import { isColor, processColorNumber } from '../utils/colorUtils';
+import { colorsAreClose, isColor } from '../utils/colorUtils';
 
 import type { TestValue, ValidPropNames } from '../types';
 import { ComparisonMode, isValidPropName } from '../types';
@@ -40,7 +40,7 @@ const COMPARATORS: {
     if (!isColor(expected) || !isColor(value)) {
       return false;
     }
-    return processColorNumber(expected) === processColorNumber(value);
+    return colorsAreClose(expected, value);
   },
 
   [ComparisonMode.PIXEL]: (expected, value) => {

--- a/apps/common-app/runtime-tests/ReJest/matchers/rawMatchers.ts
+++ b/apps/common-app/runtime-tests/ReJest/matchers/rawMatchers.ts
@@ -208,17 +208,53 @@ export const toThrowMatcher: AsyncMatcher<ToThrowArgs> = async (
   let thrownException = false;
   let thrownExceptionMessage = null;
 
+  const errorUtils = (
+    globalThis as {
+      ErrorUtils?: {
+        getGlobalHandler: () => (error: Error, isFatal?: boolean) => void;
+        setGlobalHandler: (
+          handler: (error: Error, isFatal?: boolean) => void
+        ) => void;
+      };
+    }
+  ).ErrorUtils;
+  let uncaughtErrorMessage: string | null = null;
+  const previousGlobalHandler = errorUtils?.getGlobalHandler();
+  errorUtils?.setGlobalHandler((error) => {
+    if (uncaughtErrorMessage === null) {
+      uncaughtErrorMessage = error?.message ?? String(error);
+    }
+  });
+
   try {
-    await throwingFunction();
-  } catch (e) {
-    thrownException = true;
-    thrownExceptionMessage = (e as Error)?.message || '';
+    try {
+      await throwingFunction();
+    } catch (e) {
+      thrownException = true;
+      thrownExceptionMessage = (e as Error)?.message || '';
+    }
+
+    const deadline = Date.now() + 500;
+    while (
+      !thrownException &&
+      uncaughtErrorMessage === null &&
+      getCapturedConsoleErrors().consoleErrorCount < 1 &&
+      Date.now() < deadline
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+  } finally {
+    if (previousGlobalHandler) {
+      errorUtils?.setGlobalHandler(previousGlobalHandler);
+    }
+    await restoreConsole();
   }
-  await restoreConsole();
 
   const { consoleErrorCount, consoleErrorMessage } = getCapturedConsoleErrors();
-  const errorWasThrown = thrownException || consoleErrorCount >= 1;
-  const capturedMessage = thrownExceptionMessage || consoleErrorMessage;
+  const errorWasThrown =
+    thrownException || uncaughtErrorMessage !== null || consoleErrorCount >= 1;
+  const capturedMessage =
+    thrownExceptionMessage || uncaughtErrorMessage || consoleErrorMessage;
   const messageIsCorrect = errorMessage
     ? capturedMessage.includes(errorMessage)
     : true;

--- a/apps/common-app/runtime-tests/ReJest/utils/colorUtils.ts
+++ b/apps/common-app/runtime-tests/ReJest/utils/colorUtils.ts
@@ -1,9 +1,37 @@
 import { processColor } from 'react-native';
 
 export function isColor(value: unknown): value is string {
-  return typeof value === 'string' && processColor(value) != null;
+  return typeof value === 'string' && parseColor(value) != null;
 }
 
 export function processColorNumber(value: string): number {
-  return (processColor(value) as number) ?? 0;
+  return (parseColor(value) as number) ?? 0;
+}
+
+function parseColor(value: string) {
+  const parsed = processColor(value);
+  if (parsed == null && value.startsWith('hwb(')) {
+    return processColor(value.replace(/,/g, ' '));
+  }
+  return parsed;
+}
+
+export function colorsAreClose(expected: string, value: string): boolean {
+  const expectedChannels = colorChannels(expected);
+  const valueChannels = colorChannels(value);
+  return expectedChannels.every(
+    (channel, index) => Math.abs(channel - valueChannels[index]) <= 1
+  );
+}
+
+function colorChannels(value: string): number[] {
+  /* eslint-disable no-bitwise */
+  const color = processColorNumber(value) >>> 0;
+  return [
+    color >>> 24,
+    (color >>> 16) & 0xff,
+    (color >>> 8) & 0xff,
+    color & 0xff,
+  ];
+  /* eslint-enable no-bitwise */
 }

--- a/apps/common-app/runtime-tests/ReJest/utils/stringFormatUtils.ts
+++ b/apps/common-app/runtime-tests/ReJest/utils/stringFormatUtils.ts
@@ -136,17 +136,20 @@ export function formatTestName(
   if (Array.isArray(variableObject)) {
     variableObject.forEach((value, index) => {
       // python-like syntax ${1} {2}
-      testName = testName.replace('${' + index + '}', valueToString(value));
+      testName = testName
+        .split('${' + index + '}')
+        .join(valueToString(value));
     });
   }
   if (typeof variableObject === 'object') {
     const keys = Object.keys(variableObject);
     keys.forEach((k) => {
       // Typical object literal syntax
-      testName = testName.replace(
-        '${' + k + '}',
-        valueToString(variableObject[k as keyof typeof variableObject])
-      );
+      testName = testName
+        .split('${' + k + '}')
+        .join(
+          valueToString(variableObject[k as keyof typeof variableObject])
+        );
     });
   }
 

--- a/apps/common-app/runtime-tests/reanimated/tests/core/useAnimatedStyle/reuseAnimatedStyle.test.tsx
+++ b/apps/common-app/runtime-tests/reanimated/tests/core/useAnimatedStyle/reuseAnimatedStyle.test.tsx
@@ -166,7 +166,7 @@ describe('Test reusing animatedStyles', () => {
       const componentTwo = getTestComponent(COMPONENT_REF.TWO);
       const componentThree = getTestComponent(COMPONENT_REF.THREE);
 
-      await wait(300);
+      await wait(600);
 
       // Check the distance from the top
       const finalStyleFull = { height: 80, top: 0, margin: 0, ...finalStyle };

--- a/apps/common-app/runtime-tests/reanimated/tests/utilities/relativeCoords.test.tsx
+++ b/apps/common-app/runtime-tests/reanimated/tests/utilities/relativeCoords.test.tsx
@@ -66,7 +66,6 @@ const CoordsComponent = ({
 };
 
 describe('getRelativeCoords', () => {
-  // TODO: investigate and fix, on Android sometimes we receive 49s instead of 50s
   test.each([
     ['flex-start', 'flex-start', 0, 0],
     ['flex-start', 'center', 50, 0],
@@ -92,10 +91,10 @@ describe('getRelativeCoords', () => {
       const coords = (await getRegisteredValue(REGISTERED_VALUE_KEY)).onUI;
       expect(coords).not.toBeNullable();
       if (coords) {
-        expect(Math.floor((coords as unknown as ComponentCoords).x)).toBe(
+        expect(Math.round((coords as unknown as ComponentCoords).x)).toBe(
           expectedValueX
         );
-        expect(Math.floor((coords as unknown as ComponentCoords).y)).toBe(
+        expect(Math.round((coords as unknown as ComponentCoords).y)).toBe(
           expectedValueY
         );
       }

--- a/apps/common-app/runtime-tests/worklets/suites.ts
+++ b/apps/common-app/runtime-tests/worklets/suites.ts
@@ -1,3 +1,5 @@
+import { isBundleModeEnabled } from 'react-native-worklets';
+
 import type { RuntimeTestSuite } from '../types';
 
 export const WORKLETS_TEST_SUITES: RuntimeTestSuite[] = [
@@ -37,7 +39,7 @@ export const WORKLETS_TEST_SUITES: RuntimeTestSuite[] = [
       require('./tests/runtimes/reactNativeImportShim.test');
       require('./tests/runtimes/turboModuleRegistryShim.test');
     },
-    disabled: !globalThis._WORKLETS_BUNDLE_MODE_ENABLED,
+    disabled: !isBundleModeEnabled(),
     skipByDefault: true,
   },
   {

--- a/apps/common-app/runtime-tests/worklets/tests/memory/createSerializable.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/memory/createSerializable.test.tsx
@@ -182,7 +182,9 @@ describe('Test createSerializable', () => {
       });
 
       test('createSerializableHostObject', async () => {
-        const hostObjectValue = globalThis.__reanimatedModuleProxy;
+        const hostObjectValue = getWorkletRuntimeFromPool(
+          'test'
+        ) as unknown as Record<string, unknown>;
         const hostObjectKeys = Object.keys(hostObjectValue);
         scheduleOnTarget(() => {
           'worklet';
@@ -676,11 +678,7 @@ if (__DEV__) {
       const promise = Promise.resolve();
       await expect(() => {
         createSerializable(promise);
-      }).toThrow(
-        globalThis._WORKLETS_BUNDLE_MODE_ENABLED
-          ? 'Cannot copy value of type `Promise`'
-          : 'Promises cannot be converted to serializable.'
-      );
+      }).toThrow('Promise');
     });
 
     test('throws when trying to serialize a Proxy', async () => {

--- a/apps/common-app/runtime-tests/worklets/tests/memory/createSerializableOnUI.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/memory/createSerializableOnUI.test.tsx
@@ -523,16 +523,16 @@ describe('Test createSerializableOnUI', () => {
   // });
 
   test('createSerializableOnUIInaccessibleObject', async () => {
-    const clazz = runOnUISync(() => {
-      'worklet';
-      class Clazz {
-        method() {}
-      }
-
-      return new Clazz();
-    });
-
     await expect(() => {
+      const clazz = runOnUISync(() => {
+        'worklet';
+        class Clazz {
+          method() {}
+        }
+
+        return new Clazz();
+      });
+
       clazz.method();
     }).toThrow();
   });
@@ -570,7 +570,7 @@ describe('Test createSerializableOnUI', () => {
           'worklet';
           return Promise.resolve();
         })
-      ).toThrow('Cannot copy value of type `Promise`');
+      ).toThrow('Promise');
     });
   }
 });

--- a/apps/common-app/runtime-tests/worklets/tests/memory/isSerializableRef.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/memory/isSerializableRef.test.tsx
@@ -1,6 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { isSerializableRef, createSerializable } from 'react-native-worklets';
-import { describe, expect, test } from '../../../ReJest/RuntimeTestsApi';
+import {
+  describe,
+  expect,
+  getWorkletRuntimeFromPool,
+  test,
+} from '../../../ReJest/RuntimeTestsApi';
 
 describe('Test isSerializableRef', () => {
   test('check if createSerializable<number> returns serializable ref', () => {
@@ -152,7 +157,7 @@ describe('Test isSerializableRef', () => {
   });
 
   test('check if createSerializable<host object> returns serializable ref', () => {
-    const hostObjectValue = globalThis.__reanimatedModuleProxy;
+    const hostObjectValue = getWorkletRuntimeFromPool('test');
     const serializableRef = createSerializable(hostObjectValue);
 
     expect(isSerializableRef(serializableRef)).toBe(true);

--- a/apps/common-app/runtime-tests/worklets/tests/runLoop/setInterval.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/runLoop/setInterval.test.tsx
@@ -147,10 +147,10 @@ describe('Test setInterval', () => {
               const now = performance.now();
               totalTime += now - lastTime;
               lastTime = now;
-              if (totalTime >= delay * iter) {
+              if (totalTime >= delay * iter - iter) {
                 setFlag('ok');
               } else {
-                setFlag('not_ok');
+                setFlag(`not_ok: ${totalTime}ms after ${iter} intervals`);
               }
 
               if (iter === 1) {

--- a/apps/common-app/runtime-tests/worklets/tests/runLoop/setTimeout.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/runLoop/setTimeout.test.tsx
@@ -119,8 +119,11 @@ describe('Test setTimeout', () => {
             'worklet';
             const startTime = performance.now();
             setTimeout(() => {
-              if (performance.now() - startTime >= delay) {
+              const elapsed = performance.now() - startTime;
+              if (elapsed >= delay - 1) {
                 setFlag();
+              } else {
+                setFlag(`not_ok: fired after ${elapsed}ms`);
               }
               notify(notification);
             }, delay);


### PR DESCRIPTION
> [!NOTE]
> **This PR description is AI-generated.**

## Summary

Running the runtime tests across Debug/Release and Bundle Mode/Legacy Eval Mode — locally and then on CI in #9930 — surfaced bugs in the tests themselves that only show under specific configurations or on constrained runners. Assertions depended on mode-specific error messages, exact timings and floored coordinates, `toThrow` missed errors that Worklet Runtimes report asynchronously through `ErrorUtils`, and a ~100M-character string preset OOM-killed default-RAM CI emulators.

The COLOR comparator also rejected the `hwb()` colors used by the animation tests: `@react-native/normalize-colors` dropped the legacy comma `hwb()` syntax that Reanimated still parses, and the two parsers round half-value channels to different integers. The comparator now re-parses comma `hwb()` strings in space syntax and compares RGBA channel-wise with a ±1 tolerance, keeping ReJest free of `react-native-reanimated` imports.

I fixed the tests ahead of the CLI PR so the automated runs start green. I also swapped the host-object specimens in the memory tests to a pooled `WorkletRuntime`, since `__workletsModuleProxy` stopped being a real `jsi::HostObject` after the `toOptimizedObject` refactor.

## Test plan

All three libraries pass across the full configuration matrix locally and on CI in #9930 and #9932.