### PR TITLE
feat(Worklets): Descriptive warning in createSerializable

### DIFF
--- a/apps/common-app/runtime-tests/worklets/tests/memory/createSerializable.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/memory/createSerializable.test.tsx
@@ -687,6 +687,15 @@ if (__DEV__) {
         createSerializable(proxy);
       }).toThrow('Cannot copy value of type');
     });
+
+    test('warns when passing an unserializable value to a worklet', async () => {
+      const nestedMap = new Map([[0, [{ someKey: new Date() }]]]);
+      await expect(() => {
+        createSerializable(nestedMap);
+      }).toThrow(
+        'Cannot copy value of type `Date`. It was located at `.values()[0][0]["someKey"]`.'
+      );
+    });
   });
 
   describe('Test serializable freezing', () => {

--- a/apps/common-app/runtime-tests/worklets/tests/memory/createSerializable.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/memory/createSerializable.test.tsx
@@ -689,11 +689,12 @@ if (__DEV__) {
     });
 
     test('warns when passing an unserializable value to a worklet', async () => {
-      const nestedMap = new Map([[0, [{ someKey: new Date() }]]]);
+      class Clazz {}
+      const nestedMap = new Map([[0, [{ someKey: new Clazz() }]]]);
       await expect(() => {
         createSerializable(nestedMap);
       }).toThrow(
-        'Cannot copy value of type `Date`. It was located at `.values()[0][0]["someKey"]`.'
+        'Cannot copy value of type `Clazz`. It was located at `.values()[0][0]["someKey"]`.'
       );
     });
   });

--- a/packages/react-native-worklets/__tests__/serializable.test.ts
+++ b/packages/react-native-worklets/__tests__/serializable.test.ts
@@ -1,0 +1,119 @@
+import { createSerializable } from '../src/memory/serializable';
+
+jest.mock('../src/WorkletsModule/NativeWorklets', () => {
+  const mockSerializable = (value: unknown) => ({
+    __serializableRef: true,
+    value,
+  });
+  return {
+    WorkletsModule: {
+      createSerializableString: mockSerializable,
+      createSerializableNumber: mockSerializable,
+      createSerializableBoolean: mockSerializable,
+      createSerializableBigInt: mockSerializable,
+      createSerializableUndefined: mockSerializable,
+      createSerializableNull: mockSerializable,
+      createSerializableArray: mockSerializable,
+      createSerializableObject: mockSerializable,
+      createSerializableMap: mockSerializable,
+      createSerializableSet: mockSerializable,
+    },
+  };
+});
+
+class Clazz {}
+
+function setDev(value: boolean) {
+  (globalThis as unknown as { __DEV__: boolean }).__DEV__ = value;
+}
+
+describe('createSerializable unsupported-type warning', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation();
+  });
+
+  afterEach(() => {
+    setDev(true);
+    jest.restoreAllMocks();
+  });
+
+  test('warns without a location for a top-level unsupported value', () => {
+    createSerializable(new Clazz());
+
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(console.warn).toHaveBeenCalledWith(
+      '[Worklets] Cannot copy value of type `Clazz`.'
+    );
+  });
+
+  test('includes the property path for a value nested in an object', () => {
+    createSerializable({ a: { b: new Clazz() } });
+
+    expect(console.warn).toHaveBeenCalledWith(
+      '[Worklets] Cannot copy value of type `Clazz`. It was located at `["a"]["b"]`.'
+    );
+  });
+
+  test('includes the index path for a value nested in an array', () => {
+    createSerializable([1, [new Clazz()]]);
+
+    expect(console.warn).toHaveBeenCalledWith(
+      '[Worklets] Cannot copy value of type `Clazz`. It was located at `[1][0]`.'
+    );
+  });
+
+  test('includes the map value path', () => {
+    createSerializable(new Map([[0, new Clazz()]]));
+
+    expect(console.warn).toHaveBeenCalledWith(
+      '[Worklets] Cannot copy value of type `Clazz`. It was located at `.values()[0]`.'
+    );
+  });
+
+  test('includes the map key path', () => {
+    createSerializable(new Map([[new Clazz(), 1]]));
+
+    expect(console.warn).toHaveBeenCalledWith(
+      '[Worklets] Cannot copy value of type `Clazz`. It was located at `.keys()[0]`.'
+    );
+  });
+
+  test('includes the set value path', () => {
+    createSerializable(new Set([new Clazz()]));
+
+    expect(console.warn).toHaveBeenCalledWith(
+      '[Worklets] Cannot copy value of type `Clazz`. It was located at `.values()[0]`.'
+    );
+  });
+
+  test('reconstructs the full path through a Map -> array -> object', () => {
+    createSerializable(new Map([[0, [{ someKey: new Clazz() }]]]));
+
+    expect(console.warn).toHaveBeenCalledWith(
+      '[Worklets] Cannot copy value of type `Clazz`. It was located at `.values()[0][0]["someKey"]`.'
+    );
+  });
+
+  test('keeps the path stack balanced after a thrown error', () => {
+    const cyclic: unknown[] = [];
+    cyclic.push(cyclic);
+
+    expect(() => createSerializable(cyclic)).toThrow(
+      'Trying to convert a cyclic object'
+    );
+
+    createSerializable({ onlyKey: new Clazz() });
+
+    expect(console.warn).toHaveBeenCalledWith(
+      '[Worklets] Cannot copy value of type `Clazz`. It was located at `["onlyKey"]`.'
+    );
+  });
+
+  test('does not warn outside dev', () => {
+    setDev(false);
+
+    createSerializable(new Clazz());
+
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react-native-worklets/__tests__/serializable.test.ts
+++ b/packages/react-native-worklets/__tests__/serializable.test.ts
@@ -23,23 +23,23 @@ jest.mock('../src/WorkletsModule/NativeWorklets', () => {
 
 class Clazz {}
 
-function setDev(value: boolean) {
-  (globalThis as unknown as { __DEV__: boolean }).__DEV__ = value;
-}
-
 describe('createSerializable unsupported-type warning', () => {
+  const globalWithDev = globalThis as unknown as { __DEV__?: boolean };
+
   beforeEach(() => {
     jest.spyOn(console, 'warn').mockImplementation();
+    globalWithDev.__DEV__ = true;
   });
 
   afterEach(() => {
-    setDev(true);
+    delete globalWithDev.__DEV__;
     jest.restoreAllMocks();
   });
 
   test('warns without a location for a top-level unsupported value', () => {
-    createSerializable(new Clazz());
+    const result = createSerializable(new Clazz());
 
+    expect(result).toHaveProperty('value', undefined);
     expect(console.warn).toHaveBeenCalledTimes(1);
     expect(console.warn).toHaveBeenCalledWith(
       '[Worklets] Cannot copy value of type `Clazz`.'
@@ -110,10 +110,11 @@ describe('createSerializable unsupported-type warning', () => {
   });
 
   test('does not warn outside dev', () => {
-    setDev(false);
+    globalWithDev.__DEV__ = false;
 
-    createSerializable(new Clazz());
+    const result = createSerializable(new Clazz());
 
+    expect(result).toHaveProperty('value', undefined);
     expect(console.warn).not.toHaveBeenCalled();
   });
 });

--- a/packages/react-native-worklets/src/memory/serializable.native.ts
+++ b/packages/react-native-worklets/src/memory/serializable.native.ts
@@ -91,14 +91,8 @@ let processedObjectAtThresholdDepth: unknown;
 
 const serializationPathStack: string[] = [];
 
-function withPathSegment<TValue>(
-  getSegment: () => string,
-  serialize: () => TValue
-): TValue {
-  if (!__DEV__) {
-    return serialize();
-  }
-  serializationPathStack.push(getSegment());
+function withPathSegment<TValue>(segment: string, serialize: () => TValue) {
+  serializationPathStack.push(segment);
   try {
     return serialize();
   } finally {
@@ -107,7 +101,7 @@ function withPathSegment<TValue>(
 }
 
 function formatSerializationPath(): string {
-  return __DEV__ ? serializationPathStack.join('') : '';
+  return serializationPathStack.join('');
 }
 
 export function createSerializable<TValue>(
@@ -385,10 +379,17 @@ function cloneObjectProperties<T extends object>(
     if (key === '__initData' && clonedProps.__initData !== undefined) {
       continue;
     }
-    clonedProps[key] = withPathSegment(
-      () => `[${JSON.stringify(key)}]`,
-      () => createSerializable(element, shouldPersistRemote, depth + 1)
-    );
+    if (__DEV__) {
+      clonedProps[key] = withPathSegment(`[${JSON.stringify(key)}]`, () =>
+        createSerializable(element, shouldPersistRemote, depth + 1)
+      );
+    } else {
+      clonedProps[key] = createSerializable(
+        element,
+        shouldPersistRemote,
+        depth + 1
+      );
+    }
   }
   return clonedProps;
 }
@@ -412,10 +413,11 @@ function cloneArray<T extends unknown[]>(
   depth: number
 ): SerializableRef<T> {
   const clonedElements = value.map((element, index) =>
-    withPathSegment(
-      () => `[${index}]`,
-      () => createSerializable(element, shouldPersistRemote, depth + 1)
-    )
+    __DEV__
+      ? withPathSegment(`[${index}]`, () =>
+          createSerializable(element, shouldPersistRemote, depth + 1)
+        )
+      : createSerializable(element, shouldPersistRemote, depth + 1)
   );
   const clone = WorkletsModule.createSerializableArray(
     clonedElements,
@@ -483,37 +485,39 @@ function cloneWorklet<TValue extends WorkletFunction>(
     // seems more elegant to handle it this way.
     delete (value as WorkletFunction).__stackDetails;
   }
-  return withPathSegment(
-    () => `<worklet ${value.name || 'anonymous'}>`,
-    () => {
-      const clonedProps: Record<string, unknown> = cloneObjectProperties(
-        value,
-        shouldPersistRemote,
-        depth
-      );
-      // to save on transferring static __initData field of worklet structure
-      // we request serializable value to persist its UI counterpart. This means
-      // that the __initData field that contains long strings representing the
-      // worklet code, source map, and location, will always be
-      // serialized/deserialized once.
-      clonedProps.__initData = withPathSegment(
-        () => '["__initData"]',
-        () => createSerializable(value.__initData, true, depth + 1)
-      );
+  const buildClone = (): SerializableRef<TValue> => {
+    const clonedProps: Record<string, unknown> = cloneObjectProperties(
+      value,
+      shouldPersistRemote,
+      depth
+    );
+    // to save on transferring static __initData field of worklet structure
+    // we request serializable value to persist its UI counterpart. This means
+    // that the __initData field that contains long strings representing the
+    // worklet code, source map, and location, will always be
+    // serialized/deserialized once.
+    clonedProps.__initData = __DEV__
+      ? withPathSegment('["__initData"]', () =>
+          createSerializable(value.__initData, true, depth + 1)
+        )
+      : createSerializable(value.__initData, true, depth + 1);
 
-      const clone = WorkletsModule.createSerializableWorklet(
-        clonedProps,
-        // TODO: Check after refactor if we can remove shouldPersistRemote parameter (imho it's redundant here since worklets are always persistent)
-        // retain all worklets
-        true
-      ) as SerializableRef<TValue>;
-      serializableMappingCache.set(value, clone);
-      serializableMappingCache.set(clone);
+    const clone = WorkletsModule.createSerializableWorklet(
+      clonedProps,
+      // TODO: Check after refactor if we can remove shouldPersistRemote parameter (imho it's redundant here since worklets are always persistent)
+      // retain all worklets
+      true
+    ) as SerializableRef<TValue>;
+    serializableMappingCache.set(value, clone);
+    serializableMappingCache.set(clone);
 
-      freezeObjectInDev(value);
-      return clone;
-    }
-  );
+    freezeObjectInDev(value);
+    return clone;
+  };
+
+  return __DEV__
+    ? withPathSegment(`<worklet ${value.name || 'anonymous'}>`, buildClone)
+    : buildClone();
 }
 
 /**
@@ -578,18 +582,19 @@ function cloneMap(
   const clonedValues: unknown[] = [];
   let index = 0;
   for (const [key, element] of value.entries()) {
-    clonedKeys.push(
-      withPathSegment(
-        () => `.keys()[${index}]`,
-        () => createSerializable(key)
-      )
-    );
-    clonedValues.push(
-      withPathSegment(
-        () => `.values()[${index}]`,
-        () => createSerializable(element)
-      )
-    );
+    if (__DEV__) {
+      clonedKeys.push(
+        withPathSegment(`.keys()[${index}]`, () => createSerializable(key))
+      );
+      clonedValues.push(
+        withPathSegment(`.values()[${index}]`, () =>
+          createSerializable(element)
+        )
+      );
+    } else {
+      clonedKeys.push(createSerializable(key));
+      clonedValues.push(createSerializable(element));
+    }
     index++;
   }
   const clone = WorkletsModule.createSerializableMap(clonedKeys, clonedValues);
@@ -604,12 +609,15 @@ function cloneSet(value: Set<unknown>): SerializableRef<Set<unknown>> {
   const clonedElements: unknown[] = [];
   let index = 0;
   for (const element of value) {
-    clonedElements.push(
-      withPathSegment(
-        () => `.values()[${index}]`,
-        () => createSerializable(element)
-      )
-    );
+    if (__DEV__) {
+      clonedElements.push(
+        withPathSegment(`.values()[${index}]`, () =>
+          createSerializable(element)
+        )
+      );
+    } else {
+      clonedElements.push(createSerializable(element));
+    }
     index++;
   }
   const clone = WorkletsModule.createSerializableSet(clonedElements);
@@ -692,10 +700,9 @@ function cloneCustom<TValue extends object, TPacked = unknown>(
   typeId: number
 ): SerializableRef<TValue> {
   const packedData = pack(data);
-  const serialized = withPathSegment(
-    () => '.pack()',
-    () => createSerializable(packedData)
-  );
+  const serialized = __DEV__
+    ? withPathSegment('.pack()', () => createSerializable(packedData))
+    : createSerializable(packedData);
 
   return WorkletsModule.createCustomSerializable(
     serialized,

--- a/packages/react-native-worklets/src/memory/serializable.native.ts
+++ b/packages/react-native-worklets/src/memory/serializable.native.ts
@@ -89,6 +89,27 @@ const DETECT_CYCLIC_OBJECT_DEPTH_THRESHOLD = 30;
 // We use it to check if later on the function reenters with the same object
 let processedObjectAtThresholdDepth: unknown;
 
+const serializationPathStack: string[] = [];
+
+function withPathSegment<TValue>(
+  getSegment: () => string,
+  serialize: () => TValue
+): TValue {
+  if (!__DEV__) {
+    return serialize();
+  }
+  serializationPathStack.push(getSegment());
+  try {
+    return serialize();
+  } finally {
+    serializationPathStack.pop();
+  }
+}
+
+function formatSerializationPath(): string {
+  return __DEV__ ? serializationPathStack.join('') : '';
+}
+
 export function createSerializable<TValue>(
   value: TValue,
   shouldPersistRemote = false,
@@ -213,9 +234,13 @@ export function createSerializable<TValue>(
   const constructorName =
     (value as { constructor?: { name?: string } })?.constructor?.name ||
     'unknown';
-  throw new Error(
-    `[Worklets] Cannot copy value of type \`${constructorName}\`.`
+  const path = formatSerializationPath();
+  const location = path ? ` It was located at \`${path}\`.` : '';
+  console.warn(
+    `[Worklets] Cannot copy value of type \`${constructorName}\`.${location}`
   );
+
+  return cloneUndefined() as SerializableRef<TValue>;
 }
 
 if (isBundleModeEnabled()) {
@@ -360,10 +385,9 @@ function cloneObjectProperties<T extends object>(
     if (key === '__initData' && clonedProps.__initData !== undefined) {
       continue;
     }
-    clonedProps[key] = createSerializable(
-      element,
-      shouldPersistRemote,
-      depth + 1
+    clonedProps[key] = withPathSegment(
+      () => `[${JSON.stringify(key)}]`,
+      () => createSerializable(element, shouldPersistRemote, depth + 1)
     );
   }
   return clonedProps;
@@ -387,8 +411,11 @@ function cloneArray<T extends unknown[]>(
   shouldPersistRemote: boolean,
   depth: number
 ): SerializableRef<T> {
-  const clonedElements = value.map((element) =>
-    createSerializable(element, shouldPersistRemote, depth + 1)
+  const clonedElements = value.map((element, index) =>
+    withPathSegment(
+      () => `[${index}]`,
+      () => createSerializable(element, shouldPersistRemote, depth + 1)
+    )
   );
   const clone = WorkletsModule.createSerializableArray(
     clonedElements,
@@ -456,33 +483,37 @@ function cloneWorklet<TValue extends WorkletFunction>(
     // seems more elegant to handle it this way.
     delete (value as WorkletFunction).__stackDetails;
   }
-  const clonedProps: Record<string, unknown> = cloneObjectProperties(
-    value,
-    shouldPersistRemote,
-    depth
-  );
-  // to save on transferring static __initData field of worklet structure
-  // we request serializable value to persist its UI counterpart. This means
-  // that the __initData field that contains long strings representing the
-  // worklet code, source map, and location, will always be
-  // serialized/deserialized once.
-  clonedProps.__initData = createSerializable(
-    value.__initData,
-    true,
-    depth + 1
-  );
+  return withPathSegment(
+    () => `<worklet ${value.name || 'anonymous'}>`,
+    () => {
+      const clonedProps: Record<string, unknown> = cloneObjectProperties(
+        value,
+        shouldPersistRemote,
+        depth
+      );
+      // to save on transferring static __initData field of worklet structure
+      // we request serializable value to persist its UI counterpart. This means
+      // that the __initData field that contains long strings representing the
+      // worklet code, source map, and location, will always be
+      // serialized/deserialized once.
+      clonedProps.__initData = withPathSegment(
+        () => '["__initData"]',
+        () => createSerializable(value.__initData, true, depth + 1)
+      );
 
-  const clone = WorkletsModule.createSerializableWorklet(
-    clonedProps,
-    // TODO: Check after refactor if we can remove shouldPersistRemote parameter (imho it's redundant here since worklets are always persistent)
-    // retain all worklets
-    true
-  ) as SerializableRef<TValue>;
-  serializableMappingCache.set(value, clone);
-  serializableMappingCache.set(clone);
+      const clone = WorkletsModule.createSerializableWorklet(
+        clonedProps,
+        // TODO: Check after refactor if we can remove shouldPersistRemote parameter (imho it's redundant here since worklets are always persistent)
+        // retain all worklets
+        true
+      ) as SerializableRef<TValue>;
+      serializableMappingCache.set(value, clone);
+      serializableMappingCache.set(clone);
 
-  freezeObjectInDev(value);
-  return clone;
+      freezeObjectInDev(value);
+      return clone;
+    }
+  );
 }
 
 /**
@@ -545,9 +576,21 @@ function cloneMap(
 ): SerializableRef<Map<unknown, unknown>> {
   const clonedKeys: unknown[] = [];
   const clonedValues: unknown[] = [];
+  let index = 0;
   for (const [key, element] of value.entries()) {
-    clonedKeys.push(createSerializable(key));
-    clonedValues.push(createSerializable(element));
+    clonedKeys.push(
+      withPathSegment(
+        () => `.keys()[${index}]`,
+        () => createSerializable(key)
+      )
+    );
+    clonedValues.push(
+      withPathSegment(
+        () => `.values()[${index}]`,
+        () => createSerializable(element)
+      )
+    );
+    index++;
   }
   const clone = WorkletsModule.createSerializableMap(clonedKeys, clonedValues);
   serializableMappingCache.set(value, clone);
@@ -559,8 +602,15 @@ function cloneMap(
 
 function cloneSet(value: Set<unknown>): SerializableRef<Set<unknown>> {
   const clonedElements: unknown[] = [];
+  let index = 0;
   for (const element of value) {
-    clonedElements.push(createSerializable(element));
+    clonedElements.push(
+      withPathSegment(
+        () => `.values()[${index}]`,
+        () => createSerializable(element)
+      )
+    );
+    index++;
   }
   const clone = WorkletsModule.createSerializableSet(clonedElements);
   serializableMappingCache.set(value, clone);
@@ -642,7 +692,10 @@ function cloneCustom<TValue extends object, TPacked = unknown>(
   typeId: number
 ): SerializableRef<TValue> {
   const packedData = pack(data);
-  const serialized = createSerializable(packedData);
+  const serialized = withPathSegment(
+    () => '.pack()',
+    () => createSerializable(packedData)
+  );
 
   return WorkletsModule.createCustomSerializable(
     serialized,

--- a/packages/react-native-worklets/src/memory/serializable.native.ts
+++ b/packages/react-native-worklets/src/memory/serializable.native.ts
@@ -594,11 +594,11 @@ function cloneMap(
           createSerializable(element)
         )
       );
+      index++;
     } else {
       clonedKeys.push(createSerializable(key));
       clonedValues.push(createSerializable(element));
     }
-    index++;
   }
   const clone = WorkletsModule.createSerializableMap(clonedKeys, clonedValues);
   serializableMappingCache.set(value, clone);
@@ -618,10 +618,10 @@ function cloneSet(value: Set<unknown>): SerializableRef<Set<unknown>> {
           createSerializable(element)
         )
       );
+      index++;
     } else {
       clonedElements.push(createSerializable(element));
     }
-    index++;
   }
   const clone = WorkletsModule.createSerializableSet(clonedElements);
   serializableMappingCache.set(value, clone);

--- a/packages/react-native-worklets/src/memory/serializable.native.ts
+++ b/packages/react-native-worklets/src/memory/serializable.native.ts
@@ -225,14 +225,17 @@ export function createSerializable<TValue>(
       return cloneCustom(value, pack, i) as SerializableRef<TValue>;
     }
   }
-  const constructorName =
-    (value as { constructor?: { name?: string } })?.constructor?.name ||
-    'unknown';
-  const path = formatSerializationPath();
-  const location = path ? ` It was located at \`${path}\`.` : '';
-  console.warn(
-    `[Worklets] Cannot copy value of type \`${constructorName}\`.${location}`
-  );
+
+  if (__DEV__) {
+    const constructorName =
+      (value as { constructor?: { name?: string } })?.constructor?.name ||
+      'unknown';
+    const path = formatSerializationPath();
+    const location = path ? ` It was located at \`${path}\`.` : '';
+    console.warn(
+      `[Worklets] Cannot copy value of type \`${constructorName}\`.${location}`
+    );
+  }
 
   return cloneUndefined() as SerializableRef<TValue>;
 }


### PR DESCRIPTION
## Summary

Before we threw an error when we couldn't createSerializable
This created too much friction for users migrating from older worklet versions
For now, it will be a warning
To make the warning descriptive I added a path trace for dev mode, which tells the developer exactly where the object that can't be serialized is in the closure


## Test plan

When serializing an object which has a non-serializable deep inside it, we get a warning, and in dev mode, a path to that object

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced development-mode serialization warnings for unsupported/unserializable values.
  * Warnings now include the unsupported value type and an exact location path through nested objects, arrays, maps, sets, worklets, and custom packed data.
  * Unsupported values now fail gracefully by being replaced with an undefined value instead of throwing.

* **Tests**
  * Added/expanded Jest coverage for precise warning paths, dev-only behavior, deep path reconstruction, cyclic inputs, and unsupported types (including map contents).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->