### PR TITLE
cherry-pick(4.4-stable): Prevent animated views from reverting to stale values after app pause or re-animation

### DIFF
--- a/docs/docs-reanimated/docs/guides/feature-flags.md
+++ b/docs/docs-reanimated/docs/guides/feature-flags.md
@@ -116,11 +116,27 @@ When enabled, Shared Element Transitions are available to use, also the synchron
 
 This feature flag enables a mechanism that periodically synchronizes animated style updates back to React by triggering a React render for animated components with accumulated animated styles and evicting them from the registry on the C++ side. It is supposed to improve performance by decreasing the number of `ShadowNode` clone operations in `ReanimatedCommitHook` for React commits. When enabled, it also alters the behavior when detaching animated styles from animated components—the animated styles are not reverted to the original styles. If your app depends on that previous behavior, set this flag to `false` in `reanimated.staticFeatureFlags` in your app's `package.json`.
 
+This feature flag conflicts with [`USE_ANIMATION_BACKEND`](#use_animation_backend) and they cannot be enabled simultaneously. The animation backend keeps animated changes in sync with the React tree on its own, so the settled animations synchronization mechanism is unnecessary. Since `FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS` is enabled by default, so if you want to use the animation backend, you need to explicitly disable this flag in your app's `package.json`.
+
 ### `USE_ANIMATION_BACKEND`
 
 When enabled, Reanimated will use the React Native's new Animation Backend for applying animated changes. The backend will now be responsible for keeping animation changes in sync with the current React tree. This is meant to help with long-term stability and unlock new performance optimizations.
 
 This flag is experimental and defaults to `false`. To use it, you must run React Native 0.85.2 or newer with `useSharedAnimatedBackend` feature flag enabled (which is achieved by using React Native's Experimental release level in development).
+
+This feature flag conflicts with [`FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS`](#force_react_render_for_settled_animations) and they cannot be enabled simultaneously. Since `FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS` is enabled by default, you need to explicitly disable it in your app's `package.json` when enabling `USE_ANIMATION_BACKEND`:
+
+```json
+{
+  // ...
+  "reanimated": {
+    "staticFeatureFlags": {
+      "USE_ANIMATION_BACKEND": true,
+      "FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS": false
+    }
+  }
+}
+```
 
 ## Static feature flags
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/AnimatedPropsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/AnimatedPropsRegistry.cpp
@@ -5,8 +5,10 @@
 
 #include <react/debug/react_native_assert.h>
 
+#include <functional>
 #include <memory>
 #include <utility>
+#include <vector>
 
 namespace reanimated {
 
@@ -35,26 +37,65 @@ void AnimatedPropsRegistry::update(jsi::Runtime &rt, const jsi::Value &operation
       addUpdatesToBatch(shadowNode->getFamilyShared(), jsi::dynamicFromValue(rt, updates));
     }
 
-    if constexpr (StaticFeatureFlags::getFlag("FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS")) {
-      timestampMap_[shadowNode->getTag()] = timestamp;
+    // When USE_ANIMATION_BACKEND is enabled, updates bypass `updatesRegistry_`,
+    // so entries added to `timestampMap_` would never be synced and thus never
+    // evicted, leaking until view unmount.
+    if constexpr (
+        StaticFeatureFlags::getFlag("FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS") &&
+        !StaticFeatureFlags::getFlag("USE_ANIMATION_BACKEND")) {
+      const auto tag = shadowNode->getTag();
+      timestampMap_[tag] = timestamp;
+      // If JS already has a `settledProps` snapshot for this tag, it is now
+      // stale — schedule a refresh on the next `collectSettledUpdates`.
+      if (syncedTags_.erase(tag) > 0) {
+        invalidatedTags_.insert(tag);
+      }
     }
   }
 }
 
-jsi::Value AnimatedPropsRegistry::getUpdatesOlderThanTimestamp(
-    jsi::Runtime &rt,
-    const double timestamp,
-    const double cleanupTimestamp) {
+jsi::Value AnimatedPropsRegistry::collectSettledUpdates(jsi::Runtime &rt, const double settledTimestamp) {
   react_native_assert(UpdatesRegistryManager::isLockedByCurrentThread());
-  removeUpdatesOlderThanTimestamp(cleanupTimestamp);
 
   std::vector<std::pair<Tag, std::reference_wrapper<const folly::dynamic>>> updates;
 
-  for (const auto &[viewTag, pair] : updatesRegistry_) {
-    auto it = timestampMap_.find(viewTag);
-    if (it != timestampMap_.end() && it->second < timestamp) {
-      updates.emplace_back(viewTag, std::cref(pair.second));
+  for (auto it = updatesRegistry_.begin(); it != updatesRegistry_.end();) {
+    const auto viewTag = it->first;
+
+    if (syncedTags_.contains(viewTag)) {
+      // React already has the latest value for this tag (synced on a previous
+      // call, so the `settledProps` state is committed by now) — the registry
+      // entry is redundant. `syncedTags_` is intentionally retained to detect
+      // re-animation staleness. Note that `syncedTags_` and `invalidatedTags_`
+      // are disjoint — `update()` moves tags from the former to the latter.
+      timestampMap_.erase(viewTag);
+      it = updatesRegistry_.erase(it);
+      continue;
     }
+
+    const auto timestampIt = timestampMap_.find(viewTag);
+    if (timestampIt == timestampMap_.end()) {
+      ++it;
+      continue;
+    }
+    const bool isSettled = timestampIt->second < settledTimestamp;
+    const auto invalidatedIt = invalidatedTags_.find(viewTag);
+    const bool isInvalidated = invalidatedIt != invalidatedTags_.end();
+    if (isSettled || isInvalidated) {
+      updates.emplace_back(viewTag, std::cref(it->second.second));
+      if (isSettled) {
+        // Only settled-path tags are tracked as "synced" so that an ongoing
+        // animation doesn't re-trigger an invalidation/sync on every GC tick.
+        syncedTags_.insert(viewTag);
+      }
+      if (isInvalidated) {
+        // Only erase serviced invalidations; if a tag was invalidated but the
+        // matching update batch hasn't been flushed into updatesRegistry_ yet,
+        // we leave the entry so the next sync picks it up.
+        invalidatedTags_.erase(invalidatedIt);
+      }
+    }
+    ++it;
   }
 
   const jsi::Array array(rt, updates.size());
@@ -69,22 +110,11 @@ jsi::Value AnimatedPropsRegistry::getUpdatesOlderThanTimestamp(
   return jsi::Value(rt, array);
 }
 
-void AnimatedPropsRegistry::removeUpdatesOlderThanTimestamp(const double timestamp) {
-  for (auto it = timestampMap_.begin(); it != timestampMap_.end();) {
-    const auto viewTag = it->first;
-    const auto viewTimestamp = it->second;
-    if (viewTimestamp < timestamp) {
-      it = timestampMap_.erase(it);
-      updatesRegistry_.erase(viewTag);
-    } else {
-      it++;
-    }
-  }
-}
-
 void AnimatedPropsRegistry::removeTag(const Tag tag) {
   updatesRegistry_.erase(tag);
   timestampMap_.erase(tag);
+  syncedTags_.erase(tag);
+  invalidatedTags_.erase(tag);
 }
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/AnimatedPropsRegistry.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/AnimatedPropsRegistry.h
@@ -4,10 +4,8 @@
 
 #include <react/renderer/uimanager/UIManager.h>
 
-#include <memory>
-#include <string>
 #include <unordered_map>
-#include <vector>
+#include <unordered_set>
 
 namespace reanimated {
 
@@ -15,13 +13,22 @@ class AnimatedPropsRegistry : public UpdatesRegistry {
  public:
   void update(jsi::Runtime &rt, const jsi::Value &operations, double timestamp);
 
-  /// Also removes updates older than `cleanupTimestamp` from the registry.
-  jsi::Value getUpdatesOlderThanTimestamp(jsi::Runtime &rt, double timestamp, double cleanupTimestamp);
+  /// Returns updates that settled (received no update since `settledTimestamp`)
+  /// or whose synced `settledProps` snapshot was invalidated by a fresh update.
+  /// Also evicts entries that have already been synced to React — by the time
+  /// of the next call, the corresponding `settledProps` state is guaranteed to
+  /// be committed, so the registry entries are redundant.
+  jsi::Value collectSettledUpdates(jsi::Runtime &rt, double settledTimestamp);
 
  private:
   std::unordered_map<Tag, double> timestampMap_;
+  // Tags whose latest values have already been pushed to React `settledProps`.
+  // Intentionally retained after eviction to detect re-animation staleness.
+  std::unordered_set<Tag> syncedTags_;
+  // Tags that were synced to React but received a fresh worklet update since;
+  // their `settledProps` are stale and need to be refreshed on the next sync.
+  std::unordered_set<Tag> invalidatedTags_;
 
-  void removeUpdatesOlderThanTimestamp(double timestamp);
   void removeTag(Tag tag) override;
 };
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -641,16 +641,14 @@ jsi::Value ReanimatedModuleProxy::getSettledUpdates(jsi::Runtime &rt) {
       StaticFeatureFlags::getFlag("FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS") &&
       "getSettledUpdates requires FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS static feature flag to be enabled");
 
+  constexpr double SETTLED_ANIMATION_THRESHOLD_MS = 1000;
+
   // TODO(future): use unified timestamp
   const auto currentTimestamp = getAnimationTimestamp_();
 
-  // TODO: fix bug when threshold difference is smaller than 1 second
   // TODO(future): flush updates from CSS animations and CSS transitions registries
-  // TODO(future): find a better way to obtain timestamp for removing updates
-  // TODO(future): move removing old updates to separate method
   auto lock = updatesRegistryManager_->lock();
-  return animatedPropsRegistry_->getUpdatesOlderThanTimestamp(
-      rt, currentTimestamp - 1000 /* 1 second */, currentTimestamp - 2000 /* 2 seconds */);
+  return animatedPropsRegistry_->collectSettledUpdates(rt, currentTimestamp - SETTLED_ANIMATION_THRESHOLD_MS);
 }
 
 bool ReanimatedModuleProxy::handleEvent(

--- a/packages/react-native-reanimated/android/build.gradle.kts
+++ b/packages/react-native-reanimated/android/build.gradle.kts
@@ -100,6 +100,15 @@ fun validateConflictingFeatureFlags(featureFlags: HashMap<String, String>) {
             "[Reanimated] The feature flags `ANDROID_SYNCHRONOUSLY_UPDATE_UI_PROPS` and `ENABLE_SHARED_ELEMENT_TRANSITIONS` cannot be enabled simultaneously. Please disable one of them in your package.json."
         )
     }
+
+    val useAnimationBackend = featureFlags["USE_ANIMATION_BACKEND"] == "true"
+    val forceReactRenderForSettledAnimations = featureFlags["FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS"] == "true"
+
+    if (useAnimationBackend && forceReactRenderForSettledAnimations) {
+        throw GradleException(
+            "[Reanimated] The feature flags `USE_ANIMATION_BACKEND` and `FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS` cannot be enabled simultaneously. If you want to use the animation backend, you need to explicitly disable `FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS` feature flag (enabled by default) in your package.json."
+        )
+    }
 }
 
 if (project != rootProject) {

--- a/packages/react-native-reanimated/scripts/reanimated_utils.rb
+++ b/packages/react-native-reanimated/scripts/reanimated_utils.rb
@@ -59,6 +59,13 @@ def assert_conflicting_feature_flags(feature_flags)
   if ios_sync_ui_props && shared_element_transitions
     raise "[Reanimated] The feature flags `IOS_SYNCHRONOUSLY_UPDATE_UI_PROPS` and `ENABLE_SHARED_ELEMENT_TRANSITIONS` cannot be enabled simultaneously. Please disable one of them in your package.json"
   end
+
+  use_animation_backend = feature_flags['USE_ANIMATION_BACKEND'] == 'true'
+  force_react_render_for_settled_animations = feature_flags['FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS'] == 'true'
+
+  if use_animation_backend && force_react_render_for_settled_animations
+    raise "[Reanimated] The feature flags `USE_ANIMATION_BACKEND` and `FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS` cannot be enabled simultaneously. If you want to use the animation backend, you need to explicitly disable `FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS` feature flag (enabled by default) in your package.json"
+  end
 end
 
 def get_static_feature_flags()

--- a/packages/react-native-reanimated/src/PropsRegistryGarbageCollector.ts
+++ b/packages/react-native-reanimated/src/PropsRegistryGarbageCollector.ts
@@ -11,7 +11,6 @@ import { ReanimatedModule } from './ReanimatedModule';
 const FLUSH_INTERVAL_MS = 500;
 
 export const PropsRegistryGarbageCollector = {
-  viewsCount: 0,
   viewsMap: new Map<number, IAnimatedComponentInternal>(),
   intervalId: null as NodeJS.Timeout | null,
 
@@ -25,16 +24,14 @@ export const PropsRegistryGarbageCollector = {
       return;
     }
     this.viewsMap.set(viewTag, component);
-    this.viewsCount++;
-    if (this.viewsCount === 1) {
+    if (this.viewsMap.size === 1) {
       this.registerInterval();
     }
   },
 
   unregisterView(viewTag: number) {
-    this.viewsMap.delete(viewTag);
-    this.viewsCount--;
-    if (this.viewsCount === 0) {
+    const deleted = this.viewsMap.delete(viewTag);
+    if (deleted && this.viewsMap.size === 0) {
       this.unregisterInterval();
     }
   },

--- a/packages/react-native-reanimated/src/createAnimatedComponent/AnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/AnimatedComponent.tsx
@@ -51,7 +51,9 @@ if (IS_WEB) {
 }
 
 const FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS =
-  getStaticFeatureFlag('FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS') && !IS_WEB;
+  getStaticFeatureFlag('FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS') &&
+  !getStaticFeatureFlag('USE_ANIMATION_BACKEND') &&
+  !IS_WEB;
 
 export type Options<P> = {
   setNativeProps?: (ref: AnimatedComponentRef, props: P) => void;


### PR DESCRIPTION
## Summary

Cherry-pick of #9527 to `4.4-stable`.

Fixes the `FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS` mechanism so animated views no longer revert to stale values after app pause or re-animation:

- Settled registry entries are now evicted based on sync status (React has received the value) instead of elapsed time, so pausing the app (browser intent, billing sheet, permission dialog) or a blocked JS thread can no longer cause an entry to be evicted before it was ever synced.
- `settledProps` snapshots are invalidated as soon as a fresh worklet update arrives for an already-synced tag, so a React commit during a re-animation no longer applies a stale value.
- Each settled value is synced exactly once (previously 2–3 redundant `setState` calls per animation).
- Fixes view-counter drift in `PropsRegistryGarbageCollector` for nested animated components.
- `FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS` and `USE_ANIMATION_BACKEND` are declared conflicting and validated at build time; runtime guards disable the mechanism when the backend is enabled.

Fixes #9478, #9574, #9635, #9965 (and likely #9614) on the 4.4 line. No JSI bindings are added, removed or changed, so this is safe for OTA updates in both directions and suitable for a patch release. See #9527 for the full analysis, approaches considered, and known limitations.

The squashed commit applied with two small conflicts resolved during cherry-pick:
- `scripts/reanimated_utils.rb` — this branch keeps the flag validation in a dedicated `assert_conflicting_feature_flags` method (main inlines it), so the new `USE_ANIMATION_BACKEND` check was added there
- `docs/feature-flags.md` — context conflict with the `IOS_CSS_CORE_ANIMATION` section that does not exist on this branch

Apart from these adaptations the diff is identical to the one merged to `main`.

## Test plan

Same as #9527 — both repro scenarios (pause/resume and the #9574 modal + `Linking.openURL` port) were verified fixed on the original branch, which this backport reproduces byte-for-byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
