### PR TITLE
cherry-pick(worklets-0.11-stable): removed erroring when can't createSerializable (#9884)

### DIFF
--- a/apps/common-app/runtime-tests/worklets/tests/memory/createSerializable.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/memory/createSerializable.test.tsx
@@ -620,7 +620,14 @@ describe('Test createSerializable', () => {
 
         await expect(() => {
           createSerializable(inaccessibleObject);
-        }).toThrow('Cannot copy value of type `Inaccessible`.');
+        }).not.toThrow();
+
+        scheduleOnTarget(() => {
+          'worklet';
+          scheduleOnRN(callbackPass, inaccessibleObject === undefined);
+        });
+        await waitForNotification(PASS_NOTIFICATION);
+        expect(result).toBe(true);
       });
 
       test('createSerializableRemoteNamedFunctionSyncCall', async () => {
@@ -672,22 +679,18 @@ describe('Test createSerializable', () => {
 
 if (__DEV__) {
   describe('createSerializable for unsupported types', () => {
-    test('throws when trying to serialize a Promise', async () => {
+    test('does not throw when trying to serialize a Promise', async () => {
       const promise = Promise.resolve();
       await expect(() => {
         createSerializable(promise);
-      }).toThrow(
-        globalThis._WORKLETS_BUNDLE_MODE_ENABLED
-          ? 'Cannot copy value of type `Promise`'
-          : 'Promises cannot be converted to serializable.'
-      );
+      }).not.toThrow();
     });
 
-    test('throws when trying to serialize a Proxy', async () => {
+    test('does not throw when trying to serialize a Proxy', async () => {
       const proxy = new Proxy({ a: 1 }, { getPrototypeOf: () => null });
       await expect(() => {
         createSerializable(proxy);
-      }).toThrow('Cannot copy value of type');
+      }).not.toThrow();
     });
   });
 

--- a/apps/common-app/runtime-tests/worklets/tests/memory/createSerializableOnUI.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/memory/createSerializableOnUI.test.tsx
@@ -522,7 +522,7 @@ describe('Test createSerializableOnUI', () => {
   //   expect('magicKey' in Object.getPrototypeOf(obj)).toBe(true);
   // });
 
-  test('createSerializableOnUIInaccessibleObject', async () => {
+  test('createSerializableOnUIInaccessibleObject', () => {
     const clazz = runOnUISync(() => {
       'worklet';
       class Clazz {
@@ -532,9 +532,7 @@ describe('Test createSerializableOnUI', () => {
       return new Clazz();
     });
 
-    await expect(() => {
-      clazz.method();
-    }).toThrow();
+    expect(clazz).toBe(undefined);
   });
 
   test('createSerializableOnUIRemoteNamedFunctionSyncCall', async () => {
@@ -564,13 +562,12 @@ describe('Test createSerializableOnUI', () => {
   });
 
   if (__DEV__) {
-    test('throws when trying to serialize a Promise', async () => {
-      await expect(() =>
-        runOnUISync(() => {
-          'worklet';
-          return Promise.resolve();
-        })
-      ).toThrow('Cannot copy value of type `Promise`');
+    test('replaces an unsupported Promise with undefined', () => {
+      const value = runOnUISync(() => {
+        'worklet';
+        return Promise.resolve();
+      });
+      expect(value).toBe(undefined);
     });
   }
 });

--- a/packages/react-native-worklets/src/memory/serializable.native.ts
+++ b/packages/react-native-worklets/src/memory/serializable.native.ts
@@ -210,12 +210,8 @@ export function createSerializable<TValue>(
       return cloneCustom(value, pack, i) as SerializableRef<TValue>;
     }
   }
-  const constructorName =
-    (value as { constructor?: { name?: string } })?.constructor?.name ||
-    'unknown';
-  throw new Error(
-    `[Worklets] Cannot copy value of type \`${constructorName}\`.`
-  );
+
+  return cloneUndefined() as SerializableRef<TValue>;
 }
 
 if (isBundleModeEnabled()) {


### PR DESCRIPTION
Cherry-picking #9884