### PR TITLE
fix: Adjust createSerializableInaccessibleObject to the Release createSerializable behavior

### DIFF
--- a/apps/common-app/runtime-tests/worklets/tests/memory/createSerializable.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/memory/createSerializable.test.tsx
@@ -612,28 +612,6 @@ describe('Test createSerializable', () => {
         }).toThrow('Trying to convert a cyclic object');
       });
 
-      test('createSerializableInaccessibleObject', async () => {
-        class Inaccessible {
-          access() {
-            return true;
-          }
-        }
-        const inaccessibleObject = new Inaccessible();
-
-        if (__DEV__) {
-          await expect(() => {
-            createSerializable(inaccessibleObject);
-          }).toThrow('Cannot copy value of type `Inaccessible`.');
-        } else {
-          scheduleOnTarget(() => {
-            'worklet';
-            scheduleOnRN(callbackPass, inaccessibleObject === undefined);
-          });
-          await waitForNotification(PASS_NOTIFICATION);
-          expect(result).toBe(true);
-        }
-      });
-
       test('createSerializableRemoteNamedFunctionSyncCall', async () => {
         function fooFunction() {}
         scheduleOnTarget(() => {

--- a/apps/common-app/runtime-tests/worklets/tests/memory/createSerializable.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/memory/createSerializable.test.tsx
@@ -620,9 +620,18 @@ describe('Test createSerializable', () => {
         }
         const inaccessibleObject = new Inaccessible();
 
-        await expect(() => {
-          createSerializable(inaccessibleObject);
-        }).toThrow('Cannot copy value of type `Inaccessible`.');
+        if (__DEV__) {
+          await expect(() => {
+            createSerializable(inaccessibleObject);
+          }).toThrow('Cannot copy value of type `Inaccessible`.');
+        } else {
+          scheduleOnTarget(() => {
+            'worklet';
+            scheduleOnRN(callbackPass, inaccessibleObject === undefined);
+          });
+          await waitForNotification(PASS_NOTIFICATION);
+          expect(result).toBe(true);
+        }
       });
 
       test('createSerializableRemoteNamedFunctionSyncCall', async () => {


### PR DESCRIPTION
> [!NOTE]
> **This PR description is AI-generated.**

## Summary

#9993 changed `createSerializable` to no longer throw on unserializable values — in development it warns and returns an `undefined` clone, and production builds do the same silently. The `createSerializableInaccessibleObject` runtime test still expects the old throw: Debug passes because ReJest's `toThrow` also captures the warning, but every Release configuration fails deterministically, which the nightly Release legs in #9932 caught first.

I branched the test on `__DEV__` — Debug keeps the throw expectation, while Release asserts the new contract: the unserializable capture reaches the Worklet Runtime as `undefined`.

## Test plan

The Worklets runtime tests suite in `ReleaseRuntimeTests` (via #9937) goes from 2 failures to all green on the Android emulator; Debug legs pass on CI.
