### PR TITLE
feat: detect and batch CSS animation events in C++

### DIFF
--- a/apps/common-app/src/apps/css/examples/animations/routes/index.ts
+++ b/apps/common-app/src/apps/css/examples/animations/routes/index.ts
@@ -54,6 +54,10 @@ const routes = {
     CardComponent: routeCards.MiscellaneousCard,
     name: 'Miscellaneous',
     routes: {
+      AnimationCallbacks: {
+        Component: miscellaneous.AnimationCallbacks,
+        name: 'Animation Callbacks',
+      },
       ChangingAnimation: {
         Component: miscellaneous.ChangingAnimation,
         name: 'Changing Animation',

--- a/apps/common-app/src/apps/css/examples/animations/screens/miscellaneous/AnimationCallbacks.tsx
+++ b/apps/common-app/src/apps/css/examples/animations/screens/miscellaneous/AnimationCallbacks.tsx
@@ -1,0 +1,167 @@
+import { useCallback, useState } from 'react';
+import { StyleSheet, View } from 'react-native';
+import type { CSSAnimationProperties } from 'react-native-reanimated';
+import Animated, { css } from 'react-native-reanimated';
+
+import {
+  Button,
+  ScrollScreen,
+  Section,
+  Stagger,
+  Text,
+} from '@/apps/css/components';
+import { colors, flex, radius, sizes, spacing } from '@/theme';
+
+const pulse = css.keyframes({
+  '0%, 100%': {
+    transform: [{ scale: 1 }],
+  },
+  '50%': {
+    transform: [{ scale: 1.5 }],
+  },
+});
+
+const FINITE: CSSAnimationProperties = {
+  animationDelay: '500ms',
+  animationDuration: '1s',
+  animationIterationCount: 3,
+  animationName: pulse,
+};
+
+const INFINITE: CSSAnimationProperties = {
+  animationDuration: '1s',
+  animationIterationCount: 'infinite',
+  animationName: pulse,
+};
+
+type LoggedEvent = {
+  id: number;
+  label: string;
+};
+
+export default function AnimationCallbacks() {
+  const [events, setEvents] = useState<Array<LoggedEvent>>([]);
+  const [animation, setAnimation] = useState<CSSAnimationProperties | null>(
+    FINITE
+  );
+  const [isMounted, setIsMounted] = useState(true);
+
+  const log = useCallback((type: string, elapsedTime: number) => {
+    setEvents((current) => [
+      ...current,
+      { id: current.length, label: `${type} at ${elapsedTime.toFixed(2)}s` },
+    ]);
+  }, []);
+
+  const restart = useCallback(
+    (properties: CSSAnimationProperties) => {
+      setEvents([]);
+      setIsMounted(true);
+      // Detaching first guarantees a fresh animation rather than a settings
+      // update on the running one.
+      setAnimation(null);
+      requestAnimationFrame(() => setAnimation(properties));
+    },
+    [setAnimation]
+  );
+
+  return (
+    <ScrollScreen>
+      <Stagger>
+        <Section
+          description="Animation lifecycle callbacks fired by the **native** CSS engine. `elapsedTime` is reported in **seconds**."
+          title="Animation Callbacks">
+          <View style={styles.content}>
+            <View style={styles.buttons}>
+              <Button
+                style={flex.grow}
+                title="Finite (3x)"
+                onPress={() => restart(FINITE)}
+              />
+              <Button
+                style={flex.grow}
+                title="Infinite"
+                onPress={() => restart(INFINITE)}
+              />
+              <Button
+                style={flex.grow}
+                title="Cancel"
+                onPress={() => setAnimation(null)}
+              />
+              <Button
+                style={flex.grow}
+                title="Unmount"
+                onPress={() => setIsMounted(false)}
+              />
+            </View>
+
+            <View style={styles.preview}>
+              {isMounted && (
+                <Animated.View
+                  style={[
+                    styles.box,
+                    animation,
+                    {
+                      onAnimationCancel: ({ elapsedTime }) =>
+                        log('cancel', elapsedTime),
+                      onAnimationEnd: ({ elapsedTime }) =>
+                        log('end', elapsedTime),
+                      onAnimationIteration: ({ elapsedTime }) =>
+                        log('iteration', elapsedTime),
+                      onAnimationStart: ({ elapsedTime }) =>
+                        log('start', elapsedTime),
+                    },
+                  ]}
+                />
+              )}
+            </View>
+          </View>
+        </Section>
+
+        <Section description="In order of arrival" title="Event Log">
+          <View style={styles.log}>
+            {events.length === 0 ? (
+              <Text variant="subHeading2">No events yet</Text>
+            ) : (
+              events.map((event) => (
+                <Text key={event.id} variant="body1">
+                  {event.label}
+                </Text>
+              ))
+            )}
+          </View>
+        </Section>
+      </Stagger>
+    </ScrollScreen>
+  );
+}
+
+const styles = StyleSheet.create({
+  box: {
+    backgroundColor: colors.primary,
+    borderRadius: radius.sm,
+    height: sizes.md,
+    width: sizes.md,
+  },
+  buttons: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.xxs,
+    justifyContent: 'space-between',
+  },
+  content: {
+    gap: spacing.xs,
+  },
+  log: {
+    backgroundColor: colors.background2,
+    borderRadius: radius.sm,
+    gap: spacing.xxxs,
+    padding: spacing.xs,
+  },
+  preview: {
+    ...flex.center,
+    backgroundColor: colors.background2,
+    borderRadius: radius.md,
+    height: sizes.xxl,
+  },
+});

--- a/apps/common-app/src/apps/css/examples/animations/screens/miscellaneous/index.ts
+++ b/apps/common-app/src/apps/css/examples/animations/screens/miscellaneous/index.ts
@@ -1,9 +1,11 @@
+import AnimationCallbacks from './AnimationCallbacks';
 import ChangingAnimation from './ChangingAnimation';
 import KeyframeTimingFunctions from './KeyframeTimingFunctions';
 import MultipleAnimations from './MultipleAnimations';
 import UpdatingAnimationSettings from './UpdatingAnimationSettings';
 
 export default {
+  AnimationCallbacks,
   ChangingAnimation,
   KeyframeTimingFunctions,
   MultipleAnimations,

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.cpp
@@ -22,6 +22,7 @@ CSSAnimation::CSSAnimation(
       styleInterpolator_(cssKeyframesConfig.styleInterpolatorFactory->create()),
       loopAnimation_(std::make_shared<CSSLoopAnimation>(
           viewTag,
+          name_,
           styleInterpolator_,
           settings_,
           cssKeyframesConfig.keyframeEasingConfigs,
@@ -33,6 +34,10 @@ CSSAnimation::CSSAnimation(
 
 AnimationProgressState CSSAnimation::getState() const {
   return loopAnimation_->getState();
+}
+
+void CSSAnimation::reportCancellation(const double timestamp) {
+  loopAnimation_->reportCancellation(timestamp);
 }
 
 folly::dynamic CSSAnimation::getBackwardsFillStyle() const {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.h
@@ -4,6 +4,7 @@
 #include <reanimated/CSS/configs/CSSKeyframesConfig.h>
 #include <reanimated/CSS/core/CSSPlatformAnimation.h>
 #include <reanimated/CSS/core/CSSPlatformAnimationFactory.h>
+#include <reanimated/CSS/events/CSSEvent.h>
 #include <reanimated/CSS/interpolation/styles/AnimationStyleInterpolator.h>
 #include <reanimated/CSS/progress/AnimationProgressProvider.h>
 #include <reanimated/Fabric/updates/OperationsLoop.h>
@@ -24,6 +25,10 @@ class CSSAnimation {
     // Called when the animation finishes without `forwards` fill mode and will
     // need to be reverted to the underlying style on the next flush.
     virtual void onAnimationNeedsRevert(Tag viewTag) = 0;
+    // Called when the animation crosses a lifecycle boundary the user can
+    // subscribe to. `elapsedTimeMs` follows the CSS `elapsedTime` contract.
+    virtual void
+    onAnimationEvent(Tag viewTag, const std::string &animationName, CSSEventType type, double elapsedTimeMs) = 0;
   };
 
   CSSAnimation(
@@ -57,6 +62,10 @@ class CSSAnimation {
   void unschedule(OperationsLoop &loop);
 
   void updateSettings(const PartialCSSAnimationSettings &updatedSettings, double timestamp);
+
+  /// Emits a cancel event unless the animation already finished. Must be called
+  /// before the animation is destroyed.
+  void reportCancellation(double timestamp);
 
  private:
   const Tag viewTag_;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSLoopAnimation.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSLoopAnimation.cpp
@@ -1,17 +1,22 @@
 #include <reanimated/CSS/core/CSSLoopAnimation.h>
 
+#include <algorithm>
 #include <memory>
+#include <string>
+#include <utility>
 
 namespace reanimated::css {
 
 CSSLoopAnimation::CSSLoopAnimation(
     const Tag viewTag,
+    std::string animationName,
     const std::shared_ptr<AnimationStyleInterpolator> &interpolator,
     const std::shared_ptr<CSSAnimationSettings> &settings,
     const std::shared_ptr<KeyframeEasingConfigs> &keyframeEasingConfigs,
     CSSAnimation::Observer &observer,
     const double timestamp)
     : viewTag_(viewTag),
+      animationName_(std::move(animationName)),
       settings_(settings),
       interpolator_(interpolator),
       progressProvider_(std::make_shared<AnimationProgressProvider>(
@@ -22,7 +27,9 @@ CSSLoopAnimation::CSSLoopAnimation(
           settings->direction,
           getEasingFunctionFromConfig(settings->easingConfig),
           keyframeEasingConfigs)),
-      observer_(observer) {
+      observer_(observer),
+      lastObservedState_(progressProvider_->getState()),
+      lastObservedIteration_(progressProvider_->getCurrentIteration()) {
   if (settings->playState == AnimationPlayState::Paused) {
     progressProvider_->pause(timestamp);
   }
@@ -35,6 +42,7 @@ folly::dynamic CSSLoopAnimation::getCurrentInterpolationStyle(
 
 bool CSSLoopAnimation::update(const double timestamp, OperationsLoop & /*loop*/) {
   progressProvider_->update(timestamp);
+  reportProgressEvents(timestamp);
   observer_.onAnimationUpdate(viewTag_);
 
   if (progressProvider_->getState() == AnimationProgressState::Finished && !settings_->hasForwardsFillMode()) {
@@ -42,6 +50,61 @@ bool CSSLoopAnimation::update(const double timestamp, OperationsLoop & /*loop*/)
   }
 
   return progressProvider_->getState() == AnimationProgressState::Running;
+}
+
+void CSSLoopAnimation::reportProgressEvents(const double timestamp) {
+  const auto state = progressProvider_->getState();
+
+  if (lastObservedState_ == AnimationProgressState::Pending && state != AnimationProgressState::Pending) {
+    reportStart();
+  }
+
+  reportIterations(timestamp);
+
+  if (lastObservedState_ != AnimationProgressState::Finished && state == AnimationProgressState::Finished) {
+    reportEnd();
+  }
+
+  lastObservedState_ = state;
+  lastObservedIteration_ = progressProvider_->getCurrentIteration();
+}
+
+void CSSLoopAnimation::reportStart() {
+  // A negative delay starts the animation partway through, and the spec caps
+  // the reported time at the animation's total active duration.
+  const auto activeDuration = progressProvider_->getDuration() * progressProvider_->getIterationCount();
+  const auto elapsedTime = std::clamp(-progressProvider_->getDelay(), 0.0, std::max(0.0, activeDuration));
+  observer_.onAnimationEvent(viewTag_, animationName_, CSSEventType::AnimationStart, elapsedTime);
+}
+
+void CSSLoopAnimation::reportIterations(const double timestamp) {
+  // The provider bumps the iteration counter before the final-frame clamp, so
+  // without this guard a finishing animation reports one iteration too many.
+  if (progressProvider_->shouldFinish(timestamp)) {
+    return;
+  }
+
+  const auto currentIteration = progressProvider_->getCurrentIteration();
+  const auto duration = progressProvider_->getDuration();
+
+  // A dropped frame or a negative delay can cross several boundaries at once,
+  // and each one is a separate event.
+  for (auto iteration = lastObservedIteration_ + 1; iteration <= currentIteration; iteration++) {
+    observer_.onAnimationEvent(viewTag_, animationName_, CSSEventType::AnimationIteration, (iteration - 1) * duration);
+  }
+}
+
+void CSSLoopAnimation::reportEnd() {
+  const auto elapsedTime = progressProvider_->getDuration() * progressProvider_->getIterationCount();
+  observer_.onAnimationEvent(viewTag_, animationName_, CSSEventType::AnimationEnd, elapsedTime);
+}
+
+void CSSLoopAnimation::reportCancellation(const double timestamp) {
+  if (lastObservedState_ == AnimationProgressState::Finished) {
+    return;
+  }
+  observer_.onAnimationEvent(
+      viewTag_, animationName_, CSSEventType::AnimationCancel, progressProvider_->getActiveElapsedTime(timestamp));
 }
 
 void CSSLoopAnimation::schedule(OperationsLoop &loop) {
@@ -95,6 +158,10 @@ void CSSLoopAnimation::updateSettings(const PartialCSSAnimationSettings &updated
   }
 
   progressProvider_->update(timestamp);
+  // Diffing against the state captured before `resetProgress` keeps a settings
+  // change from fabricating a restart while still reporting boundaries the new
+  // settings genuinely crossed.
+  reportProgressEvents(timestamp);
 }
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSLoopAnimation.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSLoopAnimation.h
@@ -16,6 +16,7 @@ class CSSLoopAnimation : public OperationsLoop::LoopOperation, public std::enabl
  public:
   CSSLoopAnimation(
       Tag viewTag,
+      std::string animationName,
       const std::shared_ptr<AnimationStyleInterpolator> &interpolator,
       const std::shared_ptr<CSSAnimationSettings> &settings,
       const std::shared_ptr<KeyframeEasingConfigs> &keyframeEasingConfigs,
@@ -36,14 +37,28 @@ class CSSLoopAnimation : public OperationsLoop::LoopOperation, public std::enabl
   void setAnimatedProperties(const std::unordered_set<std::string> &loopDrivenProperties);
   void updateSettings(const PartialCSSAnimationSettings &updatedSettings, double timestamp);
 
+  /// Emits a cancel event when the animation is torn down before finishing.
+  void reportCancellation(double timestamp);
+
  private:
   static constexpr double FALLBACK_INTERPOLATION_THRESHOLD = 0.5;
 
   const Tag viewTag_;
+  const std::string animationName_;
   const std::shared_ptr<CSSAnimationSettings> settings_;
   const std::shared_ptr<AnimationStyleInterpolator> interpolator_;
   const std::shared_ptr<AnimationProgressProvider> progressProvider_;
   CSSAnimation::Observer &observer_;
+
+  AnimationProgressState lastObservedState_;
+  unsigned lastObservedIteration_;
+
+  /// Diffs the progress state captured before the last provider update against
+  /// the current one and emits the boundaries that were crossed.
+  void reportProgressEvents(double timestamp);
+  void reportStart();
+  void reportIterations(double timestamp);
+  void reportEnd();
 };
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/events/CSSEvent.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/events/CSSEvent.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <react/renderer/core/ReactPrimitives.h>
+
+#include <cstdint>
+#include <string>
+#include <utility>
+
+namespace reanimated::css {
+
+/// Event kinds a view can subscribe to. The ordinal is the bit index in
+/// `CSSEventMask`, so the JS side must keep its bitmask constants in sync.
+enum class CSSEventType : std::uint8_t {
+  AnimationStart = 0,
+  AnimationEnd = 1,
+  AnimationIteration = 2,
+  AnimationCancel = 3,
+  TransitionRun = 4,
+  TransitionStart = 5,
+  TransitionEnd = 6,
+  TransitionCancel = 7,
+};
+
+using CSSEventMask = std::uint8_t;
+
+constexpr CSSEventMask cssEventBit(const CSSEventType type) {
+  return static_cast<CSSEventMask>(1U << static_cast<std::uint8_t>(type));
+}
+
+constexpr bool hasListener(const CSSEventMask mask, const CSSEventType type) {
+  return (mask & cssEventBit(type)) != 0;
+}
+
+/// Wire name of the event, matching the string union on the JS side.
+const char *cssEventTypeName(CSSEventType type);
+
+struct CSSEvent {
+  facebook::react::Tag viewTag;
+  CSSEventType type;
+  /// Animation name for animation events, RN property name for transition ones.
+  std::string name;
+  /// Seconds, matching the public `elapsedTime` contract shared with web.
+  double elapsedTime;
+};
+
+inline CSSEvent createCSSEvent(
+    const facebook::react::Tag viewTag,
+    const CSSEventType type,
+    std::string name,
+    const double elapsedTimeMs) {
+  return CSSEvent{viewTag, type, std::move(name), elapsedTimeMs / 1000};
+}
+
+} // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/events/CSSEventsEmitter.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/events/CSSEventsEmitter.cpp
@@ -1,0 +1,119 @@
+#include <reanimated/CSS/events/CSSEventsEmitter.h>
+
+#include <utility>
+#include <vector>
+
+namespace reanimated::css {
+
+using namespace facebook;
+
+const char *cssEventTypeName(const CSSEventType type) {
+  switch (type) {
+    case CSSEventType::AnimationStart:
+      return "animationStart";
+    case CSSEventType::AnimationEnd:
+      return "animationEnd";
+    case CSSEventType::AnimationIteration:
+      return "animationIteration";
+    case CSSEventType::AnimationCancel:
+      return "animationCancel";
+    case CSSEventType::TransitionRun:
+      return "transitionRun";
+    case CSSEventType::TransitionStart:
+      return "transitionStart";
+    case CSSEventType::TransitionEnd:
+      return "transitionEnd";
+    case CSSEventType::TransitionCancel:
+      return "transitionCancel";
+  }
+  return "";
+}
+
+namespace {
+
+jsi::Array eventsToJSIArray(jsi::Runtime &rt, const std::vector<CSSEvent> &events) {
+  jsi::Array result(rt, events.size());
+
+  for (size_t i = 0; i < events.size(); i++) {
+    const auto &event = events[i];
+    jsi::Object jsEvent(rt);
+    jsEvent.setProperty(rt, "tag", jsi::Value(static_cast<int>(event.viewTag)));
+    jsEvent.setProperty(rt, "type", jsi::String::createFromUtf8(rt, cssEventTypeName(event.type)));
+    jsEvent.setProperty(rt, "name", jsi::String::createFromUtf8(rt, event.name));
+    jsEvent.setProperty(rt, "elapsedTime", jsi::Value(event.elapsedTime));
+    result.setValueAtIndex(rt, i, std::move(jsEvent));
+  }
+
+  return result;
+}
+
+} // namespace
+
+CSSEventsEmitter::CSSEventsEmitter(const std::shared_ptr<react::CallInvoker> &jsInvoker) : jsInvoker_(jsInvoker) {}
+
+void CSSEventsEmitter::setEmitFunction(std::shared_ptr<jsi::Function> emitFunction) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  emitFunction_ = std::move(emitFunction);
+}
+
+void CSSEventsEmitter::invalidate() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  emitFunction_.reset();
+  masks_.clear();
+  pending_.clear();
+}
+
+void CSSEventsEmitter::setMask(const react::Tag viewTag, const CSSEventMask mask) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (mask == 0) {
+    masks_.erase(viewTag);
+  } else {
+    masks_[viewTag] = mask;
+  }
+}
+
+void CSSEventsEmitter::clearTag(const react::Tag viewTag) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  masks_.erase(viewTag);
+}
+
+bool CSSEventsEmitter::hasListener(const react::Tag viewTag, const CSSEventType type) const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  const auto it = masks_.find(viewTag);
+  return it != masks_.end() && css::hasListener(it->second, type);
+}
+
+void CSSEventsEmitter::schedule(CSSEvent event) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  const auto it = masks_.find(event.viewTag);
+  if (it == masks_.end() || !css::hasListener(it->second, event.type)) {
+    return;
+  }
+  pending_.push_back(std::move(event));
+}
+
+void CSSEventsEmitter::flush() {
+  std::vector<CSSEvent> events;
+  std::shared_ptr<jsi::Function> emitFunction;
+
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (pending_.empty() || !emitFunction_) {
+      pending_.clear();
+      return;
+    }
+    events = std::exchange(pending_, {});
+    emitFunction = emitFunction_;
+  }
+
+  jsInvoker_->invokeAsync([weakThis = weak_from_this(), emitFunction, events = std::move(events)](jsi::Runtime &rt) {
+    // The emitter owns the function, so bail out if it went away with the
+    // module while this hop was in flight.
+    if (weakThis.expired()) {
+      return;
+    }
+    emitFunction->call(rt, eventsToJSIArray(rt, events));
+  });
+}
+
+} // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/events/CSSEventsEmitter.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/events/CSSEventsEmitter.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <reanimated/CSS/events/CSSEvent.h>
+
+#include <ReactCommon/CallInvoker.h>
+#include <jsi/jsi.h>
+
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+#include <vector>
+
+namespace reanimated::css {
+
+/// Collects CSS animation and transition events produced while the frame is
+/// being processed and delivers them to JS as a single batch.
+///
+/// Events are produced on the UI thread while registry locks are held, so
+/// `schedule` only buffers. `flush` moves the buffer out under the emitter's
+/// own mutex and hands it to the JS thread, which is why it never calls into
+/// JS while a caller still holds a registry lock.
+class CSSEventsEmitter : public std::enable_shared_from_this<CSSEventsEmitter> {
+ public:
+  explicit CSSEventsEmitter(const std::shared_ptr<facebook::react::CallInvoker> &jsInvoker);
+
+  void setEmitFunction(std::shared_ptr<facebook::jsi::Function> emitFunction);
+  void invalidate();
+
+  /// A mask of 0 removes the view, so views without callbacks cost nothing
+  /// beyond a single lookup and never accumulate entries.
+  void setMask(facebook::react::Tag viewTag, CSSEventMask mask);
+  void clearTag(facebook::react::Tag viewTag);
+  bool hasListener(facebook::react::Tag viewTag, CSSEventType type) const;
+
+  /// Buffers the event, dropping it unless the view subscribed to its type.
+  void schedule(CSSEvent event);
+  void flush();
+
+ private:
+  const std::shared_ptr<facebook::react::CallInvoker> jsInvoker_;
+
+  mutable std::mutex mutex_;
+  std::shared_ptr<facebook::jsi::Function> emitFunction_;
+  std::unordered_map<facebook::react::Tag, CSSEventMask> masks_;
+  std::vector<CSSEvent> pending_;
+};
+
+} // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.cpp
@@ -1,5 +1,6 @@
 #include <reanimated/CSS/progress/AnimationProgressProvider.h>
 
+#include <algorithm>
 #include <memory>
 #include <utility>
 
@@ -65,6 +66,26 @@ double AnimationProgressProvider::getStartTimestamp(const double timestamp) cons
   // should be applied (it depends on the animation delay and the total
   // time when the animation was paused)
   return creationTimestamp_ + delay_ + getTotalPausedTime(timestamp);
+}
+
+double AnimationProgressProvider::getDuration() const {
+  return duration_;
+}
+
+double AnimationProgressProvider::getDelay() const {
+  return delay_;
+}
+
+double AnimationProgressProvider::getIterationCount() const {
+  return iterationCount_;
+}
+
+unsigned AnimationProgressProvider::getCurrentIteration() const {
+  return currentIteration_;
+}
+
+double AnimationProgressProvider::getActiveElapsedTime(const double timestamp) const {
+  return std::max(0.0, timestamp - getStartTimestamp(timestamp));
 }
 
 void AnimationProgressProvider::pause(const double timestamp) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.h
@@ -39,6 +39,15 @@ class AnimationProgressProvider final : public KeyframeProgressProvider, public 
   AnimationProgressState getState() const;
   double getStartTimestamp(double timestamp) const;
 
+  double getDuration() const;
+  double getDelay() const;
+  double getIterationCount() const;
+  unsigned getCurrentIteration() const;
+  /// Time spent in the active phase, i.e. excluding the delay and any time the
+  /// animation was paused. Zero while the animation is still delayed.
+  double getActiveElapsedTime(double timestamp) const;
+  bool shouldFinish(double timestamp) const;
+
   void pause(double timestamp);
   void play(double timestamp);
   void update(double timestamp) override;
@@ -60,7 +69,6 @@ class AnimationProgressProvider final : public KeyframeProgressProvider, public 
   double totalPausedTime_ = 0;
 
   double getTotalPausedTime(double timestamp) const;
-  bool shouldFinish(double timestamp) const;
   AnimationProgressState computeState(double timestamp) const;
 
   double updateIterationProgress(double currentIterationElapsedTime);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSAnimationsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSAnimationsRegistry.cpp
@@ -14,8 +14,12 @@ namespace reanimated::css {
 CSSAnimationsRegistry::CSSAnimationsRegistry(
     const std::shared_ptr<OperationsLoop> &loop,
     const std::shared_ptr<CSSKeyframesRegistry> &keyframesRegistry,
-    const std::shared_ptr<CSSPlatformAnimationFactory> &platformAnimationFactory)
-    : loop_(loop), keyframesRegistry_(keyframesRegistry), platformAnimationFactory_(platformAnimationFactory) {}
+    const std::shared_ptr<CSSPlatformAnimationFactory> &platformAnimationFactory,
+    const std::shared_ptr<CSSEventsEmitter> &eventsEmitter)
+    : loop_(loop),
+      keyframesRegistry_(keyframesRegistry),
+      platformAnimationFactory_(platformAnimationFactory),
+      eventsEmitter_(eventsEmitter) {}
 
 bool CSSAnimationsRegistry::needsFlush() const {
   react_native_assert(UpdatesRegistryManager::isLockedByCurrentThread());
@@ -116,13 +120,28 @@ void CSSAnimationsRegistry::AnimationObserver::onAnimationNeedsRevert(const Tag 
   owner_.pendingRevertTags_.insert(viewTag);
 }
 
+void CSSAnimationsRegistry::AnimationObserver::onAnimationEvent(
+    const Tag viewTag,
+    const std::string &animationName,
+    const CSSEventType type,
+    const double elapsedTimeMs) {
+  react_native_assert(UpdatesRegistryManager::isLockedByCurrentThread());
+  owner_.eventsEmitter_->schedule(createCSSEvent(viewTag, type, animationName, elapsedTimeMs));
+}
+
 void CSSAnimationsRegistry::removeTag(const Tag viewTag) {
   auto it = groups_.find(viewTag);
   if (it != groups_.end()) {
     it->second.unschedule(*loop_);
+    // Report before erasing, since the animations are destroyed with the group.
+    const auto timestamp = loop_->resolveTimestamp();
+    for (const auto &animation : it->second.getAnimations()) {
+      animation->reportCancellation(timestamp);
+    }
     groups_.erase(it);
   }
   removeFromUpdatesRegistry(viewTag);
+  eventsEmitter_->clearTag(viewTag);
 }
 
 std::optional<CSSAnimationsGroup> CSSAnimationsRegistry::maybeBuildNewGroup(
@@ -170,6 +189,14 @@ std::optional<CSSAnimationsGroup> CSSAnimationsRegistry::maybeBuildNewGroup(
       if (oldIt->second.empty()) {
         oldByName.erase(oldIt);
       }
+    }
+  }
+
+  // Whatever is left was not carried over into the new group, so those
+  // animations are being interrupted rather than completed.
+  for (const auto &[_, leftoverAnimations] : oldByName) {
+    for (const auto &animation : leftoverAnimations) {
+      animation->reportCancellation(timestamp);
     }
   }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSAnimationsRegistry.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSAnimationsRegistry.h
@@ -4,6 +4,7 @@
 #include <reanimated/CSS/core/CSSAnimation.h>
 #include <reanimated/CSS/core/CSSAnimationsGroup.h>
 #include <reanimated/CSS/core/CSSPlatformAnimationFactory.h>
+#include <reanimated/CSS/events/CSSEventsEmitter.h>
 #include <reanimated/CSS/registries/CSSKeyframesRegistry.h>
 #include <reanimated/CSS/utils/props.h>
 #include <reanimated/Fabric/updates/OperationsLoop.h>
@@ -25,7 +26,8 @@ class CSSAnimationsRegistry : public UpdatesRegistry {
   CSSAnimationsRegistry(
       const std::shared_ptr<OperationsLoop> &loop,
       const std::shared_ptr<CSSKeyframesRegistry> &keyframesRegistry,
-      const std::shared_ptr<CSSPlatformAnimationFactory> &platformAnimationFactory);
+      const std::shared_ptr<CSSPlatformAnimationFactory> &platformAnimationFactory,
+      const std::shared_ptr<CSSEventsEmitter> &eventsEmitter);
 
   bool needsFlush() const;
 
@@ -45,6 +47,8 @@ class CSSAnimationsRegistry : public UpdatesRegistry {
     explicit AnimationObserver(CSSAnimationsRegistry &owner);
     void onAnimationUpdate(Tag viewTag) override;
     void onAnimationNeedsRevert(Tag viewTag) override;
+    void onAnimationEvent(Tag viewTag, const std::string &animationName, CSSEventType type, double elapsedTimeMs)
+        override;
 
    private:
     CSSAnimationsRegistry &owner_;
@@ -53,6 +57,7 @@ class CSSAnimationsRegistry : public UpdatesRegistry {
   const std::shared_ptr<OperationsLoop> loop_;
   const std::shared_ptr<CSSKeyframesRegistry> keyframesRegistry_;
   const std::shared_ptr<CSSPlatformAnimationFactory> platformAnimationFactory_;
+  const std::shared_ptr<CSSEventsEmitter> eventsEmitter_;
 
   AnimationObserver animationObserver_{*this};
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -212,11 +212,13 @@ ReanimatedModuleProxy::ReanimatedModuleProxy(
           updatesRegistryManager_)),
       animatedPropsRegistry_(std::make_shared<AnimatedPropsRegistry>()),
       viewStylesRepository_(std::make_shared<ViewStylesRepository>(staticPropsRegistry_, animatedPropsRegistry_)),
+      cssEventsEmitter_(std::make_shared<CSSEventsEmitter>(jsCallInvoker)),
       cssAnimationKeyframesRegistry_(std::make_shared<CSSKeyframesRegistry>()),
       cssAnimationsRegistry_(std::make_shared<CSSAnimationsRegistry>(
           operationsLoop_,
           cssAnimationKeyframesRegistry_,
-          platformDepMethodsHolder.platformAnimationFactory)),
+          platformDepMethodsHolder.platformAnimationFactory,
+          cssEventsEmitter_)),
       cssTransitionsRegistry_(std::make_shared<CSSTransitionsRegistry>(
           viewStylesRepository_,
           operationsLoop_,
@@ -394,6 +396,8 @@ ReanimatedModuleProxy::~ReanimatedModuleProxy() {
   // event handler registry and frame callbacks store some JSI values from UI
   // runtime, so they have to go away before we tear down the runtime
   eventHandlerRegistry_.reset();
+  // The events emitter holds the JS event handler for the same reason.
+  cssEventsEmitter_->invalidate();
 }
 
 jsi::Value ReanimatedModuleProxy::registerEventHandler(
@@ -575,18 +579,37 @@ void ReanimatedModuleProxy::applyCSSAnimations(
     jsi::Runtime &rt,
     const jsi::Value &shadowNodeWrapper,
     const jsi::Value &compoundComponentName,
-    const jsi::Value &animationUpdates) {
+    const jsi::Value &animationUpdates,
+    const jsi::Value &eventMask) {
   auto shadowNode = shadowNodeFromValue(rt, shadowNodeWrapper);
   const auto compoundComponentNameStr = compoundComponentName.asString(rt).utf8(rt);
   const auto updates = parseCSSAnimationUpdates(rt, animationUpdates);
 
-  auto lock = updatesRegistryManager_->lock();
-  cssAnimationsRegistry_->apply(shadowNode, compoundComponentNameStr, updates);
+  // The mask has to be in place before the animations run, so that the very
+  // first frame can already tell whether the view listens for events.
+  cssEventsEmitter_->setMask(shadowNode->getTag(), static_cast<css::CSSEventMask>(eventMask.asNumber()));
+
+  {
+    auto lock = updatesRegistryManager_->lock();
+    cssAnimationsRegistry_->apply(shadowNode, compoundComponentNameStr, updates);
+  }
+
+  cssEventsEmitter_->flush();
 }
 
 void ReanimatedModuleProxy::unregisterCSSAnimations(const jsi::Value &viewTag) {
-  auto lock = updatesRegistryManager_->lock();
-  cssAnimationsRegistry_->remove(viewTag.asNumber());
+  {
+    auto lock = updatesRegistryManager_->lock();
+    cssAnimationsRegistry_->remove(viewTag.asNumber());
+  }
+
+  // A teardown triggered from JS may not be followed by another frame, so the
+  // cancel events it produced have to be delivered here.
+  cssEventsEmitter_->flush();
+}
+
+void ReanimatedModuleProxy::setCSSEventHandler(jsi::Runtime &rt, const jsi::Value &handler) {
+  cssEventsEmitter_->setEmitFunction(std::make_shared<jsi::Function>(handler.asObject(rt).asFunction(rt)));
 }
 
 void ReanimatedModuleProxy::runCSSTransition(
@@ -803,6 +826,11 @@ void ReanimatedModuleProxy::performOperations() {
     }
   }
 
+  // Deliberately outside the lock scope above: delivering events hops to the JS
+  // thread, and doing that under the registry lock risks a lock-order inversion
+  // against the shadow tree commit.
+  cssEventsEmitter_->flush();
+
   if constexpr (shouldUseSynchronousUpdatesInPerformOperations()) {
     applySynchronousUpdates(updatesBatch, false);
   }
@@ -937,6 +965,9 @@ AnimationMutations ReanimatedModuleProxy::runGrandCallback(
         mutations = executeOperationsAndCollectUpdates(timestamp);
         stopBackendIfIdle(!mutations.batch.empty());
       }
+      // This is the frame driver used when USE_ANIMATION_BACKEND is enabled, in
+      // which case performOperations never runs, so events must drain here too.
+      cssEventsEmitter_->flush();
       return mutations;
     }
 
@@ -1529,16 +1560,28 @@ jsi::Object ReanimatedModuleProxy::toOptimizedObject(jsi::Runtime &rt) {
         strongThis->unregisterCSSKeyframes(rt, at<0>(args), at<1>(args));
       });
 
-  addMethod<3>(
+  addMethod<4>(
       rt,
       obj,
       "applyCSSAnimations",
-      [weakThis = weak_from_this()](jsi::Runtime &rt, const jsi::Value &, const jsi::Value(&args)[3]) {
+      [weakThis = weak_from_this()](jsi::Runtime &rt, const jsi::Value &, const jsi::Value(&args)[4]) {
         auto strongThis = weakThis.lock();
         if (!strongThis) {
           return;
         }
-        strongThis->applyCSSAnimations(rt, at<0>(args), at<1>(args), at<2>(args));
+        strongThis->applyCSSAnimations(rt, at<0>(args), at<1>(args), at<2>(args), at<3>(args));
+      });
+
+  addMethod<1>(
+      rt,
+      obj,
+      "setCSSEventHandler",
+      [weakThis = weak_from_this()](jsi::Runtime &rt, const jsi::Value &, const jsi::Value(&args)[1]) {
+        auto strongThis = weakThis.lock();
+        if (!strongThis) {
+          return;
+        }
+        strongThis->setCSSEventHandler(rt, at<0>(args));
       });
 
   addMethod<1>(

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
@@ -8,6 +8,7 @@
 #include <reanimated/AnimatedSensor/AnimatedSensorModule.h>
 #include <reanimated/CSS/core/CSSAnimation.h>
 #include <reanimated/CSS/core/transition/CSSTransition.h>
+#include <reanimated/CSS/events/CSSEventsEmitter.h>
 #include <reanimated/CSS/misc/ViewStylesRepository.h>
 #include <reanimated/CSS/registries/CSSAnimationsRegistry.h>
 #include <reanimated/CSS/registries/CSSKeyframesRegistry.h>
@@ -138,8 +139,12 @@ class ReanimatedModuleProxy : public std::enable_shared_from_this<ReanimatedModu
       jsi::Runtime &rt,
       const jsi::Value &shadowNodeWrapper,
       const jsi::Value &compoundComponentName,
-      const jsi::Value &animationUpdates);
+      const jsi::Value &animationUpdates,
+      const jsi::Value &eventMask);
   void unregisterCSSAnimations(const jsi::Value &viewTag);
+
+  /// Registers the single JS function that receives batched CSS events.
+  void setCSSEventHandler(jsi::Runtime &rt, const jsi::Value &handler);
 
   void runCSSTransition(jsi::Runtime &rt, const jsi::Value &shadowNodeWrapper, const jsi::Value &transitionConfig);
   void unregisterCSSTransition(jsi::Runtime &rt, const jsi::Value &viewTag);
@@ -244,6 +249,9 @@ class ReanimatedModuleProxy : public std::enable_shared_from_this<ReanimatedModu
   const std::shared_ptr<OperationsLoop> operationsLoop_;
   const std::shared_ptr<AnimatedPropsRegistry> animatedPropsRegistry_;
   const std::shared_ptr<ViewStylesRepository> viewStylesRepository_;
+  // Declared before the registries so it is constructed first and can be
+  // injected into them.
+  const std::shared_ptr<css::CSSEventsEmitter> cssEventsEmitter_;
   const std::shared_ptr<CSSKeyframesRegistry> cssAnimationKeyframesRegistry_;
   const std::shared_ptr<CSSAnimationsRegistry> cssAnimationsRegistry_;
   const std::shared_ptr<CSSTransitionsRegistry> cssTransitionsRegistry_;

--- a/packages/react-native-reanimated/src/ReanimatedModule/NativeReanimated.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/NativeReanimated.ts
@@ -19,6 +19,7 @@ import type {
 } from '../commonTypes';
 import type {
   CSSAnimationUpdates,
+  CSSEventHandler,
   CSSPseudoStyleConfig,
   CSSTransitionConfig,
   NormalizedCSSAnimationKeyframesConfig,
@@ -183,6 +184,10 @@ See https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooti
     this.#reanimatedModuleProxy.setViewStyle(viewTag, style);
   }
 
+  setCSSEventHandler(handler: CSSEventHandler) {
+    this.#reanimatedModuleProxy.setCSSEventHandler(handler);
+  }
+
   markNodeAsRemovable(shadowNodeWrapper: ShadowNodeWrapper) {
     this.#reanimatedModuleProxy.markNodeAsRemovable(shadowNodeWrapper);
   }
@@ -213,12 +218,14 @@ See https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooti
   applyCSSAnimations(
     shadowNodeWrapper: ShadowNodeWrapper,
     compoundComponentName: string,
-    animationUpdates: CSSAnimationUpdates
+    animationUpdates: CSSAnimationUpdates,
+    eventMask: number
   ) {
     this.#reanimatedModuleProxy.applyCSSAnimations(
       shadowNodeWrapper,
       compoundComponentName,
-      animationUpdates
+      animationUpdates,
+      eventMask
     );
   }
 
@@ -269,6 +276,7 @@ class DummyReanimatedModuleProxy implements ReanimatedModuleProxy {
 
   unsubscribeFromKeyboardEvents(): void {}
   setViewStyle(): void {}
+  setCSSEventHandler(): void {}
   markNodeAsRemovable(): void {}
   unmarkNodeAsRemovable(): void {}
   registerCSSKeyframes(): void {}

--- a/packages/react-native-reanimated/src/ReanimatedModule/js-reanimated/JSReanimated.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/js-reanimated/JSReanimated.ts
@@ -18,6 +18,7 @@ import type {
 import { SensorType } from '../../commonTypes';
 import type {
   CSSAnimationUpdates,
+  CSSEventHandler,
   CSSTransitionConfig,
   NormalizedCSSAnimationKeyframesConfig,
 } from '../../css/native';
@@ -281,6 +282,12 @@ class JSReanimated implements IReanimatedModule {
     );
   }
 
+  setCSSEventHandler(_handler: CSSEventHandler): void {
+    throw new Error(
+      '[Reanimated] `setCSSEventHandler` is not available in JSReanimated.'
+    );
+  }
+
   markNodeAsRemovable(_shadowNodeWrapper: ShadowNodeWrapper): void {
     throw new Error(
       '[Reanimated] markNodeAsRemovable is not available in JSReanimated.'
@@ -315,7 +322,8 @@ class JSReanimated implements IReanimatedModule {
   applyCSSAnimations(
     _shadowNodeWrapper: ShadowNodeWrapper,
     _compoundComponentName: string,
-    _animationUpdates: CSSAnimationUpdates
+    _animationUpdates: CSSAnimationUpdates,
+    _eventMask: number
   ) {
     throw new Error(
       '[Reanimated] `applyCSSAnimations` is not available in JSReanimated.'

--- a/packages/react-native-reanimated/src/ReanimatedModule/reanimatedModuleProxy.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/reanimatedModuleProxy.ts
@@ -13,6 +13,7 @@ import type {
 } from '../commonTypes';
 import type {
   CSSAnimationUpdates,
+  CSSEventHandler,
   CSSPseudoStyleConfig,
   CSSTransitionConfig,
   NormalizedCSSAnimationKeyframesConfig,
@@ -63,6 +64,9 @@ export interface ReanimatedModuleProxy {
 
   setViewStyle(viewTag: number, style: StyleProps): void;
 
+  /** Registers the single handler receiving every CSS event batch. */
+  setCSSEventHandler(handler: CSSEventHandler): void;
+
   markNodeAsRemovable(shadowNodeWrapper: ShadowNodeWrapper): void;
   unmarkNodeAsRemovable(viewTag: number): void;
 
@@ -80,7 +84,8 @@ export interface ReanimatedModuleProxy {
   applyCSSAnimations(
     shadowNodeWrapper: ShadowNodeWrapper,
     compoundComponentName: string,
-    animationUpdates: CSSAnimationUpdates
+    animationUpdates: CSSAnimationUpdates,
+    eventMask: number
   ): void;
 
   unregisterCSSAnimations(viewTag: number): void;

--- a/packages/react-native-reanimated/src/css/native/events/CSSCallbacksRegistry.ts
+++ b/packages/react-native-reanimated/src/css/native/events/CSSCallbacksRegistry.ts
@@ -1,0 +1,72 @@
+'use strict';
+import { logger } from '../../../common';
+import type { CSSEventSubscriber, NativeCSSEvent } from './types';
+
+/**
+ * Routes CSS events emitted by the native side to the JS objects interested in
+ * a given view.
+ *
+ * Nested animated components can share a single view tag, so every tag keeps a
+ * set of subscribers instead of a single one.
+ */
+class CSSCallbacksRegistry {
+  private readonly subscribersByTag_ = new Map<
+    number,
+    Set<CSSEventSubscriber>
+  >();
+
+  register(viewTag: number, subscriber: CSSEventSubscriber): void {
+    const subscribers = this.subscribersByTag_.get(viewTag);
+    if (subscribers) {
+      subscribers.add(subscriber);
+    } else {
+      this.subscribersByTag_.set(viewTag, new Set([subscriber]));
+    }
+  }
+
+  unregister(viewTag: number, subscriber: CSSEventSubscriber): void {
+    const subscribers = this.subscribersByTag_.get(viewTag);
+    if (!subscribers) {
+      return;
+    }
+
+    subscribers.delete(subscriber);
+    if (subscribers.size === 0) {
+      this.subscribersByTag_.delete(viewTag);
+    }
+  }
+
+  dispatch(events: NativeCSSEvent[]): void {
+    for (const event of events) {
+      const subscribers = this.subscribersByTag_.get(event.tag);
+      if (!subscribers) {
+        // An event can outlive the view it was emitted for.
+        continue;
+      }
+
+      // Snapshot the subscribers as a user callback can mount or unmount views.
+      for (const subscriber of Array.from(subscribers)) {
+        this.deliver(subscriber, event);
+      }
+    }
+  }
+
+  clear(): void {
+    this.subscribersByTag_.clear();
+  }
+
+  private deliver(subscriber: CSSEventSubscriber, event: NativeCSSEvent): void {
+    try {
+      subscriber.handleCSSEvent(event);
+    } catch (error) {
+      // A throwing user callback must not drop the rest of the batch.
+      logger.error(
+        `A CSS "${event.type}" callback threw an error: ${String(error)}`
+      );
+    }
+  }
+}
+
+const cssCallbacksRegistry = new CSSCallbacksRegistry();
+
+export default cssCallbacksRegistry;

--- a/packages/react-native-reanimated/src/css/native/events/__tests__/CSSCallbacksRegistry.test.ts
+++ b/packages/react-native-reanimated/src/css/native/events/__tests__/CSSCallbacksRegistry.test.ts
@@ -1,0 +1,154 @@
+'use strict';
+import cssCallbacksRegistry from '../CSSCallbacksRegistry';
+import type { CSSEventSubscriber, NativeCSSEvent } from '../types';
+
+const event = (tag: number, name = 'anim'): NativeCSSEvent => ({
+  tag,
+  type: 'animationEnd',
+  name,
+  elapsedTime: 1,
+});
+
+const subscriber = (
+  handleCSSEvent: jest.Mock = jest.fn()
+): CSSEventSubscriber & { handleCSSEvent: jest.Mock } => ({ handleCSSEvent });
+
+describe('cssCallbacksRegistry', () => {
+  beforeEach(() => {
+    cssCallbacksRegistry.clear();
+  });
+
+  test('delivers an event to the subscriber registered for its tag', () => {
+    const sub = subscriber();
+    cssCallbacksRegistry.register(1, sub);
+
+    cssCallbacksRegistry.dispatch([event(1)]);
+
+    expect(sub.handleCSSEvent).toHaveBeenCalledWith(event(1));
+  });
+
+  test('delivers an event to every subscriber sharing a tag', () => {
+    const outer = subscriber();
+    const inner = subscriber();
+    cssCallbacksRegistry.register(1, outer);
+    cssCallbacksRegistry.register(1, inner);
+
+    cssCallbacksRegistry.dispatch([event(1)]);
+
+    expect(outer.handleCSSEvent).toHaveBeenCalledTimes(1);
+    expect(inner.handleCSSEvent).toHaveBeenCalledTimes(1);
+  });
+
+  test('registering the same subscriber twice delivers the event once', () => {
+    const sub = subscriber();
+    cssCallbacksRegistry.register(1, sub);
+    cssCallbacksRegistry.register(1, sub);
+
+    cssCallbacksRegistry.dispatch([event(1)]);
+
+    expect(sub.handleCSSEvent).toHaveBeenCalledTimes(1);
+  });
+
+  test('routes each event to the subscribers of its own tag', () => {
+    const first = subscriber();
+    const second = subscriber();
+    cssCallbacksRegistry.register(1, first);
+    cssCallbacksRegistry.register(2, second);
+
+    cssCallbacksRegistry.dispatch([event(2)]);
+
+    expect(first.handleCSSEvent).not.toHaveBeenCalled();
+    expect(second.handleCSSEvent).toHaveBeenCalledTimes(1);
+  });
+
+  test('unregistering one subscriber keeps the others attached', () => {
+    const outer = subscriber();
+    const inner = subscriber();
+    cssCallbacksRegistry.register(1, outer);
+    cssCallbacksRegistry.register(1, inner);
+
+    cssCallbacksRegistry.unregister(1, outer);
+    cssCallbacksRegistry.dispatch([event(1)]);
+
+    expect(outer.handleCSSEvent).not.toHaveBeenCalled();
+    expect(inner.handleCSSEvent).toHaveBeenCalledTimes(1);
+  });
+
+  test('drops the tag entry once its last subscriber is unregistered', () => {
+    const sub = subscriber();
+    cssCallbacksRegistry.register(1, sub);
+    cssCallbacksRegistry.unregister(1, sub);
+
+    // @ts-expect-error - reading a private field to assert there is no leak
+    expect(cssCallbacksRegistry.subscribersByTag_.has(1)).toBe(false);
+  });
+
+  test('unregistering an unknown tag or subscriber is a no-op', () => {
+    const sub = subscriber();
+    cssCallbacksRegistry.register(1, sub);
+
+    expect(() => {
+      cssCallbacksRegistry.unregister(2, sub);
+      cssCallbacksRegistry.unregister(1, subscriber());
+    }).not.toThrow();
+
+    cssCallbacksRegistry.dispatch([event(1)]);
+    expect(sub.handleCSSEvent).toHaveBeenCalledTimes(1);
+  });
+
+  test('an event for an unknown tag is silently ignored', () => {
+    const sub = subscriber();
+    cssCallbacksRegistry.register(1, sub);
+
+    expect(() => cssCallbacksRegistry.dispatch([event(99)])).not.toThrow();
+    expect(sub.handleCSSEvent).not.toHaveBeenCalled();
+  });
+
+  test('a throwing subscriber does not stop the rest of the batch', () => {
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    const throwing = subscriber(
+      jest.fn(() => {
+        throw new Error('[Reanimated] boom');
+      })
+    );
+    const healthy = subscriber();
+    cssCallbacksRegistry.register(1, throwing);
+    cssCallbacksRegistry.register(2, healthy);
+
+    cssCallbacksRegistry.dispatch([event(1), event(2), event(1)]);
+
+    expect(throwing.handleCSSEvent).toHaveBeenCalledTimes(2);
+    expect(healthy.handleCSSEvent).toHaveBeenCalledTimes(1);
+    expect(consoleError).toHaveBeenCalledTimes(2);
+
+    consoleError.mockRestore();
+  });
+
+  test('a subscriber unregistering itself while dispatching does not break the batch', () => {
+    const first: CSSEventSubscriber = {
+      handleCSSEvent: jest.fn(() => {
+        cssCallbacksRegistry.unregister(1, first);
+      }),
+    };
+    const second = subscriber();
+    cssCallbacksRegistry.register(1, first);
+    cssCallbacksRegistry.register(1, second);
+
+    cssCallbacksRegistry.dispatch([event(1)]);
+
+    expect(second.handleCSSEvent).toHaveBeenCalledTimes(1);
+  });
+
+  test('clear drops every subscription', () => {
+    const sub = subscriber();
+    cssCallbacksRegistry.register(1, sub);
+
+    cssCallbacksRegistry.clear();
+    cssCallbacksRegistry.dispatch([event(1)]);
+
+    expect(sub.handleCSSEvent).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react-native-reanimated/src/css/native/events/__tests__/mask.test.ts
+++ b/packages/react-native-reanimated/src/css/native/events/__tests__/mask.test.ts
@@ -1,0 +1,46 @@
+'use strict';
+import { getAnimationEventMaskFromProps } from '../mask';
+import { CSS_EVENT_MASK } from '../types';
+
+describe('getAnimationEventMaskFromProps', () => {
+  test('returns an empty mask when no prop is present', () => {
+    expect(getAnimationEventMaskFromProps([])).toBe(0);
+    expect(getAnimationEventMaskFromProps(new Set())).toBe(0);
+  });
+
+  test('maps each callback prop to its own bit', () => {
+    expect(getAnimationEventMaskFromProps(['onAnimationStart'])).toBe(
+      CSS_EVENT_MASK.animationStart
+    );
+    expect(getAnimationEventMaskFromProps(['onAnimationEnd'])).toBe(
+      CSS_EVENT_MASK.animationEnd
+    );
+    expect(getAnimationEventMaskFromProps(['onAnimationIteration'])).toBe(
+      CSS_EVENT_MASK.animationIteration
+    );
+    expect(getAnimationEventMaskFromProps(['onAnimationCancel'])).toBe(
+      CSS_EVENT_MASK.animationCancel
+    );
+  });
+
+  test('combines the bits of every present prop', () => {
+    expect(
+      getAnimationEventMaskFromProps(
+        new Set(['onAnimationStart', 'onAnimationCancel'] as const)
+      )
+    ).toBe(CSS_EVENT_MASK.animationStart | CSS_EVENT_MASK.animationCancel);
+  });
+
+  test('reserves the upper bits for transition events', () => {
+    expect(
+      getAnimationEventMaskFromProps([
+        'onAnimationStart',
+        'onAnimationEnd',
+        'onAnimationIteration',
+        'onAnimationCancel',
+      ])
+    ).toBe(0b1111);
+    expect(CSS_EVENT_MASK.transitionRun).toBe(1 << 4);
+    expect(CSS_EVENT_MASK.transitionCancel).toBe(1 << 7);
+  });
+});

--- a/packages/react-native-reanimated/src/css/native/events/index.ts
+++ b/packages/react-native-reanimated/src/css/native/events/index.ts
@@ -1,0 +1,11 @@
+'use strict';
+export { default as cssCallbacksRegistry } from './CSSCallbacksRegistry';
+export { getAnimationEventMaskFromProps } from './mask';
+export type {
+  CSSAnimationEventType,
+  CSSEventHandler,
+  CSSEventSubscriber,
+  CSSEventType,
+  NativeCSSEvent,
+} from './types';
+export { CSS_EVENT_MASK } from './types';

--- a/packages/react-native-reanimated/src/css/native/events/mask.ts
+++ b/packages/react-native-reanimated/src/css/native/events/mask.ts
@@ -1,0 +1,20 @@
+'use strict';
+import type { CSSAnimationCallbackProp } from '../../types';
+import { CSS_EVENT_MASK } from './types';
+
+const ANIMATION_EVENT_BIT_BY_PROP: Record<CSSAnimationCallbackProp, number> = {
+  onAnimationStart: CSS_EVENT_MASK.animationStart,
+  onAnimationEnd: CSS_EVENT_MASK.animationEnd,
+  onAnimationIteration: CSS_EVENT_MASK.animationIteration,
+  onAnimationCancel: CSS_EVENT_MASK.animationCancel,
+};
+
+export function getAnimationEventMaskFromProps(
+  props: Iterable<CSSAnimationCallbackProp>
+): number {
+  let mask = 0;
+  for (const prop of props) {
+    mask |= ANIMATION_EVENT_BIT_BY_PROP[prop];
+  }
+  return mask;
+}

--- a/packages/react-native-reanimated/src/css/native/events/types.ts
+++ b/packages/react-native-reanimated/src/css/native/events/types.ts
@@ -1,0 +1,47 @@
+'use strict';
+
+export type CSSAnimationEventType =
+  | 'animationStart'
+  | 'animationEnd'
+  | 'animationIteration'
+  | 'animationCancel';
+
+type CSSTransitionEventType =
+  | 'transitionRun'
+  | 'transitionStart'
+  | 'transitionEnd'
+  | 'transitionCancel';
+
+export type CSSEventType = CSSAnimationEventType | CSSTransitionEventType;
+
+/** A single CSS event as it comes from the native side. */
+export type NativeCSSEvent = {
+  tag: number;
+  type: CSSEventType;
+  /** Animation name for animation events, RN property name for transitions. */
+  name: string;
+  /** Already converted to seconds by the native side. */
+  elapsedTime: number;
+};
+
+export type CSSEventHandler = (events: NativeCSSEvent[]) => void;
+
+/** Receives the CSS events addressed to a single view tag. */
+export interface CSSEventSubscriber {
+  handleCSSEvent(event: NativeCSSEvent): void;
+}
+
+/**
+ * Bit requested for each event type. The native side emits an event only when
+ * its bit is set, so these values must stay in sync with the C++ ones.
+ */
+export const CSS_EVENT_MASK = {
+  animationStart: 1 << 0,
+  animationEnd: 1 << 1,
+  animationIteration: 1 << 2,
+  animationCancel: 1 << 3,
+  transitionRun: 1 << 4,
+  transitionStart: 1 << 5,
+  transitionEnd: 1 << 6,
+  transitionCancel: 1 << 7,
+} as const satisfies Record<CSSEventType, number>;

--- a/packages/react-native-reanimated/src/css/native/index.ts
+++ b/packages/react-native-reanimated/src/css/native/index.ts
@@ -1,4 +1,5 @@
 'use strict';
+export * from './events';
 export * from './keyframes';
 export * from './managers';
 export * from './normalization';

--- a/packages/react-native-reanimated/src/css/native/managers/CSSAnimationCallbacksManager.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/CSSAnimationCallbacksManager.ts
@@ -1,0 +1,92 @@
+'use strict';
+import { CSSCallbackStore } from '../../models';
+import type { CSSAnimationCallbackProp, CSSAnimationEvent } from '../../types';
+import type {
+  CSSAnimationEventType,
+  CSSEventSubscriber,
+  CSSEventType,
+  NativeCSSEvent,
+} from '../events';
+import {
+  cssCallbacksRegistry,
+  getAnimationEventMaskFromProps,
+} from '../events';
+
+const CALLBACK_PROP_BY_EVENT_TYPE: Record<
+  CSSAnimationEventType,
+  CSSAnimationCallbackProp
+> = {
+  animationStart: 'onAnimationStart',
+  animationEnd: 'onAnimationEnd',
+  animationIteration: 'onAnimationIteration',
+  animationCancel: 'onAnimationCancel',
+};
+
+const CALLBACK_PROPS = Object.values(CALLBACK_PROP_BY_EVENT_TYPE);
+
+const isAnimationEventType = (
+  type: CSSEventType
+): type is CSSAnimationEventType => type in CALLBACK_PROP_BY_EVENT_TYPE;
+
+/** A view tag of -1 means that the component has no mounted view yet. */
+const NO_VIEW_TAG = -1;
+
+export default class CSSAnimationCallbacksManager
+  extends CSSCallbackStore<CSSAnimationCallbackProp, CSSAnimationEvent>
+  implements CSSEventSubscriber
+{
+  private readonly viewTag: number;
+  private eventMask = 0;
+  private isRegistered = false;
+
+  constructor(viewTag: number) {
+    super(CALLBACK_PROPS);
+    this.viewTag = viewTag;
+  }
+
+  /** Bitmask of the events the native side has to emit for this view. */
+  getMask(): number {
+    return this.eventMask;
+  }
+
+  handleCSSEvent(event: NativeCSSEvent): void {
+    if (!isAnimationEventType(event.type)) {
+      return;
+    }
+
+    this.invoke(CALLBACK_PROP_BY_EVENT_TYPE[event.type], {
+      animationName: event.name,
+      elapsedTime: event.elapsedTime,
+    });
+  }
+
+  protected onPresenceChanged(
+    _added: readonly CSSAnimationCallbackProp[],
+    _removed: readonly CSSAnimationCallbackProp[],
+    present: ReadonlySet<CSSAnimationCallbackProp>
+  ): void {
+    this.eventMask = getAnimationEventMaskFromProps(present);
+
+    if (present.size > 0) {
+      this.register();
+    } else {
+      this.unregister();
+    }
+  }
+
+  private register(): void {
+    if (this.isRegistered || this.viewTag === NO_VIEW_TAG) {
+      return;
+    }
+    this.isRegistered = true;
+    cssCallbacksRegistry.register(this.viewTag, this);
+  }
+
+  private unregister(): void {
+    if (!this.isRegistered) {
+      return;
+    }
+    this.isRegistered = false;
+    cssCallbacksRegistry.unregister(this.viewTag, this);
+  }
+}

--- a/packages/react-native-reanimated/src/css/native/managers/CSSAnimationsManager.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/CSSAnimationsManager.ts
@@ -1,6 +1,7 @@
 'use strict';
 import type { ShadowNodeWrapper } from '../../../commonTypes';
 import type {
+  CSSAnimationCallbacks,
   CSSAnimationKeyframes,
   ExistingCSSAnimationProperties,
   ICSSAnimationsManager,
@@ -16,6 +17,7 @@ import type {
   CSSAnimationUpdates,
   NormalizedSingleCSSAnimationSettings,
 } from '../types';
+import CSSAnimationCallbacksManager from './CSSAnimationCallbacksManager';
 
 type ProcessedAnimation = {
   normalizedSettings: NormalizedSingleCSSAnimationSettings;
@@ -26,8 +28,10 @@ export default class CSSAnimationsManager implements ICSSAnimationsManager {
   private readonly shadowNodeWrapper: ShadowNodeWrapper;
   private readonly viewTag: number;
   private readonly compoundComponentName: string;
+  private readonly callbacksManager: CSSAnimationCallbacksManager;
 
   private attachedAnimations: ProcessedAnimation[] = [];
+  private appliedEventMask = 0;
 
   constructor(
     shadowNodeWrapper: ShadowNodeWrapper,
@@ -37,9 +41,18 @@ export default class CSSAnimationsManager implements ICSSAnimationsManager {
     this.shadowNodeWrapper = shadowNodeWrapper;
     this.viewTag = viewTag;
     this.compoundComponentName = compoundComponentName;
+    this.callbacksManager = new CSSAnimationCallbacksManager(viewTag);
   }
 
-  update(animationProperties: ExistingCSSAnimationProperties | null): void {
+  update(
+    animationProperties: ExistingCSSAnimationProperties | null,
+    callbacks: CSSAnimationCallbacks | null = null
+  ): void {
+    // Callbacks are synced before the animations are touched so that a cancel
+    // emitted while detaching still reaches the user.
+    this.callbacksManager.sync(callbacks ?? {});
+    const eventMask = this.callbacksManager.getMask();
+
     if (!animationProperties) {
       this.detach();
       return;
@@ -60,16 +73,27 @@ export default class CSSAnimationsManager implements ICSSAnimationsManager {
         return;
       }
 
-      applyCSSAnimations(
-        this.shadowNodeWrapper,
-        this.compoundComponentName,
-        animationUpdates
-      );
+      this.apply(animationUpdates, eventMask);
+    } else if (eventMask !== this.appliedEventMask) {
+      // The requested events changed while the animations themselves did not,
+      // so the native side still has to learn about the new mask.
+      this.apply({}, eventMask);
     }
   }
 
   unmountCleanup(): void {
+    this.callbacksManager.detach();
     this.unregisterKeyframesUsage();
+  }
+
+  private apply(animationUpdates: CSSAnimationUpdates, eventMask: number) {
+    this.appliedEventMask = eventMask;
+    applyCSSAnimations(
+      this.shadowNodeWrapper,
+      this.compoundComponentName,
+      animationUpdates,
+      eventMask
+    );
   }
 
   private detach() {
@@ -77,6 +101,7 @@ export default class CSSAnimationsManager implements ICSSAnimationsManager {
       unregisterCSSAnimations(this.viewTag);
       this.unregisterKeyframesUsage();
       this.attachedAnimations = [];
+      this.appliedEventMask = 0;
     }
   }
 

--- a/packages/react-native-reanimated/src/css/native/managers/CSSManager.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/CSSManager.ts
@@ -59,7 +59,7 @@ export default class CSSManager implements ICSSManager {
       animationProperties,
       transitionProperties,
       pseudoStylesBySelector,
-      ,
+      animationCallbacks,
       ,
       filteredStyle,
     ] = filterCSSAndStyleProperties(style);
@@ -88,7 +88,7 @@ export default class CSSManager implements ICSSManager {
       setViewStyle(this.viewTag, normalizedStyle);
     }
 
-    this.cssAnimationsManager.update(animationProperties);
+    this.cssAnimationsManager.update(animationProperties, animationCallbacks);
     this.cssPseudoStylesManager.update(
       pseudoStylesBySelector,
       transitionProperties

--- a/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSAnimationCallbacksManager.test.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSAnimationCallbacksManager.test.ts
@@ -1,0 +1,198 @@
+'use strict';
+import type { CSSEventType, NativeCSSEvent } from '../../events';
+import { CSS_EVENT_MASK, cssCallbacksRegistry } from '../../events';
+import CSSAnimationCallbacksManager from '../CSSAnimationCallbacksManager';
+
+const VIEW_TAG = 1;
+
+const event = (
+  type: CSSEventType,
+  overrides: Partial<NativeCSSEvent> = {}
+): NativeCSSEvent => ({
+  tag: VIEW_TAG,
+  type,
+  name: 'fadeIn',
+  elapsedTime: 0.25,
+  ...overrides,
+});
+
+describe('CSSAnimationCallbacksManager', () => {
+  let manager: CSSAnimationCallbacksManager;
+
+  beforeEach(() => {
+    cssCallbacksRegistry.clear();
+    manager = new CSSAnimationCallbacksManager(VIEW_TAG);
+  });
+
+  describe('mask', () => {
+    test('starts empty', () => {
+      expect(manager.getMask()).toBe(0);
+    });
+
+    test('reflects the provided callbacks', () => {
+      manager.sync({ onAnimationEnd: jest.fn() });
+
+      expect(manager.getMask()).toBe(CSS_EVENT_MASK.animationEnd);
+    });
+
+    test('drops the bit of a removed callback', () => {
+      manager.sync({ onAnimationEnd: jest.fn(), onAnimationStart: jest.fn() });
+      manager.sync({ onAnimationEnd: jest.fn() });
+
+      expect(manager.getMask()).toBe(CSS_EVENT_MASK.animationEnd);
+    });
+
+    test('is empty again after detach', () => {
+      manager.sync({ onAnimationEnd: jest.fn() });
+      manager.detach();
+
+      expect(manager.getMask()).toBe(0);
+    });
+  });
+
+  describe('event delivery', () => {
+    test('maps the native payload to the public animation event', () => {
+      const onAnimationEnd = jest.fn();
+      manager.sync({ onAnimationEnd });
+
+      cssCallbacksRegistry.dispatch([
+        event('animationEnd', { name: 'pulse', elapsedTime: 1.5 }),
+      ]);
+
+      expect(onAnimationEnd).toHaveBeenCalledWith({
+        animationName: 'pulse',
+        elapsedTime: 1.5,
+      });
+    });
+
+    test('routes every animation event type to its own callback', () => {
+      const callbacks = {
+        onAnimationStart: jest.fn(),
+        onAnimationEnd: jest.fn(),
+        onAnimationIteration: jest.fn(),
+        onAnimationCancel: jest.fn(),
+      };
+      manager.sync(callbacks);
+
+      cssCallbacksRegistry.dispatch([
+        event('animationStart'),
+        event('animationEnd'),
+        event('animationIteration'),
+        event('animationCancel'),
+      ]);
+
+      expect(callbacks.onAnimationStart).toHaveBeenCalledTimes(1);
+      expect(callbacks.onAnimationEnd).toHaveBeenCalledTimes(1);
+      expect(callbacks.onAnimationIteration).toHaveBeenCalledTimes(1);
+      expect(callbacks.onAnimationCancel).toHaveBeenCalledTimes(1);
+    });
+
+    test('ignores transition events', () => {
+      const onAnimationEnd = jest.fn();
+      manager.sync({ onAnimationEnd });
+
+      cssCallbacksRegistry.dispatch([event('transitionEnd')]);
+
+      expect(onAnimationEnd).not.toHaveBeenCalled();
+    });
+
+    test('invokes the callback from the latest sync', () => {
+      const first = jest.fn();
+      const second = jest.fn();
+      manager.sync({ onAnimationEnd: first });
+      manager.sync({ onAnimationEnd: second });
+
+      cssCallbacksRegistry.dispatch([event('animationEnd')]);
+
+      expect(first).not.toHaveBeenCalled();
+      expect(second).toHaveBeenCalledTimes(1);
+    });
+
+    test('stops delivering once the callback is removed', () => {
+      const onAnimationEnd = jest.fn();
+      manager.sync({ onAnimationEnd });
+      manager.sync({});
+
+      cssCallbacksRegistry.dispatch([event('animationEnd')]);
+
+      expect(onAnimationEnd).not.toHaveBeenCalled();
+    });
+
+    test('stops delivering after detach and resumes after a new sync', () => {
+      const onAnimationEnd = jest.fn();
+      manager.sync({ onAnimationEnd });
+      manager.detach();
+
+      cssCallbacksRegistry.dispatch([event('animationEnd')]);
+      expect(onAnimationEnd).not.toHaveBeenCalled();
+
+      manager.sync({ onAnimationEnd });
+      cssCallbacksRegistry.dispatch([event('animationEnd')]);
+      expect(onAnimationEnd).toHaveBeenCalledTimes(1);
+    });
+
+    test('ignores events addressed to another view', () => {
+      const onAnimationEnd = jest.fn();
+      manager.sync({ onAnimationEnd });
+
+      cssCallbacksRegistry.dispatch([event('animationEnd', { tag: 2 })]);
+
+      expect(onAnimationEnd).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('registration', () => {
+    test('registers only once no matter how many callbacks are added', () => {
+      const registerSpy = jest.spyOn(cssCallbacksRegistry, 'register');
+
+      manager.sync({ onAnimationStart: jest.fn() });
+      manager.sync({ onAnimationStart: jest.fn(), onAnimationEnd: jest.fn() });
+
+      expect(registerSpy).toHaveBeenCalledTimes(1);
+
+      registerSpy.mockRestore();
+    });
+
+    test('unregisters when the last callback is removed', () => {
+      const unregisterSpy = jest.spyOn(cssCallbacksRegistry, 'unregister');
+
+      manager.sync({ onAnimationStart: jest.fn() });
+      manager.sync({ onAnimationStart: undefined });
+
+      expect(unregisterSpy).toHaveBeenCalledWith(VIEW_TAG, manager);
+
+      unregisterSpy.mockRestore();
+    });
+
+    test('does not register a view that has no tag yet', () => {
+      const registerSpy = jest.spyOn(cssCallbacksRegistry, 'register');
+      const tagless = new CSSAnimationCallbacksManager(-1);
+
+      const onAnimationEnd = jest.fn();
+      tagless.sync({ onAnimationEnd });
+
+      expect(registerSpy).not.toHaveBeenCalled();
+      expect(tagless.getMask()).toBe(CSS_EVENT_MASK.animationEnd);
+
+      cssCallbacksRegistry.dispatch([event('animationEnd', { tag: -1 })]);
+      expect(onAnimationEnd).not.toHaveBeenCalled();
+
+      registerSpy.mockRestore();
+    });
+
+    test('keeps nested components with the same tag independent', () => {
+      const outer = jest.fn();
+      const inner = jest.fn();
+      const otherManager = new CSSAnimationCallbacksManager(VIEW_TAG);
+
+      manager.sync({ onAnimationEnd: outer });
+      otherManager.sync({ onAnimationEnd: inner });
+      manager.detach();
+
+      cssCallbacksRegistry.dispatch([event('animationEnd')]);
+
+      expect(outer).not.toHaveBeenCalled();
+      expect(inner).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSAnimationsManager.test.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSAnimationsManager.test.ts
@@ -4,6 +4,7 @@ import type { ShadowNodeWrapper } from '../../../../commonTypes';
 import { ANIMATION_NAME_PREFIX } from '../../../constants';
 import { CSSKeyframesRuleBase } from '../../../models';
 import type { CSSAnimationProperties } from '../../../types';
+import { CSS_EVENT_MASK, cssCallbacksRegistry } from '../../events';
 import { cssKeyframesRegistry, CSSKeyframesRuleImpl } from '../../keyframes';
 import { normalizeSingleCSSAnimationSettings } from '../../normalization';
 import {
@@ -45,6 +46,7 @@ describe('CSSAnimationsManager', () => {
     // @ts-expect-error - reset private property
     CSSKeyframesRuleBase.currentAnimationID = 0;
     cssKeyframesRegistry.clear();
+    cssCallbacksRegistry.clear();
   });
 
   // TODO - add tests with keyframes rule class
@@ -70,7 +72,8 @@ describe('CSSAnimationsManager', () => {
             newAnimationSettings: {
               0: normalizeSingleCSSAnimationSettings(animationProperties),
             },
-          }
+          },
+          0
         );
 
         expect(unregisterCSSAnimations).not.toHaveBeenCalled();
@@ -106,7 +109,8 @@ describe('CSSAnimationsManager', () => {
             settingsUpdates: {
               0: { duration: 3000, timingFunction: 'ease-in', delay: 0 },
             },
-          }
+          },
+          0
         );
         expect(unregisterCSSAnimations).not.toHaveBeenCalled();
       });
@@ -140,7 +144,8 @@ describe('CSSAnimationsManager', () => {
             newAnimationSettings: {
               0: normalizeSingleCSSAnimationSettings(newAnimationProperties),
             },
-          }
+          },
+          0
         );
         expect(unregisterCSSAnimations).not.toHaveBeenCalled();
       });
@@ -212,7 +217,8 @@ describe('CSSAnimationsManager', () => {
         expect(applyCSSAnimations).toHaveBeenLastCalledWith(
           shadowNodeWrapper,
           COMPOUND_COMPONENT_NAME,
-          expect.objectContaining({ animationNames: [rule2.name] })
+          expect.objectContaining({ animationNames: [rule2.name] }),
+          0
         );
       });
 
@@ -290,7 +296,8 @@ describe('CSSAnimationsManager', () => {
                 0: expect.objectContaining({ duration: 2000 }),
                 1: expect.objectContaining({ duration: 2000 }),
               },
-            }
+            },
+            0
           );
 
           manager.update({
@@ -304,7 +311,8 @@ describe('CSSAnimationsManager', () => {
             COMPOUND_COMPONENT_NAME,
             {
               animationNames: [animation2Name, animation1Name],
-            }
+            },
+            0
           );
         });
 
@@ -324,7 +332,8 @@ describe('CSSAnimationsManager', () => {
                 0: expect.objectContaining({ duration: 2000 }),
                 1: expect.objectContaining({ duration: 500 }),
               },
-            }
+            },
+            0
           );
 
           manager.update({
@@ -342,7 +351,8 @@ describe('CSSAnimationsManager', () => {
                 0: { duration: 2000 },
                 1: { duration: 500 },
               },
-            }
+            },
+            0
           );
         });
       });
@@ -392,6 +402,100 @@ describe('CSSAnimationsManager', () => {
         expect(unregisterCSSAnimations).not.toHaveBeenCalled();
         expect(applyCSSAnimations).not.toHaveBeenCalled();
       });
+    });
+  });
+
+  describe('animation callbacks', () => {
+    const ANIMATION = {
+      animationName: { from: { opacity: 0 } },
+      animationDuration: '2s',
+    } satisfies CSSAnimationProperties;
+
+    test('requests the events matching the provided callbacks', () => {
+      manager.update(ANIMATION, { onAnimationEnd: jest.fn() });
+
+      expect(applyCSSAnimations).toHaveBeenLastCalledWith(
+        shadowNodeWrapper,
+        COMPOUND_COMPONENT_NAME,
+        expect.anything(),
+        CSS_EVENT_MASK.animationEnd
+      );
+    });
+
+    test('sends the new mask when only the set of callbacks changes', () => {
+      manager.update(ANIMATION, { onAnimationEnd: jest.fn() });
+      manager.update(ANIMATION, {
+        onAnimationEnd: jest.fn(),
+        onAnimationStart: jest.fn(),
+      });
+
+      expect(applyCSSAnimations).toHaveBeenCalledTimes(2);
+      expect(applyCSSAnimations).toHaveBeenLastCalledWith(
+        shadowNodeWrapper,
+        COMPOUND_COMPONENT_NAME,
+        {},
+        CSS_EVENT_MASK.animationEnd | CSS_EVENT_MASK.animationStart
+      );
+    });
+
+    test('does not re-apply when only the callback identity changes', () => {
+      manager.update(ANIMATION, { onAnimationEnd: jest.fn() });
+      manager.update(ANIMATION, { onAnimationEnd: jest.fn() });
+
+      expect(applyCSSAnimations).toHaveBeenCalledTimes(1);
+    });
+
+    test('delivers a native event to the provided callback', () => {
+      const onAnimationEnd = jest.fn();
+      manager.update(ANIMATION, { onAnimationEnd });
+
+      cssCallbacksRegistry.dispatch([
+        {
+          tag: viewTag,
+          type: 'animationEnd',
+          name: animationName(0),
+          elapsedTime: 2,
+        },
+      ]);
+
+      expect(onAnimationEnd).toHaveBeenCalledWith({
+        animationName: animationName(0),
+        elapsedTime: 2,
+      });
+    });
+
+    test('keeps delivering events while the animation detaches', () => {
+      const onAnimationCancel = jest.fn();
+      manager.update(ANIMATION, { onAnimationCancel });
+      manager.update(null, { onAnimationCancel });
+
+      cssCallbacksRegistry.dispatch([
+        {
+          tag: viewTag,
+          type: 'animationCancel',
+          name: animationName(0),
+          elapsedTime: 0.5,
+        },
+      ]);
+
+      expect(onAnimationCancel).toHaveBeenCalledTimes(1);
+    });
+
+    test('stops delivering events after unmount cleanup', () => {
+      const onAnimationEnd = jest.fn();
+      manager.update(ANIMATION, { onAnimationEnd });
+      manager.unmountCleanup();
+
+      cssCallbacksRegistry.dispatch([
+        {
+          tag: viewTag,
+          type: 'animationEnd',
+          name: animationName(0),
+          elapsedTime: 2,
+        },
+      ]);
+
+      expect(onAnimationEnd).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/react-native-reanimated/src/css/native/proxy.ts
+++ b/packages/react-native-reanimated/src/css/native/proxy.ts
@@ -1,6 +1,7 @@
 'use strict';
 import type { ShadowNodeWrapper, StyleProps } from '../../commonTypes';
 import { ReanimatedModule } from '../../ReanimatedModule';
+import type { CSSEventHandler } from './events';
 import type {
   CSSAnimationUpdates,
   CSSPseudoStyleConfig,
@@ -12,6 +13,12 @@ import type {
 
 export function setViewStyle(viewTag: number, style: StyleProps) {
   ReanimatedModule.setViewStyle(viewTag, style);
+}
+
+// EVENTS
+
+export function setCSSEventHandler(handler: CSSEventHandler) {
+  ReanimatedModule.setCSSEventHandler(handler);
 }
 
 export function markNodeAsRemovable(shadowNodeWrapper: ShadowNodeWrapper) {
@@ -50,12 +57,14 @@ export function unregisterCSSKeyframes(
 export function applyCSSAnimations(
   shadowNodeWrapper: ShadowNodeWrapper,
   compoundComponentName: string,
-  animationUpdates: CSSAnimationUpdates
+  animationUpdates: CSSAnimationUpdates,
+  eventMask: number
 ) {
   ReanimatedModule.applyCSSAnimations(
     shadowNodeWrapper,
     compoundComponentName,
-    animationUpdates
+    animationUpdates,
+    eventMask
   );
 }
 

--- a/packages/react-native-reanimated/src/css/types/interfaces.ts
+++ b/packages/react-native-reanimated/src/css/types/interfaces.ts
@@ -1,11 +1,17 @@
 'use strict';
 import type { PseudoStylesBySelector } from '../utils';
-import type { ExistingCSSAnimationProperties } from './animation';
+import type {
+  CSSAnimationCallbacks,
+  ExistingCSSAnimationProperties,
+} from './animation';
 import type { CSSStyle } from './props';
 import type { CSSTransitionProperties } from './transition';
 
 export interface ICSSAnimationsManager {
-  update(animationProperties: ExistingCSSAnimationProperties | null): void;
+  update(
+    animationProperties: ExistingCSSAnimationProperties | null,
+    callbacks?: CSSAnimationCallbacks | null
+  ): void;
   unmountCleanup(): void;
 }
 

--- a/packages/react-native-reanimated/src/initializers.native.ts
+++ b/packages/react-native-reanimated/src/initializers.native.ts
@@ -6,6 +6,8 @@ import {
   toggleSlowAnimationsOnUIRuntime,
 } from 'react-native-worklets';
 
+import { cssCallbacksRegistry } from './css/native/events';
+import { setCSSEventHandler } from './css/native/proxy';
 import { initSvgCssSupport } from './css/svg';
 import { getStaticFeatureFlag } from './featureFlags';
 import type { IReanimatedModule } from './ReanimatedModule';
@@ -18,6 +20,7 @@ export function initializeReanimatedModule(
       '[Reanimated] Tried to initialize Reanimated without a valid ReanimatedModule'
     );
   }
+  setCSSEventHandler((events) => cssCallbacksRegistry.dispatch(events));
   if (getStaticFeatureFlag('EXPERIMENTAL_CSS_ANIMATIONS_FOR_SVG_COMPONENTS')) {
     initSvgCssSupport();
   }


### PR DESCRIPTION
Engine-side half of CSS animation callbacks: a channel that detects animation lifecycle boundaries and hands them to JS in batches. Nothing consumes it yet, so this is inert on its own; #10070 wires it up.

Boundaries are found by diffing the animation progress state around each tick and reported through the existing `CSSAnimation::Observer` seam, so detection lives in one place rather than being reimplemented per platform. It is also renderer independent: `CSSAnimation::schedule` always ticks the loop animation and platform routing only narrows which properties the interpolator writes, so the same clock drives events whether or not a property is handed to a platform backend. That is why there is no iOS or Android specific code here.

A view opts in with a bitmask travelling alongside the animation config it already sends, so a view without callbacks costs one hash lookup per event and never allocates. The mask argument is optional, which is what keeps this PR safe to land before the JS side starts sending it.

Events are buffered per frame and flushed after the registry lock is released, since calling into JS while holding it risks a lock order inversion against the shadow tree commit. Both frame drivers flush, so events are not silently dropped under `USE_ANIMATION_BACKEND`.

`elapsedTime` is converted to seconds once, in the event factory, matching the contract already shipped on web.

## Test plan

Builds on an iOS simulator, and the example app behaves exactly as before, which is the point: with no JS sending a mask, no events are emitted and nothing changes. Verified end to end once the full stack is applied, see #10070.

Stacked on #10068. Supersedes #9097.