### PR TITLE
chore(Worklets): amend bun patching instructions

### DIFF
--- a/packages/react-native-worklets/bundleMode/patches/README.md
+++ b/packages/react-native-worklets/bundleMode/patches/README.md
@@ -73,11 +73,11 @@ Using bun for patching gives you the benefit of the bun runtime in your project 
 1. Replace metro version with your version of patch:
    (Change the numbers at the end (0.84.4) to the version of your choice (e.g. 0.82.4)
    ```terminal
-   curl -L https://github.com/software-mansion/react-native-reanimated/raw/main/packages/react-native-worklets/bundleMode/patches/patch-package/metro/metro%2B0.84.4.patch | git apply --directory=node_modules/metro
+   curl -L https://github.com/software-mansion/react-native-reanimated/raw/main/packages/react-native-worklets/bundleMode/patches/patch-package/metro/metro%2B0.84.4.patch | git apply
    ```
    AND
    ```terminal
-   curl -L https://github.com/software-mansion/react-native-reanimated/raw/main/packages/react-native-worklets/bundleMode/patches/patch-package/metro-runtime/metro-runtime%2B0.84.4.patch | git apply --directory=node_modules/metro-runtime
+   curl -L https://github.com/software-mansion/react-native-reanimated/raw/main/packages/react-native-worklets/bundleMode/patches/patch-package/metro-runtime/metro-runtime%2B0.84.4.patch | git apply
    ```
 1. Run `bun patch --commit` to commit patches to the repo:
    ```terminal


### PR DESCRIPTION
## Summary

Bun patching instructions contained unnecessary `--directory` option.

## Test plan

Verified locally.
