### PR TITLE
fix(Worklets): mock NativeReactNativeFeatureFlagsCxx in Bundle Mode networking

### DIFF
--- a/packages/react-native-worklets/bundleMode/shims/turboModuleRegistryShim.js
+++ b/packages/react-native-worklets/bundleMode/shims/turboModuleRegistryShim.js
@@ -33,7 +33,7 @@ if (
   function getPolyfill(/** @type {string} */ name) {
     if (__DEV__ && !TurboModulesPolyfill?.has(name)) {
       throw new Error(
-        '[Worklets] Accessing TurboModules is not allowed on Worklet Runtimes.'
+        `[Worklets] Accessing TurboModules is not allowed on Worklet Runtimes. Requested: "${String(name)}".`
       );
     } else {
       return TurboModulesPolyfill?.get(name);

--- a/packages/react-native-worklets/src/bundleMode/network.native.ts
+++ b/packages/react-native-worklets/src/bundleMode/network.native.ts
@@ -17,6 +17,10 @@ export function initializeNetworking() {
   );
   TurboModules.set('WebSocketModule', makeMockTurboModule('WebSocketModule'));
   TurboModules.set(
+    'NativeReactNativeFeatureFlagsCxx',
+    new Proxy({}, { get: () => () => undefined })
+  );
+  TurboModules.set(
     'BlobModule',
     makeMockTurboModule('BlobModule', ['addNetworkingHandler'])
   );


### PR DESCRIPTION
## Summary

Stacked on #9897 (targets its branch). With #9897 applied, the first `fetch` on a Worklet Runtime still throws on RN 0.86:

```
[Worklets] Accessing TurboModules is not allowed on Worklet Runtimes.
```

RN 0.86's XHR setup pulls in `EventTarget` → `ReactNativeFeatureFlags`, whose spec module requires `NativeReactNativeFeatureFlagsCxx` at module scope via `TurboModuleRegistry.get`. The shim's dev guard throws for any module absent from `TurboModulesPolyfill`, so `require('…/setUpXHR')` inside `initializeNetworking` fails before XHR is set up.

Changes:

- Register `NativeReactNativeFeatureFlagsCxx` in `initializeNetworking` as a proxy returning `undefined` from every method. `makeMockTurboModule` is not usable here: its proxy throws on any property access regardless of `__DEV__`, and RN reads flags as `NativeReactNativeFeatureFlags?.[flagName]?.() ?? defaultValue` — a native-backed flag consulted on the networking path would crash `fetch`, in release too. Returning `undefined` makes every flag fall back to its default, identical to release behavior when the native module is absent. (On RN 0.86 the only flag on that path today, `enableNativeEventTargetEventDispatching`, happens to be JS-only, which is why the throwing mock would appear to work — until a native-backed flag lands on the path.)
- Include the requested module name in the dev guard error (`Requested: "<name>"`), so the next missing mock identifies itself instead of requiring a debugger session 😁

## Test plan

In an RN 0.86 app with Bundle Mode and `FETCH_PREVIEW_ENABLED`:

```ts
const runtime = createWorkletRuntime({ name: 'background' });
scheduleOnRuntime(runtime, () => {
  'worklet';
  fetch('https://example.com').then((r) => console.log(r.status));
});
```

Before: throws `[Worklets] Accessing TurboModules is not allowed on Worklet Runtimes. Requested: "NativeReactNativeFeatureFlagsCxx".` in dev. After: logs `200`. Verified on device in an Expo SDK 57 / RN 0.86 app running a fetch-heavy pipeline on a Worker Runtime.
