### PR TITLE
ci: Restrict GITHUB_TOKEN permissions in all workflows

### DIFF
--- a/.github/workflows/android-validation.yml
+++ b/.github/workflows/android-validation.yml
@@ -37,6 +37,9 @@ on:
         description: 'Package to validate (react-native-reanimated or react-native-worklets). If not specified, validates both.'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   android-validation:
     if: github.repository == 'software-mansion/react-native-reanimated'

--- a/.github/workflows/apple-validation.yml
+++ b/.github/workflows/apple-validation.yml
@@ -39,6 +39,9 @@ on:
         description: 'Package to validate (react-native-reanimated or react-native-worklets). If not specified, validates both.'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   apple-validation:
     if: github.repository == 'software-mansion/react-native-reanimated'

--- a/.github/workflows/babel-plugin-static-check.yml
+++ b/.github/workflows/babel-plugin-static-check.yml
@@ -18,6 +18,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   babel-plugin-static-check:
     if: github.repository == 'software-mansion/react-native-reanimated'

--- a/.github/workflows/check-branch-changes.yml
+++ b/.github/workflows/check-branch-changes.yml
@@ -9,6 +9,9 @@ on:
       has_changes:
         value: ${{ jobs.check.outputs.has_changes }}
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-ruby-pods-versions.yml
+++ b/.github/workflows/check-ruby-pods-versions.yml
@@ -6,6 +6,9 @@ on:
       - 'apps/**/Gemfile.lock'
       - 'apps/**/**/Podfile.lock'
 
+permissions:
+  contents: read
+
 jobs:
   ruby-pods-version-check:
     if: github.repository == 'software-mansion/react-native-reanimated'

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -15,6 +15,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   docs-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -12,6 +12,9 @@ on:
       - packages/react-native-worklets/compatibility.json
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   docs-publish:
     if: github.repository == 'software-mansion/react-native-reanimated'

--- a/.github/workflows/example-android-build-check.yml
+++ b/.github/workflows/example-android-build-check.yml
@@ -41,6 +41,9 @@ on:
         default: Debug
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   example-android-build-check:
     if: github.repository == 'software-mansion/react-native-reanimated'

--- a/.github/workflows/example-ios-build-check.yml
+++ b/.github/workflows/example-ios-build-check.yml
@@ -49,6 +49,9 @@ on:
         default: Debug
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   example-ios-build-check:
     if: github.repository == 'software-mansion/react-native-reanimated'

--- a/.github/workflows/example-next-build-check-and-test.yml
+++ b/.github/workflows/example-next-build-check-and-test.yml
@@ -14,6 +14,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   example-next-build-check-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/example-tvos-build-check.yml
+++ b/.github/workflows/example-tvos-build-check.yml
@@ -15,6 +15,9 @@ on:
         default: Debug
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   example-tvos-build-check:
     if: github.repository == 'software-mansion/react-native-reanimated'

--- a/.github/workflows/example-typescript-check-and-lint.yml
+++ b/.github/workflows/example-typescript-check-and-lint.yml
@@ -21,6 +21,10 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   changes:
     if: github.repository == 'software-mansion/react-native-reanimated'

--- a/.github/workflows/expo-devclient-build-check-nightly.yml
+++ b/.github/workflows/expo-devclient-build-check-nightly.yml
@@ -11,6 +11,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   expo-devclient-build-check-nightly:
     if: github.repository == 'software-mansion/react-native-reanimated'

--- a/.github/workflows/github-close-when-stale-nightly.yml
+++ b/.github/workflows/github-close-when-stale-nightly.yml
@@ -8,6 +8,10 @@ on:
     types: [created, edited]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   github-close-when-stale-nightly:
     if: github.repository == 'software-mansion/react-native-reanimated'

--- a/.github/workflows/github-issue-platforms-check.yml
+++ b/.github/workflows/github-issue-platforms-check.yml
@@ -3,6 +3,10 @@ on:
   issues:
     types: [opened, edited]
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   github-issue-platforms-check:
     if: ${{ github.repository == 'software-mansion/react-native-reanimated' && !contains(github.event.issue.labels.*.name, 'Maintainer issue') }}

--- a/.github/workflows/github-issue-repro-check.yml
+++ b/.github/workflows/github-issue-repro-check.yml
@@ -5,6 +5,10 @@ on:
   issue_comment:
     types: [created, edited, deleted]
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   github-issue-repro-check:
     if: ${{ github.repository == 'software-mansion/react-native-reanimated' && !contains(github.event.issue.labels.*.name, 'Maintainer issue') }}

--- a/.github/workflows/github-issue-template-check.yml
+++ b/.github/workflows/github-issue-template-check.yml
@@ -5,6 +5,10 @@ on:
   issues:
     types: [opened, edited]
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   github-issue-template-check:
     if: ${{ github.repository == 'software-mansion/react-native-reanimated' && !contains(github.event.issue.labels.*.name, 'Maintainer issue') }}

--- a/.github/workflows/github-pull-request-description-format.yml
+++ b/.github/workflows/github-pull-request-description-format.yml
@@ -4,6 +4,9 @@ on:
     types:
       - opened
 
+permissions:
+  pull-requests: write
+
 jobs:
   github-pull-request-description-format:
     runs-on: ubuntu-latest

--- a/.github/workflows/main-branch-build.yml
+++ b/.github/workflows/main-branch-build.yml
@@ -8,6 +8,9 @@ on:
       - .github/workflows/main-branch-build.yml
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   android:
     if: github.repository == 'software-mansion/react-native-reanimated'

--- a/.github/workflows/monorepo-static-checks.yml
+++ b/.github/workflows/monorepo-static-checks.yml
@@ -18,6 +18,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   monorepo-static-checks:
     if: github.repository == 'software-mansion/react-native-reanimated'

--- a/.github/workflows/npm-package-publish.yml
+++ b/.github/workflows/npm-package-publish.yml
@@ -35,6 +35,10 @@ on:
         type: string
         default: ''
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/react-native-nightly-reanimated-build-check-nightly.yml
+++ b/.github/workflows/react-native-nightly-reanimated-build-check-nightly.yml
@@ -10,6 +10,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   react-native-nightly-reanimated-build-check:
     if: github.repository == 'software-mansion/react-native-reanimated'

--- a/.github/workflows/reanimated-compatibility-check-nightly.yml
+++ b/.github/workflows/reanimated-compatibility-check-nightly.yml
@@ -10,6 +10,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   read-compatibility-json:
     if: github.repository == 'software-mansion/react-native-reanimated'

--- a/.github/workflows/reanimated-static-checks.yml
+++ b/.github/workflows/reanimated-static-checks.yml
@@ -12,6 +12,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   reanimated-static-checks:
     if: github.repository == 'software-mansion/react-native-reanimated'

--- a/.github/workflows/reanimated-typescript-compatibility-test-nightly.yml
+++ b/.github/workflows/reanimated-typescript-compatibility-test-nightly.yml
@@ -10,6 +10,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   read-compatibility-json:
     if: github.repository == 'software-mansion/react-native-reanimated'

--- a/.github/workflows/reanimated-worklets-compatibility-check.yml
+++ b/.github/workflows/reanimated-worklets-compatibility-check.yml
@@ -17,6 +17,9 @@ on:
   schedule:
     - cron: '30 2 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   read-compatibility-json:
     if: github.repository == 'software-mansion/react-native-reanimated'

--- a/.github/workflows/runtime-tests-android.yml
+++ b/.github/workflows/runtime-tests-android.yml
@@ -29,6 +29,9 @@ on:
         type: string
         default: DebugRuntimeTests
 
+permissions:
+  contents: read
+
 jobs:
   runtime-tests-android:
     if: github.repository == 'software-mansion/react-native-reanimated'

--- a/.github/workflows/runtime-tests-ios.yml
+++ b/.github/workflows/runtime-tests-ios.yml
@@ -29,6 +29,9 @@ on:
         type: string
         default: DebugRuntimeTests
 
+permissions:
+  contents: read
+
 jobs:
   runtime-tests-ios:
     if: github.repository == 'software-mansion/react-native-reanimated'

--- a/.github/workflows/slack-integration.yml
+++ b/.github/workflows/slack-integration.yml
@@ -11,6 +11,9 @@ on:
   pull_request_target:
     types: [opened]
 
+permissions:
+  contents: read
+
 jobs:
   daily-status-report:
     if: github.repository == 'software-mansion/react-native-reanimated' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')

--- a/.github/workflows/url-validation-nightly.yml
+++ b/.github/workflows/url-validation-nightly.yml
@@ -10,6 +10,9 @@ on:
     - cron: '37 19 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   url-validation-nightly:
     if: github.repository == 'software-mansion/react-native-reanimated'

--- a/.github/workflows/use-frameworks-reanimated-build-check-nightly.yml
+++ b/.github/workflows/use-frameworks-reanimated-build-check-nightly.yml
@@ -11,6 +11,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   use-frameworks-reanimated-build-check-nightly:
     if: github.repository == 'software-mansion/react-native-reanimated'

--- a/.github/workflows/windows-hosted-app-reanimated-build-check-nightly.yml
+++ b/.github/workflows/windows-hosted-app-reanimated-build-check-nightly.yml
@@ -10,6 +10,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   windows-hosted-app-reanimated-build-check-nightly:
     if: github.repository == 'software-mansion/react-native-reanimated'

--- a/.github/workflows/worklets-static-checks.yml
+++ b/.github/workflows/worklets-static-checks.yml
@@ -12,6 +12,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   worklets-static-checks:
     if: github.repository == 'software-mansion/react-native-reanimated'

--- a/.github/workflows/yarn-validation.yml
+++ b/.github/workflows/yarn-validation.yml
@@ -22,6 +22,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   yarn-validation:
     if: github.repository == 'software-mansion/react-native-reanimated'


### PR DESCRIPTION
> [!NOTE]
> **This PR description is AI-generated.**

## Summary

Most workflows declared no `permissions:` block, so every run inherited the repository default `GITHUB_TOKEN` grants — write-capable in jobs that only build and test, and readable by all the third-party code they execute (npm lifecycle scripts, Gradle, CocoaPods, pinned actions). A zizmor finding on #9932 flagged one workflow; this applies the same least-privilege hardening across the board.

I audited all 40 workflows (and the composite actions they use, plus the pinned sources of external actions) for actual token usage and added the minimal top-level block to each: `contents: read` for the 26 build/test workflows, and specific grants where the evidence demands them — `contents: write` for the docs deploy (pushes `gh-pages`), `issues: write` for the four swmansion-bot triage workflows, `pull-requests: write` for the PR-description formatter (which never reads the repo, so it gets no `contents` grant), `pull-requests: read` for `dorny/paths-filter`, and an explicit `contents: read` + `id-token: write` in the reusable npm publish workflow matching what its callers already grant.

The four npm publish workflows and the PR labeler already carried minimal blocks and are untouched, as is the fully commented-out macOS check.

## Test plan

The `pull_request`-triggered workflows run on this PR with the restricted token. The schedule- and issue-triggered ones can't run here; their grants are matched to the API calls in their pinned action sources (`swmansion-bot`, `npm-package-publish`, `github-pages-deploy-action`).
