### PR TITLE
cherry-pick(4.3-stable): Fix crash from withheld exiting layout animations in legacy proxy

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/SuspenseLayoutAnimationCrashExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/SuspenseLayoutAnimationCrashExample.tsx
@@ -1,0 +1,168 @@
+import React, {
+  Suspense,
+  useEffect,
+  useReducer,
+  useRef,
+  useState,
+} from 'react';
+import { Button, Text, View } from 'react-native';
+import Animated, {
+  FadeIn,
+  FadeOut,
+  LinearTransition,
+} from 'react-native-reanimated';
+
+// Minimal reproduction of a Fabric mounting crash caused by Reanimated's
+// legacy LayoutAnimationsProxy (EXC_BAD_ACCESS at 0x18 on RN 0.83 /
+// NSRangeException in -[RCTMountingManager performTransaction:] on RN 0.85+).
+//
+// Required ingredients:
+//  1. a Suspense boundary that re-suspends whenever `mode` changes
+//     (offscreen hide + fallback swap, not a normal unmount),
+//  2. Animated.FlatList with itemLayoutAnimation,
+//  3. list items with layout + entering + EXITING animations — exiting is
+//     essential: it makes the proxy withhold Remove/Delete mutations,
+//  4. a conditional subview swap with entering+exiting inside each item,
+//  5. mixed Insert/Remove/Update churn in one parent (stable keys whose text
+//     changes + keys that mount/unmount per mode).
+//
+// Tapping the button alternates mode switches and swap toggles every 200ms,
+// so each state change lands while exiting/layout animations from the
+// previous one are still in flight. Before the withheld-removal reconcile
+// fix, release builds crashed within seconds.
+
+const SUSPEND_MS = 150;
+
+const cache = new Map<
+  string,
+  { status: 'pending' | 'done'; promise: Promise<void> }
+>();
+
+function useSuspendedData(key: string) {
+  let entry = cache.get(key);
+  if (!entry) {
+    const promise = new Promise<void>((resolve) => {
+      setTimeout(() => {
+        const e = cache.get(key);
+        if (e) {
+          e.status = 'done';
+        }
+        resolve();
+      }, SUSPEND_MS);
+    });
+    entry = { status: 'pending', promise };
+    cache.set(key, entry);
+  }
+  if (entry.status === 'pending') {
+    // eslint-disable-next-line
+    throw entry.promise;
+  }
+}
+
+function buildItems(mode: number): string[] {
+  const variant = mode % 3;
+  // stable keys — survive mode switches
+  const items = Array.from({ length: 10 }, (_, i) => `stable-${i}`);
+  // key spliced into the middle — shifts the indices of the stable items
+  items.splice(3, 0, `mid-${variant}`);
+  // varying tail — mounts/unmounts (Insert/Remove with exiting) per mode
+  for (let i = 0; i < 3 + variant * 4; i++) {
+    items.push(`temp-${variant}-${i}`);
+  }
+  return items;
+}
+
+function Item({
+  id,
+  mode,
+  swapped,
+}: {
+  id: string;
+  mode: number;
+  swapped: boolean;
+}) {
+  // Two views per item: the item itself (withheld Remove/Delete via `exiting`)
+  // and a conditional subtree swap — every toggle fires an exiting animation
+  // on the outgoing view and an entering one on the incoming view. The Text
+  // includes `mode`, so stable items also get Paragraph updates every switch.
+  return (
+    <Animated.View
+      layout={LinearTransition.duration(250)}
+      entering={FadeIn.duration(200)}
+      exiting={FadeOut.duration(800)}>
+      {swapped ? (
+        <Animated.View
+          key="a"
+          entering={FadeIn.duration(200)}
+          exiting={FadeOut.duration(600)}>
+          <Text>{`${id} · A · mode ${mode}`}</Text>
+        </Animated.View>
+      ) : (
+        <Animated.View
+          key="b"
+          entering={FadeIn.duration(200)}
+          exiting={FadeOut.duration(600)}>
+          <Text>{`${id} · B · mode ${mode}`}</Text>
+        </Animated.View>
+      )}
+    </Animated.View>
+  );
+}
+
+function List({ mode, swapped }: { mode: number; swapped: boolean }) {
+  useSuspendedData(`page-${mode}`);
+  return (
+    <Animated.FlatList
+      data={buildItems(mode)}
+      keyExtractor={(id) => id}
+      itemLayoutAnimation={LinearTransition.duration(250)}
+      renderItem={({ item }) => (
+        <Item id={item} mode={mode} swapped={swapped} />
+      )}
+    />
+  );
+}
+
+function Skeleton() {
+  return (
+    <Animated.View
+      entering={FadeIn.duration(150)}
+      exiting={FadeOut.duration(400)}>
+      <Text>Loading…</Text>
+    </Animated.View>
+  );
+}
+
+export default function SuspenseLayoutAnimationCrashExample() {
+  const [mode, nextMode] = useReducer((m: number) => m + 1, 0);
+  const [swapped, setSwapped] = useState(false);
+  const interval = useRef<ReturnType<typeof setInterval> | undefined>(
+    undefined
+  );
+
+  useEffect(() => () => clearInterval(interval.current), []);
+
+  const start = () => {
+    if (interval.current) {
+      return;
+    }
+    let tick = 0;
+    interval.current = setInterval(() => {
+      tick += 1;
+      if (tick % 2 === 0) {
+        nextMode();
+      } else {
+        setSwapped((s) => !s);
+      }
+    }, 200);
+  };
+
+  return (
+    <View style={{ flex: 1, paddingTop: 8 }}>
+      <Button title="Start stress" onPress={start} />
+      <Suspense fallback={<Skeleton />}>
+        <List mode={mode} swapped={swapped} />
+      </Suspense>
+    </View>
+  );
+}

--- a/apps/common-app/src/apps/reanimated/examples/index.ts
+++ b/apps/common-app/src/apps/reanimated/examples/index.ts
@@ -138,6 +138,7 @@ import SpringPresetsExample from './SpringPresetsExample';
 import StickyHeaderExample from './StickyHeaderExample';
 import StrictDOMExample from './StrictDOMExample';
 import StrictModeComparison from './LayoutAnimations/StrictModeComparisonExample';
+import SuspenseLayoutAnimationCrashExample from './SuspenseLayoutAnimationCrashExample';
 import SvgExample from './SvgExample';
 import SwipeableList from './LayoutAnimations/SwipeableList';
 import SwipeableListExample from './SwipeableListExample';
@@ -183,6 +184,12 @@ export const EXAMPLES: Record<string, Example> = {
     icon: 'ℹ️',
     title: 'About',
     screen: AboutExample,
+  },
+
+  SuspenseLayoutAnimationCrashExample: {
+    icon: '💥',
+    title: 'Suspense + Layout Animation Crash',
+    screen: SuspenseLayoutAnimationCrashExample,
   },
 
   // Empty example for test purposes

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
@@ -39,14 +39,6 @@ std::optional<MountingTransaction> LayoutAnimationsProxy_Legacy::pullTransaction
   std::vector<std::shared_ptr<MutationNode>> roots;
   std::unordered_map<Tag, Tag> movedViews;
 
-  // If React re-creates or re-inserts a tag whose exiting removal we are still
-  // withholding, it has contradicted that withheld Remove/Delete. Flush it now
-  // instead of letting it fire later against a stale hierarchy (which would
-  // unmount the wrong, still-live view and crash the mounting layer).
-  //
-  // This must run before addOngoingAnimations (which would otherwise emit an
-  // Update for a tag we are about to Delete this frame) and before
-  // parseRemoveMutations, so the rest of the pipeline sees clean bookkeeping.
   reconcileContradictedRemovals(mutations, filteredMutations, surfaceId);
 
   addOngoingAnimations(surfaceId, filteredMutations);
@@ -74,6 +66,14 @@ std::optional<MountingTransaction> LayoutAnimationsProxy_Legacy::pullTransaction
   return MountingTransaction{surfaceId, transactionNumber, std::move(filteredMutations), telemetry};
 }
 
+// If React re-creates or re-inserts a tag whose exiting removal we are still
+// withholding, it has contradicted that withheld Remove/Delete. Flush it now
+// instead of letting it fire later against a stale hierarchy (which would
+// unmount the wrong, still-live view and crash the mounting layer).
+//
+// This must run before addOngoingAnimations (which would otherwise emit an
+// Update for a tag we are about to Delete this frame) and before
+// parseRemoveMutations, so the rest of the pipeline sees clean bookkeeping.
 void LayoutAnimationsProxy_Legacy::reconcileContradictedRemovals(
     ShadowViewMutationList &mutations,
     ShadowViewMutationList &filteredMutations,
@@ -160,10 +160,7 @@ std::optional<SurfaceId> LayoutAnimationsProxy_Legacy::endLayoutAnimation(int ta
 
   auto node = nodeForTag_[tag];
   if (!node->isMutationNode()) {
-    // The node was replaced by a plain Node (e.g. by a reparenting move) after
-    // the exiting animation started, so there is no withheld removal to
-    // finalize. Casting it to MutationNode here would corrupt the heap, and the
-    // react_native_assert that used to guard this is compiled out in release.
+    react_native_assert(false && "exiting tag must map to a MutationNode");
     return {};
   }
   auto mutationNode = std::static_pointer_cast<MutationNode>(node);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
@@ -39,6 +39,16 @@ std::optional<MountingTransaction> LayoutAnimationsProxy_Legacy::pullTransaction
   std::vector<std::shared_ptr<MutationNode>> roots;
   std::unordered_map<Tag, Tag> movedViews;
 
+  // If React re-creates or re-inserts a tag whose exiting removal we are still
+  // withholding, it has contradicted that withheld Remove/Delete. Flush it now
+  // instead of letting it fire later against a stale hierarchy (which would
+  // unmount the wrong, still-live view and crash the mounting layer).
+  //
+  // This must run before addOngoingAnimations (which would otherwise emit an
+  // Update for a tag we are about to Delete this frame) and before
+  // parseRemoveMutations, so the rest of the pipeline sees clean bookkeeping.
+  reconcileContradictedRemovals(mutations, filteredMutations, surfaceId);
+
   addOngoingAnimations(surfaceId, filteredMutations);
 
 #ifdef ANDROID
@@ -62,6 +72,32 @@ std::optional<MountingTransaction> LayoutAnimationsProxy_Legacy::pullTransaction
   addOngoingAnimations(surfaceId, filteredMutations);
 
   return MountingTransaction{surfaceId, transactionNumber, std::move(filteredMutations), telemetry};
+}
+
+void LayoutAnimationsProxy_Legacy::reconcileContradictedRemovals(
+    ShadowViewMutationList &mutations,
+    ShadowViewMutationList &filteredMutations,
+    SurfaceId surfaceId) const {
+  auto &[deadNodes] = surfaceContext_[surfaceId];
+  for (auto &mutation : mutations) {
+    if (mutation.type != ShadowViewMutation::Type::Create && mutation.type != ShadowViewMutation::Type::Insert) {
+      continue;
+    }
+    auto tag = mutation.newChildShadowView.tag;
+    auto it = nodeForTag_.find(tag);
+    // Only a MutationNode represents a withheld removal; a plain Node is just a
+    // live parent of some removed child and must be left untouched.
+    if (it == nodeForTag_.end() || !it->second->isMutationNode()) {
+      continue;
+    }
+    auto node = std::static_pointer_cast<MutationNode>(it->second);
+    // Flush the withheld Remove/Delete for this tag (and its withheld subtree)
+    // right now, mirroring the deadNodes cleanup in handleRemovals. This removes
+    // the stale view before React's Create/Insert re-registers the same tag.
+    endAnimationsRecursively(node, filteredMutations);
+    maybeDropAncestors(node->unflattenedParent, node, filteredMutations);
+    deadNodes.erase(node);
+  }
 }
 
 std::optional<SurfaceId> LayoutAnimationsProxy_Legacy::progressLayoutAnimation(int tag, const jsi::Object &newStyle) {
@@ -123,6 +159,13 @@ std::optional<SurfaceId> LayoutAnimationsProxy_Legacy::endLayoutAnimation(int ta
   }
 
   auto node = nodeForTag_[tag];
+  if (!node->isMutationNode()) {
+    // The node was replaced by a plain Node (e.g. by a reparenting move) after
+    // the exiting animation started, so there is no withheld removal to
+    // finalize. Casting it to MutationNode here would corrupt the heap, and the
+    // react_native_assert that used to guard this is compiled out in release.
+    return {};
+  }
   auto mutationNode = std::static_pointer_cast<MutationNode>(node);
   mutationNode->state = ExitingState_Legacy::DEAD;
   auto &[deadNodes] = surfaceContext_[surfaceId];

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.h
@@ -148,6 +148,10 @@ struct LayoutAnimationsProxy_Legacy : public LayoutAnimationsProxyCommon,
   std::optional<SurfaceId> endLayoutAnimation(int tag, bool shouldRemove) override;
   void maybeCancelAnimation(const int tag) const;
 
+  void reconcileContradictedRemovals(
+      ShadowViewMutationList &mutations,
+      ShadowViewMutationList &filteredMutations,
+      SurfaceId surfaceId) const;
   void parseRemoveMutations(
       std::unordered_map<Tag, Tag> &movedViews,
       ShadowViewMutationList &mutations,

--- a/packages/react-native-reanimated/src/animation/styleAnimation.ts
+++ b/packages/react-native-reanimated/src/animation/styleAnimation.ts
@@ -73,7 +73,8 @@ interface NestedObjectEntry<T> {
 
 export function withStyleAnimation(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  styleAnimations: AnimatedStyle<any>
+  styleAnimations: AnimatedStyle<any>,
+  callback?: (finished: boolean) => void
 ): StyleLayoutAnimation {
   'worklet';
   return defineAnimation<StyleLayoutAnimation>({}, () => {
@@ -236,7 +237,7 @@ export function withStyleAnimation(
       }
     };
 
-    const callback = (finished: boolean): void => {
+    const styleAnimationCallback = (finished: boolean): void => {
       if (!finished) {
         const animationsToCheck: NestedObjectValues<AnimationObject>[] = [
           styleAnimations,
@@ -267,6 +268,7 @@ export function withStyleAnimation(
           }
         }
       }
+      callback?.(finished);
     };
 
     return {
@@ -275,7 +277,7 @@ export function withStyleAnimation(
       onStart,
       current: {},
       styleAnimations,
-      callback,
+      callback: styleAnimationCallback,
     } as StyleLayoutAnimation;
   });
 }

--- a/packages/react-native-reanimated/src/layoutReanimation/animationsManager.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/animationsManager.ts
@@ -2,7 +2,7 @@
 
 import { runOnUISync } from 'react-native-worklets';
 
-import { withStyleAnimation } from '../animation';
+import { cancelAnimation, withStyleAnimation } from '../animation';
 import { SHOULD_BE_USE_WEB } from '../common';
 import type {
   LayoutAnimation,
@@ -74,9 +74,7 @@ function createLayoutAnimationManager(): {
         value._value = style.initialValues;
       }
 
-      const animation = withStyleAnimation(currentAnimation);
-
-      animation.callback = (finished?: boolean) => {
+      const animation = withStyleAnimation(currentAnimation, (finished) => {
         if (finished) {
           currentAnimationForTag.delete(tag);
           mutableValuesForTag.delete(tag);
@@ -84,9 +82,9 @@ function createLayoutAnimationManager(): {
           stopObservingProgress(tag, value, shouldRemoveView);
         }
         if (style.callback) {
-          style.callback(finished === undefined ? false : finished);
+          style.callback(finished);
         }
-      };
+      });
 
       startObservingProgress(tag, value);
       value.value = animation;
@@ -96,7 +94,11 @@ function createLayoutAnimationManager(): {
       if (!value) {
         return;
       }
-      stopObservingProgress(tag, value);
+      // native already made its cleanup, so we just do cleanup here on JS side
+      value.removeListener(tag + TAG_OFFSET);
+      cancelAnimation(value);
+      currentAnimationForTag.delete(tag);
+      mutableValuesForTag.delete(tag);
     },
   };
 }


### PR DESCRIPTION
## Summary

Cherry-pick of #9821 to `4.3-stable` (both commits).

On iOS release builds, an app that runs exiting layout animations under a Suspense boundary that keeps re-suspending crashes inside React Native's mount transaction within a few seconds. This happens with ENABLE_SHARED_ELEMENT_TRANSITIONS set to false, which is where the legacy LayoutAnimationsProxy is active.

The legacy proxy withholds Remove and Delete mutations for views that are animating out. When React later re-creates or re-inserts a tag whose exiting removal is still being withheld, the proxy kept the stale bookkeeping instead of reconciling it. The withheld removal then fired in a later frame against a hierarchy that no longer matched, unmounting the wrong, still-mounted view and corrupting the mounting layer.

The first commit reconciles those contradicted removals at the start of each transaction: if an incoming Create or Insert targets a tag that still has a withheld exiting removal, that removal is flushed right away, before the tag is re-registered, instead of firing later against a stale hierarchy.

The second commit makes `LayoutAnimationsManager.stop()` actually cancel the running style animation with `cancelAnimation()` (firing animation callbacks with `finished=false`) instead of only detaching the progress listener, so a cancelled exiting animation no longer keeps stepping invisibly and delivering a stale `_notifyAboutEnd` for a tag whose native bookkeeping is gone or reused. `withStyleAnimation` now takes the completion callback as a parameter and composes it with its internal cancellation fan-out. With cancellation propagated, the runtime guard in `endLayoutAnimation` is upgraded back to an assert.

Conflicts resolved during cherry-pick:
- `examples/index.ts` — re-applied the example registration in this branch's direct-import style (main uses lazy `require()`)
- `LayoutAnimationsProxy_Legacy.cpp` — surrounding context differs on this branch; the guard is inserted directly after the node lookup
- `animationsManager.ts` — `stopObservingProgress` has no `scheduleFlush` parameter on this branch; the new `stop()` body applies unchanged
- the repro example is reformatted to this branch's Prettier config (single quotes, `bracketSameLine`)

## Test plan

Same as #9821: set ENABLE_SHARED_ELEMENT_TRANSITIONS to false in apps/fabric-example, build fabric-example for iOS in Release, open the Suspense + Layout Animation Crash example, tap Start stress. Before the change the app crashes within seconds; after it, it keeps running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
