### PR TITLE
Fix crash from withheld exiting layout animations in experimental proxy

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
@@ -30,6 +30,8 @@ std::optional<MountingTransaction> LayoutAnimationsProxy_Experimental::pullTrans
   const std::vector<std::shared_ptr<MutationNode>> roots;
   const bool isInTransition = static_cast<bool>(transitionState_);
 
+  reconcileContradictedRemovals(mutations, filteredMutations);
+
   if (isInTransition) {
     updateLightTree(propsParserContext, mutations, filteredMutations);
     handleProgressTransition(filteredMutations, mutations, propsParserContext, surfaceId);
@@ -105,6 +107,68 @@ std::optional<MountingTransaction> LayoutAnimationsProxy_Experimental::pullTrans
   insertContainers(filteredMutations, rootChildCount, surfaceId);
 
   return MountingTransaction{surfaceId, transactionNumber, std::move(filteredMutations), telemetry};
+}
+
+// If React re-creates or re-inserts a tag whose exiting removal we are still
+// withholding, it has contradicted that withheld removal. Flush it now instead
+// of letting the stale node linger: updateLightTree would overwrite its
+// lightNodes_ entry (the "LightNode already exists" assert is compiled out in
+// release), orphaning the still-mounted exiting view, and the eventual
+// endLayoutAnimation would then remove the wrong, live view and crash the
+// mounting layer.
+//
+// This must run before updateLightTree (so the tag is re-registered cleanly)
+// and before addOngoingAnimations (which would otherwise emit an Update for a
+// tag we are about to Delete this frame).
+void LayoutAnimationsProxy_Experimental::reconcileContradictedRemovals(
+    const ShadowViewMutationList &mutations,
+    ShadowViewMutationList &filteredMutations) const {
+  for (const auto &mutation : mutations) {
+    if (mutation.type != ShadowViewMutation::Type::Create && mutation.type != ShadowViewMutation::Type::Insert) {
+      continue;
+    }
+    const auto tag = mutation.newChildShadowView.tag;
+    std::shared_ptr<LightNode> node;
+    if (const auto it = lightNodes_.find(tag); it != lightNodes_.end() && it->second->state != UNDEFINED) {
+      node = it->second;
+      lightNodes_.erase(it);
+      if (node->state == DELETED) {
+        // already unmounted — only the stale map entry had to go
+        continue;
+      }
+    } else {
+      // A settled exiting view (state DEAD) has already left lightNodes_ but is
+      // still mounted, awaiting the deadNodes cleanup in handleRemovals. That
+      // cleanup runs at the end of the transaction — after this Create would
+      // have re-registered the tag in the mounting layer's view registry — so
+      // it must be flushed now instead.
+      const auto deadIt = std::find_if(deadNodes.begin(), deadNodes.end(), [tag](const auto &deadNode) {
+        return deadNode->current.tag == tag;
+      });
+      if (deadIt == deadNodes.end()) {
+        continue;
+      }
+      node = *deadIt;
+      deadNodes.erase(deadIt);
+      if (node->state == DELETED) {
+        continue;
+      }
+    }
+    // Flush the withheld removal for this tag (and its withheld subtree) right
+    // now, mirroring the deadNodes cleanup in handleRemovals.
+    const auto parent = node->parent.lock();
+    react_native_assert(parent && "Parent node is nullptr");
+    if (!parent) {
+      continue;
+    }
+    const auto index = parent->removeChild(node);
+    react_native_assert(index != -1 && "Exiting node not found");
+    if (index == -1) {
+      continue;
+    }
+    endAnimationsRecursively(node, index, filteredMutations);
+    maybeDropAncestors(parent, filteredMutations);
+  }
 }
 
 bool LayoutAnimationsProxy_Experimental::shouldOverridePullTransaction() const {
@@ -305,11 +369,18 @@ std::optional<SurfaceId> LayoutAnimationsProxy_Experimental::endLayoutAnimation(
     return surfaceId;
   }
 
-  auto node = lightNodes_[tag];
-  react_native_assert(node && "LightNode not found");
+  const auto nodeIt = lightNodes_.find(tag);
+  // the withheld removal may have already been flushed (e.g. reconciled after
+  // React re-created the tag) — the assert alone is compiled out in release
+  // and operator[] would insert a null node here
+  if (nodeIt == lightNodes_.end() || !nodeIt->second) {
+    react_native_assert(false && "LightNode not found");
+    return surfaceId;
+  }
+  auto node = nodeIt->second;
 
   node->state = DEAD;
-  lightNodes_.erase(tag);
+  lightNodes_.erase(nodeIt);
   deadNodes.insert(node);
 
   return surfaceId;
@@ -349,6 +420,7 @@ void LayoutAnimationsProxy_Experimental::handleRemovals(
       parent->children.push_back(node);
       if (node->state == UNDEFINED) {
         node->state = WAITING;
+        lightNodes_[node->current.tag] = node;
       }
     } else {
       maybeCancelAnimation(node->current.tag);
@@ -432,6 +504,10 @@ void LayoutAnimationsProxy_Experimental::endAnimationsRecursively(
     ShadowViewMutationList &mutations) const {
   maybeCancelAnimation(node->current.tag);
   node->state = DELETED;
+  // drop the tag mapping unless it was already re-registered for a new node
+  if (const auto it = lightNodes_.find(node->current.tag); it != lightNodes_.end() && it->second == node) {
+    lightNodes_.erase(it);
+  }
   // iterate from the end, so that children
   // with higher indices appear first in the mutations list
 
@@ -463,6 +539,9 @@ void LayoutAnimationsProxy_Experimental::maybeDropAncestors(
   react_native_assert(index != -1 && "Child node not found");
 
   node->state = DELETED;
+  if (const auto it = lightNodes_.find(node->current.tag); it != lightNodes_.end() && it->second == node) {
+    lightNodes_.erase(it);
+  }
   maybeCancelAnimation(node->current.tag);
   cleanupMutations.push_back(ShadowViewMutation::RemoveMutation(parent->current.tag, node->current, index));
   cleanupMutations.push_back(ShadowViewMutation::DeleteMutation(node->current));
@@ -515,6 +594,9 @@ bool LayoutAnimationsProxy_Experimental::startAnimationsRecursively(
       mutations.push_back(ShadowViewMutation::DeleteMutation(subNode->current));
     } else {
       subNode->state = WAITING;
+      // register withheld subtree members, so that reconcileContradictedRemovals
+      // can find them when React re-creates their tags
+      lightNodes_[subNode->current.tag] = subNode;
     }
   }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
@@ -142,9 +142,8 @@ void LayoutAnimationsProxy_Experimental::reconcileContradictedRemovals(
       // cleanup runs at the end of the transaction — after this Create would
       // have re-registered the tag in the mounting layer's view registry — so
       // it must be flushed now instead.
-      const auto deadIt = std::find_if(deadNodes.begin(), deadNodes.end(), [tag](const auto &deadNode) {
-        return deadNode->current.tag == tag;
-      });
+      const auto deadIt = std::find_if(
+          deadNodes.begin(), deadNodes.end(), [tag](const auto &deadNode) { return deadNode->current.tag == tag; });
       if (deadIt == deadNodes.end()) {
         continue;
       }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.h
@@ -109,6 +109,9 @@ struct LayoutAnimationsProxy_Experimental : public LayoutAnimationsProxyCommon,
       const ShadowViewMutationList &mutations,
       ShadowViewMutationList &filteredMutations) const;
 
+  void reconcileContradictedRemovals(const ShadowViewMutationList &mutations, ShadowViewMutationList &filteredMutations)
+      const;
+
   void handleSharedTransitionsStart(
       const std::shared_ptr<LightNode> &afterTopScreen,
       const std::shared_ptr<LightNode> &beforeTopScreen,


### PR DESCRIPTION
## Summary

Closes #9822.

On iOS release builds with `ENABLE_SHARED_ELEMENT_TRANSITIONS: true` (the default on `main`), the Suspense + Layout Animation Crash example crashes within ~1–2 seconds with `EXC_BAD_ACCESS` inside `LayoutAnimationsProxy_Experimental::updateLightTree`. This is the experimental-proxy counterpart of #9820/#9821: when React re-creates a tag whose exiting removal the proxy is still withholding (a re-suspending Suspense boundary deletes a subtree and later re-creates it with the same fiber tags), the proxy's bookkeeping is contradicted and corrupts both the light tree and the mounting layer's view registry.

Unlike the legacy proxy — whose `nodeForTag_` tracks every node of a withheld subtree, so the #9821 reconcile could catch any re-created tag — the experimental proxy only kept `ANIMATING` roots in `lightNodes_`. Two whole classes of withheld views were invisible to any reconcile:

- **`WAITING` interior nodes** (e.g. FlatList cell containers kept alive under an exiting item) — tracked in neither `lightNodes_` nor `deadNodes`,
- **settled `DEAD` nodes** — already moved to `deadNodes` and erased from `lightNodes_`, but still mounted until the end-of-transaction cleanup, which runs *after* an incoming `Create` would have re-registered the tag.

A `Create` for such a tag passed straight through against a still-registered old view. Diagnosing with a mutation-stream replay showed the resulting "double Create" (an iOS `RCTComponentViewRegistry` overwrite) as the single divergence source; the wrong view then got recycled by the old node's deferred `Delete`, and subsequent transactions faulted on null light nodes / stale indices.

The fix mirrors #9821, adapted to the experimental proxy's bookkeeping:

- `reconcileContradictedRemovals` runs at the start of `pullTransaction`: an incoming `Create`/`Insert` targeting a withheld tag — found in `lightNodes_` (any non-live state) or in `deadNodes` — flushes that node's withheld Remove/Delete immediately, before the tag is re-registered, mirroring the `deadNodes` cleanup in `handleRemovals`.
- `WAITING` subtree members are now registered in `lightNodes_` (both the kept-subview branch of `startAnimationsRecursively` and the kept-root branch of `handleRemovals`), so the reconcile can find them — matching the legacy proxy's per-node bookkeeping.
- `endAnimationsRecursively` and `maybeDropAncestors` erase the deleted node's `lightNodes_` entry (guarded so a re-registered live node is never touched). This also fixes a pre-existing stale-entry leak for animating descendants force-ended together with an exiting ancestor.
- `endLayoutAnimation` replaces an unchecked `lightNodes_[tag]` lookup with a guarded `find` — the old code would default-insert a null node and dereference it in release, where the assert is compiled out.

## Test plan

Uses the Suspense + Layout Animation Crash example added in #9821, with `ENABLE_SHARED_ELEMENT_TRANSITIONS` left at its default (`true`):

1. build `fabric-example` for iOS in Release,
2. open the example and tap Start stress.

Before this change the app crashes within ~1–2 seconds; three consecutive runs on `main` produced the exact stack reported in #9822 (`SIGSEGV` in `updateLightTree` ← `pullTransaction` ← `RCTMountingManager performTransaction`). After it, the same stress ran through hundreds of mode switches (several minutes) with no crash, and a replay of ~525k logged mutations from an instrumented run showed no registry overwrites and no index divergence between the emitted mutations and the mounted hierarchy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)