### PR TITLE
feat: add Reanimated CSS migration skill

### DIFF
--- a/skills/reanimated-css-migration/SKILL.md
+++ b/skills/reanimated-css-migration/SKILL.md
@@ -36,7 +36,8 @@ Load at most one per question.
 | `references/preconditions.md` | Deciding whether a call site may be migrated |
 | `references/refusals.md` | A pattern looks unmigratable and you need the reason and advice |
 | `references/examples.md` | Calibrating what a conversion looks like |
-| `references/api-map.md` | Mapping a `with*` or `Easing.*`, or choosing transition vs animation |
+| `references/api-map.md` | Mapping a `with*`, or choosing transition vs animation |
+| `references/timing-functions.md` | Converting an `Easing.*` value or a spring |
 
 Property support:
 [supported properties](https://docs.swmansion.com/react-native-reanimated/docs/guides/supported-properties).

--- a/skills/reanimated-css-migration/SKILL.md
+++ b/skills/reanimated-css-migration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reanimated-css-migration
-description: "Converts React Native Reanimated hook-based animations into CSS animations and transitions. Use when migrating, converting or porting Reanimated animations to CSS. Use when replacing useAnimatedStyle, useSharedValue, withTiming, withRepeat or withSpring with animationName or transitionProperty. Use when auditing which animations could become CSS. Use this even if the user never says CSS, whenever they ask to simplify, modernize or remove worklets from animation code."
+description: "Converts React Native Reanimated hook-based animations into CSS animations and transitions, applying the conversions that are provably safe and leaving the rest for the user to decide on. Use when migrating, converting or porting Reanimated animations to CSS. Use when replacing useAnimatedStyle, useSharedValue, withTiming, withRepeat or withSpring with animationName or transitionProperty. Use when auditing which animations could become CSS. Use this even if the user never says CSS, whenever they ask to simplify, modernize or remove worklets from animation code."
 license: MIT
 compatibility: Requires Reanimated 4.x and the New Architecture
 ---
@@ -49,8 +49,8 @@ API signatures:
 
 | Request | Run |
 | --- | --- |
-| One call site in front of you | Phase 2 only. No inventory, report or ledger |
-| "Can this be CSS?", no edit asked for | Phase 2 reasoning, no edits |
+| One call site in front of you | Phase 2, then convert or explain. No inventory, ledger or tables |
+| "Can this be CSS?", no edit asked for | Phase 2 reasoning only. Never edit |
 | A directory, feature or app | All phases |
 
 Preconditions, refusals and the property check apply at every size.
@@ -88,43 +88,24 @@ Per call site:
 **Name the precondition permitting each migration.** Cannot name one, do not
 migrate.
 
-## Phase 3: report, before editing
+## Phase 3: apply the certain set
 
-Print as ordinary text. Not a plan object, not a collapsed block. Do not edit
-until the user agrees.
+Apply migratable sites without asking. Leave needs-review and refused untouched.
+The user reviews a diff, not a plan, so the bar for "migratable" is the whole
+safety model: all 7 preconditions pass, every property clears, and you can name
+the permitting precondition. Anything you are weighing goes to needs-review and
+is not edited.
 
-Four parts, all required. The report is incomplete without part 4, which is the
-only part showing code and the only one the user can judge the conversion from.
+Require a clean working tree first, or explicit acknowledgment. `git diff` is
+the user's undo.
 
-1. **Counts.** Migratable, needs-review, refused.
+Migrate 3 differing sites first and compare. Resolve any disagreement between
+them before continuing: a systematic mistake caught after 3 files is cheap,
+after 30 it is not.
 
-1. **Table, no code**, one row per site. Everything a site needs to say goes in
-   the Note column:
-
-   | File | Animates | Becomes | Note |
-   | --- | --- | --- | --- |
-   | `Card.tsx:34` | opacity, translateY on mount | animation | fillMode forwards |
-   | `Toggle.tsx:12` | backgroundColor on press | transition | shared value becomes state |
-
-1. **Refusals grouped by reason**, with counts. Forty gesture-driven components
-   are one line.
-
-1. **Before and after code for 2-3 representative sites**, covering the
-   different shapes in the table. Write it out; never promise a sample and omit
-   it. A diff for every site is the failure this replaces, not this itself.
-
-Keep out of this report: equivalence obligations to re-check, memoization
-advice, reduced-motion recipes, option menus. Those are Phase 4 and 5. Prose per
-site crowds out part 4 and makes the table unscannable.
-
-## Phase 4: apply
-
-Migrate 3 differing sites first, compare, resolve disagreements before
-continuing.
-
-Keep a status file on disk: every site as pending, done or refused, with its
-precondition or refusal reason. Conversation memory does not survive compaction;
-after an interruption trust the file and `git diff`, not recall.
+Keep a status file on disk: every site as pending, done, needs-review or
+refused, with its precondition or reason. Conversation memory does not survive
+compaction; after an interruption trust the file and `git diff`, not recall.
 
 Then per call site:
 
@@ -133,12 +114,48 @@ Then per call site:
 | Satisfy all 5 equivalence obligations | Leave an obligation unchecked |
 | Remove shared values, hooks, imports the conversion killed | Remove anything else |
 | Migrate inside each `Platform.select` arm, keeping structure | Collapse the arms |
-| Suggest `shadow*` to `boxShadow` in the report | Swap one API for another in this diff |
+| Note `shadow*` to `boxShadow` for later | Swap one API for another in this diff |
 
-Checkpoint per file: one line on what changed, then let the user stop you.
+Downgrade to needs-review and revert that site if anything turns up mid-edit
+that the classification missed: an unspotted property, a driver that is a
+worklet after all, an obligation you cannot satisfy. Do not push through.
 
-Stop and ask when a site differs from the agreed plan: an unspotted property, a
-driver that is a worklet after all, an obligation you cannot satisfy.
+## Phase 4: report what changed and what did not
+
+Report after applying, as ordinary text. Not a plan object, not a collapsed
+block.
+
+Lead with both numbers in one line, for example: `Migrated 14 sites across 9
+files. Left 23: 6 need a decision, 17 refused.` The user must see the size of
+what was skipped without reading further.
+
+1. **Applied.** File and what each became, one row per site. No diffs, the diff
+   is in the working tree.
+
+   | File | Animates | Became | Note |
+   | --- | --- | --- | --- |
+   | `Card.tsx:34` | opacity, translateY on mount | animation | fillMode forwards |
+   | `Toggle.tsx:12` | backgroundColor on press | transition | shared value became state |
+
+1. **Needs review, not applied.** One row per site with the specific question
+   the user has to answer, since these are the ones they can act on.
+
+   | File | Animates | Blocked on |
+   | --- | --- | --- |
+   | `Sheet.tsx:88` | height on expand | `interpolate` extrapolates past its range |
+
+1. **Refused, grouped by reason**, with counts. Forty gesture-driven components
+   are one line, not forty.
+
+1. **Before and after code for 2-3 applied sites**, covering the different
+   shapes in the table. Write it out; never promise a sample and omit it.
+
+Then ask which of the needs-review sites to take, offering the list by number so
+the user can answer "1, 3 and 5" or "none". Apply only what they name.
+
+Keep out of this report: equivalence obligations to re-check, memoization
+advice, reduced-motion recipes. Prose per site crowds out the code section and
+makes the tables unscannable.
 
 ## Phase 5: verify
 

--- a/skills/reanimated-css-migration/SKILL.md
+++ b/skills/reanimated-css-migration/SKILL.md
@@ -93,6 +93,7 @@ Print as ordinary text. Not a plan object, not a collapsed block. No diff per
 site. Do not edit until the user agrees.
 
 1. **Counts.** Migratable, needs-review, refused.
+
 1. **Table, no code**, one row per site:
 
    | File | Animates | Becomes | Note |
@@ -102,6 +103,7 @@ site. Do not edit until the user agrees.
 
 1. **Refusals grouped by reason**, with counts. Forty gesture-driven components
    are one line.
+
 1. **Before and after for 2-3 representative sites**, covering the shapes in the
    table.
 

--- a/skills/reanimated-css-migration/SKILL.md
+++ b/skills/reanimated-css-migration/SKILL.md
@@ -90,12 +90,16 @@ migrate.
 
 ## Phase 3: report, before editing
 
-Print as ordinary text. Not a plan object, not a collapsed block. No diff per
-site. Do not edit until the user agrees.
+Print as ordinary text. Not a plan object, not a collapsed block. Do not edit
+until the user agrees.
+
+Four parts, all required. The report is incomplete without part 4, which is the
+only part showing code and the only one the user can judge the conversion from.
 
 1. **Counts.** Migratable, needs-review, refused.
 
-1. **Table, no code**, one row per site:
+1. **Table, no code**, one row per site. Everything a site needs to say goes in
+   the Note column:
 
    | File | Animates | Becomes | Note |
    | --- | --- | --- | --- |
@@ -105,8 +109,13 @@ site. Do not edit until the user agrees.
 1. **Refusals grouped by reason**, with counts. Forty gesture-driven components
    are one line.
 
-1. **Before and after for 2-3 representative sites**, covering the shapes in the
-   table.
+1. **Before and after code for 2-3 representative sites**, covering the
+   different shapes in the table. Write it out; never promise a sample and omit
+   it. A diff for every site is the failure this replaces, not this itself.
+
+Keep out of this report: equivalence obligations to re-check, memoization
+advice, reduced-motion recipes, option menus. Those are Phase 4 and 5. Prose per
+site crowds out part 4 and makes the table unscannable.
 
 ## Phase 4: apply
 

--- a/skills/reanimated-css-migration/SKILL.md
+++ b/skills/reanimated-css-migration/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: reanimated-css-migration
+description: "Converts React Native Reanimated hook-based animations into CSS animations and transitions. Use when migrating, converting or porting Reanimated animations to CSS. Use when replacing useAnimatedStyle, useSharedValue, withTiming, withRepeat or withSpring with animationName or transitionProperty. Use when auditing which animations could become CSS. Use this even if the user never says CSS, whenever they ask to simplify, modernize or remove worklets from animation code."
+license: MIT
+compatibility: Requires Reanimated 4.x and the New Architecture
+---
+
+# Reanimated hooks to CSS migration
+
+Converts imperative, worklet-driven animations into Reanimated's declarative CSS
+animations and transitions, but only where the result is behaviorally identical.
+Coverage is not the goal: a migration that changes timing, interruption or
+platform coverage is a defect even when the animation still looks roughly right.
+
+The safety model is deliberately asymmetric: **which source patterns you may
+convert is open, which conditions permit conversion is closed.** You are
+expected to reason about code shapes not listed here. You are not permitted to
+migrate anything that fails a precondition or hits a refusal.
+
+## Failures that produce no error
+
+Four things break an animation without throwing, warning, or failing a typecheck
+or a test, and all four look correct in a diff. Two of them mean the call site
+must not be converted at all. Two are mistakes in the output of a conversion
+that is otherwise fine. Know which is which before you start.
+
+**Do not migrate the call site when:**
+
+- **The driver is written from a worklet.** Gesture callbacks are workletized
+  onto the UI thread by default, as are `useAnimatedReaction`, `useFrameCallback`,
+  scroll handlers and sensors. Driving React state from there needs a
+  `scheduleOnRN` thread hop per update, which is worse than the code you started
+  with. A shared value written from `useEffect` or a plain JS callback is the
+  opposite case: convert it to state and migrate.
+- **React Native renders the property but CSS cannot animate it.** The hook
+  version works today and the CSS version stops. Unsupported properties are
+  dropped by the props builder with no warning at all.
+- **The value changes every frame.** Once it is state, each change re-renders.
+  Migrate discrete changes, not streams.
+
+**Get these right in every conversion you do apply:**
+
+- **Always set a duration**, `animationDuration` or `transitionDuration` to match
+  whichever mechanism you emitted. Both default to 0, which discards the motion
+  entirely.
+- **On animations only, set `animationFillMode: 'forwards'`** when the element
+  should stay where it lands. The CSS default is `none`, which discards the
+  computed value and snaps it back to the start. Transitions have no fill mode
+  and need none, because the underlying prop value genuinely changed; adding one
+  to a transition does nothing.
+
+## References
+
+Load at most one reference file per question.
+
+| File | When to read |
+| --- | --- |
+| `references/preconditions.md` | Deciding whether a specific call site may be migrated |
+| `references/refusals.md` | A pattern looks unmigratable and you need the reason and the advice to give |
+| `references/examples.md` | You need calibration on what a good conversion looks like |
+| `references/api-map.md` | Mapping a `with*` function or an `Easing.*` value, or choosing transition vs animation |
+
+For the authoritative list of which style properties animate on which platform,
+consult
+[Supported style properties](https://docs.swmansion.com/react-native-reanimated/docs/guides/supported-properties).
+`references/refusals.md` lists only the properties where CSS is behind React
+Native, which is the subset that matters when deciding whether to migrate.
+
+For API signatures and configuration options, consult the
+[CSS Animations](https://docs.swmansion.com/react-native-reanimated/docs/category/css-animations)
+and [CSS Transitions](https://docs.swmansion.com/react-native-reanimated/docs/category/css-transitions)
+documentation.
+
+## Match the process to the request
+
+The phases below are for migrating a codebase or a feature. They are the wrong
+shape for a smaller question, and running them anyway is worse than not using
+this skill at all.
+
+- **One call site, already in front of you.** Skip to Phase 2. Check the
+  preconditions, check the properties, convert or explain why not. No inventory,
+  no report, no ledger.
+- **"Can this be CSS?" with no request to change anything.** Answer it. Phase 2
+  reasoning only, no edits.
+- **A whole directory, feature or app.** Run the full sequence.
+
+The preconditions, the refusals and the property check are never optional at any
+size. Everything else scales with the request.
+
+## Before you start
+
+1. Read the installed Reanimated version. CSS animations require 4.x and the New
+   Architecture. On 3.x, stop and say so; do not attempt the upgrade as part of
+   this work.
+1. Require a clean working tree, or an explicit acknowledgment from the user
+   that uncommitted changes are theirs. They need to be able to diff and revert.
+1. Establish the project's target platforms from package.json, app config and
+   the presence of web bundler config. Record what you found; every property
+   decision depends on it.
+1. Agree the scope. A directory, a feature, or the whole app. Never touch files
+   outside it.
+
+Infer what you can from the codebase. Ask only about things genuinely
+unresolvable, and batch those into a single message.
+
+## Phase 1: inventory
+
+Find every animation call site in scope: `useAnimatedStyle`, `useAnimatedProps`,
+`useDerivedValue`, and the `with*` functions.
+
+For each one record the file, the component, the animated properties, what
+drives the animation, and the call site's effective platforms. Effective
+platforms narrow when the file carries a platform suffix (`.ios`, `.android`,
+`.web`, `.native` on any of js, jsx, ts, tsx), or when the code sits inside a
+`Platform.OS` branch or a `Platform.select` arm. A `.ios.tsx` file only needs
+iOS support.
+
+Report the counts before going further. If nothing is migratable, say so and
+stop rather than forcing a conversion.
+
+## Phase 2: classify
+
+For each call site, work through `references/preconditions.md`. Every
+precondition must hold. If any fails, the call site is not migratable and the
+failing precondition is the reason you report.
+
+**State which precondition permits each migration.** If you cannot name the
+condition you are relying on, you have pattern-matched rather than reasoned, and
+you must not migrate. This is the single rule that keeps an open transformation
+set safe.
+
+Check every animated property against the table in `references/refusals.md` for
+the call site's effective platforms. A property covering only one platform is not
+automatically a problem: what matters is whether React Native renders it
+somewhere CSS cannot animate it.
+
+Classify each site as migratable, needs-review, or refused. Prefer needs-review
+over migratable whenever you are weighing a judgment call.
+
+## Phase 3: report before editing
+
+Print the plan as ordinary text in the conversation. Do not bury it in a plan
+object or a collapsed block, and do not start editing until the user has agreed
+to it.
+
+The plan has to stay readable at thirty call sites, so do not paste a diff per
+site. Use three parts:
+
+**A count.** One line: how many sites are migratable, how many need review, how
+many are refused.
+
+**A table of what would change**, one row per call site, no code:
+
+| File | What it animates | Becomes | Note |
+| --- | --- | --- | --- |
+| `Card.tsx:34` | opacity, translateY on mount | animation | fillMode forwards |
+| `Toggle.tsx:12` | backgroundColor on press | transition | shared value becomes state |
+
+**Refusals grouped by reason, not by file**, with a count and one explanation
+each. Forty gesture-driven components are one line saying forty, not forty
+lines. A migration is judged on what it declines and whether it explains itself,
+so this is half the output, not an appendix.
+
+Then show the full before and after for **two or three representative sites
+only**, picked to cover the different shapes in the table. That is enough for
+the user to judge the approach without reading everything.
+
+Let the user narrow the list before you apply anything.
+
+## Phase 4: apply
+
+Before fanning out, migrate three call sites that differ from each other and
+compare the results. Correcting your approach after three files is far cheaper
+than correcting the same mistake across thirty. If the three disagree about
+anything, resolve it before continuing.
+
+Keep progress in a file on disk, not in the conversation, listing every call
+site in scope with a status of pending, done or refused, plus the precondition
+or refusal reason. Update it as you go. Conversation memory does not survive
+compaction, and a migration that loses its place re-edits files it already
+finished. After any interruption, trust the file and `git diff` over your own
+recollection of what you did.
+
+Migrate one call site at a time. After each one, the component must satisfy
+every equivalence obligation in `references/preconditions.md`: same appearance
+on first render, same end state, same behavior on re-trigger, interrupt and
+unmount, and no other change to what the component renders.
+
+Remove the shared values, hooks and imports that the conversion makes dead, and
+nothing else. Keep `Platform.select` structures exactly as the author wrote
+them and migrate within each arm; flattening a deliberate platform decision is a
+regression regardless of how the animation behaves.
+
+Never rewrite one API into a different one as part of this work. Converting
+shadow properties to `boxShadow`, for example, is an independent refactor with
+its own visual risk. Suggest it in the report; do not fold it into the diff.
+
+Checkpoint per file, not per call site, and not once at the very end. After each
+file, say what changed in one line and let the user stop you. Asking after every
+call site is noise in a file with six of them; asking only at the end means a
+mistake in the approach has already been repeated thirty times.
+
+Stop and ask, rather than deciding alone, whenever a site turns out to differ
+from the plan the user agreed to: a property you had not spotted, a driver that
+is a worklet after all, or an equivalence obligation you cannot satisfy.
+
+## Phase 5: verify
+
+1. Typecheck and lint the changed files.
+1. Watch the animation run. Static checks cannot detect any of the four failure
+   modes above, so this is the only step that constitutes evidence.
+1. Watch the first frame specifically, and re-trigger once. Those are where a
+   missing fill mode and a dead driver show up.
+
+Report what you verified and what you could not. If you did not run the app, say
+so plainly rather than implying the change is confirmed.
+
+## General rules
+
+- Default to not migrating. An unrecognized shape is a refusal needing manual
+  review, never a best guess.
+- Hook-based Reanimated stays the correct answer for gesture-driven,
+  scroll-driven, measurement-driven and imperative animation. Say so when
+  refusing, so the output reads as advice rather than a limitation list.
+- Never emit `transitionProperty: 'all'` as a substitute for working out which
+  properties change.
+- Hoist keyframe objects out of render. One created during render is a new
+  object every time, which restarts the animation on every re-render.
+- If the user asks only about one phase, go straight to it.

--- a/skills/reanimated-css-migration/SKILL.md
+++ b/skills/reanimated-css-migration/SKILL.md
@@ -7,179 +7,142 @@ compatibility: Requires Reanimated 4.x and the New Architecture
 
 # Reanimated hooks to CSS migration
 
-Convert only where the result is behaviorally identical. Changed timing,
-interruption or platform coverage is a defect, even if the animation still looks
-roughly right. Coverage is not the goal.
+Convert only where behavior is identical. Changed timing, interruption or
+platform coverage is a defect. Coverage is not the goal.
 
-Which source shapes you may convert is open: reason about code not listed here.
-Which conditions permit conversion is closed: never migrate past a failed
+Source shapes you may convert: open, reason about code not listed here.
+Conditions that permit conversion: closed, never migrate past a failed
 precondition or a refusal.
 
-## Four silent failures
+## Silent failures
 
-None of these throw, warn, or fail a typecheck or test. All look correct in a
-diff.
+None throw, warn, or fail a typecheck or test. All look correct in a diff.
 
-Do not migrate when:
-
-- **The driver is written in a worklet.** Gesture callbacks, `useAnimatedReaction`,
-  `useFrameCallback`, scroll handlers and sensors run on the UI thread. Reaching
-  React state from there costs a `scheduleOnRN` hop per update.
-- **React Native renders the property where CSS cannot animate it.** It works
-  today and stops after. Unsupported properties are dropped with no warning.
-- **The value changes every frame.** As state, every change re-renders. Migrate
-  discrete changes, not streams.
-
-A shared value written from `useEffect` or a plain JS callback is the opposite
-case: convert it to state and migrate.
-
-Always, in every conversion you apply:
-
-- **Set a duration**, `animationDuration` or `transitionDuration` to match what
-  you emitted. Both default to 0, which discards the motion.
-- **Set `animationFillMode: 'forwards'` on animations** that should stay where
-  they land. The default `none` snaps back to the start. Transitions have no fill
-  mode; adding one does nothing.
+| Condition | Action |
+| --- | --- |
+| Driver written in a worklet | Refuse. React state from the UI thread costs a `scheduleOnRN` hop per update |
+| React Native renders the property where CSS cannot animate it | Refuse. Works today, stops after; dropped with no warning |
+| Value changes every frame | Refuse. As state, every change re-renders |
+| Shared value written in `useEffect` or a plain JS callback | Convert it to state and migrate |
+| Emitting any animation or transition | Set `animationDuration` / `transitionDuration`. Both default to 0, which discards the motion |
+| Emitting an animation that should stay where it lands | Set `animationFillMode: 'forwards'`. Default `none` snaps back. Transitions have no fill mode |
 
 ## References
 
 Load at most one per question.
 
-| File | When to read |
+| File | Read when |
 | --- | --- |
 | `references/preconditions.md` | Deciding whether a call site may be migrated |
-| `references/refusals.md` | A pattern looks unmigratable and you need the reason and the advice |
-| `references/examples.md` | Calibrating what a good conversion looks like |
-| `references/api-map.md` | Mapping a `with*` or `Easing.*` value, or choosing transition vs animation |
+| `references/refusals.md` | A pattern looks unmigratable and you need the reason and advice |
+| `references/examples.md` | Calibrating what a conversion looks like |
+| `references/api-map.md` | Mapping a `with*` or `Easing.*`, or choosing transition vs animation |
 
 Property support:
-[Supported style properties](https://docs.swmansion.com/react-native-reanimated/docs/guides/supported-properties).
+[supported properties](https://docs.swmansion.com/react-native-reanimated/docs/guides/supported-properties).
 API signatures:
 [CSS Animations](https://docs.swmansion.com/react-native-reanimated/docs/category/css-animations),
 [CSS Transitions](https://docs.swmansion.com/react-native-reanimated/docs/category/css-transitions).
 
-## Scale the process to the request
+## Scale to the request
 
-| Request | Do |
+| Request | Run |
 | --- | --- |
-| One call site, already in front of you | Phase 2 only. Convert or explain. No inventory, report or ledger |
-| "Can this be CSS?", no edit requested | Phase 2 reasoning, no edits |
-| A directory, feature or app | Full sequence |
+| One call site in front of you | Phase 2 only. No inventory, report or ledger |
+| "Can this be CSS?", no edit asked for | Phase 2 reasoning, no edits |
+| A directory, feature or app | All phases |
 
-Preconditions, refusals and the property check apply at every size. Everything
-else scales.
+Preconditions, refusals and the property check apply at every size.
 
-## Before you start
+## Phase 0: before starting
 
-1. Read the installed Reanimated version. On 3.x, stop and say so. Do not
-   upgrade as part of this work.
-1. Require a clean working tree, or explicit acknowledgment that uncommitted
-   changes are the user's.
-1. Determine target platforms from package.json, app config and web bundler
-   config. Record them; every property decision depends on it.
-1. Agree the scope. Never touch files outside it.
+| Check | Then |
+| --- | --- |
+| Installed Reanimated version | On 3.x, stop and say so. Do not upgrade as part of this work |
+| Working tree | Require clean, or explicit acknowledgment the changes are the user's |
+| Target platforms, from package.json, app config, web bundler config | Record them; every property decision depends on it |
+| Scope | Agree it. Never touch files outside |
 
 Infer what you can. Batch genuine questions into one message.
 
 ## Phase 1: inventory
 
 Find every `useAnimatedStyle`, `useAnimatedProps`, `useDerivedValue` and `with*`
-call site in scope. Record file, component, animated properties, driver, and
-effective platforms.
+call site in scope. Per site record: file, component, animated properties,
+driver, effective platforms.
 
-Effective platforms narrow to:
-
-- the suffix, for `.ios` / `.android` / `.web` / `.native` on js, jsx, ts, tsx
-- the branch, inside `Platform.OS` or a `Platform.select` arm
-
-Report counts before continuing. If nothing is migratable, say so and stop.
+Report counts before continuing. Nothing migratable, say so and stop.
 
 ## Phase 2: classify
 
-Work each call site through `references/preconditions.md`. Every precondition
-must hold; the first failure is the reason you report.
+Per call site:
 
-**Name the precondition that permits each migration.** Cannot name one, do not
-migrate. This is what keeps an open transformation set safe.
+1. Run `references/preconditions.md`. All 7 must pass.
+1. Check every animated property against the table in `references/refusals.md`
+   for that site's effective platforms.
+1. Label migratable, needs-review, or refused. Judgment calls go to
+   needs-review.
 
-Check every animated property against the table in `references/refusals.md` for
-that site's effective platforms. Single-platform support is not itself a
-problem; what matters is whether React Native renders it where CSS cannot.
+**Name the precondition permitting each migration.** Cannot name one, do not
+migrate.
 
-Label each site migratable, needs-review, or refused. When weighing a judgment
-call, choose needs-review.
+## Phase 3: report, before editing
 
-## Phase 3: report before editing
-
-Print as ordinary text. Not a plan object, not a collapsed block. Do not edit
-until the user agrees.
-
-Never paste a diff per site. Report three parts:
+Print as ordinary text. Not a plan object, not a collapsed block. No diff per
+site. Do not edit until the user agrees.
 
 1. **Counts.** Migratable, needs-review, refused.
+1. **Table, no code**, one row per site:
 
-1. **A table, no code**, one row per site:
-
-   | File | What it animates | Becomes | Note |
+   | File | Animates | Becomes | Note |
    | --- | --- | --- | --- |
    | `Card.tsx:34` | opacity, translateY on mount | animation | fillMode forwards |
    | `Toggle.tsx:12` | backgroundColor on press | transition | shared value becomes state |
 
 1. **Refusals grouped by reason**, with counts. Forty gesture-driven components
-   are one line, not forty.
-
-Then show before and after for two or three representative sites only, covering
-the different shapes in the table.
-
-Let the user narrow the list before applying anything.
+   are one line.
+1. **Before and after for 2-3 representative sites**, covering the shapes in the
+   table.
 
 ## Phase 4: apply
 
-Migrate three differing call sites first and compare. Resolve any disagreement
-between them before continuing: fixing the approach after three files is cheaper
-than after thirty.
+Migrate 3 differing sites first, compare, resolve disagreements before
+continuing.
 
-Keep a status file on disk listing every site as pending, done or refused, with
-its precondition or refusal reason. Update it as you go. Conversation memory does
-not survive compaction; after any interruption trust the file and `git diff`, not
-recall.
+Keep a status file on disk: every site as pending, done or refused, with its
+precondition or refusal reason. Conversation memory does not survive compaction;
+after an interruption trust the file and `git diff`, not recall.
 
-Then, one call site at a time:
+Then per call site:
 
-- Satisfy every equivalence obligation in `references/preconditions.md`.
-- Remove the shared values, hooks and imports the conversion made dead, and
-  nothing else.
-- Keep `Platform.select` structures as written; migrate inside each arm.
-- Never swap one API for another. `shadow*` to `boxShadow` is a separate
-  refactor. Suggest it in the report; keep it out of the diff.
+| Do | Do not |
+| --- | --- |
+| Satisfy all 5 equivalence obligations | Leave an obligation unchecked |
+| Remove shared values, hooks, imports the conversion killed | Remove anything else |
+| Migrate inside each `Platform.select` arm, keeping structure | Collapse the arms |
+| Suggest `shadow*` to `boxShadow` in the report | Swap one API for another in this diff |
 
-Checkpoint per file: one line on what changed, then let the user stop you. Per
-call site is noise; only at the end means the mistake already repeated thirty
-times.
+Checkpoint per file: one line on what changed, then let the user stop you.
 
-Stop and ask whenever a site differs from the agreed plan: an unspotted
-property, a driver that turns out to be a worklet, an obligation you cannot
-satisfy.
+Stop and ask when a site differs from the agreed plan: an unspotted property, a
+driver that is a worklet after all, an obligation you cannot satisfy.
 
 ## Phase 5: verify
 
-1. Typecheck and lint the changed files.
-1. Watch the animation run. Static checks catch none of the four silent
-   failures, so this is the only real evidence.
-1. Watch the first frame, and re-trigger once. That is where a missing fill mode
-   and a dead driver surface.
+1. Typecheck and lint changed files.
+1. Watch the animation run. Static checks catch none of the silent failures.
+1. Watch the first frame, and re-trigger once. Missing fill mode and dead
+   drivers surface there.
 
-Report what you verified and what you did not. If you did not run the app, say
-so plainly.
+Report what you verified and what you did not. Did not run the app, say so.
 
 ## Rules
 
-- Default to not migrating. An unrecognized shape is a refusal for manual
-  review, never a guess.
-- Hooks stay correct for gesture-, scroll-, measurement-driven and imperative
-  animation. Say so when refusing, so the output reads as advice.
-- Never emit `transitionProperty: 'all'` instead of working out which properties
-  change.
-- Hoist keyframe objects out of render. A new object each render restarts the
-  animation.
-- If the user asks about one phase, go straight to it.
+| Rule | Reason |
+| --- | --- |
+| Default to not migrating; an unrecognized shape is a refusal for manual review | A wrong conversion is silent |
+| Say hooks stay correct for gesture-, scroll-, measurement-driven and imperative animation | The output should read as advice, not limitation |
+| Never emit `transitionProperty: 'all'` | Enumerate what changes |
+| Hoist keyframe objects out of render | A new object each render restarts the animation |
+| Bare numeric durations are milliseconds | `300` is 300ms |
+| Go straight to a phase if the user asks about one | |

--- a/skills/reanimated-css-migration/SKILL.md
+++ b/skills/reanimated-css-migration/SKILL.md
@@ -24,7 +24,7 @@ None throw, warn, or fail a typecheck or test. All look correct in a diff.
 | React Native renders the property where CSS cannot animate it | Refuse. Works today, stops after; dropped with no warning |
 | Value changes every frame | Refuse. As state, every change re-renders |
 | Shared value written in `useEffect` or a plain JS callback | Convert it to state and migrate |
-| Emitting any animation or transition | Set `animationDuration` / `transitionDuration`. Both default to 0, which discards the motion |
+| Emitting any animation or transition | Set the duration, default 0 discards the motion. Set the timing function too: it defaults to `'ease'`, not the `withTiming` default of `Easing.inOut(Easing.quad)` |
 | Emitting an animation that should stay where it lands | Set `animationFillMode: 'forwards'`. Default `none` snaps back. Transitions have no fill mode |
 
 ## References
@@ -60,6 +60,7 @@ Preconditions, refusals and the property check apply at every size.
 | Check | Then |
 | --- | --- |
 | Installed Reanimated version | On 3.x, stop and say so. Do not upgrade as part of this work |
+| Reanimated < 4.4 with SVG in scope | Refuse the SVG sites. `EXPERIMENTAL_CSS_ANIMATIONS_FOR_SVG_COMPONENTS` defaults false before 4.4, so the CSS is dropped with no warning |
 | Working tree | Require clean, or explicit acknowledgment the changes are the user's |
 | Target platforms, from package.json, app config, web bundler config | Record them; every property decision depends on it |
 | Scope | Agree it. Never touch files outside |
@@ -146,6 +147,6 @@ Report what you verified and what you did not. Did not run the app, say so.
 | Default to not migrating; an unrecognized shape is a refusal for manual review | A wrong conversion is silent |
 | Say hooks stay correct for gesture-, scroll-, measurement-driven and imperative animation | The output should read as advice, not limitation |
 | Never emit `transitionProperty: 'all'` | Enumerate what changes |
-| Hoist keyframe objects out of render | A new object each render restarts the animation |
+| Hoist keyframe objects out of render | Keyframes are keyed by content, so a rebuilt identical object is only waste. One whose content varies per render does restart the animation |
 | Bare numeric durations are milliseconds | `300` is 300ms |
 | Go straight to a phase if the user asks about one | |

--- a/skills/reanimated-css-migration/SKILL.md
+++ b/skills/reanimated-css-migration/SKILL.md
@@ -7,223 +7,179 @@ compatibility: Requires Reanimated 4.x and the New Architecture
 
 # Reanimated hooks to CSS migration
 
-Converts imperative, worklet-driven animations into Reanimated's declarative CSS
-animations and transitions, but only where the result is behaviorally identical.
-Coverage is not the goal: a migration that changes timing, interruption or
-platform coverage is a defect even when the animation still looks roughly right.
+Convert only where the result is behaviorally identical. Changed timing,
+interruption or platform coverage is a defect, even if the animation still looks
+roughly right. Coverage is not the goal.
 
-The safety model is deliberately asymmetric: **which source patterns you may
-convert is open, which conditions permit conversion is closed.** You are
-expected to reason about code shapes not listed here. You are not permitted to
-migrate anything that fails a precondition or hits a refusal.
+Which source shapes you may convert is open: reason about code not listed here.
+Which conditions permit conversion is closed: never migrate past a failed
+precondition or a refusal.
 
-## Failures that produce no error
+## Four silent failures
 
-Four things break an animation without throwing, warning, or failing a typecheck
-or a test, and all four look correct in a diff. Two of them mean the call site
-must not be converted at all. Two are mistakes in the output of a conversion
-that is otherwise fine. Know which is which before you start.
+None of these throw, warn, or fail a typecheck or test. All look correct in a
+diff.
 
-**Do not migrate the call site when:**
+Do not migrate when:
 
-- **The driver is written from a worklet.** Gesture callbacks are workletized
-  onto the UI thread by default, as are `useAnimatedReaction`, `useFrameCallback`,
-  scroll handlers and sensors. Driving React state from there needs a
-  `scheduleOnRN` thread hop per update, which is worse than the code you started
-  with. A shared value written from `useEffect` or a plain JS callback is the
-  opposite case: convert it to state and migrate.
-- **React Native renders the property but CSS cannot animate it.** The hook
-  version works today and the CSS version stops. Unsupported properties are
-  dropped by the props builder with no warning at all.
-- **The value changes every frame.** Once it is state, each change re-renders.
-  Migrate discrete changes, not streams.
+- **The driver is written in a worklet.** Gesture callbacks, `useAnimatedReaction`,
+  `useFrameCallback`, scroll handlers and sensors run on the UI thread. Reaching
+  React state from there costs a `scheduleOnRN` hop per update.
+- **React Native renders the property where CSS cannot animate it.** It works
+  today and stops after. Unsupported properties are dropped with no warning.
+- **The value changes every frame.** As state, every change re-renders. Migrate
+  discrete changes, not streams.
 
-**Get these right in every conversion you do apply:**
+A shared value written from `useEffect` or a plain JS callback is the opposite
+case: convert it to state and migrate.
 
-- **Always set a duration**, `animationDuration` or `transitionDuration` to match
-  whichever mechanism you emitted. Both default to 0, which discards the motion
-  entirely.
-- **On animations only, set `animationFillMode: 'forwards'`** when the element
-  should stay where it lands. The CSS default is `none`, which discards the
-  computed value and snaps it back to the start. Transitions have no fill mode
-  and need none, because the underlying prop value genuinely changed; adding one
-  to a transition does nothing.
+Always, in every conversion you apply:
+
+- **Set a duration**, `animationDuration` or `transitionDuration` to match what
+  you emitted. Both default to 0, which discards the motion.
+- **Set `animationFillMode: 'forwards'` on animations** that should stay where
+  they land. The default `none` snaps back to the start. Transitions have no fill
+  mode; adding one does nothing.
 
 ## References
 
-Load at most one reference file per question.
+Load at most one per question.
 
 | File | When to read |
 | --- | --- |
-| `references/preconditions.md` | Deciding whether a specific call site may be migrated |
-| `references/refusals.md` | A pattern looks unmigratable and you need the reason and the advice to give |
-| `references/examples.md` | You need calibration on what a good conversion looks like |
-| `references/api-map.md` | Mapping a `with*` function or an `Easing.*` value, or choosing transition vs animation |
+| `references/preconditions.md` | Deciding whether a call site may be migrated |
+| `references/refusals.md` | A pattern looks unmigratable and you need the reason and the advice |
+| `references/examples.md` | Calibrating what a good conversion looks like |
+| `references/api-map.md` | Mapping a `with*` or `Easing.*` value, or choosing transition vs animation |
 
-For the authoritative list of which style properties animate on which platform,
-consult
+Property support:
 [Supported style properties](https://docs.swmansion.com/react-native-reanimated/docs/guides/supported-properties).
-`references/refusals.md` lists only the properties where CSS is behind React
-Native, which is the subset that matters when deciding whether to migrate.
+API signatures:
+[CSS Animations](https://docs.swmansion.com/react-native-reanimated/docs/category/css-animations),
+[CSS Transitions](https://docs.swmansion.com/react-native-reanimated/docs/category/css-transitions).
 
-For API signatures and configuration options, consult the
-[CSS Animations](https://docs.swmansion.com/react-native-reanimated/docs/category/css-animations)
-and [CSS Transitions](https://docs.swmansion.com/react-native-reanimated/docs/category/css-transitions)
-documentation.
+## Scale the process to the request
 
-## Match the process to the request
+| Request | Do |
+| --- | --- |
+| One call site, already in front of you | Phase 2 only. Convert or explain. No inventory, report or ledger |
+| "Can this be CSS?", no edit requested | Phase 2 reasoning, no edits |
+| A directory, feature or app | Full sequence |
 
-The phases below are for migrating a codebase or a feature. They are the wrong
-shape for a smaller question, and running them anyway is worse than not using
-this skill at all.
-
-- **One call site, already in front of you.** Skip to Phase 2. Check the
-  preconditions, check the properties, convert or explain why not. No inventory,
-  no report, no ledger.
-- **"Can this be CSS?" with no request to change anything.** Answer it. Phase 2
-  reasoning only, no edits.
-- **A whole directory, feature or app.** Run the full sequence.
-
-The preconditions, the refusals and the property check are never optional at any
-size. Everything else scales with the request.
+Preconditions, refusals and the property check apply at every size. Everything
+else scales.
 
 ## Before you start
 
-1. Read the installed Reanimated version. CSS animations require 4.x and the New
-   Architecture. On 3.x, stop and say so; do not attempt the upgrade as part of
-   this work.
-1. Require a clean working tree, or an explicit acknowledgment from the user
-   that uncommitted changes are theirs. They need to be able to diff and revert.
-1. Establish the project's target platforms from package.json, app config and
-   the presence of web bundler config. Record what you found; every property
-   decision depends on it.
-1. Agree the scope. A directory, a feature, or the whole app. Never touch files
-   outside it.
+1. Read the installed Reanimated version. On 3.x, stop and say so. Do not
+   upgrade as part of this work.
+1. Require a clean working tree, or explicit acknowledgment that uncommitted
+   changes are the user's.
+1. Determine target platforms from package.json, app config and web bundler
+   config. Record them; every property decision depends on it.
+1. Agree the scope. Never touch files outside it.
 
-Infer what you can from the codebase. Ask only about things genuinely
-unresolvable, and batch those into a single message.
+Infer what you can. Batch genuine questions into one message.
 
 ## Phase 1: inventory
 
-Find every animation call site in scope: `useAnimatedStyle`, `useAnimatedProps`,
-`useDerivedValue`, and the `with*` functions.
+Find every `useAnimatedStyle`, `useAnimatedProps`, `useDerivedValue` and `with*`
+call site in scope. Record file, component, animated properties, driver, and
+effective platforms.
 
-For each one record the file, the component, the animated properties, what
-drives the animation, and the call site's effective platforms. Effective
-platforms narrow when the file carries a platform suffix (`.ios`, `.android`,
-`.web`, `.native` on any of js, jsx, ts, tsx), or when the code sits inside a
-`Platform.OS` branch or a `Platform.select` arm. A `.ios.tsx` file only needs
-iOS support.
+Effective platforms narrow to:
 
-Report the counts before going further. If nothing is migratable, say so and
-stop rather than forcing a conversion.
+- the suffix, for `.ios` / `.android` / `.web` / `.native` on js, jsx, ts, tsx
+- the branch, inside `Platform.OS` or a `Platform.select` arm
+
+Report counts before continuing. If nothing is migratable, say so and stop.
 
 ## Phase 2: classify
 
-For each call site, work through `references/preconditions.md`. Every
-precondition must hold. If any fails, the call site is not migratable and the
-failing precondition is the reason you report.
+Work each call site through `references/preconditions.md`. Every precondition
+must hold; the first failure is the reason you report.
 
-**State which precondition permits each migration.** If you cannot name the
-condition you are relying on, you have pattern-matched rather than reasoned, and
-you must not migrate. This is the single rule that keeps an open transformation
-set safe.
+**Name the precondition that permits each migration.** Cannot name one, do not
+migrate. This is what keeps an open transformation set safe.
 
 Check every animated property against the table in `references/refusals.md` for
-the call site's effective platforms. A property covering only one platform is not
-automatically a problem: what matters is whether React Native renders it
-somewhere CSS cannot animate it.
+that site's effective platforms. Single-platform support is not itself a
+problem; what matters is whether React Native renders it where CSS cannot.
 
-Classify each site as migratable, needs-review, or refused. Prefer needs-review
-over migratable whenever you are weighing a judgment call.
+Label each site migratable, needs-review, or refused. When weighing a judgment
+call, choose needs-review.
 
 ## Phase 3: report before editing
 
-Print the plan as ordinary text in the conversation. Do not bury it in a plan
-object or a collapsed block, and do not start editing until the user has agreed
-to it.
+Print as ordinary text. Not a plan object, not a collapsed block. Do not edit
+until the user agrees.
 
-The plan has to stay readable at thirty call sites, so do not paste a diff per
-site. Use three parts:
+Never paste a diff per site. Report three parts:
 
-**A count.** One line: how many sites are migratable, how many need review, how
-many are refused.
+1. **Counts.** Migratable, needs-review, refused.
 
-**A table of what would change**, one row per call site, no code:
+1. **A table, no code**, one row per site:
 
-| File | What it animates | Becomes | Note |
-| --- | --- | --- | --- |
-| `Card.tsx:34` | opacity, translateY on mount | animation | fillMode forwards |
-| `Toggle.tsx:12` | backgroundColor on press | transition | shared value becomes state |
+   | File | What it animates | Becomes | Note |
+   | --- | --- | --- | --- |
+   | `Card.tsx:34` | opacity, translateY on mount | animation | fillMode forwards |
+   | `Toggle.tsx:12` | backgroundColor on press | transition | shared value becomes state |
 
-**Refusals grouped by reason, not by file**, with a count and one explanation
-each. Forty gesture-driven components are one line saying forty, not forty
-lines. A migration is judged on what it declines and whether it explains itself,
-so this is half the output, not an appendix.
+1. **Refusals grouped by reason**, with counts. Forty gesture-driven components
+   are one line, not forty.
 
-Then show the full before and after for **two or three representative sites
-only**, picked to cover the different shapes in the table. That is enough for
-the user to judge the approach without reading everything.
+Then show before and after for two or three representative sites only, covering
+the different shapes in the table.
 
-Let the user narrow the list before you apply anything.
+Let the user narrow the list before applying anything.
 
 ## Phase 4: apply
 
-Before fanning out, migrate three call sites that differ from each other and
-compare the results. Correcting your approach after three files is far cheaper
-than correcting the same mistake across thirty. If the three disagree about
-anything, resolve it before continuing.
+Migrate three differing call sites first and compare. Resolve any disagreement
+between them before continuing: fixing the approach after three files is cheaper
+than after thirty.
 
-Keep progress in a file on disk, not in the conversation, listing every call
-site in scope with a status of pending, done or refused, plus the precondition
-or refusal reason. Update it as you go. Conversation memory does not survive
-compaction, and a migration that loses its place re-edits files it already
-finished. After any interruption, trust the file and `git diff` over your own
-recollection of what you did.
+Keep a status file on disk listing every site as pending, done or refused, with
+its precondition or refusal reason. Update it as you go. Conversation memory does
+not survive compaction; after any interruption trust the file and `git diff`, not
+recall.
 
-Migrate one call site at a time. After each one, the component must satisfy
-every equivalence obligation in `references/preconditions.md`: same appearance
-on first render, same end state, same behavior on re-trigger, interrupt and
-unmount, and no other change to what the component renders.
+Then, one call site at a time:
 
-Remove the shared values, hooks and imports that the conversion makes dead, and
-nothing else. Keep `Platform.select` structures exactly as the author wrote
-them and migrate within each arm; flattening a deliberate platform decision is a
-regression regardless of how the animation behaves.
+- Satisfy every equivalence obligation in `references/preconditions.md`.
+- Remove the shared values, hooks and imports the conversion made dead, and
+  nothing else.
+- Keep `Platform.select` structures as written; migrate inside each arm.
+- Never swap one API for another. `shadow*` to `boxShadow` is a separate
+  refactor. Suggest it in the report; keep it out of the diff.
 
-Never rewrite one API into a different one as part of this work. Converting
-shadow properties to `boxShadow`, for example, is an independent refactor with
-its own visual risk. Suggest it in the report; do not fold it into the diff.
+Checkpoint per file: one line on what changed, then let the user stop you. Per
+call site is noise; only at the end means the mistake already repeated thirty
+times.
 
-Checkpoint per file, not per call site, and not once at the very end. After each
-file, say what changed in one line and let the user stop you. Asking after every
-call site is noise in a file with six of them; asking only at the end means a
-mistake in the approach has already been repeated thirty times.
-
-Stop and ask, rather than deciding alone, whenever a site turns out to differ
-from the plan the user agreed to: a property you had not spotted, a driver that
-is a worklet after all, or an equivalence obligation you cannot satisfy.
+Stop and ask whenever a site differs from the agreed plan: an unspotted
+property, a driver that turns out to be a worklet, an obligation you cannot
+satisfy.
 
 ## Phase 5: verify
 
 1. Typecheck and lint the changed files.
-1. Watch the animation run. Static checks cannot detect any of the four failure
-   modes above, so this is the only step that constitutes evidence.
-1. Watch the first frame specifically, and re-trigger once. Those are where a
-   missing fill mode and a dead driver show up.
+1. Watch the animation run. Static checks catch none of the four silent
+   failures, so this is the only real evidence.
+1. Watch the first frame, and re-trigger once. That is where a missing fill mode
+   and a dead driver surface.
 
-Report what you verified and what you could not. If you did not run the app, say
-so plainly rather than implying the change is confirmed.
+Report what you verified and what you did not. If you did not run the app, say
+so plainly.
 
-## General rules
+## Rules
 
-- Default to not migrating. An unrecognized shape is a refusal needing manual
-  review, never a best guess.
-- Hook-based Reanimated stays the correct answer for gesture-driven,
-  scroll-driven, measurement-driven and imperative animation. Say so when
-  refusing, so the output reads as advice rather than a limitation list.
-- Never emit `transitionProperty: 'all'` as a substitute for working out which
-  properties change.
-- Hoist keyframe objects out of render. One created during render is a new
-  object every time, which restarts the animation on every re-render.
-- If the user asks only about one phase, go straight to it.
+- Default to not migrating. An unrecognized shape is a refusal for manual
+  review, never a guess.
+- Hooks stay correct for gesture-, scroll-, measurement-driven and imperative
+  animation. Say so when refusing, so the output reads as advice.
+- Never emit `transitionProperty: 'all'` instead of working out which properties
+  change.
+- Hoist keyframe objects out of render. A new object each render restarts the
+  animation.
+- If the user asks about one phase, go straight to it.

--- a/skills/reanimated-css-migration/references/api-map.md
+++ b/skills/reanimated-css-migration/references/api-map.md
@@ -8,7 +8,8 @@
 
 ## Transition or animation: which one
 
-Decide by what drives each step.
+Decide by what drives each step. Classify **per property and per edge**, never
+per call site: one element may legitimately need both mechanisms at once.
 
 **Transition** when something outside the element triggers every step: press,
 toggle, expand, theme change, selection. Step count is irrelevant, a stepper is
@@ -22,18 +23,38 @@ introducing that render by converting the shared value to state is part of the
 migration. The exception is a write inside a worklet, which stays on the hooks
 API.
 
-Two failure modes:
+### Mount edges outrank the trigger
+
+A transition needs a previously rendered value to move from. It never runs on the
+element's first render, so any step whose "before" value was never painted is an
+animation, whatever triggered it.
+
+| Site | Emit |
+| --- | --- |
+| Element conditionally rendered on the driver: `if (!open) return null` | Animation with `animationFillMode: 'forwards'` on the false to true edge. The true to false edge is unobservable, the element unmounts |
+| Mount `useEffect` writes a value different from the initial one | Animation for that edge, or migrate the rest as a transition and state the dropped mount step. Not a reason to park the site |
+| A mount step and a later driver step on the same element | Both: `animationName` for the mount, `transitionProperty` for the driver-changed properties |
+| Driver toggles while the element stays mounted | Transition |
+
+Emitting a transition where the element mounts is the silent-failure direction:
+it renders at the final value and nothing moves.
+
+Three failure modes:
 
 - A transition whose value never re-renders does nothing. Convert the driver to
   state.
 - An animation used for an interaction fires on mount instead of on the event.
+- A property listed in both `animationName` keyframes and `transitionProperty` on
+  one element. Split by property; never overlap them.
 
 ## The `with*` functions, mapped
 
 | Source | CSS | Notes |
 | --- | --- | --- |
 | `withTiming(v, {duration, easing})` | `transitionDuration` + `transitionTimingFunction`, or a two-keyframe animation | Which one depends on the section above, not on the call |
-| `withDelay(ms, anim)` | `transitionDelay` or `animationDelay` | Negative `animationDelay` pre-seeds a loop mid-cycle, which has no hook equivalent and is the idiomatic way to stagger |
+| `withDelay(ms, anim)` at the top level | `transitionDelay` or `animationDelay` | Negative `animationDelay` pre-seeds a loop mid-cycle, which has no hook equivalent and is the idiomatic way to stagger |
+| `withDelay(ms, x)` inside a `withSequence` | an `ms` hold before `x` | Not a leading delay. Add `ms` to the sequence total and repeat the previous keyframe value at the offset where `x` begins |
+| `withTiming(v, { duration: 0 })` | an instant step | Two keyframes at the same offset, or `steps(1, 'jump-end')` when every step in the sequence is instant |
 | `withRepeat(anim, -1)` | `animationIterationCount: 'infinite'` | Any count `<= 0` means infinite |
 | `withRepeat(anim, n)` | `animationIterationCount: n` | |
 | `withRepeat(anim, n, true)` | plus `animationDirection: 'alternate'` | The third argument is `reverse` |

--- a/skills/reanimated-css-migration/references/api-map.md
+++ b/skills/reanimated-css-migration/references/api-map.md
@@ -45,10 +45,11 @@ Two failure modes:
 
 Two traps in that table:
 
-**Reverse plus an odd count changes where it stops.** `withRepeat(anim, 3, true)`
-ends at the start value, not the target, because the third pass runs backwards.
-`animationDirection: 'alternate'` behaves the same way, so the mapping holds, but
-check the resting state after converting.
+**Reverse plus an even count returns to the start.** `withRepeat(anim, 2, true)`
+ends at the start value, `withRepeat(anim, 3, true)` at the target:
+`numberOfReps` counts single passes and the last one runs forwards
+(`animation/repeat.ts:124`). `animationDirection: 'alternate'` matches, so the
+mapping holds, but check the resting state after converting.
 
 **`withSequence` durations are absolute, keyframe offsets are relative.** Two
 300ms steps become `animationDuration: '600ms'` with stops at `0%`, `50%`,
@@ -65,6 +66,7 @@ replace the whole shared-value or React-state round-trip:
 <Animated.View
   style={{
     backgroundColor: { default: '#eee', ':active': '#ccc' },
+    transitionProperty: ['backgroundColor'],
     transitionDuration: 150,
   }}
 />
@@ -72,6 +74,19 @@ replace the whole shared-value or React-state round-trip:
 
 Prefer this whenever the trigger is press, hover or focus. It needs no state and
 does not re-render.
+
+- Write `default` unless the resting value is the property's own default. The
+  pseudo object owns the property, so rest resolves to `default`; omit it and
+  the value falls back to the property default (`backgroundColor` transparent,
+  `transform` identity), never to `StyleSheet.create` or an earlier style in the
+  array
+- `:active` fires on the pressed element **and every ancestor declaring
+  `:active`**. React Native's responder system fired only the innermost, so
+  migrating nested press sites is a silent visual change. Put `:active-deepest`
+  on the ancestor that must stay quiet: it yields when a descendant declaring
+  `:active` or `:active-deepest` is pressed
+- When several selectors match one property, the later wins:
+  `:focus-within < :focus < :hover < :active < :active-deepest`
 
 Use `Pressable`'s render prop instead when the styled element is not the one
 being pressed, several children react differently to one press, or the value
@@ -81,14 +96,16 @@ depends on `pressed` in a way one selector cannot express:
 <Pressable>
   {({ pressed }) => (
     <Animated.Text
-      style={{ color: pressed ? '#000' : '#888', transitionDuration: 300 }}>
+      style={{
+        color: pressed ? '#000' : '#888',
+        transitionProperty: ['color'],
+        transitionDuration: 300,
+      }}>
       Press me
     </Animated.Text>
   )}
 </Pressable>
 ```
-
-Bare numbers are milliseconds, so `transitionDuration: 300` is valid.
 
 The same shape works for any boolean a parent already passes down: selection,
 focus, expansion, validity. The parent re-render fires the child's transition,

--- a/skills/reanimated-css-migration/references/api-map.md
+++ b/skills/reanimated-css-migration/references/api-map.md
@@ -13,11 +13,15 @@
 They look interchangeable and are not. Picking the wrong one is the most common
 way a migration compiles and then misbehaves at runtime.
 
-**Use a transition** when a value changes from A to B in response to something,
-and the component re-renders as a result: a press, a toggle, an expand, a theme
-change, a selection. A transition is declared in the style and fires
-whenever a watched property differs between two renders. It has no concept of a
-timeline, only of "this value changed, ease it".
+**Use a transition** when a value moves from A to B in response to something: a
+press, a toggle, an expand, a theme change, a selection. A transition is declared
+in the style and fires whenever a watched property differs between two renders.
+It has no concept of a timeline, only of "this value changed, ease it".
+
+Choose on the shape of the motion, not on whether the code re-renders today. It
+usually does not, because the value lives in a shared value, and introducing the
+render by converting that to state is part of the migration. The exception is a
+write that happens in a worklet, which stays on the hooks API.
 
 **Use an animation** when the motion is self-contained: it plays on mount,
 loops, or moves through more than two states. Nothing needs to change and

--- a/skills/reanimated-css-migration/references/api-map.md
+++ b/skills/reanimated-css-migration/references/api-map.md
@@ -23,14 +23,21 @@ usually does not, because the value lives in a shared value, and introducing the
 render by converting that to state is part of the migration. The exception is a
 write that happens in a worklet, which stays on the hooks API.
 
-**Use an animation** when the motion is self-contained: it plays on mount,
-loops, or moves through more than two states. Nothing needs to change and
-nothing needs to re-render. This is where `withSequence` and any looping
-`withRepeat` go, because a transition cannot express intermediate stops.
+**Use an animation** when the motion carries its own timeline: it plays on
+mount, loops, or runs through intermediate stops that you define as keyframes.
+Once it starts, nothing else drives it. This is where `withSequence` and any
+looping `withRepeat` go.
 
-The short test: if you can name the event that starts it, and it goes from one
-value to one other value, it is a transition. If it starts by itself, repeats,
-or has a middle, it is an animation.
+The distinction is not how many values the motion passes through, because a
+transition can pass through many. A stepper or a multi-stage progress bar eases
+from one value to the next as often as the state changes. The distinction is who
+supplies the intermediate values: with a transition the app does, one render at
+a time, and the element eases to wherever it was last told to go. With an
+animation the keyframes do, on a clock, with no further input.
+
+The short test: if every step needs something outside the element to trigger it,
+it is a transition, however many steps there are. If the steps play themselves,
+it is an animation.
 
 Two consequences follow:
 

--- a/skills/reanimated-css-migration/references/api-map.md
+++ b/skills/reanimated-css-migration/references/api-map.md
@@ -179,20 +179,44 @@ These are exact, not approximations. The polynomial easings are quadratic and
 cubic Beziers in disguise, so degree-elevating them to a cubic gives the CSS
 form with no error.
 
+Four base easings have an exact cubic Bezier form:
+
 | Source | CSS timing function |
 | --- | --- |
-| `Easing.linear` | `'linear'` |
+| `Easing.linear`, `Easing.poly(1)` | `'linear'` |
 | `Easing.ease` | `'ease-in'` or `cubicBezier(0.42, 0, 1, 1)` |
-| `Easing.quad` | `cubicBezier(1/3, 0, 2/3, 1/3)` |
-| `Easing.cubic` | `cubicBezier(1/3, 0, 2/3, 0)` |
-| `Easing.out(Easing.quad)` | `cubicBezier(1/3, 2/3, 2/3, 1)` |
-| `Easing.out(Easing.cubic)` | `cubicBezier(1/3, 1, 2/3, 1)` |
-| `Easing.out(Easing.ease)` | `'ease-out'` or `cubicBezier(0, 0, 0.58, 1)` |
-| `Easing.bezier(a, b, c, d)` | `cubicBezier(a, b, c, d)` |
-| `Easing.bezierFn(a, b, c, d)` | `cubicBezier(a, b, c, d)` |
+| `Easing.quad`, `Easing.poly(2)` | `cubicBezier(1/3, 0, 2/3, 1/3)` |
+| `Easing.cubic`, `Easing.poly(3)` | `cubicBezier(1/3, 0, 2/3, 0)` |
+| `Easing.bezier(a, b, c, d)`, `Easing.bezierFn(a, b, c, d)` | `cubicBezier(a, b, c, d)` |
 | `Easing.steps(n, true)` | `steps(n, 'jump-start')` |
 | `Easing.steps(n, false)` | `steps(n, 'jump-end')` |
-| `Easing.in(f)` | translate `f` unchanged |
+
+`Easing.poly(n)` is `t` to the power `n`, so only the integer cases above are
+exact. Any other exponent belongs in the approximations section.
+
+Two composition rules extend that table to any wrapped easing, so do not look
+for a row per combination:
+
+- **`Easing.in(f)` is `f`.** `in_` returns its argument unchanged, so translate
+  the inner easing and ignore the wrapper.
+- **`Easing.out(f)` reflects the curve.** For any `f` with an exact form
+  `cubicBezier(x1, y1, x2, y2)`, the result is
+  `cubicBezier(1 - x2, 1 - y2, 1 - x1, 1 - y1)`. This holds because
+  `out(f)(t) = 1 - f(1 - t)`, which for a cubic Bezier is the same curve rotated
+  180 degrees about its midpoint, and it stays exact even when control points
+  fall outside 0..1.
+
+Worked examples of the second rule, which is where the commonly quoted values
+come from:
+
+| Source | Reflection | CSS timing function |
+| --- | --- | --- |
+| `Easing.out(Easing.ease)` | of `(0.42, 0, 1, 1)` | `'ease-out'` or `cubicBezier(0, 0, 0.58, 1)` |
+| `Easing.out(Easing.quad)` | of `(1/3, 0, 2/3, 1/3)` | `cubicBezier(1/3, 2/3, 2/3, 1)` |
+| `Easing.out(Easing.cubic)` | of `(1/3, 0, 2/3, 0)` | `cubicBezier(1/3, 1, 2/3, 1)` |
+
+`Easing.inOut(f)` is not covered by either rule. It is piecewise, so no single
+cubic Bezier reproduces it, whatever `f` is.
 
 Match on the source expression, not on a runtime value. The library attaches its
 easing name symbol only to the top-level members, so anything wrapped in `out()`

--- a/skills/reanimated-css-migration/references/api-map.md
+++ b/skills/reanimated-css-migration/references/api-map.md
@@ -1,0 +1,224 @@
+# Animation API map
+
+## Contents
+
+- Transition or animation: which one
+- The `with*` functions, mapped
+- Springs
+- Pseudo-selectors, and why they usually beat a state round-trip
+- Easing: exact conversions, approximations, and what has no equivalent
+
+## Transition or animation: which one
+
+They look interchangeable and are not. Picking the wrong one is the most common
+way a migration compiles and then misbehaves at runtime.
+
+**Use a transition** when a value changes from A to B in response to something,
+and the component re-renders as a result: a press, a toggle, an expand, a theme
+change, a selection. A transition is declared in the style and fires
+whenever a watched property differs between two renders. It has no concept of a
+timeline, only of "this value changed, ease it".
+
+**Use an animation** when the motion is self-contained: it plays on mount,
+loops, or moves through more than two states. Nothing needs to change and
+nothing needs to re-render. This is where `withSequence` and any looping
+`withRepeat` go, because a transition cannot express intermediate stops.
+
+The short test: if you can name the event that starts it, and it goes from one
+value to one other value, it is a transition. If it starts by itself, repeats,
+or has a middle, it is an animation.
+
+Two consequences follow:
+
+- A transition on a value that never re-renders does nothing at all. That is
+  usually solved by turning the shared value into state, not by refusing, unless
+  the write happens in a worklet. An animation does not care either way, because
+  it is not driven by prop diffing.
+- An animation runs when the element mounts. If you convert an interaction into
+  an animation by mistake, it fires immediately on screen load.
+
+## The `with*` functions, mapped
+
+| Source | CSS | Notes |
+| --- | --- | --- |
+| `withTiming(v, {duration, easing})` | `transitionDuration` + `transitionTimingFunction`, or a two-keyframe animation | Which one depends on the section above, not on the call |
+| `withDelay(ms, anim)` | `transitionDelay` or `animationDelay` | Negative `animationDelay` pre-seeds a loop mid-cycle, which has no hook equivalent and is the idiomatic way to stagger |
+| `withRepeat(anim, -1)` | `animationIterationCount: 'infinite'` | Any count `<= 0` means infinite |
+| `withRepeat(anim, n)` | `animationIterationCount: n` | |
+| `withRepeat(anim, n, true)` | plus `animationDirection: 'alternate'` | The third argument is `reverse` |
+| `withSequence(a, b, c)` | one animation, keyframes at percentage offsets | Animation only. Sum the child durations for `animationDuration`, then place each stop at its cumulative fraction |
+| `withSpring(...)` | see below | |
+| `withDecay(...)` | none | Velocity-driven, no fixed target |
+| `withClamp(...)` | none | |
+| `cancelAnimation(sv)` | none | `animationPlayState: 'paused'` suspends, it does not cancel or freeze at the current value |
+
+Two traps in that table:
+
+**Reverse plus an odd count changes where it stops.** `withRepeat(anim, 3, true)`
+ends at the start value, not the target, because the third pass runs backwards.
+`animationDirection: 'alternate'` behaves the same way, so the mapping holds, but
+check the resting state after converting.
+
+**`withSequence` durations are absolute, keyframe offsets are relative.** Two
+300ms steps become `animationDuration: '600ms'` with stops at `0%`, `50%`,
+`100%`. Uneven steps move the middle stop accordingly; a 100ms step followed by a
+300ms step puts it at `25%`.
+
+## Springs
+
+There is no spring timing function in CSS. There are two honest options, and
+which applies depends on whether the spring oscillates.
+
+Reanimated ships four presets. Their damping ratios, computed from the values in
+`animation/spring/springConfigs.ts`:
+
+| Preset | zeta | Shape | Overshoot | Settles |
+| --- | --- | --- | --- | --- |
+| `SnappySpringConfig` | 0.92 | clamped, `overshootClamping: true` | none | ~386ms |
+| `GentleSpringConfig` | 1.00 | critically damped | none | ~495ms |
+| `WigglySpringConfig` | 0.75 | underdamped | ~3% | ~478ms |
+| `Reanimated3DefaultSpringConfig` | 0.50 | underdamped | ~16% | ~916ms |
+
+**Monotonic springs** (Gentle, and Snappy because clamping removes the
+overshoot) rise once and stop. A `cubicBezier` approximates them acceptably, and
+a sampled `linear(...)` matches them closely.
+
+**Oscillating springs** (Wiggly, Reanimated3Default) cross the target and come
+back. A cubic Bezier cannot express that: it can overshoot once, because the y
+control points are not clamped to 0..1, but it cannot oscillate. Sample these to
+`linear(...)` instead, which takes an arbitrary number of control points and is
+the standard way to express a spring as an easing.
+
+To sample: simulate the damped oscillator from 0 to 1, take 20-30 evenly spaced
+points across the settle time, and emit them as `linear(p0, p1, ... pn)` with
+`animationDuration` set to that settle time. The resulting motion is visually
+equivalent, though not physically identical.
+
+**When to refuse instead.** A spring whose configuration is not statically
+known cannot be sampled: anything reading `velocity` from a gesture, or building
+its config at runtime. Those stay on the hooks API. A spring is only convertible
+when every parameter is a literal you can read at migration time.
+
+Say which option you used and why. Silently substituting `ease-out` for a spring
+is the change users notice and dislike most, because the overshoot is usually
+the entire point.
+
+## Pseudo-selectors, and why they usually beat a state round-trip
+
+Reanimated supports `:hover`, `:active`, `:active-deepest`, `:focus` and
+`:focus-within` natively, plus more on web. For press and hover feedback, these
+replace the whole shared-value or React-state round-trip:
+
+```tsx
+<Animated.View
+  style={{
+    backgroundColor: { default: '#eee', ':active': '#ccc' },
+    transitionDuration: 150,
+  }}
+/>
+```
+
+That is fewer moving parts than the hook version, and it does not re-render on
+every press. Prefer it whenever the trigger is genuinely press, hover or focus.
+
+`Pressable` also takes a render prop, which is useful when the pressed state has
+to reach a child rather than the pressed element itself:
+
+```tsx
+<Pressable>
+  {({ pressed }) => (
+    <Animated.Text
+      style={{ color: pressed ? '#000' : '#888', transitionDuration: 300 }}>
+      Press me
+    </Animated.Text>
+  )}
+</Pressable>
+```
+
+Bare numbers are milliseconds, so `transitionDuration: 300` is valid.
+
+Reach for the render prop when the styled element is not the one receiving the
+touch, when several children react to one press, or when the value depends on
+`pressed` in a way a single pseudo-selector cannot express. Otherwise the
+pseudo-selector is simpler and avoids the re-render.
+
+The same shape works for any boolean a parent already tracks and passes down:
+selection, focus, expansion, validity. If the parent re-renders when the flag
+flips, a transition on the child fires. This is often the cleanest way to
+migrate a component whose driver was a shared value, because it converts the
+driver to something that actually re-renders, without restructuring the data
+flow.
+
+## Easing
+
+### The one rule that matters most
+
+`Easing.ease` is **not** CSS `ease`.
+
+In the library it is `Bezier(0.42, 0, 1, 1)` (`Easing.ts:70`), which is CSS
+`ease-in`. CSS `ease` is `cubic-bezier(0.25, 0.1, 0.25, 1)`. The two differ by
+almost half the output range at their widest, so mapping by name silently
+changes every curve it touches.
+
+Emit `'ease-in'`, or the explicit bezier. Never `'ease'` for `Easing.ease`.
+
+### Exact conversions
+
+These are exact, not approximations. The polynomial easings are quadratic and
+cubic Beziers in disguise, so degree-elevating them to a cubic gives the CSS
+form with no error.
+
+| Source | CSS timing function |
+| --- | --- |
+| `Easing.linear` | `'linear'` |
+| `Easing.ease` | `'ease-in'` or `cubicBezier(0.42, 0, 1, 1)` |
+| `Easing.quad` | `cubicBezier(1/3, 0, 2/3, 1/3)` |
+| `Easing.cubic` | `cubicBezier(1/3, 0, 2/3, 0)` |
+| `Easing.out(Easing.quad)` | `cubicBezier(1/3, 2/3, 2/3, 1)` |
+| `Easing.out(Easing.cubic)` | `cubicBezier(1/3, 1, 2/3, 1)` |
+| `Easing.out(Easing.ease)` | `'ease-out'` or `cubicBezier(0, 0, 0.58, 1)` |
+| `Easing.bezier(a, b, c, d)` | `cubicBezier(a, b, c, d)` |
+| `Easing.bezierFn(a, b, c, d)` | `cubicBezier(a, b, c, d)` |
+| `Easing.steps(n, true)` | `steps(n, 'jump-start')` |
+| `Easing.steps(n, false)` | `steps(n, 'jump-end')` |
+| `Easing.in(f)` | translate `f` unchanged |
+
+Match on the source expression, not on a runtime value. The library attaches its
+easing name symbol only to the top-level members, so anything wrapped in `out()`
+or `inOut()` loses it and falls back to linear with a warning.
+
+### Approximations, and what they cost
+
+`withTiming` with no easing config uses `Easing.inOut(Easing.quad)` and a
+duration of 300ms (`animation/timing.ts:89-92`). That easing is piecewise
+quadratic, so no single cubic Bezier reproduces it.
+
+Every unconfigured `withTiming` therefore needs a decision. Tell the user the
+error rather than substituting silently:
+
+| Choice | Maximum error over the curve |
+| --- | --- |
+| `cubicBezier(0.4625, 0.0403, 0.52, 0.9331)` | about 0.008 |
+| `'ease-in-out'` | about 0.012 |
+
+Both are visually indistinguishable at typical durations. Prefer the named
+`'ease-in-out'` for readability unless the animation is long or the user cares
+about exactness.
+
+The same applies to anything built on `inOut()`, and to `sin`, `circle`, `exp`
+and `poly` with an exponent other than 2 or 3.
+
+### No equivalent
+
+`Easing.elastic`, `Easing.back` and `Easing.bounce` leave the 0..1 range and
+oscillate. A cubic Bezier cannot express them at all.
+
+The honest options are a CSS `linear(...)` function sampled from the source
+curve, or leaving the animation on the imperative API. Do not substitute a
+similar-looking bezier: the overshoot is usually the entire point of the
+animation.
+
+There is no spring timing function in CSS, but that does not make every spring
+unconvertible: monotonic ones approximate as a cubic Bezier, and oscillating
+ones can be sampled to `linear(...)`. See `api-map.md` for which is which and
+when to refuse instead.

--- a/skills/reanimated-css-migration/references/api-map.md
+++ b/skills/reanimated-css-migration/references/api-map.md
@@ -10,43 +10,25 @@
 
 ## Transition or animation: which one
 
-They look interchangeable and are not. Picking the wrong one is the most common
-way a migration compiles and then misbehaves at runtime.
+Decide by what drives each step.
 
-**Use a transition** when a value moves from A to B in response to something: a
-press, a toggle, an expand, a theme change, a selection. A transition is declared
-in the style and fires whenever a watched property differs between two renders.
-It has no concept of a timeline, only of "this value changed, ease it".
+**Transition** when something outside the element triggers every step: press,
+toggle, expand, theme change, selection. Step count is irrelevant, a stepper is
+still a transition.
 
-Choose on the shape of the motion, not on whether the code re-renders today. It
-usually does not, because the value lives in a shared value, and introducing the
-render by converting that to state is part of the migration. The exception is a
-write that happens in a worklet, which stays on the hooks API.
+**Animation** when the steps play themselves once started: mount, loop, keyframe
+sequence. `withSequence` and looping `withRepeat` go here.
 
-**Use an animation** when the motion carries its own timeline: it plays on
-mount, loops, or runs through intermediate stops that you define as keyframes.
-Once it starts, nothing else drives it. This is where `withSequence` and any
-looping `withRepeat` go.
+Do not decide by whether the code re-renders today. It usually does not, and
+introducing that render by converting the shared value to state is part of the
+migration. The exception is a write inside a worklet, which stays on the hooks
+API.
 
-The distinction is not how many values the motion passes through, because a
-transition can pass through many. A stepper or a multi-stage progress bar eases
-from one value to the next as often as the state changes. The distinction is who
-supplies the intermediate values: with a transition the app does, one render at
-a time, and the element eases to wherever it was last told to go. With an
-animation the keyframes do, on a clock, with no further input.
+Two failure modes:
 
-The short test: if every step needs something outside the element to trigger it,
-it is a transition, however many steps there are. If the steps play themselves,
-it is an animation.
-
-Two consequences follow:
-
-- A transition on a value that never re-renders does nothing at all. That is
-  usually solved by turning the shared value into state, not by refusing, unless
-  the write happens in a worklet. An animation does not care either way, because
-  it is not driven by prop diffing.
-- An animation runs when the element mounts. If you convert an interaction into
-  an animation by mistake, it fires immediately on screen load.
+- A transition whose value never re-renders does nothing. Convert the driver to
+  state.
+- An animation used for an interaction fires on mount instead of on the event.
 
 ## The `with*` functions, mapped
 
@@ -77,42 +59,27 @@ check the resting state after converting.
 
 ## Springs
 
-There is no spring timing function in CSS. There are two honest options, and
-which applies depends on whether the spring oscillates.
+CSS has no spring timing function. Convert only when every spring parameter is a
+literal you can read at migration time. Refuse anything reading `velocity` from a
+gesture or building its config at runtime.
 
-Reanimated ships four presets. Their damping ratios, computed from the values in
-`animation/spring/springConfigs.ts`:
+Presets, from `animation/spring/springConfigs.ts`:
 
-| Preset | zeta | Shape | Overshoot | Settles |
+| Preset | zeta | Overshoot | Settles | Convert to |
 | --- | --- | --- | --- | --- |
-| `SnappySpringConfig` | 0.92 | clamped, `overshootClamping: true` | none | ~386ms |
-| `GentleSpringConfig` | 1.00 | critically damped | none | ~495ms |
-| `WigglySpringConfig` | 0.75 | underdamped | ~3% | ~478ms |
-| `Reanimated3DefaultSpringConfig` | 0.50 | underdamped | ~16% | ~916ms |
+| `SnappySpringConfig` | 0.92 clamped | none | ~386ms | `cubicBezier` or `linear(...)` |
+| `GentleSpringConfig` | 1.00 | none | ~495ms | `cubicBezier` or `linear(...)` |
+| `WigglySpringConfig` | 0.75 | ~3% | ~478ms | `linear(...)` only |
+| `Reanimated3DefaultSpringConfig` | 0.50 | ~16% | ~916ms | `linear(...)` only |
 
-**Monotonic springs** (Gentle, and Snappy because clamping removes the
-overshoot) rise once and stop. A `cubicBezier` approximates them acceptably, and
-a sampled `linear(...)` matches them closely.
-
-**Oscillating springs** (Wiggly, Reanimated3Default) cross the target and come
-back. A cubic Bezier cannot express that: it can overshoot once, because the y
-control points are not clamped to 0..1, but it cannot oscillate. Sample these to
-`linear(...)` instead, which takes an arbitrary number of control points and is
-the standard way to express a spring as an easing.
+A cubic Bezier can overshoot once but cannot oscillate, so anything that crosses
+the target and comes back needs `linear(...)`.
 
 To sample: simulate the damped oscillator from 0 to 1, take 20-30 evenly spaced
-points across the settle time, and emit them as `linear(p0, p1, ... pn)` with
-`animationDuration` set to that settle time. The resulting motion is visually
-equivalent, though not physically identical.
+points across the settle time, emit `linear(p0, p1, ... pn)`, and set
+`animationDuration` to that settle time.
 
-**When to refuse instead.** A spring whose configuration is not statically
-known cannot be sampled: anything reading `velocity` from a gesture, or building
-its config at runtime. Those stay on the hooks API. A spring is only convertible
-when every parameter is a literal you can read at migration time.
-
-Say which option you used and why. Silently substituting `ease-out` for a spring
-is the change users notice and dislike most, because the overshoot is usually
-the entire point.
+Never substitute `ease-out` for a spring. Say which option you used.
 
 ## Pseudo-selectors, and why they usually beat a state round-trip
 
@@ -129,11 +96,12 @@ replace the whole shared-value or React-state round-trip:
 />
 ```
 
-That is fewer moving parts than the hook version, and it does not re-render on
-every press. Prefer it whenever the trigger is genuinely press, hover or focus.
+Prefer this whenever the trigger is press, hover or focus. It needs no state and
+does not re-render.
 
-`Pressable` also takes a render prop, which is useful when the pressed state has
-to reach a child rather than the pressed element itself:
+Use `Pressable`'s render prop instead when the styled element is not the one
+being pressed, several children react differently to one press, or the value
+depends on `pressed` in a way one selector cannot express:
 
 ```tsx
 <Pressable>
@@ -148,17 +116,9 @@ to reach a child rather than the pressed element itself:
 
 Bare numbers are milliseconds, so `transitionDuration: 300` is valid.
 
-Reach for the render prop when the styled element is not the one receiving the
-touch, when several children react to one press, or when the value depends on
-`pressed` in a way a single pseudo-selector cannot express. Otherwise the
-pseudo-selector is simpler and avoids the re-render.
-
-The same shape works for any boolean a parent already tracks and passes down:
-selection, focus, expansion, validity. If the parent re-renders when the flag
-flips, a transition on the child fires. This is often the cleanest way to
-migrate a component whose driver was a shared value, because it converts the
-driver to something that actually re-renders, without restructuring the data
-flow.
+The same shape works for any boolean a parent already passes down: selection,
+focus, expansion, validity. The parent re-render fires the child's transition,
+which is often the shortest route out of a shared-value driver.
 
 ## Easing
 

--- a/skills/reanimated-css-migration/references/api-map.md
+++ b/skills/reanimated-css-migration/references/api-map.md
@@ -75,6 +75,11 @@ replace the whole shared-value or React-state round-trip:
 Prefer this whenever the trigger is press, hover or focus. It needs no state and
 does not re-render.
 
+Keep the element that receives the touch. `Animated.Pressable` takes pseudo
+styles; swapping a `Pressable` for a plain `Animated.View` to use `:active`
+drops the press handlers and the accessibility role, failing equivalence
+obligation 5.
+
 - Write `default` unless the resting value is the property's own default. The
   pseudo object owns the property, so rest resolves to `default`; omit it and
   the value falls back to the property default (`backgroundColor` transparent,

--- a/skills/reanimated-css-migration/references/api-map.md
+++ b/skills/reanimated-css-migration/references/api-map.md
@@ -4,9 +4,8 @@
 
 - Transition or animation: which one
 - The `with*` functions, mapped
-- Springs
+
 - Pseudo-selectors, and why they usually beat a state round-trip
-- Easing: exact conversions, approximations, and what has no equivalent
 
 ## Transition or animation: which one
 
@@ -57,30 +56,6 @@ check the resting state after converting.
 `100%`. Uneven steps move the middle stop accordingly; a 100ms step followed by a
 300ms step puts it at `25%`.
 
-## Springs
-
-CSS has no spring timing function. Convert only when every spring parameter is a
-literal you can read at migration time. Refuse anything reading `velocity` from a
-gesture or building its config at runtime.
-
-Presets, from `animation/spring/springConfigs.ts`:
-
-| Preset | zeta | Overshoot | Settles | Convert to |
-| --- | --- | --- | --- | --- |
-| `SnappySpringConfig` | 0.92 clamped | none | ~386ms | `cubicBezier` or `linear(...)` |
-| `GentleSpringConfig` | 1.00 | none | ~495ms | `cubicBezier` or `linear(...)` |
-| `WigglySpringConfig` | 0.75 | ~3% | ~478ms | `linear(...)` only |
-| `Reanimated3DefaultSpringConfig` | 0.50 | ~16% | ~916ms | `linear(...)` only |
-
-A cubic Bezier can overshoot once but cannot oscillate, so anything that crosses
-the target and comes back needs `linear(...)`.
-
-To sample: simulate the damped oscillator from 0 to 1, take 20-30 evenly spaced
-points across the settle time, emit `linear(p0, p1, ... pn)`, and set
-`animationDuration` to that settle time.
-
-Never substitute `ease-out` for a spring. Say which option you used.
-
 ## Pseudo-selectors, and why they usually beat a state round-trip
 
 Reanimated supports `:hover`, `:active`, `:active-deepest`, `:focus` and
@@ -119,101 +94,3 @@ Bare numbers are milliseconds, so `transitionDuration: 300` is valid.
 The same shape works for any boolean a parent already passes down: selection,
 focus, expansion, validity. The parent re-render fires the child's transition,
 which is often the shortest route out of a shared-value driver.
-
-## Easing
-
-### The one rule that matters most
-
-`Easing.ease` is **not** CSS `ease`.
-
-In the library it is `Bezier(0.42, 0, 1, 1)` (`Easing.ts:70`), which is CSS
-`ease-in`. CSS `ease` is `cubic-bezier(0.25, 0.1, 0.25, 1)`. The two differ by
-almost half the output range at their widest, so mapping by name silently
-changes every curve it touches.
-
-Emit `'ease-in'`, or the explicit bezier. Never `'ease'` for `Easing.ease`.
-
-### Exact conversions
-
-These are exact, not approximations. The polynomial easings are quadratic and
-cubic Beziers in disguise, so degree-elevating them to a cubic gives the CSS
-form with no error.
-
-Four base easings have an exact cubic Bezier form:
-
-| Source | CSS timing function |
-| --- | --- |
-| `Easing.linear`, `Easing.poly(1)` | `'linear'` |
-| `Easing.ease` | `'ease-in'` or `cubicBezier(0.42, 0, 1, 1)` |
-| `Easing.quad`, `Easing.poly(2)` | `cubicBezier(1/3, 0, 2/3, 1/3)` |
-| `Easing.cubic`, `Easing.poly(3)` | `cubicBezier(1/3, 0, 2/3, 0)` |
-| `Easing.bezier(a, b, c, d)`, `Easing.bezierFn(a, b, c, d)` | `cubicBezier(a, b, c, d)` |
-| `Easing.steps(n, true)` | `steps(n, 'jump-start')` |
-| `Easing.steps(n, false)` | `steps(n, 'jump-end')` |
-
-`Easing.poly(n)` is `t` to the power `n`, so only the integer cases above are
-exact. Any other exponent belongs in the approximations section.
-
-Two composition rules extend that table to any wrapped easing, so do not look
-for a row per combination:
-
-- **`Easing.in(f)` is `f`.** `in_` returns its argument unchanged, so translate
-  the inner easing and ignore the wrapper.
-- **`Easing.out(f)` reflects the curve.** For any `f` with an exact form
-  `cubicBezier(x1, y1, x2, y2)`, the result is
-  `cubicBezier(1 - x2, 1 - y2, 1 - x1, 1 - y1)`. This holds because
-  `out(f)(t) = 1 - f(1 - t)`, which for a cubic Bezier is the same curve rotated
-  180 degrees about its midpoint, and it stays exact even when control points
-  fall outside 0..1.
-
-Worked examples of the second rule, which is where the commonly quoted values
-come from:
-
-| Source | Reflection | CSS timing function |
-| --- | --- | --- |
-| `Easing.out(Easing.ease)` | of `(0.42, 0, 1, 1)` | `'ease-out'` or `cubicBezier(0, 0, 0.58, 1)` |
-| `Easing.out(Easing.quad)` | of `(1/3, 0, 2/3, 1/3)` | `cubicBezier(1/3, 2/3, 2/3, 1)` |
-| `Easing.out(Easing.cubic)` | of `(1/3, 0, 2/3, 0)` | `cubicBezier(1/3, 1, 2/3, 1)` |
-
-`Easing.inOut(f)` is not covered by either rule. It is piecewise, so no single
-cubic Bezier reproduces it, whatever `f` is.
-
-Match on the source expression, not on a runtime value. The library attaches its
-easing name symbol only to the top-level members, so anything wrapped in `out()`
-or `inOut()` loses it and falls back to linear with a warning.
-
-### Approximations, and what they cost
-
-`withTiming` with no easing config uses `Easing.inOut(Easing.quad)` and a
-duration of 300ms (`animation/timing.ts:89-92`). That easing is piecewise
-quadratic, so no single cubic Bezier reproduces it.
-
-Every unconfigured `withTiming` therefore needs a decision. Tell the user the
-error rather than substituting silently:
-
-| Choice | Maximum error over the curve |
-| --- | --- |
-| `cubicBezier(0.4625, 0.0403, 0.52, 0.9331)` | about 0.008 |
-| `'ease-in-out'` | about 0.012 |
-
-Both are visually indistinguishable at typical durations. Prefer the named
-`'ease-in-out'` for readability unless the animation is long or the user cares
-about exactness.
-
-The same applies to anything built on `inOut()`, and to `sin`, `circle`, `exp`
-and `poly` with an exponent other than 2 or 3.
-
-### No equivalent
-
-`Easing.elastic`, `Easing.back` and `Easing.bounce` leave the 0..1 range and
-oscillate. A cubic Bezier cannot express them at all.
-
-The honest options are a CSS `linear(...)` function sampled from the source
-curve, or leaving the animation on the imperative API. Do not substitute a
-similar-looking bezier: the overshoot is usually the entire point of the
-animation.
-
-There is no spring timing function in CSS, but that does not make every spring
-unconvertible: monotonic ones approximate as a cubic Bezier, and oscillating
-ones can be sampled to `linear(...)`. See `api-map.md` for which is which and
-when to refuse instead.

--- a/skills/reanimated-css-migration/references/api-map.md
+++ b/skills/reanimated-css-migration/references/api-map.md
@@ -4,7 +4,6 @@
 
 - Transition or animation: which one
 - The `with*` functions, mapped
-
 - Pseudo-selectors, and why they usually beat a state round-trip
 
 ## Transition or animation: which one

--- a/skills/reanimated-css-migration/references/examples.md
+++ b/skills/reanimated-css-migration/references/examples.md
@@ -10,6 +10,7 @@ that permits it.
 - Migrate: play once on mount
 - Migrate: React state toggle
 - Migrate: staggered loop
+- Migrate: withSequence to percentage keyframes
 - Migrate: shared value written from a JS callback
 - Leave alone: spring
 - Preserve: platform-specific values
@@ -154,6 +155,37 @@ Negative `animationDelay` pre-seeds each item mid-cycle. No hook equivalent.
   />
 ))}
 ```
+
+## Migrate: withSequence to percentage keyframes
+
+Durations are absolute in the source and relative in keyframes. Sum them for
+`animationDuration`, then place each stop at its cumulative fraction.
+
+```tsx
+// Old (hooks) - 100 + 200 + 100 = 400ms total
+scale.value = withSequence(
+  withTiming(1.2, { duration: 100 }),
+  withTiming(0.9, { duration: 200 }),
+  withTiming(1, { duration: 100 })
+);
+```
+
+```tsx
+// New (CSS) - stops at 0, 100/400, 300/400, 400/400
+const pop: CSSAnimationKeyframes = {
+  '0%': { transform: [{ scale: 1 }] },
+  '25%': { transform: [{ scale: 1.2 }] },
+  '75%': { transform: [{ scale: 0.9 }] },
+  '100%': { transform: [{ scale: 1 }] },
+};
+// on the element:
+{ animationName: pop, animationDuration: '400ms', animationFillMode: 'forwards' }
+```
+
+- Animation only. A transition has one start and one end, so it cannot express
+  intermediate stops
+- The first keyframe is the value before the sequence ran, not the first
+  `withTiming` target
 
 ## Migrate: shared value written from a JS callback
 

--- a/skills/reanimated-css-migration/references/examples.md
+++ b/skills/reanimated-css-migration/references/examples.md
@@ -1,9 +1,8 @@
 # Worked examples
 
-Calibration, not an allow-list. These show what a correct conversion looks like
-and what the common traps look like. Converting a shape that is not shown here
-is expected, provided every precondition in `preconditions.md` holds and you can
-name the one that permits it.
+Calibration, not an allow-list. Converting a shape not shown here is expected,
+provided every precondition in `preconditions.md` holds and you can name the one
+that permits it.
 
 ## Contents
 
@@ -11,7 +10,7 @@ name the one that permits it.
 - Migrate: play once on mount
 - Migrate: React state toggle
 - Migrate: staggered loop
-- Leave alone: handler-written shared value
+- Migrate: shared value written from a JS callback
 - Leave alone: spring
 - Preserve: platform-specific values
 - Trap: easing names
@@ -68,18 +67,17 @@ function Spinner() {
 }
 ```
 
-Note where the CSS properties live: inline in the style array, never inside
-`StyleSheet.create`. Putting them in the stylesheet is a type error, because
-`StyleSheet.create` is typed against React Native's own style types. Keep the
-static styles in the stylesheet and put the animation properties beside them.
-
-The shared value, the effect and the cleanup all become dead and are removed.
-`cancelAnimation` in a cleanup is not imperative control in the sense of the
-refusal list: it only stops the animation on unmount, which CSS does anyway.
-
-`withRepeat`'s third argument reverses the direction. When it is `true`, add
-`animationDirection: 'alternate'`. Hoist the keyframes to module scope, because
-an object created during render restarts the animation on every re-render.
+- CSS properties go inline in the style array, never in `StyleSheet.create`.
+  That is a type error: `StyleSheet.create` is typed against React Native's own
+  style types. Static styles stay in the stylesheet, animation properties beside
+  it.
+- Hoist keyframes to module scope. An object created during render restarts the
+  animation every render.
+- Remove the now-dead shared value, effect and cleanup.
+- `cancelAnimation` in a cleanup is not imperative control. It only stops the
+  animation on unmount, which CSS does anyway.
+- `withRepeat`'s third argument is `reverse`. When `true`, add
+  `animationDirection: 'alternate'`.
 
 ## Migrate: play once on mount
 

--- a/skills/reanimated-css-migration/references/examples.md
+++ b/skills/reanimated-css-migration/references/examples.md
@@ -17,12 +17,8 @@ that permits it.
 
 ## Migrate: infinite loop
 
-The most common migratable shape. A mount effect starts a repeating animation
-and a cleanup cancels it.
-
-Before:
-
 ```tsx
+// Old (hooks)
 function Spinner() {
   const rotation = useSharedValue(0);
 
@@ -42,9 +38,8 @@ function Spinner() {
 }
 ```
 
-After:
-
 ```tsx
+// New (CSS)
 const rotate: CSSAnimationKeyframes = {
   from: { transform: [{ rotateZ: '0deg' }] },
   to: { transform: [{ rotateZ: '360deg' }] },
@@ -67,31 +62,26 @@ function Spinner() {
 }
 ```
 
-- CSS properties go inline in the style array, never in `StyleSheet.create`.
-  That is a type error: `StyleSheet.create` is typed against React Native's own
-  style types. Static styles stay in the stylesheet, animation properties beside
-  it.
-- Hoist keyframes to module scope. An object created during render restarts the
-  animation every render.
-- Remove the now-dead shared value, effect and cleanup.
-- `cancelAnimation` in a cleanup is not imperative control. It only stops the
-  animation on unmount, which CSS does anyway.
-- `withRepeat`'s third argument is `reverse`. When `true`, add
-  `animationDirection: 'alternate'`.
+- CSS properties go inline in the style array, never `StyleSheet.create` — that
+  is a type error, it is typed against React Native's own style types
+- Keyframes at module scope — an object built during render restarts the
+  animation every render
+- Delete the now-dead shared value, effect and cleanup
+- `cancelAnimation` in an unmount cleanup is not imperative control — CSS stops
+  on unmount anyway
+- `withRepeat` third argument `reverse: true` -> `animationDirection: 'alternate'`
 
 ## Migrate: play once on mount
 
-Before:
-
 ```tsx
+// Old (hooks)
 useEffect(() => {
   opacity.value = withTiming(1, { duration: 300 });
 }, []);
 ```
 
-After:
-
 ```tsx
+// New (CSS)
 const fadeIn: CSSAnimationKeyframes = {
   from: { opacity: 0 },
   to: { opacity: 1 },
@@ -100,18 +90,17 @@ const fadeIn: CSSAnimationKeyframes = {
 { animationName: fadeIn, animationDuration: '300ms', animationFillMode: 'forwards' }
 ```
 
-`animationFillMode: 'forwards'` is required. The CSS default is `none`, which
-discards the computed value at the end and snaps the view back to `opacity: 0`.
-Omitting it is the single most common way a converted mount animation breaks.
+- `animationFillMode: 'forwards'` is required — default `none` discards the
+  computed value and snaps back to `opacity: 0`. The most common way a converted
+  mount animation breaks
 
 ## Migrate: React state toggle
 
-The driver is already React state, so the change happens across a render and a
-transition fires.
-
-Before:
+Driver is already React state, so the change crosses a render and the transition
+fires.
 
 ```tsx
+// Old (hooks)
 const [expanded, setExpanded] = useState(false);
 const progress = useSharedValue(0);
 
@@ -125,9 +114,8 @@ const style = useAnimatedStyle(() => ({
 }));
 ```
 
-After:
-
 ```tsx
+// New (CSS)
 const [expanded, setExpanded] = useState(false);
 
 <Animated.View
@@ -143,15 +131,14 @@ const [expanded, setExpanded] = useState(false);
 />
 ```
 
-Enumerate the properties. Never fall back to `transitionProperty: 'all'`.
+- Enumerate the properties. Never `transitionProperty: 'all'`
 
 ## Migrate: staggered loop
 
-CSS expresses stagger with a negative delay, which pre-seeds each item at a
-different point in the cycle. There is no hook equivalent, so this is a case
-where the migrated code is simpler than the original.
+Negative `animationDelay` pre-seeds each item mid-cycle. No hook equivalent.
 
 ```tsx
+// New (CSS)
 {items.map((item, index) => (
   <Animated.View
     key={item.id}
@@ -170,13 +157,11 @@ where the migrated code is simpler than the original.
 
 ## Migrate: shared value written from a JS callback
 
-The most common shape in real code, and the one that needs the shared value
-turned into state. The write is already on the JS thread, so the conversion is
-safe.
-
-Before:
+The most common shape in real code. The write is already on the JS thread, so
+turning the shared value into state is safe.
 
 ```tsx
+// Old (hooks)
 const sv = useSharedValue(false);
 
 const style = useAnimatedStyle(() => ({
@@ -188,9 +173,8 @@ const toggle = () => {
 };
 ```
 
-After:
-
 ```tsx
+// New (CSS)
 const [on, setOn] = useState(false);
 
 const toggle = () => setOn((v) => !v);
@@ -204,31 +188,28 @@ const toggle = () => setOn((v) => !v);
 />
 ```
 
-The shared value and the style hook both disappear. Note what makes this safe:
-`toggle` is a plain JS callback, so it can call `setOn` directly. Had the write
-been inside a gesture callback, it would be running in a worklet on the UI
-thread, and reaching React state from there would need a `scheduleOnRN` hop per
-update. Leave those alone.
-
-One behavior change worth stating in the report: each toggle now re-renders the
-component. That is fine for a press, and wrong for anything changing per frame.
+- Shared value and style hook both disappear
+- Safe because `toggle` is a plain JS callback. In a gesture callback it would be
+  a worklet on the UI thread, needing a `scheduleOnRN` hop per update — refuse
+  those
+- Report the behavior change: each toggle now re-renders. Fine for a press, wrong
+  for anything per-frame
 
 ## Leave alone: spring
 
 ```tsx
+// Old (hooks) - keep as is
 scale.value = withSpring(pressed ? 0.95 : 1, { damping: 15, stiffness: 200 });
 ```
 
-CSS offers `cubicBezier`, `linear` and `steps`. None reproduce a spring, and a
-bezier approximation loses the overshoot that makes it read as one. Keep it on
-the hooks API and say why.
+- CSS offers `cubicBezier`, `linear`, `steps`. None reproduce a spring
+- A bezier approximation loses the overshoot that makes it read as one
+- Keep it on the hooks API and say why
 
 ## Preserve: platform-specific values
 
-Migrate inside each arm and keep the structure. The author chose these values
-deliberately.
-
 ```tsx
+// New (CSS) - migrate inside each arm, keep the structure
 <Animated.View
   style={[
     Platform.select({
@@ -240,10 +221,9 @@ deliberately.
 />
 ```
 
-These properties are safe to migrate even though each covers one platform:
-React Native does not render `shadowOpacity` on Android or `elevation` on iOS
-either, so nothing is lost. Do not "improve" this into `boxShadow`. That is a
-separate refactor with its own visual risk.
+- Safe despite each covering one platform — React Native renders neither
+  `shadowOpacity` on Android nor `elevation` on iOS, so nothing is lost
+- Do not "improve" this into `boxShadow`. Separate refactor, own visual risk
 
 ## Trap: easing names
 
@@ -251,8 +231,7 @@ separate refactor with its own visual risk.
 withTiming(1, { easing: Easing.ease })   // Bezier(0.42, 0, 1, 1)
 ```
 
-`Easing.ease` is CSS `ease-in`, not CSS `ease`. Emitting
-`animationTimingFunction: 'ease'` silently changes the curve. See
-`timing-functions.md`, including what to do about the
-`withTiming` default of `Easing.inOut(Easing.quad)`, which has no exact
-equivalent.
+- `Easing.ease` -> `'ease-in'`, never `'ease'`. Emitting `'ease'` silently
+  changes the curve
+- `withTiming` default is `Easing.inOut(Easing.quad)`, which has no exact
+  equivalent. See `timing-functions.md`

--- a/skills/reanimated-css-migration/references/examples.md
+++ b/skills/reanimated-css-migration/references/examples.md
@@ -1,0 +1,260 @@
+# Worked examples
+
+Calibration, not an allow-list. These show what a correct conversion looks like
+and what the common traps look like. Converting a shape that is not shown here
+is expected, provided every precondition in `preconditions.md` holds and you can
+name the one that permits it.
+
+## Contents
+
+- Migrate: infinite loop
+- Migrate: play once on mount
+- Migrate: React state toggle
+- Migrate: staggered loop
+- Leave alone: handler-written shared value
+- Leave alone: spring
+- Preserve: platform-specific values
+- Trap: easing names
+
+## Migrate: infinite loop
+
+The most common migratable shape. A mount effect starts a repeating animation
+and a cleanup cancels it.
+
+Before:
+
+```tsx
+function Spinner() {
+  const rotation = useSharedValue(0);
+
+  useEffect(() => {
+    rotation.value = withRepeat(
+      withTiming(360, { duration: 2000, easing: Easing.linear }),
+      -1
+    );
+    return () => cancelAnimation(rotation);
+  }, []);
+
+  const style = useAnimatedStyle(() => ({
+    transform: [{ rotateZ: `${rotation.value}deg` }],
+  }));
+
+  return <Animated.View style={[styles.box, style]} />;
+}
+```
+
+After:
+
+```tsx
+const rotate: CSSAnimationKeyframes = {
+  from: { transform: [{ rotateZ: '0deg' }] },
+  to: { transform: [{ rotateZ: '360deg' }] },
+};
+
+function Spinner() {
+  return (
+    <Animated.View
+      style={[
+        styles.box,
+        {
+          animationName: rotate,
+          animationDuration: '2s',
+          animationIterationCount: 'infinite',
+          animationTimingFunction: 'linear',
+        },
+      ]}
+    />
+  );
+}
+```
+
+Note where the CSS properties live: inline in the style array, never inside
+`StyleSheet.create`. Putting them in the stylesheet is a type error, because
+`StyleSheet.create` is typed against React Native's own style types. Keep the
+static styles in the stylesheet and put the animation properties beside them.
+
+The shared value, the effect and the cleanup all become dead and are removed.
+`cancelAnimation` in a cleanup is not imperative control in the sense of the
+refusal list: it only stops the animation on unmount, which CSS does anyway.
+
+`withRepeat`'s third argument reverses the direction. When it is `true`, add
+`animationDirection: 'alternate'`. Hoist the keyframes to module scope, because
+an object created during render restarts the animation on every re-render.
+
+## Migrate: play once on mount
+
+Before:
+
+```tsx
+useEffect(() => {
+  opacity.value = withTiming(1, { duration: 300 });
+}, []);
+```
+
+After:
+
+```tsx
+const fadeIn: CSSAnimationKeyframes = {
+  from: { opacity: 0 },
+  to: { opacity: 1 },
+};
+// on the element:
+{ animationName: fadeIn, animationDuration: '300ms', animationFillMode: 'forwards' }
+```
+
+`animationFillMode: 'forwards'` is required. The CSS default is `none`, which
+discards the computed value at the end and snaps the view back to `opacity: 0`.
+Omitting it is the single most common way a converted mount animation breaks.
+
+## Migrate: React state toggle
+
+The driver is already React state, so the change happens across a render and a
+transition fires.
+
+Before:
+
+```tsx
+const [expanded, setExpanded] = useState(false);
+const progress = useSharedValue(0);
+
+useEffect(() => {
+  progress.value = withTiming(expanded ? 1 : 0, { duration: 200 });
+}, [expanded]);
+
+const style = useAnimatedStyle(() => ({
+  height: 100 + progress.value * 200,
+  opacity: 0.5 + progress.value * 0.5,
+}));
+```
+
+After:
+
+```tsx
+const [expanded, setExpanded] = useState(false);
+
+<Animated.View
+  style={[
+    styles.panel,
+    {
+      height: expanded ? 300 : 100,
+      opacity: expanded ? 1 : 0.5,
+      transitionProperty: ['height', 'opacity'],
+      transitionDuration: '200ms',
+    },
+  ]}
+/>
+```
+
+Enumerate the properties. Never fall back to `transitionProperty: 'all'`.
+
+## Migrate: staggered loop
+
+CSS expresses stagger with a negative delay, which pre-seeds each item at a
+different point in the cycle. There is no hook equivalent, so this is a case
+where the migrated code is simpler than the original.
+
+```tsx
+{items.map((item, index) => (
+  <Animated.View
+    key={item.id}
+    style={[
+      styles.dot,
+      {
+        animationName: pulse,
+        animationDuration: '1s',
+        animationIterationCount: 'infinite',
+        animationDelay: `${-0.15 * index}s`,
+      },
+    ]}
+  />
+))}
+```
+
+## Migrate: shared value written from a JS callback
+
+The most common shape in real code, and the one that needs the shared value
+turned into state. The write is already on the JS thread, so the conversion is
+safe.
+
+Before:
+
+```tsx
+const sv = useSharedValue(false);
+
+const style = useAnimatedStyle(() => ({
+  backgroundColor: withTiming(sv.value ? 'red' : 'cyan', { duration: 200 }),
+}));
+
+const toggle = () => {
+  sv.value = !sv.value;
+};
+```
+
+After:
+
+```tsx
+const [on, setOn] = useState(false);
+
+const toggle = () => setOn((v) => !v);
+
+<Animated.View
+  style={[styles.box, {
+    backgroundColor: on ? 'red' : 'cyan',
+    transitionProperty: ['backgroundColor'],
+    transitionDuration: 200,
+  }]}
+/>
+```
+
+The shared value and the style hook both disappear. Note what makes this safe:
+`toggle` is a plain JS callback, so it can call `setOn` directly. Had the write
+been inside a gesture callback, it would be running in a worklet on the UI
+thread, and reaching React state from there would need a `scheduleOnRN` hop per
+update. Leave those alone.
+
+One behavior change worth stating in the report: each toggle now re-renders the
+component. That is fine for a press, and wrong for anything changing per frame.
+
+## Leave alone: spring
+
+```tsx
+scale.value = withSpring(pressed ? 0.95 : 1, { damping: 15, stiffness: 200 });
+```
+
+CSS offers `cubicBezier`, `linear` and `steps`. None reproduce a spring, and a
+bezier approximation loses the overshoot that makes it read as one. Keep it on
+the hooks API and say why.
+
+## Preserve: platform-specific values
+
+Migrate inside each arm and keep the structure. The author chose these values
+deliberately.
+
+```tsx
+<Animated.View
+  style={[
+    Platform.select({
+      ios: { shadowOpacity: pressed ? 0.3 : 0.1 },
+      android: { elevation: pressed ? 8 : 2 },
+    }),
+    { transitionProperty: Platform.OS === 'ios' ? ['shadowOpacity'] : ['elevation'], transitionDuration: '150ms' },
+  ]}
+/>
+```
+
+These properties are safe to migrate even though each covers one platform:
+React Native does not render `shadowOpacity` on Android or `elevation` on iOS
+either, so nothing is lost. Do not "improve" this into `boxShadow`. That is a
+separate refactor with its own visual risk.
+
+## Trap: easing names
+
+```tsx
+withTiming(1, { easing: Easing.ease })   // Bezier(0.42, 0, 1, 1)
+```
+
+`Easing.ease` is CSS `ease-in`, not CSS `ease`. Emitting
+`animationTimingFunction: 'ease'` silently changes the curve. See
+the Easing section of `api-map.md`, including what to do about the
+`withTiming` default of `Easing.inOut(Easing.quad)`, which has no exact
+equivalent.

--- a/skills/reanimated-css-migration/references/examples.md
+++ b/skills/reanimated-css-migration/references/examples.md
@@ -12,7 +12,7 @@ that permits it.
 - Migrate: staggered loop
 - Migrate: withSequence to percentage keyframes
 - Migrate: shared value written from a JS callback
-- Leave alone: spring
+- Refuse: spring with a runtime config
 - Preserve: platform-specific values
 - Trap: easing names
 
@@ -63,12 +63,13 @@ function Spinner() {
 }
 ```
 
-- CSS properties go inline in the style array, never `StyleSheet.create` — that
+- CSS properties go inline in the style array, never `StyleSheet.create`, that
   is a type error, it is typed against React Native's own style types
-- Keyframes at module scope — an object built during render restarts the
-  animation every render
+- Keyframes at module scope, they are keyed by content, so a rebuilt identical
+  object is only waste, but one whose content varies per render restarts the
+  animation
 - Delete the now-dead shared value, effect and cleanup
-- `cancelAnimation` in an unmount cleanup is not imperative control — CSS stops
+- `cancelAnimation` in an unmount cleanup is not imperative control, CSS stops
   on unmount anyway
 - `withRepeat` third argument `reverse: true` -> `animationDirection: 'alternate'`
 
@@ -88,10 +89,10 @@ const fadeIn: CSSAnimationKeyframes = {
   to: { opacity: 1 },
 };
 // on the element:
-{ animationName: fadeIn, animationDuration: '300ms', animationFillMode: 'forwards' }
+{ animationName: fadeIn, animationDuration: '300ms', animationTimingFunction: 'ease-in-out', animationFillMode: 'forwards' }
 ```
 
-- `animationFillMode: 'forwards'` is required — default `none` discards the
+- `animationFillMode: 'forwards'` is required, default `none` discards the
   computed value and snaps back to `opacity: 0`. The most common way a converted
   mount animation breaks
 
@@ -126,6 +127,7 @@ const [expanded, setExpanded] = useState(false);
       height: expanded ? 300 : 100,
       opacity: expanded ? 1 : 0.5,
       transitionProperty: ['height', 'opacity'],
+      transitionTimingFunction: 'ease-in-out',
       transitionDuration: '200ms',
     },
   ]}
@@ -179,7 +181,7 @@ const pop: CSSAnimationKeyframes = {
   '100%': { transform: [{ scale: 1 }] },
 };
 // on the element:
-{ animationName: pop, animationDuration: '400ms', animationFillMode: 'forwards' }
+{ animationName: pop, animationDuration: '400ms', animationTimingFunction: 'ease-in-out', animationFillMode: 'forwards' }
 ```
 
 - Animation only. A transition has one start and one end, so it cannot express
@@ -215,6 +217,7 @@ const toggle = () => setOn((v) => !v);
   style={[styles.box, {
     backgroundColor: on ? 'red' : 'cyan',
     transitionProperty: ['backgroundColor'],
+    transitionTimingFunction: 'ease-in-out',
     transitionDuration: 200,
   }]}
 />
@@ -222,21 +225,21 @@ const toggle = () => setOn((v) => !v);
 
 - Shared value and style hook both disappear
 - Safe because `toggle` is a plain JS callback. In a gesture callback it would be
-  a worklet on the UI thread, needing a `scheduleOnRN` hop per update — refuse
+  a worklet on the UI thread, needing a `scheduleOnRN` hop per update, refuse
   those
 - Report the behavior change: each toggle now re-renders. Fine for a press, wrong
   for anything per-frame
 
-## Leave alone: spring
+## Refuse: spring with a runtime config
 
 ```tsx
 // Old (hooks) - keep as is
-scale.value = withSpring(pressed ? 0.95 : 1, { damping: 15, stiffness: 200 });
+scale.value = withSpring(target, { damping: props.damping, stiffness: 200 });
 ```
 
-- CSS offers `cubicBezier`, `linear`, `steps`. None reproduce a spring
-- A bezier approximation loses the overshoot that makes it read as one
-- Keep it on the hooks API and say why
+- A parameter not readable at migration time cannot be sampled
+- An all-literal config **is** convertible to `linear(...)`, see
+  `timing-functions.md`
 
 ## Preserve: platform-specific values
 
@@ -253,7 +256,7 @@ scale.value = withSpring(pressed ? 0.95 : 1, { damping: 15, stiffness: 200 });
 />
 ```
 
-- Safe despite each covering one platform — React Native renders neither
+- Safe despite each covering one platform, React Native renders neither
   `shadowOpacity` on Android nor `elevation` on iOS, so nothing is lost
 - Do not "improve" this into `boxShadow`. Separate refactor, own visual risk
 

--- a/skills/reanimated-css-migration/references/examples.md
+++ b/skills/reanimated-css-migration/references/examples.md
@@ -253,6 +253,6 @@ withTiming(1, { easing: Easing.ease })   // Bezier(0.42, 0, 1, 1)
 
 `Easing.ease` is CSS `ease-in`, not CSS `ease`. Emitting
 `animationTimingFunction: 'ease'` silently changes the curve. See
-the Easing section of `api-map.md`, including what to do about the
+`timing-functions.md`, including what to do about the
 `withTiming` default of `Easing.inOut(Easing.quad)`, which has no exact
 equivalent.

--- a/skills/reanimated-css-migration/references/preconditions.md
+++ b/skills/reanimated-css-migration/references/preconditions.md
@@ -2,125 +2,111 @@
 
 ## Contents
 
-- Preconditions: every one must hold before migrating a call site
+- Preconditions: all seven must hold before migrating a call site
 - Equivalence obligations: what must still be true afterwards
-- Effective platforms: narrowing the property check to what a call site targets
+- Effective platforms: narrowing the property check
 
 ## Preconditions
 
-Every precondition below must hold. A single failure makes the call site
-unmigratable, and the failing precondition is the reason you report to the user.
+All must hold. The first failure is the reason you report.
 
-### 1. The driver is written from the JS thread, in discrete steps
+### 1. The driver is written on the JS thread, in discrete steps
 
-CSS transitions are computed by diffing props between two renders, so the driver
-has to be something React renders. Most hook-based code does not re-render, and
-that is expected: **converting the shared value to React state is part of this
-migration, not a reason to refuse it.** A `useSharedValue` whose only job was to
-carry a value into `useAnimatedStyle` becomes a `useState`, and the state change
+Migrate when the write happens in:
+
+- `useEffect`
+- a plain JS callback: `onPress`, `onChange`, a timer, a network response
+- a gesture callback with `.runOnJS(true)`
+
+Converting the shared value to `useState` is **part of this migration**, not a
+reason to refuse. Most hook code does not re-render today; the new state change
 is what fires the transition.
 
-That conversion is safe only where the write already happens on the JS thread:
+Refuse when the write happens in a worklet: gesture callbacks (workletized onto
+the UI thread by default), `useAnimatedReaction`, `useFrameCallback`, scroll
+handlers, sensors, the keyboard hook. React state from there costs a
+`scheduleOnRN` hop per update.
 
-- inside `useEffect`
-- inside a plain JS callback: `onPress`, `onChange`, a timer, a network response
-- inside a gesture callback explicitly moved to the JS thread with
-  `.runOnJS(true)`
+Refuse continuous updates even on the JS thread. A pan following a finger would
+re-render every frame once it is state.
 
-**Refuse when the write happens in a worklet.** Gesture callbacks are
-automatically workletized onto the UI thread when Reanimated is installed, and
-the same applies to `useAnimatedReaction`, `useFrameCallback`, scroll handlers,
-sensors and the keyboard hook. Setting React state from there means hopping
-threads with `scheduleOnRN` on every update, which is slower and more fragile
-than the code you started with. Leave those on the hooks API.
-
-To tell the two apart, read the gesture: it runs on the UI thread unless
-`.runOnJS(true)` is set, or one of its callbacks is not a worklet.
-
-**Refuse continuous updates even on the JS thread.** A value that changes every
-frame, such as a pan following a finger, would re-render the component every
-frame once it is state. Migrate discrete changes, not streams.
+To classify a gesture: UI thread unless `.runOnJS(true)` is set or one of its
+callbacks is not a worklet.
 
 ### 2. Every animated value is a pure function of the driver
 
-Each style value must be expressible as fixed keyframe endpoints. Affine
-arithmetic on the driver and color interpolation qualify. Trigonometry,
-`Math.atan2`, parametric geometry, and anything reading runtime layout do not,
-because CSS has no way to evaluate an arbitrary expression per frame.
+Values must be expressible as fixed keyframe endpoints.
 
-This is the precondition most often missed, because a call site can have a
-perfectly migratable driver and a body that is impossible to express. Check both
-independently.
+| Qualifies | Does not |
+| --- | --- |
+| affine arithmetic on the driver | trigonometry, `Math.atan2`, parametric geometry |
+| color interpolation | anything reading runtime layout |
 
-### 3. Every property is animatable on the call site's effective platforms
+Check this independently of precondition 1. A call site often has a migratable
+driver and an inexpressible body.
 
-Check the table in `refusals.md` rather than reasoning from memory, and the
+### 3. Every property is animatable on the effective platforms
+
+Check the table in `refusals.md`, then
 [supported properties](https://docs.swmansion.com/react-native-reanimated/docs/guides/supported-properties)
-page for anything not listed there.
+for anything not listed. Do not reason from memory.
 
-A property is safe when React Native does not render it on a platform either:
-the animation was already inert there, so nothing is lost. It is unsafe when
-React Native renders it and CSS cannot animate it, because the hook version
-works today and the CSS version would stop.
+Safe when React Native does not render it there either: the animation was
+already inert, so nothing is lost. Unsafe when React Native renders it and CSS
+cannot animate it.
 
 ### 4. No explicit reduced-motion handling
 
-If the code passes a `reduceMotion` config, references the `ReduceMotion` enum,
-or calls `useReducedMotion`, leave it untouched. CSS has no reduced-motion
-support, so migrating would drop behavior the author deliberately asked for.
+Refuse if the code passes a `reduceMotion` config, references `ReduceMotion`, or
+calls `useReducedMotion`. CSS has no reduced-motion support.
 
-Every `with*` call carries an implicit `ReduceMotion.System` default, which
-migrating does lose. That is accepted. This precondition only protects code
-whose author showed they cared.
+Every `with*` carries an implicit `ReduceMotion.System` that migrating does
+lose. That is accepted. This protects only code whose author showed they cared.
 
 ### 5. No consumed completion callback
 
-`withTiming(value, config, callback)` and its siblings run a callback with a
-`finished` flag. The CSS callbacks are typed on all platforms but only wired up
-on web, so on iOS and Android they never fire at all, and they carry no
+CSS callbacks are typed on all platforms but wired up only on web, and carry no
 `finished` equivalent anywhere.
 
-A callback that only logs can be dropped. A callback that chains the next
-animation or updates state is load-bearing and blocks migration.
+- Callback only logs: drop it, migrate.
+- Callback chains an animation or sets state: refuse.
 
 ### 6. No imperative control
 
-`cancelAnimation`, or any code that pauses, reverses, restarts or interrupts an
-animation from an effect or handler. CSS offers no cancel, only a re-render that
-changes `animationPlayState` or removes `animationName`, which is not the same
-thing and does not freeze at the current value.
+Refuse `cancelAnimation`, or anything that pauses, reverses, restarts or
+interrupts from an effect or handler. `animationPlayState` suspends; it does not
+cancel or freeze at the current value.
 
 ### 7. The target is an Animated component
 
-CSS properties on a plain component are ignored silently. The element must be an
-`Animated` built-in or wrapped with `Animated.createAnimatedComponent`.
+Must be an `Animated` built-in or wrapped with
+`Animated.createAnimatedComponent`. CSS properties on a plain component are
+ignored silently.
 
 ## Equivalence obligations
 
-After converting a call site, every obligation below must hold. If you cannot
-convince yourself of one, revert that call site and report it as needs-review.
+All must hold after converting. If you cannot confirm one, revert that site and
+report it as needs-review.
 
-1. **First render is identical.** No flash of the unstyled or final state. A
-   converted mount animation usually needs `animationFillMode: 'forwards'`,
-   because the CSS default of `none` discards the computed value and snaps back.
-1. **End state is identical**, including after the animation completes and after
-   a fill mode applies.
-1. **Re-triggering behaves the same.** Fire the driver twice in quick
-   succession and confirm the second run starts where the hook version would.
-1. **Interrupting and unmounting behave the same.** Unmount mid-animation and
-   confirm nothing throws and nothing is left running.
-1. **Nothing else about the render changed.** Same element tree, same props,
-   same conditional logic. Only the animation mechanism moved.
+1. **First render identical.** No flash of unstyled or final state. A converted
+   mount animation usually needs `animationFillMode: 'forwards'`.
+1. **End state identical**, after completion and after fill mode applies.
+1. **Re-trigger identical.** Fire the driver twice quickly; the second run must
+   start where the hook version would.
+1. **Interrupt and unmount identical.** Unmount mid-animation; nothing throws,
+   nothing keeps running.
+1. **Nothing else changed.** Same element tree, props and conditional logic.
+   Only the animation mechanism moved.
 
 ## Effective platforms
 
-A call site does not always have to satisfy every platform the project ships.
+A call site need not satisfy every platform the project ships.
 
-Narrow the requirement when the file carries a platform suffix on any JavaScript
-or TypeScript extension: `.ios`, `.android`, `.web`, or `.native`, where
-`.native` means iOS and Android but not web. Narrow it likewise inside a
-`Platform.OS` comparison or a `Platform.select` arm.
+| Context | Requires |
+| --- | --- |
+| `.ios` / `.android` / `.web` suffix | that platform |
+| `.native` suffix | iOS and Android, not web |
+| `Platform.OS` branch, `Platform.select` arm | that branch's platform |
 
-Migrate inside each `Platform.select` arm separately and keep the structure. The
-author chose platform-specific values deliberately, and collapsing that is a
-regression on its own terms, independent of the animation.
+Migrate inside each `Platform.select` arm and keep the structure. Collapsing a
+deliberate platform decision is a regression on its own terms.

--- a/skills/reanimated-css-migration/references/preconditions.md
+++ b/skills/reanimated-css-migration/references/preconditions.md
@@ -142,7 +142,7 @@ needs-review.
 | 2 | End state identical | After completion, and after fill mode applies |
 | 3 | Re-trigger identical | Fire the driver twice quickly; second run starts where the hook version would |
 | 4 | Interrupt and unmount identical | Unmount mid-animation; nothing throws, nothing keeps running |
-| 5 | Nothing else changed | Same element tree, props, conditional logic |
+| 5 | Nothing else changed | Same element tree, props, conditional logic. Swapping `Pressable` for `Animated.View` to use `:active` fails this: it drops the press handlers and the accessibility role |
 
 ## Effective platforms
 

--- a/skills/reanimated-css-migration/references/preconditions.md
+++ b/skills/reanimated-css-migration/references/preconditions.md
@@ -2,63 +2,57 @@
 
 ## Contents
 
-- Preconditions: all seven must hold before migrating a call site
-- Equivalence obligations: what must still be true afterwards
-- Effective platforms: narrowing the property check
+- Preconditions: check all 7 before converting a call site
+- Equivalence obligations: check all 5 after converting
+- Effective platforms
 
 ## Preconditions
 
-All must hold. The first failure is the reason you report.
+All 7 must pass. Report the first failure as the reason.
 
-### 1. The driver is written on the JS thread, in discrete steps
+### 1. Driver written on the JS thread, changing discretely
 
-Migrate when the write happens in:
+| Where the shared value is written | Verdict |
+| --- | --- |
+| `useEffect` | pass |
+| plain JS callback: `onPress`, `onChange`, timer, network response | pass |
+| gesture with `.runOnJS(true)` | pass |
+| gesture without `.runOnJS(true)` | refuse, worklet |
+| `useAnimatedReaction`, `useFrameCallback`, scroll handler, sensor, keyboard hook | refuse, worklet |
+| anything updating every frame | refuse, would re-render per frame |
 
-- `useEffect`
-- a plain JS callback: `onPress`, `onChange`, a timer, a network response
-- a gesture callback with `.runOnJS(true)`
+Converting the shared value to `useState` is the migration, not a reason to
+refuse. Most hook code does not re-render today.
 
-Converting the shared value to `useState` is **part of this migration**, not a
-reason to refuse. Most hook code does not re-render today; the new state change
-is what fires the transition.
+Gesture classification: UI thread unless `.runOnJS(true)` is set or a callback
+is not a worklet.
 
-Refuse when the write happens in a worklet: gesture callbacks (workletized onto
-the UI thread by default), `useAnimatedReaction`, `useFrameCallback`, scroll
-handlers, sensors, the keyboard hook. React state from there costs a
-`scheduleOnRN` hop per update.
+### 2. Animated values are pure functions of the driver
 
-Refuse continuous updates even on the JS thread. A pan following a finger would
-re-render every frame once it is state.
+Every value must reduce to fixed keyframe endpoints.
 
-To classify a gesture: UI thread unless `.runOnJS(true)` is set or one of its
-callbacks is not a worklet.
-
-### 2. Every animated value is a pure function of the driver
-
-Values must be expressible as fixed keyframe endpoints.
-
-| Qualifies | Does not |
+| Pass | Refuse |
 | --- | --- |
 | affine arithmetic on the driver | trigonometry, `Math.atan2`, parametric geometry |
 | color interpolation | anything reading runtime layout |
 
-Check this independently of precondition 1. A call site often has a migratable
-driver and an inexpressible body.
+Check independently of precondition 1: a migratable driver often has an
+inexpressible body.
 
-### 3. Every property is animatable on the effective platforms
+### 3. Properties animatable on the effective platforms
 
-Check the table in `refusals.md`, then
-[supported properties](https://docs.swmansion.com/react-native-reanimated/docs/guides/supported-properties)
-for anything not listed. Do not reason from memory.
+Check `refusals.md`, then
+[supported properties](https://docs.swmansion.com/react-native-reanimated/docs/guides/supported-properties).
+Never from memory.
 
-Safe when React Native does not render it there either: the animation was
-already inert, so nothing is lost. Unsafe when React Native renders it and CSS
-cannot animate it.
+| Condition | Verdict |
+| --- | --- |
+| React Native does not render it there either | pass, already inert |
+| React Native renders it, CSS cannot animate it | refuse, would stop working |
 
-### 4. Reduced motion is carried across, not dropped
+### 4. Reduced motion carried across
 
-CSS has no reduced-motion support of its own. Preserve it with the hook
-Reanimated already exports, and drive the duration from it:
+Emit a guard; do not drop it.
 
 ```tsx
 const reduced = useReducedMotion();
@@ -72,65 +66,61 @@ const reduced = useReducedMotion();
 />
 ```
 
-Emit the guard whenever the source passes a `reduceMotion` config, references
-`ReduceMotion`, or calls `useReducedMotion`. Every `with*` also carries an
-implicit `ReduceMotion.System`, so emit it by default for anything a user would
-notice. Where you decide the motion is too small to matter, say so in the report
-rather than dropping it silently.
+| Condition | Action |
+| --- | --- |
+| source uses `reduceMotion`, `ReduceMotion`, `useReducedMotion` | emit the guard |
+| no explicit use, motion is user-noticeable | emit the guard, `with*` implied `ReduceMotion.System` |
+| motion too small to matter | may drop, state it in the report |
 
-Use a small non-zero duration, never `0`. A transition whose `duration + delay`
-is `<= 0` is discarded outright (`css/native/normalization/transition/config.ts`),
-so the element jumps and no transition event can fire. `1` keeps the motion
-imperceptible while leaving the transition real, which also keeps behavior
-consistent with web once animation and transition events land.
+Reduced-motion duration: `1`. Never `0`: `duration + delay <= 0` discards the
+transition outright (`css/native/normalization/transition/config.ts`), so the
+element jumps and no transition event can fire.
 
-Bare numbers are milliseconds: `1` is 1ms. Do not write `0.01` expecting 10ms,
-that is 0.01ms.
+Bare numbers are milliseconds. `1` is 1ms; `0.01` is 0.01ms, not 10ms.
 
 ### 5. No consumed completion callback
 
-CSS callbacks are typed on all platforms but wired up only on web, and carry no
-`finished` equivalent anywhere.
+CSS callbacks are wired up only on web and carry no `finished` equivalent.
 
-- Callback only logs: drop it, migrate.
-- Callback chains an animation or sets state: refuse.
+| Callback body | Action |
+| --- | --- |
+| logging only | drop it, migrate |
+| chains an animation, sets state, anything observable | refuse |
 
 ### 6. No imperative control
 
-Refuse `cancelAnimation`, or anything that pauses, reverses, restarts or
-interrupts from an effect or handler. `animationPlayState` suspends; it does not
-cancel or freeze at the current value.
+Refuse `cancelAnimation`, or pausing, reversing, restarting, interrupting from
+an effect or handler. `animationPlayState` suspends; it does not cancel or
+freeze at the current value.
 
-### 7. The target is an Animated component
+Exception: `cancelAnimation` in an unmount cleanup. CSS stops on unmount anyway.
 
-Must be an `Animated` built-in or wrapped with
-`Animated.createAnimatedComponent`. CSS properties on a plain component are
-ignored silently.
+### 7. Target is an Animated component
+
+Must be an `Animated` built-in or `Animated.createAnimatedComponent`. CSS
+properties on a plain component are ignored silently.
 
 ## Equivalence obligations
 
-All must hold after converting. If you cannot confirm one, revert that site and
-report it as needs-review.
+Check all 5 after converting. Cannot confirm one, revert that site and report
+needs-review.
 
-1. **First render identical.** No flash of unstyled or final state. A converted
-   mount animation usually needs `animationFillMode: 'forwards'`.
-1. **End state identical**, after completion and after fill mode applies.
-1. **Re-trigger identical.** Fire the driver twice quickly; the second run must
-   start where the hook version would.
-1. **Interrupt and unmount identical.** Unmount mid-animation; nothing throws,
-   nothing keeps running.
-1. **Nothing else changed.** Same element tree, props and conditional logic.
-   Only the animation mechanism moved.
+| # | Must hold | How to check |
+| --- | --- | --- |
+| 1 | First render identical | No flash of unstyled or final state. Mount animations usually need `animationFillMode: 'forwards'` |
+| 2 | End state identical | After completion, and after fill mode applies |
+| 3 | Re-trigger identical | Fire the driver twice quickly; second run starts where the hook version would |
+| 4 | Interrupt and unmount identical | Unmount mid-animation; nothing throws, nothing keeps running |
+| 5 | Nothing else changed | Same element tree, props, conditional logic |
 
 ## Effective platforms
 
-A call site need not satisfy every platform the project ships.
-
 | Context | Requires |
 | --- | --- |
-| `.ios` / `.android` / `.web` suffix | that platform |
+| `.ios` / `.android` / `.web` suffix | that platform only |
 | `.native` suffix | iOS and Android, not web |
-| `Platform.OS` branch, `Platform.select` arm | that branch's platform |
+| `Platform.OS` branch or `Platform.select` arm | that branch's platform only |
+| none of the above | every platform the project ships |
 
-Migrate inside each `Platform.select` arm and keep the structure. Collapsing a
-deliberate platform decision is a regression on its own terms.
+Migrate inside each `Platform.select` arm; keep the structure. Collapsing a
+deliberate platform decision is a regression on its own.

--- a/skills/reanimated-css-migration/references/preconditions.md
+++ b/skills/reanimated-css-migration/references/preconditions.md
@@ -1,0 +1,126 @@
+# Preconditions and equivalence obligations
+
+## Contents
+
+- Preconditions: every one must hold before migrating a call site
+- Equivalence obligations: what must still be true afterwards
+- Effective platforms: narrowing the property check to what a call site targets
+
+## Preconditions
+
+Every precondition below must hold. A single failure makes the call site
+unmigratable, and the failing precondition is the reason you report to the user.
+
+### 1. The driver is written from the JS thread, in discrete steps
+
+CSS transitions are computed by diffing props between two renders, so the driver
+has to be something React renders. Most hook-based code does not re-render, and
+that is expected: **converting the shared value to React state is part of this
+migration, not a reason to refuse it.** A `useSharedValue` whose only job was to
+carry a value into `useAnimatedStyle` becomes a `useState`, and the state change
+is what fires the transition.
+
+That conversion is safe only where the write already happens on the JS thread:
+
+- inside `useEffect`
+- inside a plain JS callback: `onPress`, `onChange`, a timer, a network response
+- inside a gesture callback explicitly moved to the JS thread with
+  `.runOnJS(true)`
+
+**Refuse when the write happens in a worklet.** Gesture callbacks are
+automatically workletized onto the UI thread when Reanimated is installed, and
+the same applies to `useAnimatedReaction`, `useFrameCallback`, scroll handlers,
+sensors and the keyboard hook. Setting React state from there means hopping
+threads with `scheduleOnRN` on every update, which is slower and more fragile
+than the code you started with. Leave those on the hooks API.
+
+To tell the two apart, read the gesture: it runs on the UI thread unless
+`.runOnJS(true)` is set, or one of its callbacks is not a worklet.
+
+**Refuse continuous updates even on the JS thread.** A value that changes every
+frame, such as a pan following a finger, would re-render the component every
+frame once it is state. Migrate discrete changes, not streams.
+
+### 2. Every animated value is a pure function of the driver
+
+Each style value must be expressible as fixed keyframe endpoints. Affine
+arithmetic on the driver and color interpolation qualify. Trigonometry,
+`Math.atan2`, parametric geometry, and anything reading runtime layout do not,
+because CSS has no way to evaluate an arbitrary expression per frame.
+
+This is the precondition most often missed, because a call site can have a
+perfectly migratable driver and a body that is impossible to express. Check both
+independently.
+
+### 3. Every property is animatable on the call site's effective platforms
+
+Check the table in `refusals.md` rather than reasoning from memory, and the
+[supported properties](https://docs.swmansion.com/react-native-reanimated/docs/guides/supported-properties)
+page for anything not listed there.
+
+A property is safe when React Native does not render it on a platform either:
+the animation was already inert there, so nothing is lost. It is unsafe when
+React Native renders it and CSS cannot animate it, because the hook version
+works today and the CSS version would stop.
+
+### 4. No explicit reduced-motion handling
+
+If the code passes a `reduceMotion` config, references the `ReduceMotion` enum,
+or calls `useReducedMotion`, leave it untouched. CSS has no reduced-motion
+support, so migrating would drop behavior the author deliberately asked for.
+
+Every `with*` call carries an implicit `ReduceMotion.System` default, which
+migrating does lose. That is accepted. This precondition only protects code
+whose author showed they cared.
+
+### 5. No consumed completion callback
+
+`withTiming(value, config, callback)` and its siblings run a callback with a
+`finished` flag. The CSS callbacks are typed on all platforms but only wired up
+on web, so on iOS and Android they never fire at all, and they carry no
+`finished` equivalent anywhere.
+
+A callback that only logs can be dropped. A callback that chains the next
+animation or updates state is load-bearing and blocks migration.
+
+### 6. No imperative control
+
+`cancelAnimation`, or any code that pauses, reverses, restarts or interrupts an
+animation from an effect or handler. CSS offers no cancel, only a re-render that
+changes `animationPlayState` or removes `animationName`, which is not the same
+thing and does not freeze at the current value.
+
+### 7. The target is an Animated component
+
+CSS properties on a plain component are ignored silently. The element must be an
+`Animated` built-in or wrapped with `Animated.createAnimatedComponent`.
+
+## Equivalence obligations
+
+After converting a call site, every obligation below must hold. If you cannot
+convince yourself of one, revert that call site and report it as needs-review.
+
+1. **First render is identical.** No flash of the unstyled or final state. A
+   converted mount animation usually needs `animationFillMode: 'forwards'`,
+   because the CSS default of `none` discards the computed value and snaps back.
+1. **End state is identical**, including after the animation completes and after
+   a fill mode applies.
+1. **Re-triggering behaves the same.** Fire the driver twice in quick
+   succession and confirm the second run starts where the hook version would.
+1. **Interrupting and unmounting behave the same.** Unmount mid-animation and
+   confirm nothing throws and nothing is left running.
+1. **Nothing else about the render changed.** Same element tree, same props,
+   same conditional logic. Only the animation mechanism moved.
+
+## Effective platforms
+
+A call site does not always have to satisfy every platform the project ships.
+
+Narrow the requirement when the file carries a platform suffix on any JavaScript
+or TypeScript extension: `.ios`, `.android`, `.web`, or `.native`, where
+`.native` means iOS and Android but not web. Narrow it likewise inside a
+`Platform.OS` comparison or a `Platform.select` arm.
+
+Migrate inside each `Platform.select` arm separately and keep the structure. The
+author chose platform-specific values deliberately, and collapsing that is a
+regression on its own terms, independent of the animation.

--- a/skills/reanimated-css-migration/references/preconditions.md
+++ b/skills/reanimated-css-migration/references/preconditions.md
@@ -2,8 +2,8 @@
 
 ## Contents
 
-- Preconditions: check all 7 before converting a call site (2b covers derived values)
-- Equivalence obligations: check all 5 after converting
+- Preconditions: check all 7 before converting a call site (2b covers indirection)
+- Equivalence obligations: check all 5 after converting (3 has a re-trigger table)
 - Effective platforms
 
 ## Preconditions
@@ -54,15 +54,21 @@ equivalence obligation catches it. Refuse.
 Check independently of precondition 1: a migratable driver often has an
 inexpressible body.
 
-### 2b. Derived values resolve to the same driver
+### 2b. Indirection resolves to the same driver
 
-`useDerivedValue` is not itself a blocker. Classify what it derives from.
+`useDerivedValue`, and a shared value passed to a child as a prop, are not
+themselves blockers. Classify the root writer.
 
 | Shape | Verdict |
 | --- | --- |
 | Derives from one migratable driver, read only by this style | Inline it into the style and migrate |
 | Derives from a worklet-written value | Refuse, precondition 1 applies to the root driver |
 | Read by several consumers, or by a worklet | Refuse, the conversion would change more than this call site |
+| `SharedValue` passed to a child as a prop, root writer on the JS thread, one animated-style reader | Migrate. Replace the prop with the plain value the writer switches on, render the endpoints in the child, delete the shared value and its type |
+| `SharedValue` prop read in more than one component, or by any worklet | Refuse, same reason as the multi-consumer row |
+
+Prove the reader count before migrating a prop: grep the shared value's name
+across the scope. Crossing a file boundary is not itself a refusal.
 
 ### 3. Properties animatable on the effective platforms
 
@@ -140,9 +146,29 @@ needs-review.
 | --- | --- | --- |
 | 1 | First render identical | No flash of unstyled or final state. Mount animations usually need `animationFillMode: 'forwards'` |
 | 2 | End state identical | After completion, and after fill mode applies |
-| 3 | Re-trigger identical | Fire the driver twice quickly; second run starts where the hook version would |
+| 3 | Re-trigger identical | Fire the driver twice quickly. Start value **and** remaining duration must match; see the re-trigger table below |
 | 4 | Interrupt and unmount identical | Unmount mid-animation; nothing throws, nothing keeps running |
 | 5 | Nothing else changed | Same element tree, props, conditional logic. Swapping `Pressable` for `Animated.View` to use `:active` fails this: it drops the press handlers and the accessibility role |
+
+### Re-trigger, in detail
+
+`withTiming` inherits the previous run's start time and value only when the new
+`toValue` equals the running animation's (`animation/timing.ts:127`). A CSS
+transition applies a reversing-shortening factor whenever a new target reverses a
+transition that has not finished
+(`Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp`), so the
+reversed run is shortened in proportion to how far it had got.
+
+| Second write, mid-flight | Hooks | CSS transition | Action |
+| --- | --- | --- | --- |
+| same `toValue` | keeps the original start time and value | does not reproduce the inherited timeline | Refuse if the timing matters. The `refusals.md` rapid-re-trigger row covers this shape and only this shape |
+| reversed `toValue` | restarts from the current value, full duration | restarts from the current value, `duration * remaining fraction` | Endpoints and start value match, duration does not. Migrate and state the difference, or needs-review when the reversal is the interaction |
+| any write after the previous run finished | identical | identical | pass |
+
+The reversal is the interaction, not an edge case, when a tap toggles one target
+back and forth, or a timer's interval is shorter than the duration. Silence is
+the defect: state it on the applied row or park the site, never leave it
+unrecorded.
 
 ## Effective platforms
 
@@ -151,6 +177,7 @@ needs-review.
 | `.ios` / `.android` / `.web` suffix | that platform only |
 | `.native` suffix | iOS and Android, not web |
 | `Platform.OS` branch or `Platform.select` arm | that branch's platform only |
+| a platform constant short-circuiting the write, `if (IS_WEB) return` | the platforms that reach the write. Reproduce the gate in the converted style, do not widen coverage |
 | none of the above | every platform the project ships |
 
 Migrate inside each `Platform.select` arm; keep the structure. Collapsing a

--- a/skills/reanimated-css-migration/references/preconditions.md
+++ b/skills/reanimated-css-migration/references/preconditions.md
@@ -34,7 +34,7 @@ Every value must reduce to fixed keyframe endpoints.
 | Pass | Refuse |
 | --- | --- |
 | affine arithmetic on the driver | trigonometry, `Math.atan2`, parametric geometry |
-| `interpolateColor` | anything reading runtime layout |
+| `interpolateColor` with the default `'RGB'` space | `interpolateColor` with `'HSV'` or `'LAB'` |
 | `interpolate` with 2 input stops | `interpolate` whose output feeds further non-affine work |
 | `interpolate` with N stops, converting to an animation | `interpolate` with N stops, converting to a transition |
 
@@ -46,6 +46,10 @@ multi-stop `interpolate` needs an animation, not a transition.
 (`interpolation.ts:86-87`); CSS clamps at the outermost keyframe. Equivalent
 only when the driver stays inside the input range, or the source already passes
 `Extrapolation.CLAMP`. Otherwise refuse, or state the difference in the report.
+
+`interpolateColor` with `'HSV'` or `'LAB'` traverses hue or perceptual space
+between the endpoints; CSS lerps RGBA channels. The endpoints match, so no
+equivalence obligation catches it. Refuse.
 
 Check independently of precondition 1: a migratable driver often has an
 inexpressible body.
@@ -93,9 +97,15 @@ const reduced = useReducedMotion();
 | no explicit use, motion is user-noticeable | emit the guard, `with*` implied `ReduceMotion.System` |
 | motion too small to matter | may drop, state it in the report |
 
-Reduced-motion duration: `1`. Never `0`: `duration + delay <= 0` discards the
-transition outright (`css/native/normalization/transition/config.ts`), so the
-element jumps and no transition event can fire.
+The guard's shape differs by mechanism:
+
+| Kind | Reduced-motion form |
+| --- | --- |
+| Transition | `transitionDuration: reduced ? 1 : D`. Never `0`: `duration + delay <= 0` drops the transition (`css/native/normalization/transition/config.ts:113`), so the element jumps and no transition event fires |
+| Animation | Drop `animationName` and render the value the hook rests at: the last keyframe, or the first for an infinite `alternate`. Never shorten the duration, a 1ms infinite animation strobes |
+
+There is no `duration <= 0` skip for animations, so the transition recipe does
+not transfer.
 
 Bare numbers are milliseconds. `1` is 1ms; `0.01` is 0.01ms, not 10ms.
 

--- a/skills/reanimated-css-migration/references/preconditions.md
+++ b/skills/reanimated-css-migration/references/preconditions.md
@@ -2,7 +2,7 @@
 
 ## Contents
 
-- Preconditions: check all 7 before converting a call site
+- Preconditions: check all 7 before converting a call site (2b covers derived values)
 - Equivalence obligations: check all 5 after converting
 - Effective platforms
 
@@ -34,10 +34,31 @@ Every value must reduce to fixed keyframe endpoints.
 | Pass | Refuse |
 | --- | --- |
 | affine arithmetic on the driver | trigonometry, `Math.atan2`, parametric geometry |
-| color interpolation | anything reading runtime layout |
+| `interpolateColor` | anything reading runtime layout |
+| `interpolate` with 2 input stops | `interpolate` whose output feeds further non-affine work |
+| `interpolate` with N stops, converting to an animation | `interpolate` with N stops, converting to a transition |
+
+`interpolate` maps to keyframes, one stop per input value, placed at the
+input's fraction of the range. A transition has only a start and an end, so a
+multi-stop `interpolate` needs an animation, not a transition.
+
+`interpolate` defaults to `Extrapolation.EXTEND` on both edges
+(`interpolation.ts:86-87`); CSS clamps at the outermost keyframe. Equivalent
+only when the driver stays inside the input range, or the source already passes
+`Extrapolation.CLAMP`. Otherwise refuse, or state the difference in the report.
 
 Check independently of precondition 1: a migratable driver often has an
 inexpressible body.
+
+### 2b. Derived values resolve to the same driver
+
+`useDerivedValue` is not itself a blocker. Classify what it derives from.
+
+| Shape | Verdict |
+| --- | --- |
+| Derives from one migratable driver, read only by this style | Inline it into the style and migrate |
+| Derives from a worklet-written value | Refuse, precondition 1 applies to the root driver |
+| Read by several consumers, or by a worklet | Refuse, the conversion would change more than this call site |
 
 ### 3. Properties animatable on the effective platforms
 

--- a/skills/reanimated-css-migration/references/preconditions.md
+++ b/skills/reanimated-css-migration/references/preconditions.md
@@ -55,13 +55,37 @@ Safe when React Native does not render it there either: the animation was
 already inert, so nothing is lost. Unsafe when React Native renders it and CSS
 cannot animate it.
 
-### 4. No explicit reduced-motion handling
+### 4. Reduced motion is carried across, not dropped
 
-Refuse if the code passes a `reduceMotion` config, references `ReduceMotion`, or
-calls `useReducedMotion`. CSS has no reduced-motion support.
+CSS has no reduced-motion support of its own. Preserve it with the hook
+Reanimated already exports, and drive the duration from it:
 
-Every `with*` carries an implicit `ReduceMotion.System` that migrating does
-lose. That is accepted. This protects only code whose author showed they cared.
+```tsx
+const reduced = useReducedMotion();
+
+<Animated.View
+  style={[styles.panel, {
+    height: expanded ? 300 : 100,
+    transitionProperty: ['height'],
+    transitionDuration: reduced ? 1 : 300,
+  }]}
+/>
+```
+
+Emit the guard whenever the source passes a `reduceMotion` config, references
+`ReduceMotion`, or calls `useReducedMotion`. Every `with*` also carries an
+implicit `ReduceMotion.System`, so emit it by default for anything a user would
+notice. Where you decide the motion is too small to matter, say so in the report
+rather than dropping it silently.
+
+Use a small non-zero duration, never `0`. A transition whose `duration + delay`
+is `<= 0` is discarded outright (`css/native/normalization/transition/config.ts`),
+so the element jumps and no transition event can fire. `1` keeps the motion
+imperceptible while leaving the transition real, which also keeps behavior
+consistent with web once animation and transition events land.
+
+Bare numbers are milliseconds: `1` is 1ms. Do not write `0.01` expecting 10ms,
+that is 0.01ms.
 
 ### 5. No consumed completion callback
 

--- a/skills/reanimated-css-migration/references/refusals.md
+++ b/skills/reanimated-css-migration/references/refusals.md
@@ -1,0 +1,106 @@
+# Refusals
+
+The closed list. Anything here is never migrated, whatever the surrounding code
+looks like. Report the reason and the advice; do not approximate.
+
+Hook-based Reanimated is the correct tool for most of these, not a legacy one.
+Say that when refusing, so the output reads as guidance rather than a list of
+things the tool cannot do.
+
+## Contents
+
+- No CSS equivalent exists
+- Lossy: an equivalent exists but changes behavior
+- Properties that would regress
+- What to say
+
+## No CSS equivalent exists
+
+| Pattern | Why | What to tell the user |
+| --- | --- | --- |
+| `withSpring` with a runtime config | Sampling needs every parameter known at migration time. A `velocity` taken from a gesture, or a config built at runtime, cannot be sampled | Keep it on the hooks API. Statically configured springs are convertible; see `api-map.md` |
+| `withDecay` | Velocity-driven with no fixed target | Keep it. CSS timelines are fixed-duration by definition |
+| `withClamp` | No bounding concept in CSS | Keep it |
+| Gesture-driven values | Gesture callbacks are workletized onto the UI thread by default, so reaching React state needs a `scheduleOnRN` hop per update | Keep it. This is exactly what the hooks API is for. A gesture with `.runOnJS(true)` runs on the JS thread and is migratable if its updates are discrete |
+| Scroll-driven values | Same reason | Keep it |
+| Sensor, keyboard, frame callback drivers | CSS animations advance on time only. There is no scroll, sensor or keyboard timeline | Keep it |
+| `measure`, `useAnimatedRef` reads | Targets depend on runtime layout, which cannot be written as a keyframe | Keep it |
+| `useAnimatedProps` for non-style props | CSS styles are keyed off view, text and image styles | Keep it. SVG geometry props are the exception: those do animate, via `animatedProps` |
+| Layout animations, `Keyframe`, shared element transitions | A separate subsystem with its own lifecycle | Leave untouched. Out of scope for this migration |
+| SVG `transform` and its parts | Not supported. Several forms still carry unfinished preprocessors and none are documented | Keep it on the hooks API |
+
+## Lossy: an equivalent exists but changes behavior
+
+These look migratable and are the most dangerous cases, because the result
+compiles and often appears to work.
+
+**Completion callbacks.** `withTiming(value, config, callback)` gives a
+`finished` flag. The CSS callbacks are typed for every platform but only wired
+up on web, so on iOS and Android they never fire. They also carry no `finished`
+equivalent. A callback that only logs can be dropped; one that chains an
+animation or sets state is load-bearing and blocks the migration.
+
+**Imperative control.** `cancelAnimation` has no CSS counterpart.
+`animationPlayState: 'paused'` suspends an animation, it does not cancel it and
+does not freeze it at the current value the way cancelling does.
+
+**Explicit reduced motion.** CSS has no reduced-motion support on any platform.
+If the source passes a `reduceMotion` config, uses the `ReduceMotion` enum, or
+calls `useReducedMotion`, leave it alone: the author asked for behavior that
+would silently disappear.
+
+**Discrete properties.** Keyword-valued properties such as `display`,
+`position`, `flexDirection`, `justifyContent`, `alignItems`, `overflow`,
+`fontWeight` and `textAlign` are dropped from transitions entirely unless
+`transitionBehavior: 'allow-discrete'` is set, and even then they flip at the
+midpoint rather than interpolating. Either refuse, or set the behavior and warn
+about the midpoint flip.
+
+**Mid-flight retargeting.** Re-issuing `withTiming` toward the same target
+inherits the original start time and value. CSS transitions approximate this but
+do not reproduce it, so animations that are re-triggered rapidly will differ.
+
+## Properties that would regress
+
+A property is unsafe when React Native renders it on a target platform and CSS
+cannot animate it there: the hook version works today and the CSS version stops
+silently, with no warning, no error, and a passing typecheck.
+
+That is a small set. Refuse these on the platforms listed, and treat everything
+else as animatable per the
+[supported properties](https://docs.swmansion.com/react-native-reanimated/docs/guides/supported-properties)
+table:
+
+| Property | Refuse on |
+| --- | --- |
+| `flexBasis` | iOS, Android (interpolates but is never applied) |
+| `boxSizing` | iOS, Android |
+| `userSelect` | iOS, Android |
+| `isolation` | iOS, Android |
+| `objectFit` | all |
+| `overlayColor` | all |
+| `backgroundImage` and `experimental_background*` | all |
+| `verticalAlign` | Android |
+| `writingDirection` | iOS |
+| `borderCurve` | iOS |
+| `tintColor` | web |
+| `resizeMode` | web |
+| `direction`, `start`, `end` | web |
+
+The inverse case is safe and worth stating, because it looks alarming: when
+React Native does not render a property on a platform either, the animation was
+already inert there, so migrating costs nothing. That is why the iOS `shadow*`
+properties, Android `elevation`, the iOS-only `textDecoration*` and the
+Android-only `textAlignVertical` and `includeFontPadding` are all migratable
+despite covering a single platform.
+
+## What to say
+
+Give each refusal a file, a one-sentence reason, and a next step. Group them by
+reason rather than listing them per file, so a user with forty gesture-driven
+components reads one explanation and not forty.
+
+Where a follow-up refactor would unlock the migration, offer it as a separate
+piece of work with its own risk, never as part of this diff. Converting shadow
+properties to `boxShadow` is the common example: it would widen platform
+coverage, and it is a visual change that deserves its own review.

--- a/skills/reanimated-css-migration/references/refusals.md
+++ b/skills/reanimated-css-migration/references/refusals.md
@@ -37,7 +37,7 @@ The dangerous set: these compile and often appear to work.
 | --- | --- | --- |
 | Completion callback that chains an animation or sets state | CSS callbacks are wired up only on web and carry no `finished` flag anywhere | Refuse. A callback that only logs can be dropped instead |
 | `cancelAnimation`, or pausing, reversing, restarting from an effect or handler | `animationPlayState` suspends; it does not cancel or freeze at the current value | Refuse |
-| `reduceMotion` config, `ReduceMotion` enum, `useReducedMotion` | CSS has no reduced-motion support on any platform | Refuse |
+| `reduceMotion` config, `ReduceMotion` enum, `useReducedMotion` | CSS has no reduced-motion support of its own | Not a refusal. Emit a `useReducedMotion()` guard and drive the duration from it, per precondition 4 |
 | Discrete keyword properties: `display`, `position`, `flexDirection`, `justifyContent`, `alignItems`, `overflow`, `fontWeight`, `textAlign` | Dropped from transitions unless `transitionBehavior: 'allow-discrete'`, and then they flip at the midpoint | Refuse, or set the behavior and warn about the midpoint flip |
 | Rapid re-triggering of the same target | `withTiming` inherits the original start time and value; CSS approximates but does not reproduce it | Refuse if the timing matters |
 

--- a/skills/reanimated-css-migration/references/refusals.md
+++ b/skills/reanimated-css-migration/references/refusals.md
@@ -18,7 +18,7 @@ things the tool cannot do.
 
 | Pattern | Why | What to tell the user |
 | --- | --- | --- |
-| `withSpring` with a runtime config | Sampling needs every parameter known at migration time. A `velocity` taken from a gesture, or a config built at runtime, cannot be sampled | Keep it on the hooks API. Statically configured springs are convertible; see `api-map.md` |
+| `withSpring` with a runtime config | Sampling needs every parameter known at migration time. A `velocity` taken from a gesture, or a config built at runtime, cannot be sampled | Keep it on the hooks API. Statically configured springs are convertible; see `timing-functions.md` |
 | `withDecay` | Velocity-driven with no fixed target | Keep it. CSS timelines are fixed-duration by definition |
 | `withClamp` | No bounding concept in CSS | Keep it |
 | Gesture-driven values | Gesture callbacks are workletized onto the UI thread by default, so reaching React state needs a `scheduleOnRN` hop per update | Keep it. This is exactly what the hooks API is for. A gesture with `.runOnJS(true)` runs on the JS thread and is migratable if its updates are discrete |

--- a/skills/reanimated-css-migration/references/refusals.md
+++ b/skills/reanimated-css-migration/references/refusals.md
@@ -24,9 +24,9 @@ things the tool cannot do.
 | Gesture-driven values | Gesture callbacks are workletized onto the UI thread by default, so reaching React state needs a `scheduleOnRN` hop per update | Keep it. This is exactly what the hooks API is for. A gesture with `.runOnJS(true)` runs on the JS thread and is migratable if its updates are discrete |
 | Scroll-driven values | Same reason | Keep it |
 | Sensor, keyboard, frame callback drivers | CSS animations advance on time only. There is no scroll, sensor or keyboard timeline | Keep it |
-| `measure`, `useAnimatedRef` reads | Targets depend on runtime layout, which cannot be written as a keyframe | Keep it |
+| `measure`, `useAnimatedRef` reads **feeding an animated value** | Targets depend on runtime layout, which cannot be written as a keyframe | Keep it. A measured value used for a static `top`/`left` in the same hook does not refuse the animated properties beside it |
 | `useAnimatedProps` for non-style props | CSS styles are keyed off view, text and image styles | Keep it. `react-native-svg` is the exception: geometry (`cx`, `r`, `d`, `points`) and appearance (`fill`, `stroke`, `opacity`) both animate via `animatedProps`. Platform coverage differs per prop, check [Animating SVG](https://docs.swmansion.com/react-native-reanimated/docs/guides/animating-svg) |
-| Layout animations, `Keyframe`, shared element transitions | A separate subsystem with its own lifecycle | Leave untouched. Out of scope for this migration |
+| Layout animations, `Keyframe`, shared element transitions | A separate subsystem with its own lifecycle | Leave the `entering`/`exiting`/`layout` props untouched. They do not refuse the rest of the component: a `useAnimatedStyle` on the same element is judged on its own |
 | SVG `transform` and its parts | Not supported. Several forms still carry unfinished preprocessors and none are documented | Keep it on the hooks API |
 
 ## Lossy: an equivalent exists but changes behavior
@@ -39,7 +39,7 @@ The dangerous set: these compile and often appear to work.
 | `cancelAnimation`, or pausing, reversing, restarting from an effect or handler | `animationPlayState` suspends; it does not cancel or freeze at the current value | Refuse |
 | `reduceMotion` config, `ReduceMotion` enum, `useReducedMotion` | CSS has no reduced-motion support of its own | Not a refusal. Emit a `useReducedMotion()` guard and drive the duration from it, per precondition 4 |
 | Discrete keyword properties: `display`, `position`, `flexDirection`, `justifyContent`, `alignItems`, `overflow`, `fontWeight`, `textAlign` | Dropped from transitions unless `transitionBehavior: 'allow-discrete'`, and then they flip at the midpoint | Refuse, or set the behavior and warn about the midpoint flip |
-| Rapid re-triggering of the same target | `withTiming` inherits the original start time and value; CSS approximates but does not reproduce it | Refuse if the timing matters |
+| Rapid re-triggering with the same `toValue` | `withTiming` inherits the original start time and value, but only when the target is unchanged; CSS does not reproduce it | Refuse if the timing matters. A driver alternating between two targets, timer or toggle, does NOT hit this row: see the re-trigger table in `preconditions.md` |
 
 ## Properties that would regress
 

--- a/skills/reanimated-css-migration/references/refusals.md
+++ b/skills/reanimated-css-migration/references/refusals.md
@@ -25,7 +25,7 @@ things the tool cannot do.
 | Scroll-driven values | Same reason | Keep it |
 | Sensor, keyboard, frame callback drivers | CSS animations advance on time only. There is no scroll, sensor or keyboard timeline | Keep it |
 | `measure`, `useAnimatedRef` reads | Targets depend on runtime layout, which cannot be written as a keyframe | Keep it |
-| `useAnimatedProps` for non-style props | CSS styles are keyed off view, text and image styles | Keep it. SVG geometry props are the exception: those do animate, via `animatedProps` |
+| `useAnimatedProps` for non-style props | CSS styles are keyed off view, text and image styles | Keep it. `react-native-svg` is the exception: geometry (`cx`, `r`, `d`, `points`) and appearance (`fill`, `stroke`, `opacity`) both animate via `animatedProps`. Platform coverage differs per prop, check [Animating SVG](https://docs.swmansion.com/react-native-reanimated/docs/guides/animating-svg) |
 | Layout animations, `Keyframe`, shared element transitions | A separate subsystem with its own lifecycle | Leave untouched. Out of scope for this migration |
 | SVG `transform` and its parts | Not supported. Several forms still carry unfinished preprocessors and none are documented | Keep it on the hooks API |
 

--- a/skills/reanimated-css-migration/references/refusals.md
+++ b/skills/reanimated-css-migration/references/refusals.md
@@ -31,34 +31,15 @@ things the tool cannot do.
 
 ## Lossy: an equivalent exists but changes behavior
 
-These look migratable and are the most dangerous cases, because the result
-compiles and often appears to work.
+The dangerous set: these compile and often appear to work.
 
-**Completion callbacks.** `withTiming(value, config, callback)` gives a
-`finished` flag. The CSS callbacks are typed for every platform but only wired
-up on web, so on iOS and Android they never fire. They also carry no `finished`
-equivalent. A callback that only logs can be dropped; one that chains an
-animation or sets state is load-bearing and blocks the migration.
-
-**Imperative control.** `cancelAnimation` has no CSS counterpart.
-`animationPlayState: 'paused'` suspends an animation, it does not cancel it and
-does not freeze it at the current value the way cancelling does.
-
-**Explicit reduced motion.** CSS has no reduced-motion support on any platform.
-If the source passes a `reduceMotion` config, uses the `ReduceMotion` enum, or
-calls `useReducedMotion`, leave it alone: the author asked for behavior that
-would silently disappear.
-
-**Discrete properties.** Keyword-valued properties such as `display`,
-`position`, `flexDirection`, `justifyContent`, `alignItems`, `overflow`,
-`fontWeight` and `textAlign` are dropped from transitions entirely unless
-`transitionBehavior: 'allow-discrete'` is set, and even then they flip at the
-midpoint rather than interpolating. Either refuse, or set the behavior and warn
-about the midpoint flip.
-
-**Mid-flight retargeting.** Re-issuing `withTiming` toward the same target
-inherits the original start time and value. CSS transitions approximate this but
-do not reproduce it, so animations that are re-triggered rapidly will differ.
+| Pattern | What breaks | Do |
+| --- | --- | --- |
+| Completion callback that chains an animation or sets state | CSS callbacks are wired up only on web and carry no `finished` flag anywhere | Refuse. A callback that only logs can be dropped instead |
+| `cancelAnimation`, or pausing, reversing, restarting from an effect or handler | `animationPlayState` suspends; it does not cancel or freeze at the current value | Refuse |
+| `reduceMotion` config, `ReduceMotion` enum, `useReducedMotion` | CSS has no reduced-motion support on any platform | Refuse |
+| Discrete keyword properties: `display`, `position`, `flexDirection`, `justifyContent`, `alignItems`, `overflow`, `fontWeight`, `textAlign` | Dropped from transitions unless `transitionBehavior: 'allow-discrete'`, and then they flip at the midpoint | Refuse, or set the behavior and warn about the midpoint flip |
+| Rapid re-triggering of the same target | `withTiming` inherits the original start time and value; CSS approximates but does not reproduce it | Refuse if the timing matters |
 
 ## Properties that would regress
 
@@ -96,11 +77,12 @@ despite covering a single platform.
 
 ## What to say
 
-Give each refusal a file, a one-sentence reason, and a next step. Group them by
-reason rather than listing them per file, so a user with forty gesture-driven
-components reads one explanation and not forty.
+Per refusal: the file, a one-sentence reason, a next step.
 
-Where a follow-up refactor would unlock the migration, offer it as a separate
-piece of work with its own risk, never as part of this diff. Converting shadow
-properties to `boxShadow` is the common example: it would widen platform
-coverage, and it is a visual change that deserves its own review.
+Group by reason, not by file. Forty gesture-driven components get one
+explanation, not forty.
+
+Where a follow-up refactor would unlock the migration, offer it as separate
+work with its own risk. Never fold it into this diff. `shadow*` to `boxShadow`
+is the common example: it widens platform coverage and is a visual change that
+needs its own review.

--- a/skills/reanimated-css-migration/references/timing-functions.md
+++ b/skills/reanimated-css-migration/references/timing-functions.md
@@ -3,13 +3,17 @@
 ## Contents
 
 - Springs
-- Easing: exact conversions, approximations, no equivalent
+- Easing: exact conversions, composition rules, approximations, no equivalent
 
 ## Springs
 
-CSS has no spring timing function. Convert only when every spring parameter is a
-literal you can read at migration time. Refuse anything reading `velocity` from a
-gesture or building its config at runtime.
+CSS has no spring timing function.
+
+- Convert only when every spring parameter is a literal readable at migration
+  time
+- Refuse anything reading `velocity` from a gesture, or building its config at
+  runtime
+- Never substitute `ease-out` for a spring. Say which option you used
 
 Presets, from `animation/spring/springConfigs.ts`:
 
@@ -20,35 +24,24 @@ Presets, from `animation/spring/springConfigs.ts`:
 | `WigglySpringConfig` | 0.75 | ~3% | ~478ms | `linear(...)` only |
 | `Reanimated3DefaultSpringConfig` | 0.50 | ~16% | ~916ms | `linear(...)` only |
 
-A cubic Bezier can overshoot once but cannot oscillate, so anything that crosses
-the target and comes back needs `linear(...)`.
+A cubic Bezier overshoots once but cannot oscillate. Anything crossing the
+target and coming back needs `linear(...)`.
 
-To sample: simulate the damped oscillator from 0 to 1, take 20-30 evenly spaced
-points across the settle time, emit `linear(p0, p1, ... pn)`, and set
-`animationDuration` to that settle time.
-
-Never substitute `ease-out` for a spring. Say which option you used.
+To sample: simulate the damped oscillator 0 to 1, take 20-30 evenly spaced
+points across the settle time, emit `linear(p0, p1, ... pn)`, set
+`animationDuration` to the settle time.
 
 ## Easing
 
-#### The one rule that matters most
+### Never map `Easing.ease` to CSS `ease`
 
-`Easing.ease` is **not** CSS `ease`.
+`Easing.ease` is `Bezier(0.42, 0, 1, 1)` (`Easing.ts:70`) = CSS `ease-in`.
+CSS `ease` is `cubic-bezier(0.25, 0.1, 0.25, 1)`. They differ by almost half the
+output range at the widest.
 
-In the library it is `Bezier(0.42, 0, 1, 1)` (`Easing.ts:70`), which is CSS
-`ease-in`. CSS `ease` is `cubic-bezier(0.25, 0.1, 0.25, 1)`. The two differ by
-almost half the output range at their widest, so mapping by name silently
-changes every curve it touches.
+Emit `'ease-in'` or the explicit bezier.
 
-Emit `'ease-in'`, or the explicit bezier. Never `'ease'` for `Easing.ease`.
-
-#### Exact conversions
-
-These are exact, not approximations. The polynomial easings are quadratic and
-cubic Beziers in disguise, so degree-elevating them to a cubic gives the CSS
-form with no error.
-
-Four base easings have an exact cubic Bezier form:
+### Exact conversions
 
 | Source | CSS timing function |
 | --- | --- |
@@ -60,69 +53,57 @@ Four base easings have an exact cubic Bezier form:
 | `Easing.steps(n, true)` | `steps(n, 'jump-start')` |
 | `Easing.steps(n, false)` | `steps(n, 'jump-end')` |
 
-`Easing.poly(n)` is `t` to the power `n`, so only the integer cases above are
-exact. Any other exponent belongs in the approximations section.
+Exact, not approximations: the polynomial easings are Beziers in disguise.
+`Easing.poly(n)` is `t^n`, so only the integer cases above are exact.
 
-Two composition rules extend that table to any wrapped easing, so do not look
-for a row per combination:
+### Composition rules
 
-- **`Easing.in(f)` is `f`.** `in_` returns its argument unchanged, so translate
-  the inner easing and ignore the wrapper.
-- **`Easing.out(f)` reflects the curve.** For any `f` with an exact form
-  `cubicBezier(x1, y1, x2, y2)`, the result is
-  `cubicBezier(1 - x2, 1 - y2, 1 - x1, 1 - y1)`. This holds because
-  `out(f)(t) = 1 - f(1 - t)`, which for a cubic Bezier is the same curve rotated
-  180 degrees about its midpoint, and it stays exact even when control points
-  fall outside 0..1.
+Do not look for a row per combination. Two rules cover any wrapper:
 
-Worked examples of the second rule, which is where the commonly quoted values
+- `Easing.in(f)` -> `f`. `in_` returns its argument unchanged
+- `Easing.out(f)` -> reflect. For `f` = `cubicBezier(x1, y1, x2, y2)`, the result
+  is `cubicBezier(1 - x2, 1 - y2, 1 - x1, 1 - y1)`. Stays exact even when control
+  points fall outside 0..1
+- `Easing.inOut(f)` -> no exact form, whatever `f` is. Piecewise
+
+Worked examples of the reflection, which is where the commonly quoted values
 come from:
 
-| Source | Reflection | CSS timing function |
+| Source | Reflection of | CSS timing function |
 | --- | --- | --- |
-| `Easing.out(Easing.ease)` | of `(0.42, 0, 1, 1)` | `'ease-out'` or `cubicBezier(0, 0, 0.58, 1)` |
-| `Easing.out(Easing.quad)` | of `(1/3, 0, 2/3, 1/3)` | `cubicBezier(1/3, 2/3, 2/3, 1)` |
-| `Easing.out(Easing.cubic)` | of `(1/3, 0, 2/3, 0)` | `cubicBezier(1/3, 1, 2/3, 1)` |
+| `Easing.out(Easing.ease)` | `(0.42, 0, 1, 1)` | `'ease-out'` or `cubicBezier(0, 0, 0.58, 1)` |
+| `Easing.out(Easing.quad)` | `(1/3, 0, 2/3, 1/3)` | `cubicBezier(1/3, 2/3, 2/3, 1)` |
+| `Easing.out(Easing.cubic)` | `(1/3, 0, 2/3, 0)` | `cubicBezier(1/3, 1, 2/3, 1)` |
 
-`Easing.inOut(f)` is not covered by either rule. It is piecewise, so no single
-cubic Bezier reproduces it, whatever `f` is.
+Match on the source expression, never a runtime value. The easing name symbol is
+attached only to top-level members, so anything wrapped in `out()` or `inOut()`
+loses it and falls back to linear with a warning.
 
-Match on the source expression, not on a runtime value. The library attaches its
-easing name symbol only to the top-level members, so anything wrapped in `out()`
-or `inOut()` loses it and falls back to linear with a warning.
+### Approximations, and what they cost
 
-#### Approximations, and what they cost
+`withTiming` with no easing config uses `Easing.inOut(Easing.quad)`, duration
+300ms (`animation/timing.ts:89-92`). Piecewise quadratic, so no exact cubic
+Bezier. Every unconfigured `withTiming` needs a decision. State the error rather
+than substituting silently.
 
-`withTiming` with no easing config uses `Easing.inOut(Easing.quad)` and a
-duration of 300ms (`animation/timing.ts:89-92`). That easing is piecewise
-quadratic, so no single cubic Bezier reproduces it.
-
-Every unconfigured `withTiming` therefore needs a decision. Tell the user the
-error rather than substituting silently:
-
-| Choice | Maximum error over the curve |
+| Choice | Max error |
 | --- | --- |
-| `cubicBezier(0.4625, 0.0403, 0.52, 0.9331)` | about 0.008 |
-| `'ease-in-out'` | about 0.012 |
+| `cubicBezier(0.4625, 0.0403, 0.52, 0.9331)` | ~0.008 |
+| `'ease-in-out'` | ~0.012 |
 
-Both are visually indistinguishable at typical durations. Prefer the named
-`'ease-in-out'` for readability unless the animation is long or the user cares
-about exactness.
+Both are visually indistinguishable at typical durations. Prefer
+`'ease-in-out'` for readability unless the animation is long or exactness was
+asked for.
 
-The same applies to anything built on `inOut()`, and to `sin`, `circle`, `exp`
-and `poly` with an exponent other than 2 or 3.
+Same treatment for anything built on `inOut()`, and for `sin`, `circle`, `exp`,
+and `poly(n)` where n is not 1, 2 or 3.
 
-#### No equivalent
+### No equivalent
 
-`Easing.elastic`, `Easing.back` and `Easing.bounce` leave the 0..1 range and
-oscillate. A cubic Bezier cannot express them at all.
+`Easing.elastic`, `Easing.back`, `Easing.bounce` leave the 0..1 range and
+oscillate. No cubic Bezier expresses them.
 
-The honest options are a CSS `linear(...)` function sampled from the source
-curve, or leaving the animation on the imperative API. Do not substitute a
-similar-looking bezier: the overshoot is usually the entire point of the
-animation.
+- Sample to `linear(...)` from the source curve, or
+- Leave the animation on the hooks API
 
-There is no spring timing function in CSS, but that does not make every spring
-unconvertible: monotonic ones approximate as a cubic Bezier, and oscillating
-ones can be sampled to `linear(...)`. See the Springs section above for which is which and
-when to refuse instead.
+Do not substitute a similar-looking bezier. The overshoot is usually the point.

--- a/skills/reanimated-css-migration/references/timing-functions.md
+++ b/skills/reanimated-css-migration/references/timing-functions.md
@@ -1,0 +1,128 @@
+# Timing functions
+
+## Contents
+
+- Springs
+- Easing: exact conversions, approximations, no equivalent
+
+## Springs
+
+CSS has no spring timing function. Convert only when every spring parameter is a
+literal you can read at migration time. Refuse anything reading `velocity` from a
+gesture or building its config at runtime.
+
+Presets, from `animation/spring/springConfigs.ts`:
+
+| Preset | zeta | Overshoot | Settles | Convert to |
+| --- | --- | --- | --- | --- |
+| `SnappySpringConfig` | 0.92 clamped | none | ~386ms | `cubicBezier` or `linear(...)` |
+| `GentleSpringConfig` | 1.00 | none | ~495ms | `cubicBezier` or `linear(...)` |
+| `WigglySpringConfig` | 0.75 | ~3% | ~478ms | `linear(...)` only |
+| `Reanimated3DefaultSpringConfig` | 0.50 | ~16% | ~916ms | `linear(...)` only |
+
+A cubic Bezier can overshoot once but cannot oscillate, so anything that crosses
+the target and comes back needs `linear(...)`.
+
+To sample: simulate the damped oscillator from 0 to 1, take 20-30 evenly spaced
+points across the settle time, emit `linear(p0, p1, ... pn)`, and set
+`animationDuration` to that settle time.
+
+Never substitute `ease-out` for a spring. Say which option you used.
+
+## Easing
+
+#### The one rule that matters most
+
+`Easing.ease` is **not** CSS `ease`.
+
+In the library it is `Bezier(0.42, 0, 1, 1)` (`Easing.ts:70`), which is CSS
+`ease-in`. CSS `ease` is `cubic-bezier(0.25, 0.1, 0.25, 1)`. The two differ by
+almost half the output range at their widest, so mapping by name silently
+changes every curve it touches.
+
+Emit `'ease-in'`, or the explicit bezier. Never `'ease'` for `Easing.ease`.
+
+#### Exact conversions
+
+These are exact, not approximations. The polynomial easings are quadratic and
+cubic Beziers in disguise, so degree-elevating them to a cubic gives the CSS
+form with no error.
+
+Four base easings have an exact cubic Bezier form:
+
+| Source | CSS timing function |
+| --- | --- |
+| `Easing.linear`, `Easing.poly(1)` | `'linear'` |
+| `Easing.ease` | `'ease-in'` or `cubicBezier(0.42, 0, 1, 1)` |
+| `Easing.quad`, `Easing.poly(2)` | `cubicBezier(1/3, 0, 2/3, 1/3)` |
+| `Easing.cubic`, `Easing.poly(3)` | `cubicBezier(1/3, 0, 2/3, 0)` |
+| `Easing.bezier(a, b, c, d)`, `Easing.bezierFn(a, b, c, d)` | `cubicBezier(a, b, c, d)` |
+| `Easing.steps(n, true)` | `steps(n, 'jump-start')` |
+| `Easing.steps(n, false)` | `steps(n, 'jump-end')` |
+
+`Easing.poly(n)` is `t` to the power `n`, so only the integer cases above are
+exact. Any other exponent belongs in the approximations section.
+
+Two composition rules extend that table to any wrapped easing, so do not look
+for a row per combination:
+
+- **`Easing.in(f)` is `f`.** `in_` returns its argument unchanged, so translate
+  the inner easing and ignore the wrapper.
+- **`Easing.out(f)` reflects the curve.** For any `f` with an exact form
+  `cubicBezier(x1, y1, x2, y2)`, the result is
+  `cubicBezier(1 - x2, 1 - y2, 1 - x1, 1 - y1)`. This holds because
+  `out(f)(t) = 1 - f(1 - t)`, which for a cubic Bezier is the same curve rotated
+  180 degrees about its midpoint, and it stays exact even when control points
+  fall outside 0..1.
+
+Worked examples of the second rule, which is where the commonly quoted values
+come from:
+
+| Source | Reflection | CSS timing function |
+| --- | --- | --- |
+| `Easing.out(Easing.ease)` | of `(0.42, 0, 1, 1)` | `'ease-out'` or `cubicBezier(0, 0, 0.58, 1)` |
+| `Easing.out(Easing.quad)` | of `(1/3, 0, 2/3, 1/3)` | `cubicBezier(1/3, 2/3, 2/3, 1)` |
+| `Easing.out(Easing.cubic)` | of `(1/3, 0, 2/3, 0)` | `cubicBezier(1/3, 1, 2/3, 1)` |
+
+`Easing.inOut(f)` is not covered by either rule. It is piecewise, so no single
+cubic Bezier reproduces it, whatever `f` is.
+
+Match on the source expression, not on a runtime value. The library attaches its
+easing name symbol only to the top-level members, so anything wrapped in `out()`
+or `inOut()` loses it and falls back to linear with a warning.
+
+#### Approximations, and what they cost
+
+`withTiming` with no easing config uses `Easing.inOut(Easing.quad)` and a
+duration of 300ms (`animation/timing.ts:89-92`). That easing is piecewise
+quadratic, so no single cubic Bezier reproduces it.
+
+Every unconfigured `withTiming` therefore needs a decision. Tell the user the
+error rather than substituting silently:
+
+| Choice | Maximum error over the curve |
+| --- | --- |
+| `cubicBezier(0.4625, 0.0403, 0.52, 0.9331)` | about 0.008 |
+| `'ease-in-out'` | about 0.012 |
+
+Both are visually indistinguishable at typical durations. Prefer the named
+`'ease-in-out'` for readability unless the animation is long or the user cares
+about exactness.
+
+The same applies to anything built on `inOut()`, and to `sin`, `circle`, `exp`
+and `poly` with an exponent other than 2 or 3.
+
+#### No equivalent
+
+`Easing.elastic`, `Easing.back` and `Easing.bounce` leave the 0..1 range and
+oscillate. A cubic Bezier cannot express them at all.
+
+The honest options are a CSS `linear(...)` function sampled from the source
+curve, or leaving the animation on the imperative API. Do not substitute a
+similar-looking bezier: the overshoot is usually the entire point of the
+animation.
+
+There is no spring timing function in CSS, but that does not make every spring
+unconvertible: monotonic ones approximate as a cubic Bezier, and oscillating
+ones can be sampled to `linear(...)`. See the Springs section above for which is which and
+when to refuse instead.

--- a/skills/reanimated-css-migration/references/timing-functions.md
+++ b/skills/reanimated-css-migration/references/timing-functions.md
@@ -75,9 +75,11 @@ come from:
 | `Easing.out(Easing.quad)` | `(1/3, 0, 2/3, 1/3)` | `cubicBezier(1/3, 2/3, 2/3, 1)` |
 | `Easing.out(Easing.cubic)` | `(1/3, 0, 2/3, 0)` | `cubicBezier(1/3, 1, 2/3, 1)` |
 
-Match on the source expression, never a runtime value. The easing name symbol is
-attached only to top-level members, so anything wrapped in `out()` or `inOut()`
-loses it and falls back to linear with a warning.
+Match on the source expression, never a runtime value. A CSS timing function must
+be a predefined string, or `cubicBezier` / `linear` / `steps` from
+`react-native-reanimated`. An `Easing.*` value passed to
+`animationTimingFunction` or `transitionTimingFunction` throws
+(`css/native/normalization/common/settings.ts:55-62`).
 
 ### Approximations, and what they cost
 
@@ -86,10 +88,16 @@ loses it and falls back to linear with a warning.
 Bezier. Every unconfigured `withTiming` needs a decision. State the error rather
 than substituting silently.
 
+Omitting it is not neutral. Both properties default to `'ease'` =
+`cubicBezier(0.25, 0.1, 0.25, 1)`
+(`css/native/normalization/common/settings.ts:44`), max error ~0.36 against
+`inOut(quad)`, worse than `'linear'` at 0.125. Always emit one.
+
 | Choice | Max error |
 | --- | --- |
 | `cubicBezier(0.4625, 0.0403, 0.52, 0.9331)` | ~0.008 |
 | `'ease-in-out'` | ~0.012 |
+| omitted, so `'ease'` | ~0.36 |
 
 Both are visually indistinguishable at typical durations. Prefer
 `'ease-in-out'` for readability unless the animation is long or exactness was


### PR DESCRIPTION
Adds an [Agent Skill](https://agentskills.io) that migrates hook-based Reanimated animations to CSS animations and transitions.

## What it does

It converts a call site only when the result is behaviorally identical, and reports everything else with the reason it was left alone. Coverage is not the goal: on this repo's own example app roughly 70% of animations are correctly refused, mostly because they are gesture-driven, scroll-driven or use `withSpring`.

## How it works

The safety model is asymmetric. Which source patterns may be converted is open, so the agent can reason about shapes the skill does not list. Which conditions permit conversion is closed:

- **preconditions** every call site must satisfy, the load-bearing one being that the driver has to change through a React render. A shared value written from an `onPress` never re-renders, so a transition converted from it compiles, typechecks and animates nothing.
- **refusals**, including the small set of properties where CSS is behind React Native and migrating would silently stop an animation that works today.
- **equivalence obligations** that must hold afterwards.

The agent must name which precondition permits each migration. If it cannot, it does not migrate.

## Using it

`skills/reanimated-css-migration/` is plain markdown with portable frontmatter, so it works with any agent that reads the Agent Skills format, and can be pointed at directly by any that does not. For a local checkout:

```bash
mkdir -p .claude/skills
ln -s ../../skills/reanimated-css-migration .claude/skills/reanimated-css-migration
```

## Verified

Every code construct in the skill typechecks against the built library types on native and web. The easing mapping was checked on device: `Easing.ease` is `Bezier(0.42, 0, 1, 1)`, so it maps to CSS `ease-in` and is pixel-identical to the hook version, while the name-matching conversion to CSS `ease` drifts about 20% of travel.

Trigger evaluation has not been run yet, and four properties (`tintColor` and `direction` on web, `userSelect` and `isolation` on native) are refused pending confirmation of whether React Native renders them there.