### PR TITLE
chore(rnre): fixed callback type mismatch in commonTypes

### DIFF
--- a/packages/react-native-reanimated/src/hook/commonTypes.ts
+++ b/packages/react-native-reanimated/src/hook/commonTypes.ts
@@ -34,6 +34,9 @@ export type MaybeObserverCleanup = (() => void) | undefined;
 
 export type AnimatedRefObserver = (tag: number | null) => MaybeObserverCleanup;
 
+/** Removes the observer registered via `AnimatedRef.observe`. */
+type ObserverUnsubscribe = () => void;
+
 export type ExtractElementRef<TRef> = TRef extends ElementType
   ? ComponentRef<TRef> extends never // Ensure that ref type is explicitly defined (is not any)
     ? TRef
@@ -54,7 +57,7 @@ export type AnimatedRef<TRef extends InstanceOrElement = HostInstance> = {
     | ShadowNodeWrapper // Native
     | HTMLElement; // web
   current: AnimatedRefCurrent<TRef> | null;
-  observe: (observer: AnimatedRefObserver) => void;
+  observe: (observer: AnimatedRefObserver) => ObserverUnsubscribe;
   getTag?: () => Maybe<number>;
 };
 


### PR DESCRIPTION
## Summary

observe does not return void but () => void.

## Test plan

tsc clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the animated reference observer API to return an unsubscribe function, allowing observers to be removed when no longer needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->