### PR TITLE
fix: correct copy-paste errors in CSS typography examples

### DIFF
--- a/apps/common-app/src/apps/css/examples/animations/screens/animatedProperties/base/typography/decoration/TextDecorationColor.tsx
+++ b/apps/common-app/src/apps/css/examples/animations/screens/animatedProperties/base/typography/decoration/TextDecorationColor.tsx
@@ -7,7 +7,7 @@ import { ExamplesScreen, VerticalExampleCard } from '@/apps/css/components';
 import type { ExampleScreenProps } from '@/apps/css/navigation/types';
 import { colors } from '@/theme';
 
-export default function TextDecorationStyle({
+export default function TextDecorationColor({
   labelTypes,
 }: ExampleScreenProps) {
   return (

--- a/apps/common-app/src/apps/css/examples/animations/screens/animatedProperties/base/typography/others/IncludeFontPadding.tsx
+++ b/apps/common-app/src/apps/css/examples/animations/screens/animatedProperties/base/typography/others/IncludeFontPadding.tsx
@@ -27,7 +27,7 @@ export default function IncludeFontPadding({ labelTypes }: ExampleScreenProps) {
           examples: [
             {
               description:
-                "`textAlignVertical` is a **discrete** property. That means, it **can't be smoothly animated** between values. However, we can still change this property in the animation keyframes but the change will be **abrupt**.",
+                "`includeFontPadding` is a **discrete** property. That means, it **can't be smoothly animated** between values. However, we can still change this property in the animation keyframes but the change will be **abrupt**.",
               keyframes: {
                 from: {
                   includeFontPadding: true,


### PR DESCRIPTION
Two copy-paste errors in the CSS example app, carried over from the neighbouring screens.

- `IncludeFontPadding` described `textAlignVertical` in its example text.
- `TextDecorationColor` exported a component named `TextDecorationStyle`.