### PR TITLE
chore: Collapse the CSS platform transition apply hooks

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.cpp
@@ -8,12 +8,10 @@ namespace reanimated::css {
 
 CSSPlatformTransitionProxy::CSSPlatformTransitionProxy(
     CSSCanRoutePropertyFunction canRoute,
-    CSSApplyTransitionJSIFunction applyJSI,
-    CSSApplyTransitionDynamicFunction applyDynamic,
+    CSSApplyTransitionFunction applyTransition,
     CSSRemoveTransitionFunction removeTransition)
     : canRoute_(std::move(canRoute)),
-      applyJSI_(std::move(applyJSI)),
-      applyDynamic_(std::move(applyDynamic)),
+      applyTransition_(std::move(applyTransition)),
       removeTransition_(std::move(removeTransition)) {}
 
 bool CSSPlatformTransitionProxy::canRoute(const std::string &propertyName, const EasingConfig &easing) const {
@@ -21,23 +19,13 @@ bool CSSPlatformTransitionProxy::canRoute(const std::string &propertyName, const
 }
 
 bool CSSPlatformTransitionProxy::apply(
-    jsi::Runtime &rt,
     const Tag viewTag,
     const std::string &propertyName,
-    const jsi::Value &fromValue,
-    const jsi::Value &toValue,
-    const CSSTransitionPropertySettings &settings,
+    const PlatformValue &fromValue,
+    const PlatformValue &toValue,
+    const CSSTransitionPropertySettings *settings,
     const double timestamp) const {
-  return applyJSI_ && applyJSI_(rt, viewTag, propertyName, fromValue, toValue, settings, timestamp);
-}
-
-bool CSSPlatformTransitionProxy::apply(
-    const Tag viewTag,
-    const std::string &propertyName,
-    const folly::dynamic &fromValue,
-    const folly::dynamic &toValue,
-    const double timestamp) const {
-  return applyDynamic_ && applyDynamic_(viewTag, propertyName, fromValue, toValue, timestamp);
+  return applyTransition_ && applyTransition_(viewTag, propertyName, fromValue, toValue, settings, timestamp);
 }
 
 void CSSPlatformTransitionProxy::remove(const Tag viewTag, const std::string &propertyName) const {
@@ -68,7 +56,8 @@ CSSTransitionConfig CSSPlatformTransitionProxy::processConfig(
 
     bool routable = canRoute(propertyName, settings.easingConfig);
     if (routable && hasValue) {
-      routable = apply(rt, viewTag, propertyName, valueIt->second.first, valueIt->second.second, settings, timestamp);
+      const auto values = parsePlatformValues(rt, propertyName, valueIt->second.first, valueIt->second.second);
+      routable = values && apply(viewTag, propertyName, values->first, values->second, &settings, timestamp);
     } else if (routable) {
       // Settings-only: stay on the platform only if already animating there.
       routable = routing.platform.contains(propertyName);
@@ -120,7 +109,8 @@ PropertyValueDynamicDiffsMap CSSPlatformTransitionProxy::processDynamicDiffs(
     // A platform-routed property keeps animating natively while the platform can
     // still express the toggled value; otherwise it migrates to the loop.
     if (routing.platform.contains(propertyName)) {
-      if (apply(viewTag, propertyName, propertyDiff.first, propertyDiff.second, timestamp)) {
+      const auto values = parsePlatformValues(propertyName, propertyDiff.first, propertyDiff.second);
+      if (values && apply(viewTag, propertyName, values->first, values->second, nullptr, timestamp)) {
         continue;
       }
       routing.platform.erase(propertyName);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.h
@@ -3,6 +3,7 @@
 #include <reanimated/CSS/common/definitions.h>
 #include <reanimated/CSS/configs/CSSTransitionConfig.h>
 #include <reanimated/CSS/easing/EasingConfigs.h>
+#include <reanimated/CSS/utils/platform.h>
 
 #include <folly/dynamic.h>
 #include <jsi/jsi.h>
@@ -18,22 +19,15 @@ using namespace react;
 
 /// Whether the platform can animate the property natively for the given easing.
 using CSSCanRoutePropertyFunction = std::function<bool(const std::string &propertyName, const EasingConfig &easing)>;
-/// Animates a routed property natively; a false (no-op) return means the platform
-/// can't express the value, so it falls back to the loop. The jsi overload is the
-/// config path (carries a runtime + settings); the folly overload, the toggle path.
-using CSSApplyTransitionJSIFunction = std::function<bool(
-    jsi::Runtime &rt,
+/// Animates a routed property natively; a false return falls back to the loop.
+/// `settings` is null on the pseudo-selector toggle path, where the backend reuses
+/// the settings captured at config-apply time and holds the animation persistently.
+using CSSApplyTransitionFunction = std::function<bool(
     Tag viewTag,
     const std::string &propertyName,
-    const jsi::Value &fromValue,
-    const jsi::Value &toValue,
-    const CSSTransitionPropertySettings &settings,
-    double timestamp)>;
-using CSSApplyTransitionDynamicFunction = std::function<bool(
-    Tag viewTag,
-    const std::string &propertyName,
-    const folly::dynamic &fromValue,
-    const folly::dynamic &toValue,
+    const PlatformValue &fromValue,
+    const PlatformValue &toValue,
+    const CSSTransitionPropertySettings *settings,
     double timestamp)>;
 /// Cancels the property's native transition and drops its platform-side state.
 using CSSRemoveTransitionFunction = std::function<void(Tag viewTag, const std::string &propertyName)>;
@@ -46,15 +40,14 @@ struct CSSTransitionRouting {
 };
 
 /// Stateless, shared routing engine: per property it routes a view's CSS transition
-/// to the platform (animated natively via the hooks above) or the C++ loop, never
-/// seeing the value - it forwards the raw JS source to the platform. Per-view routing
-/// state is passed in; an absent hook keeps that property on the loop.
+/// to the platform or the C++ loop. Endpoints are parsed here, so a value the
+/// platform can't express never crosses the seam. Per-view routing state is passed
+/// in; an absent hook keeps that property on the loop.
 class CSSPlatformTransitionProxy {
  public:
   CSSPlatformTransitionProxy(
       CSSCanRoutePropertyFunction canRoute,
-      CSSApplyTransitionJSIFunction applyJSI,
-      CSSApplyTransitionDynamicFunction applyDynamic,
+      CSSApplyTransitionFunction applyTransition,
       CSSRemoveTransitionFunction removeTransition);
 
   /// Routes the config between platform and loop, updating `routing` and returning
@@ -80,24 +73,16 @@ class CSSPlatformTransitionProxy {
  private:
   bool canRoute(const std::string &propertyName, const EasingConfig &easing) const;
   bool apply(
-      jsi::Runtime &rt,
       Tag viewTag,
       const std::string &propertyName,
-      const jsi::Value &fromValue,
-      const jsi::Value &toValue,
-      const CSSTransitionPropertySettings &settings,
-      double timestamp) const;
-  bool apply(
-      Tag viewTag,
-      const std::string &propertyName,
-      const folly::dynamic &fromValue,
-      const folly::dynamic &toValue,
+      const PlatformValue &fromValue,
+      const PlatformValue &toValue,
+      const CSSTransitionPropertySettings *settings,
       double timestamp) const;
   void remove(Tag viewTag, const std::string &propertyName) const;
 
   CSSCanRoutePropertyFunction canRoute_;
-  CSSApplyTransitionJSIFunction applyJSI_;
-  CSSApplyTransitionDynamicFunction applyDynamic_;
+  CSSApplyTransitionFunction applyTransition_;
   CSSRemoveTransitionFunction removeTransition_;
 };
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/platform.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/platform.cpp
@@ -1,7 +1,4 @@
 #include <reanimated/CSS/utils/platform.h>
-
-#if __APPLE__
-
 #include <reanimated/CSS/utils/props.h>
 #include <reanimated/Tools/FeatureFlags.h>
 
@@ -23,8 +20,8 @@ struct CSSPropertyTraits {
   PlatformValue defaultValue;
 };
 
-// The natively animatable properties: each one's value kind and CSS default
-// (mirrors InterpolatorRegistry.cpp). Grows as more properties are routed.
+// Value kind and CSS default per property (mirrors InterpolatorRegistry.cpp).
+// Which of them a platform actually routes is canRouteCSSProperty's decision.
 const CSSPropertyTraits *traitsFor(const std::string &propertyName) {
   constexpr std::array<double, 4> kTransparentColor = {0, 0, 0, 0};
   constexpr std::array<double, 4> kBlackColor = {0, 0, 0, 1};
@@ -55,33 +52,11 @@ PlatformValue parseColorNumber(const double number) {
   };
 }
 
-} // namespace
-
-bool canRouteCSSProperty(const std::string &propertyName, const EasingConfig &easing) {
-  if constexpr (!StaticFeatureFlags::getFlag("IOS_CSS_CORE_ANIMATION")) {
-    return false;
-  }
-  if (traitsFor(propertyName) == nullptr) {
-    return false;
-  }
-  // TODO: border props route unconditionally, but snap when RN rasterizes the
-  // border (view fails useCoreAnimationBorderRendering); they should route only
-  // when the platform can render them correctly (follow-up PR).
-  // CAMediaTimingFunction can express only linear and cubic-bezier curves;
-  // steps / linear-stops easings have to interpolate per-frame on the loop.
-  return std::holds_alternative<LinearEasing>(easing) || std::holds_alternative<CubicBezierEasing>(easing);
-}
-
-std::optional<PlatformValue>
-parsePlatformValue(jsi::Runtime &rt, const std::string &propertyName, const jsi::Value &value) {
-  const auto *traits = traitsFor(propertyName);
-  if (traits == nullptr) {
-    return std::nullopt;
-  }
+std::optional<PlatformValue> parseValue(const CSSPropertyTraits &traits, jsi::Runtime &rt, const jsi::Value &value) {
   if (value.isNull() || value.isUndefined()) {
-    return traits->defaultValue;
+    return traits.defaultValue;
   }
-  switch (traits->kind) {
+  switch (traits.kind) {
     case CSSValueKind::Scalar:
       return value.isNumber() ? std::optional<PlatformValue>(value.asNumber()) : std::nullopt;
     case CSSValueKind::Color:
@@ -102,15 +77,11 @@ parsePlatformValue(jsi::Runtime &rt, const std::string &propertyName, const jsi:
   return std::nullopt;
 }
 
-std::optional<PlatformValue> parsePlatformValue(const std::string &propertyName, const folly::dynamic &value) {
-  const auto *traits = traitsFor(propertyName);
-  if (traits == nullptr) {
-    return std::nullopt;
-  }
+std::optional<PlatformValue> parseValue(const CSSPropertyTraits &traits, const folly::dynamic &value) {
   if (value.isNull()) {
-    return traits->defaultValue;
+    return traits.defaultValue;
   }
-  switch (traits->kind) {
+  switch (traits.kind) {
     case CSSValueKind::Scalar:
       return value.isNumber() ? std::optional<PlatformValue>(value.asDouble()) : std::nullopt;
     case CSSValueKind::Color:
@@ -130,26 +101,57 @@ std::optional<PlatformValue> parsePlatformValue(const std::string &propertyName,
   return std::nullopt;
 }
 
-} // namespace reanimated::css
+} // namespace
 
-#else // !__APPLE__
-
-namespace reanimated::css {
-
-// No native routing backend on this platform yet; every property runs on the loop.
-bool canRouteCSSProperty(const std::string &, const EasingConfig &) {
+bool canRouteCSSProperty(const std::string &propertyName, const EasingConfig &easing) {
+#if __APPLE__
+  if constexpr (!StaticFeatureFlags::getFlag("IOS_CSS_CORE_ANIMATION")) {
+    return false;
+  }
+  if (traitsFor(propertyName) == nullptr) {
+    return false;
+  }
+  // TODO: border props route unconditionally, but snap when RN rasterizes the
+  // border (view fails useCoreAnimationBorderRendering); they should route only
+  // when the platform can render them correctly (follow-up PR).
+  // CAMediaTimingFunction can express only linear and cubic-bezier curves;
+  // steps / linear-stops easings have to interpolate per-frame on the loop.
+  return std::holds_alternative<LinearEasing>(easing) || std::holds_alternative<CubicBezierEasing>(easing);
+#else
+  // No native routing backend on this platform yet; every property runs on the loop.
   return false;
+#endif // __APPLE__
 }
 
-std::optional<PlatformValue>
-parsePlatformValue(facebook::jsi::Runtime &, const std::string &, const facebook::jsi::Value &) {
-  return std::nullopt;
+std::optional<PlatformValuePair> parsePlatformValues(
+    jsi::Runtime &rt,
+    const std::string &propertyName,
+    const jsi::Value &fromValue,
+    const jsi::Value &toValue) {
+  const auto *traits = traitsFor(propertyName);
+  if (traits == nullptr) {
+    return std::nullopt;
+  }
+  const auto from = parseValue(*traits, rt, fromValue);
+  const auto to = parseValue(*traits, rt, toValue);
+  if (!from || !to) {
+    return std::nullopt;
+  }
+  return PlatformValuePair{*from, *to};
 }
 
-std::optional<PlatformValue> parsePlatformValue(const std::string &, const folly::dynamic &) {
-  return std::nullopt;
+std::optional<PlatformValuePair>
+parsePlatformValues(const std::string &propertyName, const folly::dynamic &fromValue, const folly::dynamic &toValue) {
+  const auto *traits = traitsFor(propertyName);
+  if (traits == nullptr) {
+    return std::nullopt;
+  }
+  const auto from = parseValue(*traits, fromValue);
+  const auto to = parseValue(*traits, toValue);
+  if (!from || !to) {
+    return std::nullopt;
+  }
+  return PlatformValuePair{*from, *to};
 }
 
 } // namespace reanimated::css
-
-#endif // __APPLE__

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/platform.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/platform.h
@@ -8,6 +8,7 @@
 #include <array>
 #include <optional>
 #include <string>
+#include <utility>
 #include <variant>
 
 namespace reanimated::css {
@@ -21,11 +22,18 @@ using PlatformValue = std::variant<double, std::array<double, 2>, std::array<dou
 /// route, so every property runs on the C++ loop.
 bool canRouteCSSProperty(const std::string &propertyName, const EasingConfig &easing);
 
-/// Parses a transition endpoint into a platform value. Null/undefined falls back
-/// to the property's CSS default; nullopt means it can't be animated natively and
-/// runs on the loop. Two overloads: jsi::Value (config) and folly::dynamic (toggle).
-std::optional<PlatformValue>
-parsePlatformValue(facebook::jsi::Runtime &rt, const std::string &propertyName, const facebook::jsi::Value &value);
-std::optional<PlatformValue> parsePlatformValue(const std::string &propertyName, const folly::dynamic &value);
+/// Parses a transition's endpoints, looking the property up once. Null/undefined
+/// falls back to its CSS default; nullopt means the platform can't express the
+/// pair, so it runs on the loop. jsi::Value is the config path, folly::dynamic the
+/// pseudo-selector toggle path.
+using PlatformValuePair = std::pair<PlatformValue, PlatformValue>;
+
+std::optional<PlatformValuePair> parsePlatformValues(
+    facebook::jsi::Runtime &rt,
+    const std::string &propertyName,
+    const facebook::jsi::Value &fromValue,
+    const facebook::jsi::Value &toValue);
+std::optional<PlatformValuePair>
+parsePlatformValues(const std::string &propertyName, const folly::dynamic &fromValue, const folly::dynamic &toValue);
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -222,8 +222,7 @@ ReanimatedModuleProxy::ReanimatedModuleProxy(
           operationsLoop_,
           std::make_shared<CSSPlatformTransitionProxy>(
               platformDepMethodsHolder.cssCanRouteProperty,
-              platformDepMethodsHolder.cssApplyTransitionJSI,
-              platformDepMethodsHolder.cssApplyTransitionDynamic,
+              platformDepMethodsHolder.cssApplyTransition,
               platformDepMethodsHolder.cssRemoveTransition))),
       pseudoStylesRegistry_(std::make_shared<PseudoStylesRegistry>(
           platformDepMethodsHolder.attachPseudoSelector,

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Tools/PlatformDepMethodsHolder.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Tools/PlatformDepMethodsHolder.h
@@ -71,8 +71,7 @@ struct PlatformDepMethodsHolder {
   PlatformAttachPseudoSelectorFunction attachPseudoSelector;
   PlatformDetachPseudoSelectorFunction detachPseudoSelector;
   css::CSSCanRoutePropertyFunction cssCanRouteProperty;
-  css::CSSApplyTransitionJSIFunction cssApplyTransitionJSI;
-  css::CSSApplyTransitionDynamicFunction cssApplyTransitionDynamic;
+  css::CSSApplyTransitionFunction cssApplyTransition;
   css::CSSRemoveTransitionFunction cssRemoveTransition;
   // Last so platform initializers that don't supply it (iOS, Android today)
   // can omit it and rely on value-init (= null shared_ptr).

--- a/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.h
@@ -1,11 +1,10 @@
 #pragma once
 
 #import <reanimated/CSS/configs/CSSTransitionConfig.h>
+#import <reanimated/CSS/utils/platform.h>
 
 #import <React/RCTSurfacePresenter.h>
 
-#import <folly/dynamic.h>
-#import <jsi/jsi.h>
 #import <react/renderer/core/ReactPrimitives.h>
 
 #import <Foundation/Foundation.h>
@@ -18,25 +17,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithSurfacePresenter:(RCTSurfacePresenter *)surfacePresenter;
 
-/// Config path: animates the property natively and remembers its settings for
-/// later toggles. Returns NO if the value can't be animated natively, in which
-/// case it runs on the loop instead.
+/// Animates the property natively and remembers its settings for later toggles.
+/// A null `settings` marks the toggle path: the stored settings are reused and the
+/// animation is held persistently. Returns NO when there are none to reuse.
 - (BOOL)applyTransitionForTag:(facebook::react::Tag)viewTag
                  propertyName:(const std::string &)propertyName
-                    fromValue:(const facebook::jsi::Value &)fromValue
-                      toValue:(const facebook::jsi::Value &)toValue
-                      runtime:(facebook::jsi::Runtime &)runtime
-                     settings:(const reanimated::css::CSSTransitionPropertySettings &)settings
+                    fromValue:(const reanimated::css::PlatformValue &)fromValue
+                      toValue:(const reanimated::css::PlatformValue &)toValue
+                     settings:(nullable const reanimated::css::CSSTransitionPropertySettings *)settings
                     timestamp:(double)timestamp;
-
-/// Toggle path: a runtime-free version that reuses the settings stored by the
-/// config apply. Returns NO if there are no stored settings or the value can't be
-/// animated natively.
-- (BOOL)applyDynamicTransitionForTag:(facebook::react::Tag)viewTag
-                        propertyName:(const std::string &)propertyName
-                           fromValue:(const folly::dynamic &)fromValue
-                             toValue:(const folly::dynamic &)toValue
-                           timestamp:(double)timestamp;
 
 - (void)removeTransitionForTag:(facebook::react::Tag)viewTag propertyName:(const std::string &)propertyName;
 

--- a/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.mm
@@ -58,99 +58,63 @@ struct ActiveTransition {
   return view.layer;
 }
 
-// Reverse-shortens against any in-flight transition, animates natively, and
-// records the new active state. fromValue/toValue are already parsed.
-- (void)applyForTag:(Tag)viewTag
-       propertyName:(const std::string &)propertyName
-          fromValue:(const PlatformValue &)fromValue
-            toValue:(const PlatformValue &)toValue
-           settings:(const CSSTransitionPropertySettings &)settings
-          timestamp:(double)timestamp
-         persistent:(BOOL)persistent
+- (const ActiveTransition *)activeTransitionForTag:(Tag)viewTag propertyName:(const std::string &)propertyName
 {
-  auto &properties = _active[viewTag];
-  const auto activeIt = properties.find(propertyName);
+  const auto propertiesIt = _active.find(viewTag);
+  if (propertiesIt == _active.end()) {
+    return nullptr;
+  }
+  const auto activeIt = propertiesIt->second.find(propertyName);
+  return activeIt != propertiesIt->second.end() ? &activeIt->second : nullptr;
+}
+
+- (BOOL)applyTransitionForTag:(Tag)viewTag
+                 propertyName:(const std::string &)propertyName
+                    fromValue:(const PlatformValue &)fromValue
+                      toValue:(const PlatformValue &)toValue
+                     settings:(const CSSTransitionPropertySettings *)settings
+                    timestamp:(double)timestamp
+{
+  const ActiveTransition *active = [self activeTransitionForTag:viewTag propertyName:propertyName];
+
+  // The toggle path has no settings of its own and holds its value indefinitely.
+  const BOOL persistent = settings == nullptr;
+  if (persistent && active == nullptr) {
+    return NO;
+  }
+  // Copy: the active entry is re-assigned below.
+  const CSSTransitionPropertySettings resolvedSettings = persistent ? active->settings : *settings;
+
   // Targeting the in-flight transition's start value means this is a reversal.
-  const ActiveTransition *previous =
-      (activeIt != properties.end() && activeIt->second.adjustedStart && toValue == *activeIt->second.adjustedStart)
-      ? &activeIt->second
-      : nullptr;
-  ReversingState reversing = previous
-      ? reverseShorten(previous->reversing, timestamp, settings.duration, settings.delay, settings.easingConfig)
-      : makeReversingState(timestamp, settings.duration, settings.delay, settings.easingConfig);
+  const bool isReversal = active != nullptr && active->adjustedStart && toValue == *active->adjustedStart;
+  ReversingState reversing = isReversal
+      ? reverseShorten(
+            active->reversing,
+            timestamp,
+            resolvedSettings.duration,
+            resolvedSettings.delay,
+            resolvedSettings.easingConfig)
+      : makeReversingState(timestamp, resolvedSettings.duration, resolvedSettings.delay, resolvedSettings.easingConfig);
 
   // https://drafts.csswg.org/css-transitions/#reversing
   std::optional<PlatformValue> adjustedStart;
-  if (previous) {
-    adjustedStart = previous->adjustedEnd;
-  } else if (activeIt == properties.end()) {
+  if (isReversal) {
+    adjustedStart = active->adjustedEnd;
+  } else if (active == nullptr) {
     adjustedStart = fromValue;
-  } else if (timestamp >= activeIt->second.reversing.startTimestamp + activeIt->second.reversing.duration) {
-    adjustedStart = activeIt->second.adjustedEnd;
+  } else if (timestamp >= active->reversing.startTimestamp + active->reversing.duration) {
+    adjustedStart = active->adjustedEnd;
   }
+
   [self animateTag:viewTag
       propertyName:propertyName
          fromValue:fromValue
            toValue:toValue
         durationMs:reversing.duration
        startTimeMs:reversing.startTimestamp
-            easing:settings.easingConfig
+            easing:resolvedSettings.easingConfig
         persistent:persistent];
-  properties[propertyName] = ActiveTransition{adjustedStart, toValue, std::move(reversing), settings};
-}
-
-- (BOOL)applyTransitionForTag:(Tag)viewTag
-                 propertyName:(const std::string &)propertyName
-                    fromValue:(const jsi::Value &)fromValue
-                      toValue:(const jsi::Value &)toValue
-                      runtime:(jsi::Runtime &)runtime
-                     settings:(const CSSTransitionPropertySettings &)settings
-                    timestamp:(double)timestamp
-{
-  const auto from = parsePlatformValue(runtime, propertyName, fromValue);
-  const auto to = parsePlatformValue(runtime, propertyName, toValue);
-  if (!from || !to) {
-    return NO;
-  }
-  [self applyForTag:viewTag
-       propertyName:propertyName
-          fromValue:*from
-            toValue:*to
-           settings:settings
-          timestamp:timestamp
-         persistent:NO];
-  return YES;
-}
-
-- (BOOL)applyDynamicTransitionForTag:(Tag)viewTag
-                        propertyName:(const std::string &)propertyName
-                           fromValue:(const folly::dynamic &)fromValue
-                             toValue:(const folly::dynamic &)toValue
-                           timestamp:(double)timestamp
-{
-  const auto propertiesIt = _active.find(viewTag);
-  if (propertiesIt == _active.end()) {
-    return NO;
-  }
-  const auto activeIt = propertiesIt->second.find(propertyName);
-  if (activeIt == propertiesIt->second.end()) {
-    // No config apply ran for this property, so there are no settings to reuse.
-    return NO;
-  }
-  const auto from = parsePlatformValue(propertyName, fromValue);
-  const auto to = parsePlatformValue(propertyName, toValue);
-  if (!from || !to) {
-    return NO;
-  }
-  // Copy: applyForTag re-assigns this property's active entry below.
-  const CSSTransitionPropertySettings settings = activeIt->second.settings;
-  [self applyForTag:viewTag
-       propertyName:propertyName
-          fromValue:*from
-            toValue:*to
-           settings:settings
-          timestamp:timestamp
-         persistent:YES];
+  _active[viewTag][propertyName] = ActiveTransition{adjustedStart, toValue, std::move(reversing), resolvedSettings};
   return YES;
 }
 

--- a/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.mm
@@ -132,39 +132,21 @@ css::CSSCanRoutePropertyFunction makeCSSCanRouteProperty()
   return &css::canRouteCSSProperty;
 }
 
-css::CSSApplyTransitionJSIFunction makeCSSApplyTransitionJSI(REACSSPlatformTransitions *platformTransitions)
+css::CSSApplyTransitionFunction makeCSSApplyTransition(REACSSPlatformTransitions *platformTransitions)
 {
   return [platformTransitions](
-             jsi::Runtime &rt,
              Tag viewTag,
              const std::string &propertyName,
-             const jsi::Value &fromValue,
-             const jsi::Value &toValue,
-             const css::CSSTransitionPropertySettings &settings,
+             const css::PlatformValue &fromValue,
+             const css::PlatformValue &toValue,
+             const css::CSSTransitionPropertySettings *settings,
              double timestamp) {
     return [platformTransitions applyTransitionForTag:viewTag
                                          propertyName:propertyName
                                             fromValue:fromValue
                                               toValue:toValue
-                                              runtime:rt
                                              settings:settings
                                             timestamp:timestamp];
-  };
-}
-
-css::CSSApplyTransitionDynamicFunction makeCSSApplyTransitionDynamic(REACSSPlatformTransitions *platformTransitions)
-{
-  return [platformTransitions](
-             Tag viewTag,
-             const std::string &propertyName,
-             const folly::dynamic &fromValue,
-             const folly::dynamic &toValue,
-             double timestamp) {
-    return [platformTransitions applyDynamicTransitionForTag:viewTag
-                                                propertyName:propertyName
-                                                   fromValue:fromValue
-                                                     toValue:toValue
-                                                   timestamp:timestamp];
   };
 }
 
@@ -239,8 +221,7 @@ PlatformDepMethodsHolder makePlatformDepMethodsHolder(RCTModuleRegistry *moduleR
   REACSSPlatformTransitions *platformTransitions =
       [[REACSSPlatformTransitions alloc] initWithSurfacePresenter:nodesManager.surfacePresenter];
   auto cssCanRouteProperty = makeCSSCanRouteProperty();
-  auto cssApplyTransitionJSI = makeCSSApplyTransitionJSI(platformTransitions);
-  auto cssApplyTransitionDynamic = makeCSSApplyTransitionDynamic(platformTransitions);
+  auto cssApplyTransition = makeCSSApplyTransition(platformTransitions);
   auto cssRemoveTransition = makeCSSRemoveTransition(platformTransitions);
 
   PlatformDepMethodsHolder platformDepMethodsHolder = {
@@ -257,8 +238,7 @@ PlatformDepMethodsHolder makePlatformDepMethodsHolder(RCTModuleRegistry *moduleR
       attachPseudoSelectorFunction,
       detachPseudoSelectorFunction,
       cssCanRouteProperty,
-      cssApplyTransitionJSI,
-      cssApplyTransitionDynamic,
+      cssApplyTransition,
       cssRemoveTransition,
   };
   return platformDepMethodsHolder;


### PR DESCRIPTION
Collapses the two CSS platform-transition apply hooks into one, so a second backend implements one function instead of two.

They differed only in how the endpoint arrived (`jsi::Value` on the config path, `folly::dynamic` on the pseudo toggle path) and `parsePlatformValue` already had both overloads in common. The proxy now parses and passes a `PlatformValue`; a null `settings` marks the toggle path. The traits table and parsing also leave `#if __APPLE__`; `canRouteCSSProperty` stays forked.