### PR TITLE
feat(repo): bundle size measurement

### DIFF
--- a/packages/react-native-worklets/plugin/index.js
+++ b/packages/react-native-worklets/plugin/index.js
@@ -1453,7 +1453,7 @@ var require_generate = __commonJS({
     var imports_1 = require_imports();
     var types_2 = require_types();
     function generateWorkletFile(moduleBindingsToImport, relativeBindingsToImport, factory, workletHash, state) {
-      var _a;
+      var _a, _b;
       const libraryImports = Array.from(moduleBindingsToImport).filter((binding) => (binding.path.isImportSpecifier() || binding.path.isImportDefaultSpecifier()) && binding.path.parentPath.isImportDeclaration()).map((binding) => (0, types_12.importDeclaration)([(0, types_12.cloneNode)(binding.path.node, true)], (0, types_12.stringLiteral)(binding.path.parentPath.node.source.value)));
       const filesDirPath = (0, path_1.resolve)((0, path_1.dirname)(require.resolve("react-native-worklets/package.json")), types_2.generatedWorkletsDir);
       const relativeImports = Array.from(relativeBindingsToImport).filter((binding) => binding.path.isImportSpecifier() && binding.path.parentPath.isImportDeclaration()).map((binding) => (0, types_12.importDeclaration)([(0, types_12.cloneNode)(binding.path.node, true)], (0, imports_1.createImportPathLiteral)(binding.path.parentPath.node.source.value, state)));
@@ -1470,7 +1470,9 @@ var require_generate = __commonJS({
       })) === null || _a === void 0 ? void 0 : _a.code;
       (0, assert_1.default)(transformedProg, "[Worklets] `transformedProg` is undefined.");
       const dedicatedFilePath = (0, path_1.resolve)(filesDirPath, `${workletHash}.js`);
-      (0, fs_1.writeFileSync)(dedicatedFilePath, transformedProg);
+      const output = process.env.WORKLETS_WRITE_ORIGIN ? `// __workletOrigin: ${(_b = state.file.opts.filename) !== null && _b !== void 0 ? _b : "unknown"}
+${transformedProg}` : transformedProg;
+      (0, fs_1.writeFileSync)(dedicatedFilePath, output);
     }
     function resolvePresetTypescript() {
       try {

--- a/packages/react-native-worklets/plugin/src/generate.ts
+++ b/packages/react-native-worklets/plugin/src/generate.ts
@@ -84,7 +84,11 @@ export function generateWorkletFile(
 
   const dedicatedFilePath = resolve(filesDirPath, `${workletHash}.js`);
 
-  writeFileSync(dedicatedFilePath, transformedProg);
+  const output = process.env.WORKLETS_WRITE_ORIGIN
+    ? `// __workletOrigin: ${state.file.opts.filename ?? 'unknown'}\n${transformedProg}`
+    : transformedProg;
+
+  writeFileSync(dedicatedFilePath, output);
 }
 
 function resolvePresetTypescript(): string {

--- a/scripts/measure-bundle-cost.js
+++ b/scripts/measure-bundle-cost.js
@@ -73,7 +73,6 @@ function parseArgs(argv) {
   const args = {
     platforms: [],
     bundleMode: true,
-    attributions: false,
     json: false,
     keep: false,
   };
@@ -88,11 +87,6 @@ function parseArgs(argv) {
         a.slice('--bundle-mode='.length),
         'bundle-mode'
       );
-    } else if (a.startsWith('--attributions=')) {
-      args.attributions = parseBool(
-        a.slice('--attributions='.length),
-        'attributions'
-      );
     } else if (a.startsWith('--platform=')) {
       args.platforms = a.slice('--platform='.length).split(',').filter(Boolean);
     } else if (!a.startsWith('-')) {
@@ -102,14 +96,6 @@ function parseArgs(argv) {
     }
   }
   if (args.platforms.length === 0) args.platforms = ['ios'];
-
-  if (args.attributions && !args.bundleMode) {
-    fail(
-      '--attributions=true requires --bundle-mode=true.\n' +
-        'Worklets are only extracted into dedicated files (and thus only need ' +
-        're-attribution) in bundle mode.'
-    );
-  }
   return args;
 }
 
@@ -124,21 +110,9 @@ Options:
   --platform=<ios,android>   Platform(s) to bundle (default: ios). May also be
                              passed as positional args.
   --bundle-mode=<bool>       Build with worklets bundle mode on (default: true).
-                             Verified against the built bundle; if it does not
-                             match, scripts/toggle-bundle-mode.sh is run and the
-                             bundle rebuilt (and restored afterwards).
-  --attributions=<bool>      Credit generated worklets back to the library that
-                             authored them instead of react-native-worklets
-                             (default: false). Only valid with bundle mode on.
   --json                     Emit machine-readable JSON instead of a table.
   --keep                     Keep the generated bundle/source-map artifacts.
-  -h, --help                 Show this help.
-
-Valid combinations:
-  --bundle-mode=true  --attributions=false   (default) worklets counted raw
-  --bundle-mode=true  --attributions=true    worklets credited to their author
-  --bundle-mode=false                        no bundle mode (plain tree-shaking)
-  --bundle-mode=false --attributions=true    INVALID`
+  -h, --help                 Show this help.`
   );
 }
 
@@ -233,12 +207,12 @@ function buildBundle(platform, outDir, attribute) {
  *
  * @param {string} platform
  * @param {string} outDir
- * @param {{ bundleMode: boolean; attributions: boolean }} args
+ * @param {{ bundleMode: boolean }} args
  * @param {{ toggled: boolean }} state
  * @returns {{ bundle: string; map: string }}
  */
 function buildInRequestedMode(platform, outDir, args, state) {
-  const built = buildBundle(platform, outDir, args.attributions);
+  const built = buildBundle(platform, outDir, args.bundleMode);
   if (detectBundleMode(built.bundle) === args.bundleMode) return built;
 
   if (state.toggled) {
@@ -320,7 +294,7 @@ async function main() {
 
   const state = { toggled: false };
 
-  const modeLabel = `bundle-mode=${args.bundleMode}, attributions=${args.attributions}`;
+  const modeLabel = `bundle-mode=${args.bundleMode}`;
   console.error(`• ${modeLabel}`);
 
   /** @type {Record<string, any>} */
@@ -331,7 +305,7 @@ async function main() {
       const { total, groups } = await attributeBundle(
         bundle,
         map,
-        args.attributions
+        args.bundleMode
       );
       report[platform] = {
         total,

--- a/scripts/measure-bundle-cost.js
+++ b/scripts/measure-bundle-cost.js
@@ -177,10 +177,17 @@ function isBundleModeOn() {
  */
 function setBundleMode(on) {
   if (isBundleModeOn() === on) return false;
-  const ok = on
-    ? PATCH_FILES.every((p) => git(['apply', p]))
-    : PATCH_FILES.every((p) => git(['apply', '--reverse', p]));
-  if (!ok) throw new Error('failed to toggle bundle-mode patches');
+  const apply = on ? ['apply'] : ['apply', '--reverse'];
+  const undo = on ? ['apply', '--reverse'] : ['apply'];
+  const done = [];
+  for (const p of PATCH_FILES) {
+    if (git([...apply, p])) {
+      done.push(p);
+      continue;
+    }
+    for (const d of done.reverse()) git([...undo, d]);
+    throw new Error('failed to toggle bundle-mode patches');
+  }
   return true;
 }
 

--- a/scripts/measure-bundle-cost.js
+++ b/scripts/measure-bundle-cost.js
@@ -229,6 +229,45 @@ function buildInRequestedMode(platform, outDir, args, state) {
   return buildInRequestedMode(platform, outDir, args, state);
 }
 
+/**
+ * Read every mapping of a flat source map as `[line, column, source]`.
+ *
+ * @param {any} map
+ * @returns {Promise<[number, number, string | null][]>}
+ */
+async function readFlatMappings(map) {
+  const consumer = await new SourceMapConsumer(map);
+  /** @type {[number, number, string | null][]} */
+  const mappings = [];
+  consumer.eachMapping(
+    (m) => mappings.push([m.generatedLine, m.generatedColumn, m.source]),
+    null,
+    SourceMapConsumer.GENERATED_ORDER
+  );
+  if (typeof consumer.destroy === 'function') consumer.destroy();
+  return mappings;
+}
+
+/**
+ * Read every mapping of a source map, in generated order.
+ * @param {any} map
+ * @returns {Promise<[number, number, string | null][]>}
+ */
+async function collectMappings(map) {
+  if (!map.sections) return readFlatMappings(map);
+
+  /** @type {[number, number, string | null][]} */
+  const mappings = [];
+  for (const section of map.sections) {
+    const { line, column } = section.offset;
+    for (const [l, c, source] of await readFlatMappings(section.map)) {
+      mappings.push([l + line, l === 1 ? c + column : c, source]);
+    }
+  }
+  mappings.sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+  return mappings;
+}
+
 async function attributeBundle(bundleFile, mapFile, attribute) {
   const code = fs.readFileSync(bundleFile, 'utf8');
   const lines = code.split('\n');
@@ -244,16 +283,8 @@ async function attributeBundle(bundleFile, mapFile, attribute) {
     lineStart[line] +
     Buffer.byteLength(lines[line - 1].slice(0, column), 'utf8');
 
-  const consumer = await new SourceMapConsumer(
+  const mappings = await collectMappings(
     JSON.parse(fs.readFileSync(mapFile, 'utf8'))
-  );
-
-  /** @type {[number, number, string | null][]} */
-  const mappings = [];
-  consumer.eachMapping(
-    (m) => mappings.push([m.generatedLine, m.generatedColumn, m.source]),
-    null,
-    SourceMapConsumer.GENERATED_ORDER
   );
 
   /** @type {Record<string, number>} */
@@ -269,7 +300,6 @@ async function attributeBundle(bundleFile, mapFile, attribute) {
     groups[classify(source, attribute)] += size;
   }
 
-  if (typeof consumer.destroy === 'function') consumer.destroy();
   return { total, groups };
 }
 

--- a/scripts/measure-bundle-cost.js
+++ b/scripts/measure-bundle-cost.js
@@ -124,6 +124,9 @@ Options:
   --platform=<ios,android>   Platform(s) to bundle (default: ios). May also be
                              passed as positional args.
   --bundle-mode=<bool>       Build with worklets bundle mode on (default: true).
+                             Verified against the built bundle; if it does not
+                             match, scripts/toggle-bundle-mode.sh is run and the
+                             bundle rebuilt (and restored afterwards).
   --attributions=<bool>      Credit generated worklets back to the library that
                              authored them instead of react-native-worklets
                              (default: false). Only valid with bundle mode on.
@@ -139,52 +142,43 @@ Valid combinations:
   );
 }
 
-const PATCH_FILES = [
-  'fabric-example-metro-config.patch',
-  'fabric-example-babel-config.patch',
-].map((f) => path.join(MONOREPO_ROOT, 'scripts', 'patches', f));
+const TOGGLE_SCRIPT = path.join(
+  MONOREPO_ROOT,
+  'scripts',
+  'toggle-bundle-mode.sh'
+);
 
-function git(gitArgs) {
-  return (
-    spawnSync('git', gitArgs, { cwd: MONOREPO_ROOT, stdio: 'ignore' })
-      .status === 0
-  );
-}
-
-/** @returns {boolean} True if the bundle-mode patches are currently applied. */
-function isBundleModeOn() {
-  const applied = PATCH_FILES.every((p) =>
-    git(['apply', '--reverse', '--check', p])
-  );
-  const reversed = PATCH_FILES.every((p) => git(['apply', '--check', p]));
-  if (applied && !reversed) return true;
-  if (reversed && !applied) return false;
-  throw new Error(
-    'bundle-mode patches are in a mixed/unknown state; fix ' +
-      'apps/fabric-example/{metro,babel}.config.js manually and retry.'
-  );
-}
+const BUNDLE_MODE_ASSIGN =
+  /_WORKLETS_BUNDLE_MODE_ENABLED\s*=\s*(!0|!1|true|false)/g;
 
 /**
- * Bring bundle mode to `on`.
- *
- * @param {boolean} on
- * @returns {boolean} Whether anything changed.
+ * @param {string} bundleFile
+ * @returns {boolean} Whether the built bundle has bundle mode enabled.
  */
-function setBundleMode(on) {
-  if (isBundleModeOn() === on) return false;
-  const apply = on ? ['apply'] : ['apply', '--reverse'];
-  const undo = on ? ['apply', '--reverse'] : ['apply'];
-  const done = [];
-  for (const p of PATCH_FILES) {
-    if (git([...apply, p])) {
-      done.push(p);
-      continue;
-    }
-    for (const d of done.reverse()) git([...undo, d]);
-    throw new Error('failed to toggle bundle-mode patches');
+function detectBundleMode(bundleFile) {
+  const matches = [
+    ...fs.readFileSync(bundleFile, 'utf8').matchAll(BUNDLE_MODE_ASSIGN),
+  ];
+  if (matches.length === 0) {
+    throw new Error(
+      'could not find _WORKLETS_BUNDLE_MODE_ENABLED in the bundle; ' +
+        'is react-native-worklets part of the app?'
+    );
   }
-  return true;
+  return matches.some((m) => m[1] === '!0' || m[1] === 'true');
+}
+
+function toggleBundleMode() {
+  const res = spawnSync('bash', [TOGGLE_SCRIPT], {
+    cwd: MONOREPO_ROOT,
+    stdio: ['ignore', 2, 2],
+  });
+  if (res.error) throw res.error;
+  if (res.status !== 0) {
+    throw new Error(
+      `scripts/toggle-bundle-mode.sh failed with exit code ${res.status}`
+    );
+  }
 }
 
 /**
@@ -231,6 +225,34 @@ function buildBundle(platform, outDir, attribute) {
     );
   }
   return { bundle, map };
+}
+
+/**
+ * Build `platform` and make sure the result really is in the requested bundle
+ * mode, toggling the repo once and rebuilding if it isn't.
+ *
+ * @param {string} platform
+ * @param {string} outDir
+ * @param {{ bundleMode: boolean; attributions: boolean }} args
+ * @param {{ toggled: boolean }} state
+ * @returns {{ bundle: string; map: string }}
+ */
+function buildInRequestedMode(platform, outDir, args, state) {
+  const built = buildBundle(platform, outDir, args.attributions);
+  if (detectBundleMode(built.bundle) === args.bundleMode) return built;
+
+  if (state.toggled) {
+    throw new Error(
+      'scripts/toggle-bundle-mode.sh ran but the bundle is still ' +
+        `bundle-mode=${!args.bundleMode}`
+    );
+  }
+  console.error(
+    `• bundle came out bundle-mode=${!args.bundleMode}, toggling and rebuilding…`
+  );
+  toggleBundleMode();
+  state.toggled = true;
+  return buildInRequestedMode(platform, outDir, args, state);
 }
 
 async function attributeBundle(bundleFile, mapFile, attribute) {
@@ -296,8 +318,7 @@ async function main() {
   const args = parseArgs(process.argv.slice(2));
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'reanimated-bundle-cost-'));
 
-  const originalBundleMode = isBundleModeOn();
-  let toggled = false;
+  const state = { toggled: false };
 
   const modeLabel = `bundle-mode=${args.bundleMode}, attributions=${args.attributions}`;
   console.error(`• ${modeLabel}`);
@@ -305,9 +326,8 @@ async function main() {
   /** @type {Record<string, any>} */
   const report = {};
   try {
-    toggled = setBundleMode(args.bundleMode);
     for (const platform of args.platforms) {
-      const { bundle, map } = buildBundle(platform, tmp, args.attributions);
+      const { bundle, map } = buildInRequestedMode(platform, tmp, args, state);
       const { total, groups } = await attributeBundle(
         bundle,
         map,
@@ -320,7 +340,7 @@ async function main() {
       };
     }
   } finally {
-    if (toggled) setBundleMode(originalBundleMode);
+    if (state.toggled) toggleBundleMode();
     if (args.keep) console.error(`\nartifacts kept in ${tmp}`);
     else fs.rmSync(tmp, { recursive: true, force: true });
   }

--- a/scripts/measure-bundle-cost.js
+++ b/scripts/measure-bundle-cost.js
@@ -1,0 +1,337 @@
+#!/usr/bin/env node
+// @ts-check
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const zlib = require('zlib');
+const { spawnSync } = require('child_process');
+const { SourceMapConsumer } = require('source-map');
+
+const MONOREPO_ROOT = path.resolve(__dirname, '..');
+const FABRIC_APP = path.join(MONOREPO_ROOT, 'apps', 'fabric-example');
+
+/** @type {{ label: string; test: RegExp }[]} * */
+const GROUPS = [
+  {
+    label: 'react-native-worklets',
+    test: /(?:node_modules|packages)[/\\]react-native-worklets[/\\]/,
+  },
+  {
+    label: 'react-native-reanimated',
+    test: /(?:node_modules|packages)[/\\]react-native-reanimated[/\\]/,
+  },
+];
+
+const WORKLETS_GEN = /[/\\]react-native-worklets[/\\]\.worklets[/\\]/;
+const ORIGIN_RE = /^\/\/ __workletOrigin: (.*)$/m;
+/** @type {Map<string, string>} */
+const originCache = new Map();
+
+function resolveWorkletOrigin(file, seen) {
+  if (originCache.has(file)) return originCache.get(file);
+  let origin = file;
+  try {
+    const match = fs.readFileSync(file, 'utf8').match(ORIGIN_RE);
+    if (match) origin = match[1].trim();
+  } catch {
+    throw new Error(
+      'worklet file was cleaned up while running the bundle analysis'
+    );
+  }
+  if (origin !== file && WORKLETS_GEN.test(origin)) {
+    seen = seen || new Set();
+    if (!seen.has(origin)) {
+      seen.add(origin);
+      origin = resolveWorkletOrigin(origin, seen);
+    }
+  }
+  originCache.set(file, origin);
+  return origin;
+}
+
+function classify(source, attribute) {
+  if (!source) return 'other';
+  const resolved =
+    attribute && WORKLETS_GEN.test(source)
+      ? resolveWorkletOrigin(source)
+      : source;
+  const group = GROUPS.find((g) => g.test.test(resolved));
+  return group ? group.label : 'other';
+}
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+function parseBool(value, name) {
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  fail(`--${name} expects true or false (got "${value}")`);
+  return false; // unreachable
+}
+
+function parseArgs(argv) {
+  const args = {
+    platforms: [],
+    bundleMode: true,
+    attributions: false,
+    json: false,
+    keep: false,
+  };
+  for (const a of argv) {
+    if (a === '--json') args.json = true;
+    else if (a === '--keep') args.keep = true;
+    else if (a === '-h' || a === '--help') {
+      printHelp();
+      process.exit(0);
+    } else if (a.startsWith('--bundle-mode=')) {
+      args.bundleMode = parseBool(
+        a.slice('--bundle-mode='.length),
+        'bundle-mode'
+      );
+    } else if (a.startsWith('--attributions=')) {
+      args.attributions = parseBool(
+        a.slice('--attributions='.length),
+        'attributions'
+      );
+    } else if (a.startsWith('--platform=')) {
+      args.platforms = a.slice('--platform='.length).split(',').filter(Boolean);
+    } else if (!a.startsWith('-')) {
+      args.platforms.push(a);
+    } else {
+      fail(`Unknown argument: ${a}\nRun with --help for usage.`);
+    }
+  }
+  if (args.platforms.length === 0) args.platforms = ['ios'];
+
+  if (args.attributions && !args.bundleMode) {
+    fail(
+      '--attributions=true requires --bundle-mode=true.\n' +
+        'Worklets are only extracted into dedicated files (and thus only need ' +
+        're-attribution) in bundle mode.'
+    );
+  }
+  return args;
+}
+
+function printHelp() {
+  console.log(
+    `Measure per-library bundle cost of the fabric example app.
+
+Usage:
+  node scripts/measure-bundle-cost.js [options] [platforms...]
+
+Options:
+  --platform=<ios,android>   Platform(s) to bundle (default: ios). May also be
+                             passed as positional args.
+  --bundle-mode=<bool>       Build with worklets bundle mode on (default: true).
+  --attributions=<bool>      Credit generated worklets back to the library that
+                             authored them instead of react-native-worklets
+                             (default: false). Only valid with bundle mode on.
+  --json                     Emit machine-readable JSON instead of a table.
+  --keep                     Keep the generated bundle/source-map artifacts.
+  -h, --help                 Show this help.
+
+Valid combinations:
+  --bundle-mode=true  --attributions=false   (default) worklets counted raw
+  --bundle-mode=true  --attributions=true    worklets credited to their author
+  --bundle-mode=false                        no bundle mode (plain tree-shaking)
+  --bundle-mode=false --attributions=true    INVALID`
+  );
+}
+
+const PATCH_FILES = [
+  'fabric-example-metro-config.patch',
+  'fabric-example-babel-config.patch',
+].map((f) => path.join(MONOREPO_ROOT, 'scripts', 'patches', f));
+
+function git(gitArgs) {
+  return (
+    spawnSync('git', gitArgs, { cwd: MONOREPO_ROOT, stdio: 'ignore' })
+      .status === 0
+  );
+}
+
+/** @returns {boolean} True if the bundle-mode patches are currently applied. */
+function isBundleModeOn() {
+  const applied = PATCH_FILES.every((p) =>
+    git(['apply', '--reverse', '--check', p])
+  );
+  const reversed = PATCH_FILES.every((p) => git(['apply', '--check', p]));
+  if (applied && !reversed) return true;
+  if (reversed && !applied) return false;
+  throw new Error(
+    'bundle-mode patches are in a mixed/unknown state; fix ' +
+      'apps/fabric-example/{metro,babel}.config.js manually and retry.'
+  );
+}
+
+/**
+ * Bring bundle mode to `on`.
+ *
+ * @param {boolean} on
+ * @returns {boolean} Whether anything changed.
+ */
+function setBundleMode(on) {
+  if (isBundleModeOn() === on) return false;
+  const ok = on
+    ? PATCH_FILES.every((p) => git(['apply', p]))
+    : PATCH_FILES.every((p) => git(['apply', '--reverse', p]));
+  if (!ok) throw new Error('failed to toggle bundle-mode patches');
+  return true;
+}
+
+/**
+ * Build a minified production bundle with a source map for `platform`.
+ *
+ * @param {string} platform
+ * @param {string} outDir
+ * @param {boolean} attribute
+ * @returns {{ bundle: string; map: string }}
+ */
+function buildBundle(platform, outDir, attribute) {
+  const bundle = path.join(outDir, `${platform}.bundle.js`);
+  const map = `${bundle}.map`;
+  console.error(`• building ${platform} bundle…`);
+  const res = spawnSync(
+    'yarn',
+    [
+      'react-native',
+      'bundle',
+      '--entry-file',
+      'App.tsx',
+      '--platform',
+      platform,
+      '--bundle-output',
+      bundle,
+      '--sourcemap-output',
+      map,
+      '--dev=false',
+      '--minify=true',
+      '--reset-cache',
+    ],
+    {
+      cwd: FABRIC_APP,
+      stdio: ['ignore', 'ignore', 'inherit'],
+      env: attribute
+        ? { ...process.env, WORKLETS_WRITE_ORIGIN: '1' }
+        : process.env,
+    }
+  );
+  if (res.error) throw res.error;
+  if (res.status !== 0) {
+    throw new Error(
+      `react-native bundle (${platform}) failed with exit code ${res.status}`
+    );
+  }
+  return { bundle, map };
+}
+
+async function attributeBundle(bundleFile, mapFile, attribute) {
+  const code = fs.readFileSync(bundleFile, 'utf8');
+  const lines = code.split('\n');
+
+  const lineStart = [0, 0];
+  let offset = 0;
+  for (let i = 0; i < lines.length; i++) {
+    lineStart[i + 1] = offset;
+    offset += Buffer.byteLength(lines[i], 'utf8') + 1; // +1 for the '\n'
+  }
+  const total = Buffer.byteLength(code, 'utf8');
+  const byteOf = (line, column) =>
+    lineStart[line] +
+    Buffer.byteLength(lines[line - 1].slice(0, column), 'utf8');
+
+  const consumer = await new SourceMapConsumer(
+    JSON.parse(fs.readFileSync(mapFile, 'utf8'))
+  );
+
+  /** @type {[number, number, string | null][]} */
+  const mappings = [];
+  consumer.eachMapping(
+    (m) => mappings.push([m.generatedLine, m.generatedColumn, m.source]),
+    null,
+    SourceMapConsumer.GENERATED_ORDER
+  );
+
+  /** @type {Record<string, number>} */
+  const groups = { other: 0 };
+  for (const g of GROUPS) groups[g.label] = 0;
+
+  for (let i = 0; i < mappings.length; i++) {
+    const [line, column, source] = mappings[i];
+    const start = byteOf(line, column);
+    const next = mappings[i + 1];
+    const end = next ? byteOf(next[0], next[1]) : total;
+    const size = Math.max(0, end - start);
+    groups[classify(source, attribute)] += size;
+  }
+
+  if (typeof consumer.destroy === 'function') consumer.destroy();
+  return { total, groups };
+}
+
+const mb = (n) => `${(n / 1024 / 1024).toFixed(2)} MB`;
+const pct = (n, total) => `${total ? ((n / total) * 100).toFixed(1) : '0.0'}%`;
+const gzipSize = (buf) => zlib.gzipSync(buf, { level: 9 }).length;
+
+function printReport(title, result) {
+  const { total, gzip, groups } = result;
+  console.log(`\n${title}    total ${mb(total)} (${mb(gzip)} gzipped)`);
+  const rows = Object.entries(groups).sort((a, b) => b[1] - a[1]);
+  for (const [label, size] of rows) {
+    console.log(
+      `  ${label.padEnd(26)} ${mb(size).padStart(9)}  ${pct(size, total).padStart(6)}`
+    );
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'reanimated-bundle-cost-'));
+
+  const originalBundleMode = isBundleModeOn();
+  let toggled = false;
+
+  const modeLabel = `bundle-mode=${args.bundleMode}, attributions=${args.attributions}`;
+  console.error(`• ${modeLabel}`);
+
+  /** @type {Record<string, any>} */
+  const report = {};
+  try {
+    toggled = setBundleMode(args.bundleMode);
+    for (const platform of args.platforms) {
+      const { bundle, map } = buildBundle(platform, tmp, args.attributions);
+      const { total, groups } = await attributeBundle(
+        bundle,
+        map,
+        args.attributions
+      );
+      report[platform] = {
+        total,
+        gzip: gzipSize(fs.readFileSync(bundle)),
+        groups,
+      };
+    }
+  } finally {
+    if (toggled) setBundleMode(originalBundleMode);
+    if (args.keep) console.error(`\nartifacts kept in ${tmp}`);
+    else fs.rmSync(tmp, { recursive: true, force: true });
+  }
+
+  if (args.json) {
+    console.log(JSON.stringify({ mode: modeLabel, ...report }, null, 2));
+  } else {
+    for (const [title, result] of Object.entries(report)) {
+      printReport(`${title}  [${modeLabel}]`, result);
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(err.message || err);
+  process.exit(1);
+});

--- a/scripts/measure-bundle-cost.js
+++ b/scripts/measure-bundle-cost.js
@@ -1,7 +1,3 @@
-#!/usr/bin/env node
-// @ts-check
-'use strict';
-
 const fs = require('fs');
 const os = require('os');
 const path = require('path');

--- a/scripts/measure-bundle-cost.mts
+++ b/scripts/measure-bundle-cost.mts
@@ -1,15 +1,46 @@
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
-const zlib = require('zlib');
-const { spawnSync } = require('child_process');
-const { SourceMapConsumer } = require('source-map');
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import zlib from 'node:zlib';
+import { SourceMapConsumer as UntypedSourceMapConsumer } from 'source-map';
 
-const MONOREPO_ROOT = path.resolve(__dirname, '..');
+type Mapping = [number, number, string | null];
+
+interface MappingItem {
+  generatedLine: number;
+  generatedColumn: number;
+  source: string | null;
+}
+
+interface Consumer {
+  eachMapping(
+    callback: (mapping: MappingItem) => void,
+    context: unknown,
+    order: number
+  ): void;
+  destroy?: () => void;
+}
+
+interface SourceMapConsumerConstructor {
+  new (map: unknown): Consumer | Promise<Consumer>;
+  GENERATED_ORDER: number;
+}
+
+const SourceMapConsumer =
+  UntypedSourceMapConsumer as SourceMapConsumerConstructor;
+
+interface RawSourceMap {
+  sections?: {
+    offset: { line: number; column: number };
+    map: RawSourceMap;
+  }[];
+}
+
+const MONOREPO_ROOT = path.resolve(import.meta.dirname, '..');
 const FABRIC_APP = path.join(MONOREPO_ROOT, 'apps', 'fabric-example');
 
-/** @type {{ label: string; test: RegExp }[]} * */
-const GROUPS = [
+const GROUPS: { label: string; test: RegExp }[] = [
   {
     label: 'react-native-worklets',
     test: /(?:node_modules|packages)[/\\]react-native-worklets[/\\]/,
@@ -22,11 +53,11 @@ const GROUPS = [
 
 const WORKLETS_GEN = /[/\\]react-native-worklets[/\\]\.worklets[/\\]/;
 const ORIGIN_RE = /^\/\/ __workletOrigin: (.*)$/m;
-/** @type {Map<string, string>} */
-const originCache = new Map();
+const originCache = new Map<string, string>();
 
-function resolveWorkletOrigin(file, seen) {
-  if (originCache.has(file)) return originCache.get(file);
+function resolveWorkletOrigin(file: string, seen?: Set<string>): string {
+  const cached = originCache.get(file);
+  if (cached !== undefined) return cached;
   let origin = file;
   try {
     const match = fs.readFileSync(file, 'utf8').match(ORIGIN_RE);
@@ -47,7 +78,7 @@ function resolveWorkletOrigin(file, seen) {
   return origin;
 }
 
-function classify(source, attribute) {
+function classify(source: string | null, attribute: boolean): string {
   if (!source) return 'other';
   const resolved =
     attribute && WORKLETS_GEN.test(source)
@@ -57,31 +88,38 @@ function classify(source, attribute) {
   return group ? group.label : 'other';
 }
 
-function fail(message) {
-  console.error(message);
-  process.exit(1);
+function fail(message: string): never {
+  throw new Error(message);
 }
 
-function parseBool(value, name) {
+function parseBool(value: string, name: string): boolean {
   if (value === 'true') return true;
   if (value === 'false') return false;
   fail(`--${name} expects true or false (got "${value}")`);
-  return false; // unreachable
 }
 
-function parseArgs(argv) {
-  const args = {
+interface Args {
+  platforms: string[];
+  bundleMode: boolean;
+  json: boolean;
+  keep: boolean;
+  help: boolean;
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = {
     platforms: [],
     bundleMode: true,
     json: false,
     keep: false,
+    help: false,
   };
   for (const a of argv) {
     if (a === '--json') args.json = true;
     else if (a === '--keep') args.keep = true;
     else if (a === '-h' || a === '--help') {
-      printHelp();
-      process.exit(0);
+      args.help = true;
+      return args;
     } else if (a.startsWith('--bundle-mode=')) {
       args.bundleMode = parseBool(
         a.slice('--bundle-mode='.length),
@@ -99,12 +137,12 @@ function parseArgs(argv) {
   return args;
 }
 
-function printHelp() {
+function printHelp(): void {
   console.log(
     `Measure per-library bundle cost of the fabric example app.
 
 Usage:
-  node scripts/measure-bundle-cost.js [options] [platforms...]
+  node scripts/measure-bundle-cost.mts [options] [platforms...]
 
 Options:
   --platform=<ios,android>   Platform(s) to bundle (default: ios). May also be
@@ -125,11 +163,8 @@ const TOGGLE_SCRIPT = path.join(
 const BUNDLE_MODE_ASSIGN =
   /_WORKLETS_BUNDLE_MODE_ENABLED\s*=\s*(!0|!1|true|false)/g;
 
-/**
- * @param {string} bundleFile
- * @returns {boolean} Whether the built bundle has bundle mode enabled.
- */
-function detectBundleMode(bundleFile) {
+/** @returns Whether the built bundle has bundle mode enabled. */
+function detectBundleMode(bundleFile: string): boolean {
   const matches = [
     ...fs.readFileSync(bundleFile, 'utf8').matchAll(BUNDLE_MODE_ASSIGN),
   ];
@@ -142,7 +177,7 @@ function detectBundleMode(bundleFile) {
   return matches.some((m) => m[1] === '!0' || m[1] === 'true');
 }
 
-function toggleBundleMode() {
+function toggleBundleMode(): void {
   const res = spawnSync('bash', [TOGGLE_SCRIPT], {
     cwd: MONOREPO_ROOT,
     stdio: ['ignore', 2, 2],
@@ -155,15 +190,12 @@ function toggleBundleMode() {
   }
 }
 
-/**
- * Build a minified production bundle with a source map for `platform`.
- *
- * @param {string} platform
- * @param {string} outDir
- * @param {boolean} attribute
- * @returns {{ bundle: string; map: string }}
- */
-function buildBundle(platform, outDir, attribute) {
+/** Build a minified production bundle with a source map for `platform`. */
+function buildBundle(
+  platform: string,
+  outDir: string,
+  attribute: boolean
+): { bundle: string; map: string } {
   const bundle = path.join(outDir, `${platform}.bundle.js`);
   const map = `${bundle}.map`;
   console.error(`• building ${platform} bundle…`);
@@ -204,14 +236,13 @@ function buildBundle(platform, outDir, attribute) {
 /**
  * Build `platform` and make sure the result really is in the requested bundle
  * mode, toggling the repo once and rebuilding if it isn't.
- *
- * @param {string} platform
- * @param {string} outDir
- * @param {{ bundleMode: boolean }} args
- * @param {{ toggled: boolean }} state
- * @returns {{ bundle: string; map: string }}
  */
-function buildInRequestedMode(platform, outDir, args, state) {
+function buildInRequestedMode(
+  platform: string,
+  outDir: string,
+  args: { bundleMode: boolean },
+  state: { toggled: boolean }
+): { bundle: string; map: string } {
   const built = buildBundle(platform, outDir, args.bundleMode);
   if (detectBundleMode(built.bundle) === args.bundleMode) return built;
 
@@ -229,35 +260,24 @@ function buildInRequestedMode(platform, outDir, args, state) {
   return buildInRequestedMode(platform, outDir, args, state);
 }
 
-/**
- * Read every mapping of a flat source map as `[line, column, source]`.
- *
- * @param {any} map
- * @returns {Promise<[number, number, string | null][]>}
- */
-async function readFlatMappings(map) {
+/** Read every mapping of a flat source map. */
+async function readFlatMappings(map: RawSourceMap): Promise<Mapping[]> {
   const consumer = await new SourceMapConsumer(map);
-  /** @type {[number, number, string | null][]} */
-  const mappings = [];
+  const mappings: Mapping[] = [];
   consumer.eachMapping(
     (m) => mappings.push([m.generatedLine, m.generatedColumn, m.source]),
     null,
     SourceMapConsumer.GENERATED_ORDER
   );
-  if (typeof consumer.destroy === 'function') consumer.destroy();
+  consumer.destroy?.();
   return mappings;
 }
 
-/**
- * Read every mapping of a source map, in generated order.
- * @param {any} map
- * @returns {Promise<[number, number, string | null][]>}
- */
-async function collectMappings(map) {
+/** Read every mapping of a source map, in generated order. */
+async function collectMappings(map: RawSourceMap): Promise<Mapping[]> {
   if (!map.sections) return readFlatMappings(map);
 
-  /** @type {[number, number, string | null][]} */
-  const mappings = [];
+  const mappings: Mapping[] = [];
   for (const section of map.sections) {
     const { line, column } = section.offset;
     for (const [l, c, source] of await readFlatMappings(section.map)) {
@@ -268,8 +288,12 @@ async function collectMappings(map) {
   return mappings;
 }
 
-async function attributeBundle(bundleFile, mapFile, attribute) {
-  const code = fs.readFileSync(bundleFile, 'utf8');
+async function attributeBundle(
+  bundleFile: string,
+  mapFile: string,
+  attribute: boolean
+): Promise<{ total: number; groups: Record<string, number> }> {
+  const code: string = fs.readFileSync(bundleFile, 'utf8');
   const lines = code.split('\n');
 
   const lineStart = [0, 0];
@@ -279,7 +303,7 @@ async function attributeBundle(bundleFile, mapFile, attribute) {
     offset += Buffer.byteLength(lines[i], 'utf8') + 1; // +1 for the '\n'
   }
   const total = Buffer.byteLength(code, 'utf8');
-  const byteOf = (line, column) =>
+  const byteOf = (line: number, column: number) =>
     lineStart[line] +
     Buffer.byteLength(lines[line - 1].slice(0, column), 'utf8');
 
@@ -287,8 +311,7 @@ async function attributeBundle(bundleFile, mapFile, attribute) {
     JSON.parse(fs.readFileSync(mapFile, 'utf8'))
   );
 
-  /** @type {Record<string, number>} */
-  const groups = { other: 0 };
+  const groups: Record<string, number> = { other: 0 };
   for (const g of GROUPS) groups[g.label] = 0;
 
   for (let i = 0; i < mappings.length; i++) {
@@ -303,11 +326,18 @@ async function attributeBundle(bundleFile, mapFile, attribute) {
   return { total, groups };
 }
 
-const mb = (n) => `${(n / 1024 / 1024).toFixed(2)} MB`;
-const pct = (n, total) => `${total ? ((n / total) * 100).toFixed(1) : '0.0'}%`;
-const gzipSize = (buf) => zlib.gzipSync(buf, { level: 9 }).length;
+const mb = (n: number) => `${(n / 1024 / 1024).toFixed(2)} MB`;
+const pct = (n: number, total: number) =>
+  `${total ? ((n / total) * 100).toFixed(1) : '0.0'}%`;
+const gzipSize = (buf: Buffer) => zlib.gzipSync(buf, { level: 9 }).length;
 
-function printReport(title, result) {
+interface Result {
+  total: number;
+  gzip: number;
+  groups: Record<string, number>;
+}
+
+function printReport(title: string, result: Result): void {
   const { total, gzip, groups } = result;
   console.log(`\n${title}    total ${mb(total)} (${mb(gzip)} gzipped)`);
   const rows = Object.entries(groups).sort((a, b) => b[1] - a[1]);
@@ -318,8 +348,12 @@ function printReport(title, result) {
   }
 }
 
-async function main() {
+async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    return;
+  }
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'reanimated-bundle-cost-'));
 
   const state = { toggled: false };
@@ -327,8 +361,7 @@ async function main() {
   const modeLabel = `bundle-mode=${args.bundleMode}`;
   console.error(`• ${modeLabel}`);
 
-  /** @type {Record<string, any>} */
-  const report = {};
+  const report: Record<string, Result> = {};
   try {
     for (const platform of args.platforms) {
       const { bundle, map } = buildInRequestedMode(platform, tmp, args, state);
@@ -358,7 +391,7 @@ async function main() {
   }
 }
 
-main().catch((err) => {
+main().catch((err: Error) => {
   console.error(err.message || err);
-  process.exit(1);
+  process.exitCode = 1;
 });


### PR DESCRIPTION
## Summary
This PR adds a script that measures the share of our libraries in the bundle of the fabric example app
It does this by going through the bundle with a source map.
It's worth noting that metro-inserted code (e.g. wrappers) are attributed to neither library. The cost of such code has been measured locally to be 48B of HBC per module, which was measured to be ~9% overhead for the reanimated package, and ~1% for worklets.

When measuring the bundle mode, worklets from libraries are attributed to those libraries (including reanimated).
This is because worklets generated on behalf of other libraries are generated in the .worklets folder, and were previously attributed to worklets.

To make the attributions possible, a new option, `WORKLETS_WRITE_ORIGIN` was added to the worklets plugin. It inserts a comment with the library name for which a worklet is generated in the first line of the worklet.