### PR TITLE
feat: Resolve CSS transition timelines for Android and bridge them over JNI

### DIFF
--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
@@ -94,18 +94,13 @@ bool CSSPlatformTransitions::applyTransition(
     adjustedStart = active->adjustedEnd;
   }
 
-  // Elapsed rather than an absolute start: reverse-shortening backdates the start
-  // (elapsed > 0, the animator seeks) and transition-delay pushes it forward
-  // (elapsed < 0, the animator waits). Computing it here also keeps Kotlin off a
-  // second clock, which would drift from the loop's slow-animations timestamp.
-  const double elapsedMs = timestamp - reversing.startTimestamp;
   if (!animate_(
           static_cast<int>(viewTag),
           propertyName,
           *from,
           *to,
           reversing.duration,
-          elapsedMs,
+          reversing.startTimestamp,
           toPlatformEasing(resolvedSettings.easingConfig))) {
     return false;
   }

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
@@ -15,7 +15,6 @@ std::vector<float> toFloats(const std::vector<double> &values) {
   return {values.begin(), values.end()};
 }
 
-// EasingConfig has exactly these four alternatives, so the conversion is total.
 PlatformEasing toPlatformEasing(const css::EasingConfig &easingConfig) {
   if (const auto *bezier = std::get_if<css::CubicBezierEasing>(&easingConfig)) {
     return {
@@ -64,8 +63,6 @@ bool CSSPlatformTransitions::applyTransition(
 
   const ActiveTransition *active = activeTransitionFor(viewTag, propertyName);
 
-  // The toggle path carries no settings of its own, so it reuses the ones the
-  // config apply stored.
   if (settings == nullptr && active == nullptr) {
     return false;
   }

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
@@ -1,0 +1,128 @@
+#include <reanimated/android/CSS/CSSPlatformTransitions.h>
+
+#include <reanimated/CSS/easing/EasingConfigs.h>
+
+#include <variant>
+#include <vector>
+
+#include <utility>
+
+namespace reanimated {
+
+namespace {
+
+std::vector<float> toFloats(const std::vector<double> &values) {
+  return {values.begin(), values.end()};
+}
+
+// EasingConfig has exactly these four alternatives, so the conversion is total.
+PlatformEasing toPlatformEasing(const css::EasingConfig &easingConfig) {
+  if (const auto *bezier = std::get_if<css::CubicBezierEasing>(&easingConfig)) {
+    return {
+        PlatformEasing::Type::CubicBezier,
+        {static_cast<float>(bezier->x1), static_cast<float>(bezier->x2)},
+        {static_cast<float>(bezier->y1), static_cast<float>(bezier->y2)}};
+  }
+  if (const auto *steps = std::get_if<css::StepsEasing>(&easingConfig)) {
+    return {PlatformEasing::Type::Steps, toFloats(steps->pointsX), toFloats(steps->pointsY)};
+  }
+  if (const auto *stops = std::get_if<css::LinearStopsEasing>(&easingConfig)) {
+    return {PlatformEasing::Type::LinearStops, toFloats(stops->pointsX), toFloats(stops->pointsY)};
+  }
+  return {PlatformEasing::Type::Linear, {}, {}};
+}
+
+} // namespace
+
+CSSPlatformTransitions::CSSPlatformTransitions(AnimateFunction animate, RemoveFunction remove)
+    : animate_(std::move(animate)), remove_(std::move(remove)) {}
+
+const CSSPlatformTransitions::ActiveTransition *CSSPlatformTransitions::activeTransitionFor(
+    const Tag viewTag,
+    const std::string &propertyName) const {
+  const auto propertiesIt = active_.find(viewTag);
+  if (propertiesIt == active_.end()) {
+    return nullptr;
+  }
+  const auto activeIt = propertiesIt->second.find(propertyName);
+  return activeIt != propertiesIt->second.end() ? &activeIt->second : nullptr;
+}
+
+bool CSSPlatformTransitions::applyTransition(
+    const Tag viewTag,
+    const std::string &propertyName,
+    const css::PlatformValue &fromValue,
+    const css::PlatformValue &toValue,
+    const css::CSSTransitionPropertySettings *settings,
+    const double timestamp) {
+  // Only scalars are routed today (opacity); anything else stays on the loop.
+  const auto *from = std::get_if<double>(&fromValue);
+  const auto *to = std::get_if<double>(&toValue);
+  if (from == nullptr || to == nullptr) {
+    return false;
+  }
+
+  const ActiveTransition *active = activeTransitionFor(viewTag, propertyName);
+
+  // The toggle path carries no settings of its own, so it reuses the ones the
+  // config apply stored.
+  if (settings == nullptr && active == nullptr) {
+    return false;
+  }
+  // Copy: the active entry is re-assigned below.
+  const css::CSSTransitionPropertySettings resolvedSettings = settings == nullptr ? active->settings : *settings;
+
+  // Targeting the in-flight transition's start value means this is a reversal.
+  const bool isReversal = active != nullptr && active->adjustedStart && toValue == *active->adjustedStart;
+  css::ReversingState reversing = isReversal
+      ? css::reverseShorten(
+            active->reversing,
+            timestamp,
+            resolvedSettings.duration,
+            resolvedSettings.delay,
+            resolvedSettings.easingConfig)
+      : css::makeReversingState(
+            timestamp, resolvedSettings.duration, resolvedSettings.delay, resolvedSettings.easingConfig);
+
+  // https://drafts.csswg.org/css-transitions/#reversing
+  std::optional<css::PlatformValue> adjustedStart;
+  if (isReversal) {
+    adjustedStart = active->adjustedEnd;
+  } else if (active == nullptr) {
+    adjustedStart = fromValue;
+  } else if (timestamp >= active->reversing.startTimestamp + active->reversing.duration) {
+    adjustedStart = active->adjustedEnd;
+  }
+
+  // Elapsed rather than an absolute start: reverse-shortening backdates the start
+  // (elapsed > 0, the animator seeks) and transition-delay pushes it forward
+  // (elapsed < 0, the animator waits). Computing it here also keeps Kotlin off a
+  // second clock, which would drift from the loop's slow-animations timestamp.
+  const double elapsedMs = timestamp - reversing.startTimestamp;
+  if (!animate_(
+          static_cast<int>(viewTag),
+          propertyName,
+          *from,
+          *to,
+          reversing.duration,
+          elapsedMs,
+          toPlatformEasing(resolvedSettings.easingConfig))) {
+    return false;
+  }
+
+  active_[viewTag][propertyName] = ActiveTransition{adjustedStart, toValue, std::move(reversing), resolvedSettings};
+  return true;
+}
+
+void CSSPlatformTransitions::removeTransition(const Tag viewTag, const std::string &propertyName) {
+  const auto propertiesIt = active_.find(viewTag);
+  if (propertiesIt != active_.end()) {
+    propertiesIt->second.erase(propertyName);
+    if (propertiesIt->second.empty()) {
+      active_.erase(propertiesIt);
+    }
+  }
+  remove_(static_cast<int>(viewTag), propertyName);
+}
+
+} // namespace reanimated

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
@@ -98,7 +98,8 @@ bool CSSPlatformTransitions::applyTransition(
           *to,
           reversing.duration,
           reversing.startTimestamp,
-          toPlatformEasing(resolvedSettings.easingConfig))) {
+          toPlatformEasing(resolvedSettings.easingConfig),
+          settings == nullptr)) {
     return false;
   }
 

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <reanimated/CSS/configs/CSSTransitionConfig.h>
+#include <reanimated/CSS/utils/platform.h>
+#include <reanimated/CSS/utils/reversingShortening.h>
+
+#include <react/renderer/core/ReactPrimitives.h>
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace reanimated {
+
+using namespace facebook::react;
+
+/// A CSS easing described exactly rather than sampled: `type` selects the curve
+/// and the point arrays carry its parameters. Kotlin rebuilds the interpolator,
+/// so steps() keeps its discontinuities at any duration.
+struct PlatformEasing {
+  enum class Type : std::uint8_t { Linear = 0, CubicBezier = 1, Steps = 2, LinearStops = 3 };
+
+  Type type;
+  std::vector<float> pointsX;
+  std::vector<float> pointsY;
+};
+
+/// Android counterpart of REACSSPlatformTransitions. Owns the per-property state
+/// CSS reversing needs and resolves the timeline for the Kotlin animator.
+class CSSPlatformTransitions {
+ public:
+  /// Returns false when the view can't carry the animation, in which case the
+  /// property falls back to the loop.
+  using AnimateFunction = std::function<bool(
+      int viewTag,
+      const std::string &propertyName,
+      double fromValue,
+      double toValue,
+      double durationMs,
+      double elapsedMs,
+      const PlatformEasing &easing)>;
+  using RemoveFunction = std::function<void(int viewTag, const std::string &propertyName)>;
+
+  CSSPlatformTransitions(AnimateFunction animate, RemoveFunction remove);
+
+  /// A null `settings` marks the pseudo-selector toggle path, which reuses the
+  /// settings stored by the config apply. Returns false when there are none.
+  bool applyTransition(
+      Tag viewTag,
+      const std::string &propertyName,
+      const css::PlatformValue &fromValue,
+      const css::PlatformValue &toValue,
+      const css::CSSTransitionPropertySettings *settings,
+      double timestamp);
+
+  void removeTransition(Tag viewTag, const std::string &propertyName);
+
+ private:
+  // adjustedStart/adjustedEnd drive reversal detection; settings serve the
+  // toggle path.
+  struct ActiveTransition {
+    std::optional<css::PlatformValue> adjustedStart;
+    css::PlatformValue adjustedEnd;
+    css::ReversingState reversing;
+    css::CSSTransitionPropertySettings settings;
+  };
+
+  const ActiveTransition *activeTransitionFor(Tag viewTag, const std::string &propertyName) const;
+
+  std::unordered_map<Tag, std::unordered_map<std::string, ActiveTransition>> active_;
+  AnimateFunction animate_;
+  RemoveFunction remove_;
+};
+
+} // namespace reanimated

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
@@ -40,7 +40,7 @@ class CSSPlatformTransitions {
       double fromValue,
       double toValue,
       double durationMs,
-      double elapsedMs,
+      double startTimestampMs,
       const PlatformEasing &easing)>;
   using RemoveFunction = std::function<void(int viewTag, const std::string &propertyName)>;
 

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
@@ -17,9 +17,8 @@ namespace reanimated {
 
 using namespace facebook::react;
 
-/// A CSS easing described exactly rather than sampled: `type` selects the curve
-/// and the point arrays carry its parameters. Kotlin rebuilds the interpolator,
-/// so steps() keeps its discontinuities at any duration.
+/// Carries the curve's own points rather than a sampled table, so a discontinuous
+/// steps() survives at any duration.
 struct PlatformEasing {
   enum class Type : std::uint8_t { Linear = 0, CubicBezier = 1, Steps = 2, LinearStops = 3 };
 
@@ -28,8 +27,6 @@ struct PlatformEasing {
   std::vector<float> pointsY;
 };
 
-/// Android counterpart of REACSSPlatformTransitions. Owns the per-property state
-/// CSS reversing needs and resolves the timeline for the Kotlin animator.
 class CSSPlatformTransitions {
  public:
   /// Returns false when the view can't carry the animation, in which case the
@@ -59,8 +56,6 @@ class CSSPlatformTransitions {
   void removeTransition(Tag viewTag, const std::string &propertyName);
 
  private:
-  // adjustedStart/adjustedEnd drive reversal detection; settings serve the
-  // toggle path.
   struct ActiveTransition {
     std::optional<css::PlatformValue> adjustedStart;
     css::PlatformValue adjustedEnd;

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
@@ -43,8 +43,9 @@ class CSSPlatformTransitions {
 
   CSSPlatformTransitions(AnimateFunction animate, RemoveFunction remove);
 
-  /// A null `settings` marks the pseudo-selector toggle path, which reuses the
-  /// settings stored by the config apply. Returns false when there are none.
+  /// A null `settings` marks the pseudo-selector toggle path, which carries none of
+  /// its own and reuses whatever the last config apply stored. A settings-only config
+  /// change does not re-apply, so those can be a revision behind.
   bool applyTransition(
       Tag viewTag,
       const std::string &propertyName,

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
@@ -30,7 +30,8 @@ struct PlatformEasing {
 class CSSPlatformTransitions {
  public:
   /// Returns false when the view can't carry the animation, in which case the
-  /// property falls back to the loop.
+  /// property falls back to the loop. A `persistent` transition has no committed
+  /// style behind it, so its value must outlive the animation itself.
   using AnimateFunction = std::function<bool(
       int viewTag,
       const std::string &propertyName,
@@ -38,7 +39,8 @@ class CSSPlatformTransitions {
       double toValue,
       double durationMs,
       double startTimestampMs,
-      const PlatformEasing &easing)>;
+      const PlatformEasing &easing,
+      bool persistent)>;
   using RemoveFunction = std::function<void(int viewTag, const std::string &propertyName)>;
 
   CSSPlatformTransitions(AnimateFunction animate, RemoveFunction remove);

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
@@ -379,9 +379,13 @@ PlatformDepMethodsHolder NativeProxy::getPlatformDependentMethods() {
 
   auto cssCanRouteProperty = css::CSSCanRoutePropertyFunction(&css::canRouteCSSProperty);
 
-  auto cssApplyTransition = bindShared(cssPlatformTransitions, &CSSPlatformTransitions::applyTransition);
+  auto cssApplyTransition = [transitions = cssPlatformTransitions](auto &&...args) {
+    return transitions->applyTransition(std::forward<decltype(args)>(args)...);
+  };
 
-  auto cssRemoveTransition = bindShared(cssPlatformTransitions, &CSSPlatformTransitions::removeTransition);
+  auto cssRemoveTransition = [transitions = cssPlatformTransitions](auto &&...args) {
+    transitions->removeTransition(std::forward<decltype(args)>(args)...);
+  };
 
   return {
       requestRender,

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
@@ -256,7 +256,8 @@ bool NativeProxy::cssAnimateTransition(
     const double toValue,
     const double durationMs,
     const double startTimestampMs,
-    const PlatformEasing &easing) {
+    const PlatformEasing &easing,
+    const bool persistent) {
   static const auto method = getJniMethod<jboolean(
       int,
       jni::alias_ref<jni::JString>,
@@ -266,7 +267,8 @@ bool NativeProxy::cssAnimateTransition(
       double,
       int,
       jni::alias_ref<jni::JArrayFloat>,
-      jni::alias_ref<jni::JArrayFloat>)>("cssAnimateTransition");
+      jni::alias_ref<jni::JArrayFloat>,
+      jboolean)>("cssAnimateTransition");
   auto jPointsX = jni::JArrayFloat::newArray(easing.pointsX.size());
   jPointsX->setRegion(0, easing.pointsX.size(), easing.pointsX.data());
   auto jPointsY = jni::JArrayFloat::newArray(easing.pointsY.size());
@@ -281,7 +283,8 @@ bool NativeProxy::cssAnimateTransition(
              startTimestampMs,
              static_cast<int>(easing.type),
              jPointsX,
-             jPointsY) != JNI_FALSE;
+             jPointsY,
+             static_cast<jboolean>(persistent)) != JNI_FALSE;
 }
 
 void NativeProxy::cssRemoveTransition(const int viewTag, const std::string &propertyName) {

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
@@ -255,7 +255,7 @@ bool NativeProxy::cssAnimateTransition(
     const double fromValue,
     const double toValue,
     const double durationMs,
-    const double elapsedMs,
+    const double startTimestampMs,
     const PlatformEasing &easing) {
   static const auto method = getJniMethod<jboolean(
       int,
@@ -278,7 +278,7 @@ bool NativeProxy::cssAnimateTransition(
              fromValue,
              toValue,
              durationMs,
-             elapsedMs,
+             startTimestampMs,
              static_cast<int>(easing.type),
              jPointsX,
              jPointsY) != JNI_FALSE;

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
@@ -249,6 +249,46 @@ void NativeProxy::attachPseudoSelector(Tag tag, PseudoSelector selector, std::fu
       PseudoSelectorCallback::newObjectCxxArgs(std::move(callback)).get());
 }
 
+bool NativeProxy::cssAnimateTransition(
+    const int viewTag,
+    const std::string &propertyName,
+    const double fromValue,
+    const double toValue,
+    const double durationMs,
+    const double elapsedMs,
+    const PlatformEasing &easing) {
+  static const auto method = getJniMethod<jboolean(
+      int,
+      jni::alias_ref<jni::JString>,
+      double,
+      double,
+      double,
+      double,
+      int,
+      jni::alias_ref<jni::JArrayFloat>,
+      jni::alias_ref<jni::JArrayFloat>)>("cssAnimateTransition");
+  auto jPointsX = jni::JArrayFloat::newArray(easing.pointsX.size());
+  jPointsX->setRegion(0, easing.pointsX.size(), easing.pointsX.data());
+  auto jPointsY = jni::JArrayFloat::newArray(easing.pointsY.size());
+  jPointsY->setRegion(0, easing.pointsY.size(), easing.pointsY.data());
+  return method(
+             javaPart_.get(),
+             viewTag,
+             jni::make_jstring(propertyName),
+             fromValue,
+             toValue,
+             durationMs,
+             elapsedMs,
+             static_cast<int>(easing.type),
+             jPointsX,
+             jPointsY) != JNI_FALSE;
+}
+
+void NativeProxy::cssRemoveTransition(const int viewTag, const std::string &propertyName) {
+  static const auto method = getJniMethod<void(int, jni::alias_ref<jni::JString>)>("cssRemoveTransition");
+  method(javaPart_.get(), viewTag, jni::make_jstring(propertyName));
+}
+
 void NativeProxy::detachPseudoSelector(Tag tag, PseudoSelector selector) {
   static const auto method = getJniMethod<void(int, int)>("detachPseudoSelector");
   method(javaPart_.get(), static_cast<int>(tag), static_cast<int>(selector));
@@ -331,6 +371,18 @@ PlatformDepMethodsHolder NativeProxy::getPlatformDependentMethods() {
 
   auto detachPseudoSelectorFunction = bindThis(&NativeProxy::detachPseudoSelector);
 
+  // Owned by the two callbacks below rather than by NativeProxy: this runs from
+  // the constructor's member-initializer list, where a member would still be raw
+  // memory.
+  auto cssPlatformTransitions = std::make_shared<CSSPlatformTransitions>(
+      bindThis(&NativeProxy::cssAnimateTransition), bindThis(&NativeProxy::cssRemoveTransition));
+
+  auto cssCanRouteProperty = css::CSSCanRoutePropertyFunction(&css::canRouteCSSProperty);
+
+  auto cssApplyTransition = bindShared(cssPlatformTransitions, &CSSPlatformTransitions::applyTransition);
+
+  auto cssRemoveTransition = bindShared(cssPlatformTransitions, &CSSPlatformTransitions::removeTransition);
+
   return {
       requestRender,
       preserveMountedTags,
@@ -344,6 +396,9 @@ PlatformDepMethodsHolder NativeProxy::getPlatformDependentMethods() {
       maybeFlushUiUpdatesQueueFunction,
       attachPseudoSelectorFunction,
       detachPseudoSelectorFunction,
+      cssCanRouteProperty,
+      cssApplyTransition,
+      cssRemoveTransition,
   };
 }
 

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
@@ -8,6 +8,7 @@
 #include <react/renderer/scheduler/Scheduler.h>
 #include <reanimated/Compat/WorkletsApi.h>
 #include <reanimated/NativeModules/ReanimatedModuleProxy.h>
+#include <reanimated/android/CSS/CSSPlatformTransitions.h>
 
 #include <memory>
 #include <string>
@@ -73,6 +74,15 @@ class NativeProxy : public jni::HybridClass<NativeProxy>, std::enable_shared_fro
       jboolean isInDrawPass);
   void attachPseudoSelector(Tag tag, PseudoSelector selector, std::function<void(bool)> callback);
   void detachPseudoSelector(Tag tag, PseudoSelector selector);
+  bool cssAnimateTransition(
+      int viewTag,
+      const std::string &propertyName,
+      double fromValue,
+      double toValue,
+      double durationMs,
+      double elapsedMs,
+      const PlatformEasing &easing);
+  void cssRemoveTransition(int viewTag, const std::string &propertyName);
 
   /***
    * Wraps a method of `NativeProxy` in a function object capturing `this`
@@ -87,6 +97,17 @@ class NativeProxy : public jni::HybridClass<NativeProxy>, std::enable_shared_fro
     // It's probably safe to pass `this` as reference here...
     return [this, methodPtr](TParams &&...args) {
       return (this->*methodPtr)(std::forward<TParams>(args)...);
+    };
+  }
+
+  /// Binds a method of a separately owned object, keeping that object alive for
+  /// as long as the callback lives.
+  template <typename TObject, typename TReturn, typename... TParams>
+  static std::function<TReturn(TParams...)> bindShared(
+      std::shared_ptr<TObject> object,
+      TReturn (TObject::*methodPtr)(TParams...)) {
+    return [object = std::move(object), methodPtr](TParams &&...args) {
+      return ((*object).*methodPtr)(std::forward<TParams>(args)...);
     };
   }
 

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
@@ -100,17 +100,6 @@ class NativeProxy : public jni::HybridClass<NativeProxy>, std::enable_shared_fro
     };
   }
 
-  /// Binds a method of a separately owned object, keeping that object alive for
-  /// as long as the callback lives.
-  template <typename TObject, typename TReturn, typename... TParams>
-  static std::function<TReturn(TParams...)> bindShared(
-      std::shared_ptr<TObject> object,
-      TReturn (TObject::*methodPtr)(TParams...)) {
-    return [object = std::move(object), methodPtr](TParams &&...args) {
-      return ((*object).*methodPtr)(std::forward<TParams>(args)...);
-    };
-  }
-
   template <class Signature>
   JMethod<Signature> getJniMethod(std::string const &methodName) {
     return javaPart_->getClass()->getMethod<Signature>(methodName.c_str());

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
@@ -81,7 +81,8 @@ class NativeProxy : public jni::HybridClass<NativeProxy>, std::enable_shared_fro
       double toValue,
       double durationMs,
       double startTimestampMs,
-      const PlatformEasing &easing);
+      const PlatformEasing &easing,
+      bool persistent);
   void cssRemoveTransition(int viewTag, const std::string &propertyName);
 
   /***

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
@@ -80,7 +80,7 @@ class NativeProxy : public jni::HybridClass<NativeProxy>, std::enable_shared_fro
       double fromValue,
       double toValue,
       double durationMs,
-      double elapsedMs,
+      double startTimestampMs,
       const PlatformEasing &easing);
   void cssRemoveTransition(int viewTag, const std::string &propertyName);
 

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
@@ -279,6 +279,7 @@ open class NativeProxy {
         easingType: Int,
         easingPointsX: FloatArray,
         easingPointsY: FloatArray,
+        persistent: Boolean,
     ): Boolean =
         cssPlatformTransitionsManager.animateTransition(
             viewTag,
@@ -290,6 +291,7 @@ open class NativeProxy {
             easingType,
             easingPointsX,
             easingPointsY,
+            persistent,
         )
 
     @DoNotStrip

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
@@ -99,7 +99,7 @@ open class NativeProxy {
         pseudoSelectorManager = PseudoSelectorManager(mFabricUIManager, mContext)
         cssPlatformTransitionsManager =
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                CSSPlatformTransitionsManager(mFabricUIManager, mContext)
+                CSSPlatformTransitionsManager(mFabricUIManager, mContext, ::getAnimationTimestamp)
             } else {
                 null
             }
@@ -280,7 +280,7 @@ open class NativeProxy {
         fromValue: Double,
         toValue: Double,
         durationMs: Double,
-        elapsedMs: Double,
+        startTimestampMs: Double,
         easingType: Int,
         easingPointsX: FloatArray,
         easingPointsY: FloatArray,
@@ -291,7 +291,7 @@ open class NativeProxy {
             fromValue,
             toValue,
             durationMs,
-            elapsedMs,
+            startTimestampMs,
             easingType,
             easingPointsX,
             easingPointsY,

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
@@ -1,7 +1,6 @@
 package com.swmansion.reanimated
 
 import android.content.ContentResolver
-import android.os.Build
 import android.os.SystemClock
 import android.provider.Settings
 import android.util.Log
@@ -48,7 +47,7 @@ open class NativeProxy {
     private val gestureHandlerStateManager: GestureHandlerStateManager?
     private val keyboardAnimationManager: KeyboardAnimationManager
     private val pseudoSelectorManager: PseudoSelectorManager
-    private val cssPlatformTransitionsManager: CSSPlatformTransitionsManager?
+    private val cssPlatformTransitionsManager: CSSPlatformTransitionsManager
     private var firstUptime: Long = SystemClock.uptimeMillis()
     private var slowAnimationsEnabled = false
     private val animationsDragFactor = 10
@@ -98,11 +97,7 @@ open class NativeProxy {
             UIManagerHelper.getUIManager(context, UIManagerType.FABRIC) as FabricUIManager
         pseudoSelectorManager = PseudoSelectorManager(mFabricUIManager, mContext)
         cssPlatformTransitionsManager =
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                CSSPlatformTransitionsManager(mFabricUIManager, mContext, ::getAnimationTimestamp)
-            } else {
-                null
-            }
+            CSSPlatformTransitionsManager(mFabricUIManager, mContext, ::getAnimationTimestamp)
 
         val callInvokerHolder = context.jsCallInvokerHolder as CallInvokerHolderImpl
         mHybridData =
@@ -285,7 +280,7 @@ open class NativeProxy {
         easingPointsX: FloatArray,
         easingPointsY: FloatArray,
     ): Boolean =
-        cssPlatformTransitionsManager?.animateTransition(
+        cssPlatformTransitionsManager.animateTransition(
             viewTag,
             propertyName,
             fromValue,
@@ -295,14 +290,14 @@ open class NativeProxy {
             easingType,
             easingPointsX,
             easingPointsY,
-        ) ?: false
+        )
 
     @DoNotStrip
     fun cssRemoveTransition(
         viewTag: Int,
         propertyName: String,
     ) {
-        cssPlatformTransitionsManager?.removeTransition(viewTag, propertyName)
+        cssPlatformTransitionsManager.removeTransition(viewTag, propertyName)
     }
 
     @DoNotStrip

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
@@ -1,6 +1,7 @@
 package com.swmansion.reanimated
 
 import android.content.ContentResolver
+import android.os.Build
 import android.os.SystemClock
 import android.provider.Settings
 import android.util.Log
@@ -17,6 +18,7 @@ import com.facebook.react.uimanager.UIManagerHelper
 import com.facebook.react.uimanager.common.UIManagerType
 import com.facebook.soloader.SoLoader
 import com.swmansion.common.GestureHandlerStateManager
+import com.swmansion.reanimated.css.CSSPlatformTransitionsManager
 import com.swmansion.reanimated.keyboard.KeyboardAnimationManager
 import com.swmansion.reanimated.keyboard.KeyboardWorkletWrapper
 import com.swmansion.reanimated.nativeProxy.AnimationFrameCallback
@@ -46,6 +48,7 @@ open class NativeProxy {
     private val gestureHandlerStateManager: GestureHandlerStateManager?
     private val keyboardAnimationManager: KeyboardAnimationManager
     private val pseudoSelectorManager: PseudoSelectorManager
+    private val cssPlatformTransitionsManager: CSSPlatformTransitionsManager?
     private var firstUptime: Long = SystemClock.uptimeMillis()
     private var slowAnimationsEnabled = false
     private val animationsDragFactor = 10
@@ -94,6 +97,12 @@ open class NativeProxy {
         mFabricUIManager =
             UIManagerHelper.getUIManager(context, UIManagerType.FABRIC) as FabricUIManager
         pseudoSelectorManager = PseudoSelectorManager(mFabricUIManager, mContext)
+        cssPlatformTransitionsManager =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                CSSPlatformTransitionsManager(mFabricUIManager, mContext)
+            } else {
+                null
+            }
 
         val callInvokerHolder = context.jsCallInvokerHolder as CallInvokerHolderImpl
         mHybridData =
@@ -262,6 +271,38 @@ open class NativeProxy {
                 mFabricUIManager.synchronouslyUpdateViewOnUIThread(viewTag, props)
             }
         }
+    }
+
+    @DoNotStrip
+    fun cssAnimateTransition(
+        viewTag: Int,
+        propertyName: String,
+        fromValue: Double,
+        toValue: Double,
+        durationMs: Double,
+        elapsedMs: Double,
+        easingType: Int,
+        easingPointsX: FloatArray,
+        easingPointsY: FloatArray,
+    ): Boolean =
+        cssPlatformTransitionsManager?.animateTransition(
+            viewTag,
+            propertyName,
+            fromValue,
+            toValue,
+            durationMs,
+            elapsedMs,
+            easingType,
+            easingPointsX,
+            easingPointsY,
+        ) ?: false
+
+    @DoNotStrip
+    fun cssRemoveTransition(
+        viewTag: Int,
+        propertyName: String,
+    ) {
+        cssPlatformTransitionsManager?.removeTransition(viewTag, propertyName)
     }
 
     @DoNotStrip

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSEasing.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSEasing.kt
@@ -6,7 +6,7 @@ import android.view.animation.PathInterpolator
 
 /** `steps()` and `linear()` stops are evaluated directly so steps keeps its discontinuities. */
 internal object CSSEasing {
-    // 0 is linear and carries no points, so it needs no constant.
+    // Must match `PlatformEasing::Type` in CSSPlatformTransitions.h; 0 is linear, no constant needed.
     private const val CUBIC_BEZIER = 1
     private const val STEPS = 2
     private const val LINEAR_STOPS = 3

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
@@ -140,9 +140,8 @@ internal class CSSPlatformTransitionsManager(
                 override fun onAnimationEnd(animation: Animator) {
                     val running = animators[key] ?: return
                     if (running.animator !== animation) return
-                    // A pseudo-selector value has no committed style behind it, so releasing the
-                    // entry would let the next commit revert the view. Hold the final value until
-                    // removeTransition instead, which is what fillMode does on Apple platforms.
+                    // A persistent value has no committed style behind it, so dropping the entry
+                    // would let the next commit revert the view.
                     if (persistent) {
                         running.heldValue = animator.animatedValue as Float
                     } else {

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
@@ -35,8 +35,11 @@ internal class CSSPlatformTransitionsManager(
         val writer: FloatProperty<View>,
         val startValue: Float,
     ) {
+        /** Final value of a finished persistent transition, which outlives its animator. */
+        var heldValue: Float? = null
+
         /** Uninitialised until the first frame, which a start delay defers, so show startValue. */
-        fun currentValue(): Float = if (animator.isRunning) animator.animatedValue as Float else startValue
+        fun currentValue(): Float = heldValue ?: if (animator.isRunning) animator.animatedValue as Float else startValue
     }
 
     private data class InterpolatorKey(
@@ -56,6 +59,7 @@ internal class CSSPlatformTransitionsManager(
         easingType: Int,
         easingPointsX: FloatArray,
         easingPointsY: FloatArray,
+        persistent: Boolean,
     ): Boolean {
         val writer = cssPropertyWriterFor(propertyName) ?: return false
         val context = reactContext.get() ?: return false
@@ -71,7 +75,7 @@ internal class CSSPlatformTransitionsManager(
             beginWhenMounted(key, token, startTimestampMs + durationMs) {
                 viewForTag(viewTag)?.also { view ->
                     val interpolator = interpolatorFor(easingType, easingPointsX, easingPointsY)
-                    start(view, key, writer, fromValue, toValue, durationMs, startTimestampMs, interpolator, scale)
+                    start(view, key, writer, fromValue, toValue, durationMs, startTimestampMs, interpolator, scale, persistent)
                 } != null
             }
         }
@@ -117,6 +121,7 @@ internal class CSSPlatformTransitionsManager(
         startTimestampMs: Double,
         interpolator: TimeInterpolator,
         scale: Float,
+        persistent: Boolean,
     ) {
         // Resume from what is on screen; fromValue is the committed style, which would snap back.
         val interrupted = animators.remove(key)
@@ -133,7 +138,16 @@ internal class CSSPlatformTransitionsManager(
         animator.addListener(
             object : AnimatorListenerAdapter() {
                 override fun onAnimationEnd(animation: Animator) {
-                    if (animators[key]?.animator === animation) animators.remove(key)
+                    val running = animators[key] ?: return
+                    if (running.animator !== animation) return
+                    // A pseudo-selector value has no committed style behind it, so releasing the
+                    // entry would let the next commit revert the view. Hold the final value until
+                    // removeTransition instead, which is what fillMode does on Apple platforms.
+                    if (persistent) {
+                        running.heldValue = animator.animatedValue as Float
+                    } else {
+                        animators.remove(key)
+                    }
                 }
             },
         )


### PR DESCRIPTION
Owns the per-property state CSS reversing needs: it detects a reversal against the in-flight transition's start value, reverse-shortens the duration through the easing curve, and hands the resolved timeline to the Kotlin animator from #10090.

Elapsed time crosses the boundary instead of an absolute start. Reverse-shortening backdates the start and `transition-delay` pushes it forward, and computing it here keeps Kotlin off a second clock that would drift from the loop's timestamp.

Easings cross as the same normalized point arrays the loop uses, so nothing reimplements the easing spec on the other side of the boundary.

Nothing routes to this yet; it is inert until the next PR flips the gate.

Stacked on #10090.