### PR TITLE
fix(Reanimated): jumping sticky header on Android during scroll

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ShadowTreeCloner.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ShadowTreeCloner.cpp
@@ -25,7 +25,7 @@ mergeProps(const ShadowNode &shadowNode, const PropsMap &propsMap, const ShadowN
   if (propsVector.size() > 1) {
     folly::dynamic newPropsDynamic = folly::dynamic::object;
     for (const auto &props : propsVector) {
-      newPropsDynamic = folly::dynamic::merge(props.operator folly::dynamic(), newPropsDynamic);
+      newPropsDynamic = folly::dynamic::merge(newPropsDynamic, props.operator folly::dynamic());
     }
     return shadowNode.getComponentDescriptor().cloneProps(propsParserContext, newProps, RawProps(newPropsDynamic));
   }


### PR DESCRIPTION
## Summary

On Android, a scroll-driven sticky header jumps backward for a frame while scrolling.

When a single commit carries **more than one** update for the same view, the Android-only fast path in `mergeProps` folded them with `folly::dynamic::merge` in the wrong argument order, so the **oldest** update won and newer scroll positions were dropped. The shadow tree was committed with a stale value and the header rendered at an earlier scroll position for a frame.

### Multiple updates in one commit

Reanimated appends every `updateProps` to a pending batch **in order, without collapsing per view**. A commit flushes the whole batch, so if the same view was updated more than once since the last commit, its entries appear multiple times in that commit's `propsVector` and go through `mergeProps`. During scrolling this happens via two flush paths in `performOperationsRespectingDrawPass`:

- **Full-commit path** (not in a draw pass) → `performOperations()` commits to the shadow tree.
- **Draw-pass path** (event arrives during a draw pass) → `performNonLayoutOperations()` applies the transform synchronously to the view and **defers** the shadow-tree commit to the next frame via `startUpdatingOnAnimationFrame()`. More scroll events keep appending updates in the meantime, so when the deferred `performOperations()` runs it flushes the whole accumulated batch at once.

Either way the header's `propsVector` for that commit contains `[older, …, newer]`, which is where the merge order matters.

### Root cause

`propsVector` is chronological (oldest → newest), so the newest entry must win. The non-Android path already does this via a sequential last-write-wins loop. The Android fast path merges all entries into one `folly::dynamic` (a single `cloneProps` call) but passed the accumulator as the winning argument:

```cpp
// folly::dynamic::merge(a, b) => b wins on conflicts, a only fills missing keys
// before: accumulator (holding the OLDEST value) is `b` => oldest wins
newPropsDynamic = folly::dynamic::merge(props, newPropsDynamic);
```

## Test plan

<details>
<summary>code</summary>

```js
import * as React from "react";

import { StyleSheet, Text, View } from "react-native";

import Reanimated, {
  runOnJS,
  useAnimatedScrollHandler,
  useAnimatedStyle,
  useSharedValue,
} from "react-native-reanimated";

const REAWorkaroundView = Reanimated.View;

const BANNER_HEIGHT = 200;
const HEADER_HEIGHT = 72;
const ROW_COUNT = 500;

export default function ReanimatedScrollHeaderRepro() {
  const scrollY = useSharedValue(0);
  const [, setTick] = React.useState(0);
  const bumpTick = React.useCallback((bucket: number) => setTick(bucket), []);

  const scrollHandler = useAnimatedScrollHandler({
    onScroll: (event) => {
      scrollY.value = event.contentOffset.y;
      runOnJS(bumpTick)(Math.floor(event.contentOffset.y / 4));
    },
  });

  const stickyStyle = useAnimatedStyle(() => ({
    transform: [{ translateY: Math.max(0, scrollY.value - BANNER_HEIGHT) }],

    // width: (scrollY.value % 300) + 50,
  }));

  return (
    <View style={styles.container}>
      <Reanimated.ScrollView onScroll={scrollHandler} scrollEventThrottle={16}>
        <View style={styles.banner}>
          <Text style={styles.bannerText}>Banner (scrolls away)</Text>
        </View>

        <REAWorkaroundView style={[styles.header, stickyStyle]}>
          <Text style={styles.headerTitle}>Sticky header</Text>

          <Text style={styles.headerSubtitle}>
            pins to top on scroll — should stay put smoothly
          </Text>
        </REAWorkaroundView>

        {Array.from({ length: ROW_COUNT }).map((_, i) => (
          <View
            key={i}
            style={[
              styles.row,
              { backgroundColor: i % 2 === 0 ? "#232428" : "#2b2d31" },
            ]}
          >
            <Text style={styles.rowText}>Row {i}</Text>
          </View>
        ))}
      </Reanimated.ScrollView>
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
  },
  banner: {
    height: BANNER_HEIGHT,
    backgroundColor: "#404249",
    alignItems: "center",
    justifyContent: "center",
  },
  bannerText: {
    color: "#dbdee1",
  },
  header: {
    height: HEADER_HEIGHT,
    backgroundColor: "#5865f2",
    paddingHorizontal: 20,
    justifyContent: "center",
    zIndex: 10,
    elevation: 10,
  },
  headerTitle: {
    color: "#fff",
    fontSize: 18,
    fontWeight: "700",
  },
  headerSubtitle: {
    color: "#dbdee1",
    fontSize: 12,
    marginTop: 2,
  },
  row: {
    height: 56,
    justifyContent: "center",
    paddingHorizontal: 20,
  },
  rowText: {
    color: "#fff",
  },
});
```

</details>