### PR TITLE
fix(Reanimated): use Reanimated Keyframe declaration types

### DIFF
--- a/packages/react-native-reanimated/src/UpdateLayoutAnimations.native.ts
+++ b/packages/react-native-reanimated/src/UpdateLayoutAnimations.native.ts
@@ -7,6 +7,7 @@ import type {
   LayoutAnimationType,
 } from './commonTypes';
 import { configureLayoutAnimationBatch } from './core';
+import type { ReanimatedKeyframe } from './layoutReanimation/animationBuilder/Keyframe';
 
 function createUpdateManager() {
   const animations: LayoutAnimationBatchItem[] = [];
@@ -55,7 +56,7 @@ const updateLayoutAnimationsManager = createUpdateManager();
 export const updateLayoutAnimations: (
   viewTag: number,
   type: LayoutAnimationType,
-  config?: Keyframe | LayoutAnimationFunction,
+  config?: ReanimatedKeyframe | LayoutAnimationFunction,
   isUnmounting?: boolean,
   sharedTransitionTag?: string
 ) => void = (viewTag, type, config, isUnmounting, sharedTransitionTag) =>

--- a/packages/react-native-reanimated/src/UpdateLayoutAnimations.ts
+++ b/packages/react-native-reanimated/src/UpdateLayoutAnimations.ts
@@ -3,6 +3,7 @@ import type {
   LayoutAnimationFunction,
   LayoutAnimationType,
 } from './commonTypes';
+import type { ReanimatedKeyframe } from './layoutReanimation/animationBuilder/Keyframe';
 
 /**
  * Lets you update the current configuration of the layout animation or shared
@@ -23,7 +24,7 @@ import type {
 export const updateLayoutAnimations: (
   viewTag: number,
   type: LayoutAnimationType,
-  config?: Keyframe | LayoutAnimationFunction,
+  config?: ReanimatedKeyframe | LayoutAnimationFunction,
   isUnmounting?: boolean,
   sharedTransitionTag?: string
 ) => void = () => {

--- a/packages/react-native-reanimated/src/animationBuilder.tsx
+++ b/packages/react-native-reanimated/src/animationBuilder.tsx
@@ -7,6 +7,7 @@ import type {
   StyleProps,
 } from './commonTypes';
 import type { NestedArray } from './createAnimatedComponent/commonTypes';
+import type { ReanimatedKeyframe } from './layoutReanimation/animationBuilder/Keyframe';
 
 const mockTargetValues: LayoutAnimationValues = {
   targetOriginX: 0,
@@ -58,7 +59,7 @@ export function checkStyleOverwriting(
   layoutAnimationOrBuilder:
     | ILayoutAnimationBuilder
     | LayoutAnimationFunction
-    | Keyframe,
+    | ReanimatedKeyframe,
   style: NestedArray<StyleProps>,
   displayName: string,
   onWarn: () => void
@@ -102,8 +103,8 @@ export function maybeBuild(
   layoutAnimationOrBuilder:
     | ILayoutAnimationBuilder
     | LayoutAnimationFunction
-    | Keyframe
-): LayoutAnimationFunction | Keyframe {
+    | ReanimatedKeyframe
+): LayoutAnimationFunction | ReanimatedKeyframe {
   if (isAnimationBuilder(layoutAnimationOrBuilder)) {
     const animationFactory = layoutAnimationOrBuilder.build();
     return animationFactory;
@@ -113,7 +114,7 @@ export function maybeBuild(
 }
 
 function isAnimationBuilder(
-  value: ILayoutAnimationBuilder | LayoutAnimationFunction | Keyframe
+  value: ILayoutAnimationBuilder | LayoutAnimationFunction | ReanimatedKeyframe
 ): value is ILayoutAnimationBuilder {
   return 'build' in value && typeof value.build === 'function';
 }

--- a/packages/react-native-reanimated/src/commonTypes.ts
+++ b/packages/react-native-reanimated/src/commonTypes.ts
@@ -15,6 +15,7 @@ import type { Maybe, MutuallyExclusiveUnion } from './common';
 import type { CSSStyle } from './css';
 import type { EasingFunctionFactory } from './Easing';
 import type { AnimatedStyleHandle } from './hook/commonTypes';
+import type { ReanimatedKeyframe } from './layoutReanimation/animationBuilder/Keyframe';
 
 type LayoutAnimationOptions =
   | 'originX'
@@ -168,7 +169,9 @@ export type StylePropsWithArrayTransform = StyleProps & {
 export interface LayoutAnimationBatchItem {
   viewTag: number;
   type: LayoutAnimationType;
-  config: SerializableRef<Keyframe | LayoutAnimationFunction> | undefined;
+  config:
+    | SerializableRef<ReanimatedKeyframe | LayoutAnimationFunction>
+    | undefined;
   sharedTransitionTag?: string;
 }
 

--- a/packages/react-native-reanimated/src/createAnimatedComponent/commonTypes.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/commonTypes.ts
@@ -12,6 +12,7 @@ import type {
 } from '../commonTypes';
 import type { SkipEnteringContext } from '../component/LayoutAnimationConfig';
 import type { BaseAnimationBuilder } from '../layoutReanimation';
+import type { ReanimatedKeyframe } from '../layoutReanimation/animationBuilder/Keyframe';
 import type { SharedTransition } from '../layoutReanimation/SharedTransition';
 import type { ViewDescriptorsSet } from '../ViewDescriptorsSet';
 
@@ -95,14 +96,14 @@ export type AnimatedComponentProps<
     | BaseAnimationBuilder
     | typeof BaseAnimationBuilder
     | EntryExitAnimationFunction
-    | Keyframe
+    | ReanimatedKeyframe
   ) &
     LayoutAnimationStaticContext;
   exiting?: (
     | BaseAnimationBuilder
     | typeof BaseAnimationBuilder
     | EntryExitAnimationFunction
-    | Keyframe
+    | ReanimatedKeyframe
   ) &
     LayoutAnimationStaticContext;
 };
@@ -111,7 +112,7 @@ export type LayoutAnimationOrBuilder = (
   | BaseAnimationBuilder
   | typeof BaseAnimationBuilder
   | EntryExitAnimationFunction
-  | Keyframe
+  | ReanimatedKeyframe
   | ILayoutAnimationBuilder
 ) &
   LayoutAnimationStaticContext;


### PR DESCRIPTION
## Summary

Replace accidental DOM Keyframe types with explicit ReanimatedKeyframe imports.

This prevents generated declarations from depending on the DOM Keyframe global. (we were using `Keyframe` as type without ever importing it from our own files)

Discovered during typecheck test on a separate clean app with `skipLibCheck: false`

## Tests

- yarn workspace react-native-reanimated type:check
- yarn workspace react-native-reanimated type:check:legacy-rn-types
- yarn workspace react-native-reanimated lint