### PR TITLE
chore: extract a platform-agnostic CSS callback store

### DIFF
--- a/packages/react-native-reanimated/src/css/models/CSSCallbackStore.ts
+++ b/packages/react-native-reanimated/src/css/models/CSSCallbackStore.ts
@@ -1,0 +1,60 @@
+'use strict';
+
+type CSSCallbackMap<Prop extends string, Payload> = Partial<
+  Record<Prop, ((payload: Payload) => void) | undefined>
+>;
+
+/**
+ * Holds the user's CSS callbacks and tracks which of them are present.
+ *
+ * Callbacks are read from a mutable slot at fire time, so a callback replaced
+ * by a re-render can never fire, and re-created inline arrow functions cost
+ * nothing. Subscription is driven by presence rather than identity, so
+ * subclasses are only notified when a callback appears or disappears.
+ */
+export default abstract class CSSCallbackStore<Prop extends string, Payload> {
+  private callbacks: CSSCallbackMap<Prop, Payload> = {};
+  private readonly present = new Set<Prop>();
+  private readonly props: readonly Prop[];
+
+  constructor(props: readonly Prop[]) {
+    this.props = props;
+  }
+
+  sync(callbacks: CSSCallbackMap<Prop, Payload>): void {
+    this.callbacks = callbacks;
+
+    const added: Prop[] = [];
+    const removed: Prop[] = [];
+
+    for (const prop of this.props) {
+      const hasCallback = typeof callbacks[prop] === 'function';
+
+      if (hasCallback && !this.present.has(prop)) {
+        this.present.add(prop);
+        added.push(prop);
+      } else if (!hasCallback && this.present.has(prop)) {
+        this.present.delete(prop);
+        removed.push(prop);
+      }
+    }
+
+    if (added.length > 0 || removed.length > 0) {
+      this.onPresenceChanged(added, removed, this.present);
+    }
+  }
+
+  detach(): void {
+    this.sync({});
+  }
+
+  protected invoke(prop: Prop, payload: Payload): void {
+    this.callbacks[prop]?.(payload);
+  }
+
+  protected abstract onPresenceChanged(
+    added: readonly Prop[],
+    removed: readonly Prop[],
+    present: ReadonlySet<Prop>
+  ): void;
+}

--- a/packages/react-native-reanimated/src/css/models/__tests__/CSSCallbackStore.test.ts
+++ b/packages/react-native-reanimated/src/css/models/__tests__/CSSCallbackStore.test.ts
@@ -1,0 +1,132 @@
+'use strict';
+import CSSCallbackStore from '../CSSCallbackStore';
+
+type Prop = 'onFoo' | 'onBar';
+
+type Payload = { detail: string };
+
+type PresenceChange = {
+  added: Prop[];
+  removed: Prop[];
+  present: Prop[];
+};
+
+class TestStore extends CSSCallbackStore<Prop, Payload> {
+  readonly changes: PresenceChange[] = [];
+
+  constructor() {
+    super(['onFoo', 'onBar']);
+  }
+
+  fire(prop: Prop, payload: Payload): void {
+    this.invoke(prop, payload);
+  }
+
+  protected onPresenceChanged(
+    added: readonly Prop[],
+    removed: readonly Prop[],
+    present: ReadonlySet<Prop>
+  ): void {
+    this.changes.push({
+      added: [...added],
+      present: [...present],
+      removed: [...removed],
+    });
+  }
+}
+
+describe('CSSCallbackStore', () => {
+  let store: TestStore;
+
+  beforeEach(() => {
+    store = new TestStore();
+  });
+
+  test('reports a prop as added the first time a callback is provided', () => {
+    store.sync({ onFoo: jest.fn() });
+
+    expect(store.changes).toEqual([
+      { added: ['onFoo'], present: ['onFoo'], removed: [] },
+    ]);
+  });
+
+  test('does not report a change when only the callback identity changes', () => {
+    store.sync({ onFoo: jest.fn() });
+    store.sync({ onFoo: jest.fn() });
+
+    expect(store.changes).toHaveLength(1);
+  });
+
+  test('invokes the callback from the latest sync', () => {
+    const first = jest.fn();
+    const second = jest.fn();
+
+    store.sync({ onFoo: first });
+    store.sync({ onFoo: second });
+    store.fire('onFoo', { detail: 'x' });
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledWith({ detail: 'x' });
+  });
+
+  test('reports a prop as removed when its callback becomes undefined', () => {
+    store.sync({ onFoo: jest.fn() });
+    store.sync({ onFoo: undefined });
+
+    expect(store.changes[1]).toEqual({
+      added: [],
+      present: [],
+      removed: ['onFoo'],
+    });
+  });
+
+  test('reports additions and removals from a single sync together', () => {
+    store.sync({ onFoo: jest.fn() });
+    store.sync({ onBar: jest.fn() });
+
+    expect(store.changes[1]).toEqual({
+      added: ['onBar'],
+      present: ['onBar'],
+      removed: ['onFoo'],
+    });
+  });
+
+  test('ignores props that the store does not manage', () => {
+    store.sync({ onBaz: jest.fn() } as never);
+
+    expect(store.changes).toHaveLength(0);
+  });
+
+  test('detach removes every present prop and stops invocations', () => {
+    const onFoo = jest.fn();
+    store.sync({ onFoo, onBar: jest.fn() });
+    store.detach();
+
+    expect(store.changes[1]).toEqual({
+      added: [],
+      present: [],
+      removed: ['onFoo', 'onBar'],
+    });
+
+    store.fire('onFoo', { detail: 'x' });
+    expect(onFoo).not.toHaveBeenCalled();
+  });
+
+  test('re-adds a prop after detach', () => {
+    store.sync({ onFoo: jest.fn() });
+    store.detach();
+    store.sync({ onFoo: jest.fn() });
+
+    expect(store.changes[2]).toEqual({
+      added: ['onFoo'],
+      present: ['onFoo'],
+      removed: [],
+    });
+  });
+
+  test('detach on an empty store reports nothing', () => {
+    store.detach();
+
+    expect(store.changes).toHaveLength(0);
+  });
+});

--- a/packages/react-native-reanimated/src/css/models/index.ts
+++ b/packages/react-native-reanimated/src/css/models/index.ts
@@ -1,2 +1,3 @@
 'use strict';
+export { default as CSSCallbackStore } from './CSSCallbackStore';
 export { default as CSSKeyframesRuleBase } from './CSSKeyframesRuleBase';

--- a/packages/react-native-reanimated/src/css/web/managers/CSSCallbackListeners.ts
+++ b/packages/react-native-reanimated/src/css/web/managers/CSSCallbackListeners.ts
@@ -1,44 +1,38 @@
 'use strict';
 import type { ReanimatedHTMLElement } from '../../../ReanimatedModule/js-reanimated';
+import { CSSCallbackStore } from '../../models';
 
-type CallbackMap<Prop extends string, Payload> = Partial<
-  Record<Prop, ((payload: Payload) => void) | undefined>
->;
-
-export class CSSCallbackListeners<Prop extends string, Payload> {
-  private callbacks: CallbackMap<Prop, Payload> = {};
+export class CSSCallbackListeners<
+  Prop extends string,
+  Payload,
+> extends CSSCallbackStore<Prop, Payload> {
   private readonly attachedListeners = new Map<Prop, EventListener>();
-  private readonly props: Prop[];
 
   constructor(
     private readonly element: ReanimatedHTMLElement,
     private readonly eventNameByProp: Record<Prop, string>,
     private readonly buildPayload: (event: Event) => Payload
   ) {
-    this.props = Object.keys(eventNameByProp) as Prop[];
+    super(Object.keys(eventNameByProp) as Prop[]);
   }
 
-  sync(callbacks: CallbackMap<Prop, Payload>): void {
-    this.callbacks = callbacks;
-
-    for (const prop of this.props) {
-      const eventName = this.eventNameByProp[prop];
-      const hasCallback = typeof callbacks[prop] === 'function';
+  protected onPresenceChanged(
+    added: readonly Prop[],
+    removed: readonly Prop[]
+  ): void {
+    for (const prop of removed) {
       const listener = this.attachedListeners.get(prop);
-
-      if (hasCallback && !listener) {
-        const newListener = this.createListener(prop);
-        this.attachedListeners.set(prop, newListener);
-        this.element.addEventListener(eventName, newListener);
-      } else if (!hasCallback && listener) {
-        this.element.removeEventListener(eventName, listener);
+      if (listener) {
         this.attachedListeners.delete(prop);
+        this.element.removeEventListener(this.eventNameByProp[prop], listener);
       }
     }
-  }
 
-  detach(): void {
-    this.sync({});
+    for (const prop of added) {
+      const listener = this.createListener(prop);
+      this.attachedListeners.set(prop, listener);
+      this.element.addEventListener(this.eventNameByProp[prop], listener);
+    }
   }
 
   private createListener(prop: Prop): EventListener {
@@ -47,7 +41,7 @@ export class CSSCallbackListeners<Prop extends string, Payload> {
       if (event.target !== this.element) {
         return;
       }
-      this.callbacks[prop]?.(this.buildPayload(event));
+      this.invoke(prop, this.buildPayload(event));
     };
   }
 }


### PR DESCRIPTION
Pulls the CSS callback bookkeeping out of the web-only listener class so the native managers can share it instead of reimplementing it.

Two behaviours are easy to get subtly different on a second implementation: callbacks live in a mutable slot read at fire time, and subscription is driven by presence rather than identity. Together they mean re-rendering with fresh inline arrow callbacks costs nothing and can never fire a stale callback.

`CSSCallbackListeners` becomes a subclass that maps presence changes onto `addEventListener` / `removeEventListener`. Web behaviour is unchanged and its existing test suite passes untouched.

First of the CSS-callbacks-on-native series.