### PR TITLE
ci: don't set up yarn cache in skipped nightly TS compatibility jobs

### DIFF
--- a/.github/workflows/reanimated-typescript-compatibility-test-nightly.yml
+++ b/.github/workflows/reanimated-typescript-compatibility-test-nightly.yml
@@ -49,20 +49,23 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      - name: Use Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
-        with:
-          cache: 'yarn'
-      - name: Clear annotations
-        run: .github/workflows/helper/clear-annotations.sh
 
       - name: Check if react-native version exists
         id: check-react-native-version
         run: |
-          if ! npm view react-native@${{ matrix.react-native-version }} dist-tags ; then 
+          if ! npm view react-native@${{ matrix.react-native-version }} dist-tags ; then
             echo "React Native version ${{ matrix.react-native-version }} does not exist - Skipping..."
             echo "SKIP_BUILD=true" >> $GITHUB_OUTPUT
           fi
+
+      - name: Use Node.js
+        if: ${{ steps.check-react-native-version.outputs.SKIP_BUILD != 'true' }}
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          cache: 'yarn'
+      - name: Clear annotations
+        if: ${{ steps.check-react-native-version.outputs.SKIP_BUILD != 'true' }}
+        run: .github/workflows/helper/clear-annotations.sh
 
       - name: Run TypeScript Compatibility Check
         if: ${{ steps.check-react-native-version.outputs.SKIP_BUILD != 'true' }}


### PR DESCRIPTION
> [!NOTE] **This PR description is AI-generated.**

## Summary

The nightly TypeScript compatibility run failed for `react-native@0.87` in the `Post Use Node.js` step: https://github.com/software-mansion/react-native-reanimated/actions/runs/29530153525/job/87728324781

When the matrix version isn't published yet (`0.87` today — only `0.87.0-rc.0` exists), the job skips the compatibility check, so `yarn install` never creates `.yarn/cache` and the `actions/setup-node` cache-save post step fails with `Path Validation Error` whenever the cache restore missed. The restore misses on the first nightly after every `yarn.lock` change on `main`, so the failure keeps recurring until `react-native@0.87.0` ships.

I moved the version-existence check before the Node.js setup (it only needs the runner's preinstalled `npm`) and skip `setup-node` and `clear-annotations.sh` when the version doesn't exist, so a skipped job never engages the cache machinery.

## Test plan

This workflow runs on PRs that modify it — the `0.87` matrix job takes the skip path and stays green.
