### PR TITLE
feat(ci): notify Slack about new pull requests from outside contributors

### DIFF
--- a/.github/workflows/helper/pull-request-opened-notification.ts
+++ b/.github/workflows/helper/pull-request-opened-notification.ts
@@ -1,0 +1,36 @@
+import { postToSlack } from './slack.ts';
+
+async function main(): Promise<void> {
+  const number = process.env.PR_NUMBER;
+  const url = process.env.PR_URL;
+  const title = process.env.PR_TITLE;
+  const author = process.env.PR_AUTHOR;
+  const authorAssociation = process.env.PR_AUTHOR_ASSOCIATION;
+
+  if (!number || !url) {
+    throw new Error(
+      'PR_NUMBER and PR_URL are required to post a new-pull-request notification.'
+    );
+  }
+
+  const heading = title
+    ? `🔀 New pull request from an outside contributor: #${number} — ${title}`
+    : `🔀 New pull request from an outside contributor: #${number}`;
+
+  const lines = [heading];
+  if (author) {
+    lines.push(
+      authorAssociation
+        ? `Opened by ${author} (${authorAssociation})`
+        : `Opened by ${author}`
+    );
+  }
+  lines.push(url);
+
+  await postToSlack({ text: lines.join('\n') });
+}
+
+main().catch((err: unknown) => {
+  console.error('Error posting new pull request notification to Slack:', err);
+  process.exitCode = 1;
+});

--- a/.github/workflows/slack-integration.yml
+++ b/.github/workflows/slack-integration.yml
@@ -8,10 +8,12 @@ on:
   workflow_dispatch:
   issues:
     types: [opened]
+  pull_request_target:
+    types: [opened]
 
 jobs:
   daily-status-report:
-    if: github.repository == 'software-mansion/react-native-reanimated' && github.event_name != 'issues'
+    if: github.repository == 'software-mansion/react-native-reanimated' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -52,3 +54,36 @@ jobs:
           ISSUE_URL: ${{ github.event.issue.html_url }}
           ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
         run: node --experimental-strip-types .github/workflows/helper/issue-opened-notification.ts
+
+  pull-request-opened-report:
+    if: >-
+      github.repository == 'software-mansion/react-native-reanimated' &&
+      github.event_name == 'pull_request_target' &&
+      github.event.pull_request.user.type != 'Bot' &&
+      github.event.pull_request.author_association != 'OWNER' &&
+      github.event.pull_request.author_association != 'MEMBER' &&
+      github.event.pull_request.author_association != 'COLLABORATOR'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          sparse-checkout: .github/workflows/helper
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Report new pull request to Slack
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+        run: node --experimental-strip-types .github/workflows/helper/pull-request-opened-notification.ts


### PR DESCRIPTION
> [!NOTE] **This PR description is AI-generated.**

## Summary

The Slack integration from #9910 reported new issues but not new pull requests, so contributions from outside the team could go unnoticed. I added a `pull_request_target` trigger and a `pull-request-opened-report` job to `slack-integration.yml` that posts opened PRs to Slack, gated to outside contributors by excluding the `OWNER`/`MEMBER`/`COLLABORATOR` `author_association` values and skipping bot authors so Dependabot stays out of the channel.

I chose `pull_request_target` over `pull_request` because fork PRs don't receive `secrets` on the latter, and kept the job safe by sparse-checking-out only `.github/workflows/helper` from the base branch and passing PR fields through env vars rather than interpolating them into a shell. The new `pull-request-opened-notification.ts` helper mirrors the existing issue notifier. I also narrowed the `daily-status-report` gate to `schedule`/`workflow_dispatch` so it no longer runs on the new PR events.

## Test plan

Ran `pull-request-opened-notification.ts` locally: it throws on missing `PR_NUMBER`/`PR_URL` and on a missing `SLACK_WEBHOOK_URL`, and `tsc` over the helper scripts passes. The Slack POST path is unchanged from the issue notifier merged in #9910.
