### PR TITLE
chore: add a CSS animation callbacks example

### DIFF
--- a/apps/common-app/src/apps/css/examples/animations/routes/index.ts
+++ b/apps/common-app/src/apps/css/examples/animations/routes/index.ts
@@ -54,6 +54,10 @@ const routes = {
     CardComponent: routeCards.MiscellaneousCard,
     name: 'Miscellaneous',
     routes: {
+      AnimationCallbacks: {
+        Component: miscellaneous.AnimationCallbacks,
+        name: 'Animation Callbacks',
+      },
       ChangingAnimation: {
         Component: miscellaneous.ChangingAnimation,
         name: 'Changing Animation',

--- a/apps/common-app/src/apps/css/examples/animations/screens/miscellaneous/AnimationCallbacks.tsx
+++ b/apps/common-app/src/apps/css/examples/animations/screens/miscellaneous/AnimationCallbacks.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { FlatList, StyleSheet, View } from 'react-native';
 import type { CSSAnimationProperties } from 'react-native-reanimated';
 import Animated, { css } from 'react-native-reanimated';
@@ -47,17 +47,43 @@ export default function AnimationCallbacks() {
     ]);
   }, []);
 
+  // A queued re-attach would otherwise land after a cancel and undo it.
+  const restartFrame = useRef<number | null>(null);
+
+  const cancelPendingRestart = useCallback(() => {
+    if (restartFrame.current !== null) {
+      cancelAnimationFrame(restartFrame.current);
+      restartFrame.current = null;
+    }
+  }, []);
+
+  useEffect(() => cancelPendingRestart, [cancelPendingRestart]);
+
   const restart = useCallback(
     (properties: CSSAnimationProperties) => {
+      cancelPendingRestart();
       setEvents([]);
       setIsMounted(true);
       // Detaching first guarantees a fresh animation rather than a settings
       // update on the running one.
       setAnimation(null);
-      requestAnimationFrame(() => setAnimation(properties));
+      restartFrame.current = requestAnimationFrame(() => {
+        restartFrame.current = null;
+        setAnimation(properties);
+      });
     },
-    [setAnimation]
+    [cancelPendingRestart]
   );
+
+  const cancel = useCallback(() => {
+    cancelPendingRestart();
+    setAnimation(null);
+  }, [cancelPendingRestart]);
+
+  const unmount = useCallback(() => {
+    cancelPendingRestart();
+    setIsMounted(false);
+  }, [cancelPendingRestart]);
 
   return (
     <Screen style={styles.screen}>
@@ -76,16 +102,8 @@ export default function AnimationCallbacks() {
               title="Infinite"
               onPress={() => restart(INFINITE)}
             />
-            <Button
-              style={flex.grow}
-              title="Cancel"
-              onPress={() => setAnimation(null)}
-            />
-            <Button
-              style={flex.grow}
-              title="Unmount"
-              onPress={() => setIsMounted(false)}
-            />
+            <Button style={flex.grow} title="Cancel" onPress={cancel} />
+            <Button style={flex.grow} title="Unmount" onPress={unmount} />
             <Button
               style={flex.grow}
               title="Clear log"

--- a/apps/common-app/src/apps/css/examples/animations/screens/miscellaneous/AnimationCallbacks.tsx
+++ b/apps/common-app/src/apps/css/examples/animations/screens/miscellaneous/AnimationCallbacks.tsx
@@ -1,0 +1,167 @@
+import { useCallback, useState } from 'react';
+import { StyleSheet, View } from 'react-native';
+import type { CSSAnimationProperties } from 'react-native-reanimated';
+import Animated, { css } from 'react-native-reanimated';
+
+import {
+  Button,
+  ScrollScreen,
+  Section,
+  Stagger,
+  Text,
+} from '@/apps/css/components';
+import { colors, flex, radius, sizes, spacing } from '@/theme';
+
+const pulse = css.keyframes({
+  '0%, 100%': {
+    transform: [{ scale: 1 }],
+  },
+  '50%': {
+    transform: [{ scale: 1.5 }],
+  },
+});
+
+const FINITE: CSSAnimationProperties = {
+  animationDelay: '500ms',
+  animationDuration: '1s',
+  animationIterationCount: 3,
+  animationName: pulse,
+};
+
+const INFINITE: CSSAnimationProperties = {
+  animationDuration: '1s',
+  animationIterationCount: 'infinite',
+  animationName: pulse,
+};
+
+type LoggedEvent = {
+  id: number;
+  label: string;
+};
+
+export default function AnimationCallbacks() {
+  const [events, setEvents] = useState<Array<LoggedEvent>>([]);
+  const [animation, setAnimation] = useState<CSSAnimationProperties | null>(
+    FINITE
+  );
+  const [isMounted, setIsMounted] = useState(true);
+
+  const log = useCallback((type: string, elapsedTime: number) => {
+    setEvents((current) => [
+      ...current,
+      { id: current.length, label: `${type} at ${elapsedTime.toFixed(2)}s` },
+    ]);
+  }, []);
+
+  const restart = useCallback(
+    (properties: CSSAnimationProperties) => {
+      setEvents([]);
+      setIsMounted(true);
+      // Detaching first guarantees a fresh animation rather than a settings
+      // update on the running one.
+      setAnimation(null);
+      requestAnimationFrame(() => setAnimation(properties));
+    },
+    [setAnimation]
+  );
+
+  return (
+    <ScrollScreen>
+      <Stagger>
+        <Section
+          description="Animation lifecycle callbacks fired by the **native** CSS engine. `elapsedTime` is reported in **seconds**."
+          title="Animation Callbacks">
+          <View style={styles.content}>
+            <View style={styles.buttons}>
+              <Button
+                style={flex.grow}
+                title="Finite (3x)"
+                onPress={() => restart(FINITE)}
+              />
+              <Button
+                style={flex.grow}
+                title="Infinite"
+                onPress={() => restart(INFINITE)}
+              />
+              <Button
+                style={flex.grow}
+                title="Cancel"
+                onPress={() => setAnimation(null)}
+              />
+              <Button
+                style={flex.grow}
+                title="Unmount"
+                onPress={() => setIsMounted(false)}
+              />
+            </View>
+
+            <View style={styles.preview}>
+              {isMounted && (
+                <Animated.View
+                  style={[
+                    styles.box,
+                    animation,
+                    {
+                      onAnimationCancel: ({ elapsedTime }) =>
+                        log('cancel', elapsedTime),
+                      onAnimationEnd: ({ elapsedTime }) =>
+                        log('end', elapsedTime),
+                      onAnimationIteration: ({ elapsedTime }) =>
+                        log('iteration', elapsedTime),
+                      onAnimationStart: ({ elapsedTime }) =>
+                        log('start', elapsedTime),
+                    },
+                  ]}
+                />
+              )}
+            </View>
+          </View>
+        </Section>
+
+        <Section description="In order of arrival" title="Event Log">
+          <View style={styles.log}>
+            {events.length === 0 ? (
+              <Text variant="subHeading2">No events yet</Text>
+            ) : (
+              events.map((event) => (
+                <Text key={event.id} variant="body1">
+                  {event.label}
+                </Text>
+              ))
+            )}
+          </View>
+        </Section>
+      </Stagger>
+    </ScrollScreen>
+  );
+}
+
+const styles = StyleSheet.create({
+  box: {
+    backgroundColor: colors.primary,
+    borderRadius: radius.sm,
+    height: sizes.md,
+    width: sizes.md,
+  },
+  buttons: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.xxs,
+    justifyContent: 'space-between',
+  },
+  content: {
+    gap: spacing.xs,
+  },
+  log: {
+    backgroundColor: colors.background2,
+    borderRadius: radius.sm,
+    gap: spacing.xxxs,
+    padding: spacing.xs,
+  },
+  preview: {
+    ...flex.center,
+    backgroundColor: colors.background2,
+    borderRadius: radius.md,
+    height: sizes.xxl,
+  },
+});

--- a/apps/common-app/src/apps/css/examples/animations/screens/miscellaneous/AnimationCallbacks.tsx
+++ b/apps/common-app/src/apps/css/examples/animations/screens/miscellaneous/AnimationCallbacks.tsx
@@ -116,7 +116,7 @@ export default function AnimationCallbacks() {
         </View>
       </Section>
 
-      <Section fill description="In order of arrival" title="Event Log">
+      <Section description="In order of arrival" title="Event Log" fill>
         <FlatList
           contentContainerStyle={styles.logContent}
           data={events}

--- a/apps/common-app/src/apps/css/examples/animations/screens/miscellaneous/AnimationCallbacks.tsx
+++ b/apps/common-app/src/apps/css/examples/animations/screens/miscellaneous/AnimationCallbacks.tsx
@@ -1,15 +1,9 @@
 import { useCallback, useState } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { FlatList, StyleSheet, View } from 'react-native';
 import type { CSSAnimationProperties } from 'react-native-reanimated';
 import Animated, { css } from 'react-native-reanimated';
 
-import {
-  Button,
-  ScrollScreen,
-  Section,
-  Stagger,
-  Text,
-} from '@/apps/css/components';
+import { Button, Screen, Section, Text } from '@/apps/css/components';
 import { colors, flex, radius, sizes, spacing } from '@/theme';
 
 const pulse = css.keyframes({
@@ -66,73 +60,73 @@ export default function AnimationCallbacks() {
   );
 
   return (
-    <ScrollScreen>
-      <Stagger>
-        <Section
-          description="Animation lifecycle callbacks fired by the **native** CSS engine. `elapsedTime` is reported in **seconds**."
-          title="Animation Callbacks">
-          <View style={styles.content}>
-            <View style={styles.buttons}>
-              <Button
-                style={flex.grow}
-                title="Finite (3x)"
-                onPress={() => restart(FINITE)}
-              />
-              <Button
-                style={flex.grow}
-                title="Infinite"
-                onPress={() => restart(INFINITE)}
-              />
-              <Button
-                style={flex.grow}
-                title="Cancel"
-                onPress={() => setAnimation(null)}
-              />
-              <Button
-                style={flex.grow}
-                title="Unmount"
-                onPress={() => setIsMounted(false)}
-              />
-            </View>
-
-            <View style={styles.preview}>
-              {isMounted && (
-                <Animated.View
-                  style={[
-                    styles.box,
-                    animation,
-                    {
-                      onAnimationCancel: ({ elapsedTime }) =>
-                        log('cancel', elapsedTime),
-                      onAnimationEnd: ({ elapsedTime }) =>
-                        log('end', elapsedTime),
-                      onAnimationIteration: ({ elapsedTime }) =>
-                        log('iteration', elapsedTime),
-                      onAnimationStart: ({ elapsedTime }) =>
-                        log('start', elapsedTime),
-                    },
-                  ]}
-                />
-              )}
-            </View>
+    <Screen style={styles.screen}>
+      <Section
+        description="Animation lifecycle callbacks fired by the **native** CSS engine. `elapsedTime` is reported in **seconds**."
+        title="Animation Callbacks">
+        <View style={styles.content}>
+          <View style={styles.buttons}>
+            <Button
+              style={flex.grow}
+              title="Finite (3x)"
+              onPress={() => restart(FINITE)}
+            />
+            <Button
+              style={flex.grow}
+              title="Infinite"
+              onPress={() => restart(INFINITE)}
+            />
+            <Button
+              style={flex.grow}
+              title="Cancel"
+              onPress={() => setAnimation(null)}
+            />
+            <Button
+              style={flex.grow}
+              title="Unmount"
+              onPress={() => setIsMounted(false)}
+            />
+            <Button
+              style={flex.grow}
+              title="Clear log"
+              onPress={() => setEvents([])}
+            />
           </View>
-        </Section>
 
-        <Section description="In order of arrival" title="Event Log">
-          <View style={styles.log}>
-            {events.length === 0 ? (
-              <Text variant="subHeading2">No events yet</Text>
-            ) : (
-              events.map((event) => (
-                <Text key={event.id} variant="body1">
-                  {event.label}
-                </Text>
-              ))
+          <View style={styles.preview}>
+            {isMounted && (
+              <Animated.View
+                style={[
+                  styles.box,
+                  animation,
+                  {
+                    onAnimationCancel: ({ elapsedTime }) =>
+                      log('cancel', elapsedTime),
+                    onAnimationEnd: ({ elapsedTime }) =>
+                      log('end', elapsedTime),
+                    onAnimationIteration: ({ elapsedTime }) =>
+                      log('iteration', elapsedTime),
+                    onAnimationStart: ({ elapsedTime }) =>
+                      log('start', elapsedTime),
+                  },
+                ]}
+              />
             )}
           </View>
-        </Section>
-      </Stagger>
-    </ScrollScreen>
+        </View>
+      </Section>
+
+      <Section fill description="In order of arrival" title="Event Log">
+        <FlatList
+          contentContainerStyle={styles.logContent}
+          data={events}
+          keyExtractor={(event) => String(event.id)}
+          ListEmptyComponent={<Text variant="subHeading2">No events yet</Text>}
+          renderItem={({ item }) => <Text variant="body1">{item.label}</Text>}
+          style={styles.log}
+        />
+      </Section>
+    </Screen>
   );
 }
 
@@ -155,6 +149,9 @@ const styles = StyleSheet.create({
   log: {
     backgroundColor: colors.background2,
     borderRadius: radius.sm,
+    flex: 1,
+  },
+  logContent: {
     gap: spacing.xxxs,
     padding: spacing.xs,
   },
@@ -163,5 +160,9 @@ const styles = StyleSheet.create({
     backgroundColor: colors.background2,
     borderRadius: radius.md,
     height: sizes.xxl,
+  },
+  screen: {
+    gap: spacing.sm,
+    padding: spacing.sm,
   },
 });

--- a/apps/common-app/src/apps/css/examples/animations/screens/miscellaneous/index.ts
+++ b/apps/common-app/src/apps/css/examples/animations/screens/miscellaneous/index.ts
@@ -1,9 +1,11 @@
+import AnimationCallbacks from './AnimationCallbacks';
 import ChangingAnimation from './ChangingAnimation';
 import KeyframeTimingFunctions from './KeyframeTimingFunctions';
 import MultipleAnimations from './MultipleAnimations';
 import UpdatingAnimationSettings from './UpdatingAnimationSettings';
 
 export default {
+  AnimationCallbacks,
   ChangingAnimation,
   KeyframeTimingFunctions,
   MultipleAnimations,


### PR DESCRIPTION
Adds a screen under CSS > Animations > Miscellaneous that attaches all four animation callbacks and logs each event with its `elapsedTime`, so the timings can be checked against the spec.

Covers the cases that are easy to get wrong: a finite animation with a delay, an infinite one that never ends, and interrupting one mid-flight. The unmount button stays silent until #10255 lands, which is what makes that cancel reach the callback.

Stacked on #10071.