### PR TITLE
chore: report the lifecycle milestones a run crosses

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.cpp
@@ -96,7 +96,7 @@ void AnimationProgressProvider::play(const double timestamp) {
 
 void AnimationProgressProvider::update(const double timestamp) {
   TimeProgressProvider::update(timestamp);
-  lifecycle_.reachPosition(computeStage(timestamp), currentIteration_);
+  lifecycle_.reachPhase(computePhase(timestamp), currentIteration_);
 }
 
 void AnimationProgressProvider::resetProgress() {
@@ -147,15 +147,15 @@ bool AnimationProgressProvider::shouldFinish(const double timestamp) const {
   return elapsedDuration >= duration_ * iterationCount_;
 }
 
-RunStage AnimationProgressProvider::computeStage(const double timestamp) const {
+RunPhase AnimationProgressProvider::computePhase(const double timestamp) const {
   if (shouldFinish(timestamp)) {
-    return RunStage::Ended;
+    return RunPhase::After;
   }
   // A paused run sits at its start timestamp, so this covers it too.
   if (timestamp < getStartTimestamp(timestamp) || !rawProgress_.has_value()) {
-    return RunStage::Created;
+    return RunPhase::Before;
   }
-  return RunStage::Started;
+  return RunPhase::Active;
 }
 
 double AnimationProgressProvider::updateIterationProgress(const double currentIterationElapsedTime) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.cpp
@@ -133,13 +133,18 @@ double AnimationProgressProvider::getTotalPausedTime(const double timestamp) con
 }
 
 bool AnimationProgressProvider::shouldFinish(const double timestamp) const {
-  if (iterationCount_ == 0) {
-    return true;
-  }
   if (iterationCount_ == -1) {
     return false;
   }
   const auto elapsedDuration = timestamp - getStartTimestamp(timestamp);
+  // A run still waiting out its delay cannot be over, however short it is. A
+  // paused run sits exactly at its start, so zero still finishes below.
+  if (elapsedDuration < 0) {
+    return false;
+  }
+  if (iterationCount_ == 0) {
+    return true;
+  }
   return elapsedDuration >= duration_ * iterationCount_;
 }
 
@@ -147,12 +152,10 @@ RunStage AnimationProgressProvider::computeStage(const double timestamp) const {
   if (shouldFinish(timestamp)) {
     return RunStage::Ended;
   }
+  // A paused run sits at its start timestamp, so this also covers a run paused
+  // before its delay ran out. One paused after that has started, and the web
+  // reports it as started too.
   if (timestamp < getStartTimestamp(timestamp) || !rawProgress_.has_value()) {
-    return RunStage::Created;
-  }
-  // A paused run sits at its start timestamp with a raw progress of 0, so it
-  // looks started. It cannot start until it is played.
-  if (pauseTimestamp_ > 0 && !lifecycle_.hasStarted()) {
     return RunStage::Created;
   }
   return RunStage::Started;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.cpp
@@ -137,8 +137,7 @@ bool AnimationProgressProvider::shouldFinish(const double timestamp) const {
     return false;
   }
   const auto elapsedDuration = timestamp - getStartTimestamp(timestamp);
-  // A run still waiting out its delay cannot be over, however short it is. A
-  // paused run sits exactly at its start, so zero still finishes below.
+  // Ordered first: a run still in its delay is not over, however short it is.
   if (elapsedDuration < 0) {
     return false;
   }
@@ -152,9 +151,7 @@ RunStage AnimationProgressProvider::computeStage(const double timestamp) const {
   if (shouldFinish(timestamp)) {
     return RunStage::Ended;
   }
-  // A paused run sits at its start timestamp, so this also covers a run paused
-  // before its delay ran out. One paused after that has started, and the web
-  // reports it as started too.
+  // A paused run sits at its start timestamp, so this covers it too.
   if (timestamp < getStartTimestamp(timestamp) || !rawProgress_.has_value()) {
     return RunStage::Created;
   }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.cpp
@@ -68,8 +68,8 @@ AnimationProgressState AnimationProgressProvider::getState() const {
   return lifecycle_.hasStarted() ? AnimationProgressState::Running : AnimationProgressState::Pending;
 }
 
-void AnimationProgressProvider::onMilestone(RunLifecycle::Reporter reporter) {
-  lifecycle_.onMilestone(std::move(reporter));
+void AnimationProgressProvider::setMilestoneReporter(RunLifecycle::Reporter reporter) {
+  lifecycle_.setMilestoneReporter(std::move(reporter));
 }
 
 void AnimationProgressProvider::abort() {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.cpp
@@ -59,7 +59,21 @@ double AnimationProgressProvider::getKeyframeProgress(const double fromOffset, c
 }
 
 AnimationProgressState AnimationProgressProvider::getState() const {
-  return state_;
+  if (lifecycle_.hasEnded()) {
+    return AnimationProgressState::Finished;
+  }
+  if (pauseTimestamp_ > 0) {
+    return AnimationProgressState::Paused;
+  }
+  return lifecycle_.hasStarted() ? AnimationProgressState::Running : AnimationProgressState::Pending;
+}
+
+void AnimationProgressProvider::onMilestone(RunLifecycle::Reporter reporter) {
+  lifecycle_.onMilestone(std::move(reporter));
+}
+
+void AnimationProgressProvider::abort() {
+  lifecycle_.abort();
 }
 
 double AnimationProgressProvider::getStartTimestamp(const double timestamp) const {
@@ -82,14 +96,13 @@ void AnimationProgressProvider::play(const double timestamp) {
 
 void AnimationProgressProvider::update(const double timestamp) {
   TimeProgressProvider::update(timestamp);
-  state_ = computeState(timestamp);
+  lifecycle_.reachPosition(computeStage(timestamp), currentIteration_);
 }
 
 void AnimationProgressProvider::resetProgress() {
   TimeProgressProvider::resetProgress();
   currentIteration_ = 1;
   previousIterationsDuration_ = 0;
-  state_ = AnimationProgressState::Pending;
 }
 
 std::optional<double> AnimationProgressProvider::calculateRawProgress(const double timestamp) {
@@ -130,17 +143,19 @@ bool AnimationProgressProvider::shouldFinish(const double timestamp) const {
   return elapsedDuration >= duration_ * iterationCount_;
 }
 
-AnimationProgressState AnimationProgressProvider::computeState(const double timestamp) const {
+RunStage AnimationProgressProvider::computeStage(const double timestamp) const {
   if (shouldFinish(timestamp)) {
-    return AnimationProgressState::Finished;
-  }
-  if (pauseTimestamp_ > 0) {
-    return AnimationProgressState::Paused;
+    return RunStage::Ended;
   }
   if (timestamp < getStartTimestamp(timestamp) || !rawProgress_.has_value()) {
-    return AnimationProgressState::Pending;
+    return RunStage::Created;
   }
-  return AnimationProgressState::Running;
+  // A paused run sits at its start timestamp with a raw progress of 0, so it
+  // looks started. It cannot start until it is played.
+  if (pauseTimestamp_ > 0 && !lifecycle_.hasStarted()) {
+    return RunStage::Created;
+  }
+  return RunStage::Started;
 }
 
 double AnimationProgressProvider::updateIterationProgress(const double currentIterationElapsedTime) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.h
@@ -56,8 +56,8 @@ class AnimationProgressProvider final : public KeyframeProgressProvider, public 
   EasingFunction easingFunction_;
   std::shared_ptr<KeyframeEasingConfigs> keyframeEasingConfigs_;
 
-  // Survives resetProgress: the replay updateSettings performs re-times the run
-  // rather than starting a new one, so its phase carries over.
+  // Survives resetProgress, because updateSettings re-times the run rather than
+  // starting a new one.
   RunLifecycle lifecycle_;
 
   unsigned currentIteration_ = 1;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.h
@@ -4,6 +4,7 @@
 #include <reanimated/CSS/configs/CSSKeyframesConfig.h>
 #include <reanimated/CSS/easing/EasingFunctions.h>
 #include <reanimated/CSS/progress/KeyframeProgressProvider.h>
+#include <reanimated/CSS/progress/RunLifecycle.h>
 #include <reanimated/CSS/progress/TimeProgressProvider.h>
 
 #include <memory>
@@ -37,6 +38,8 @@ class AnimationProgressProvider final : public KeyframeProgressProvider, public 
   double getKeyframeProgress(double fromOffset, double toOffset) const override;
 
   AnimationProgressState getState() const;
+  void onMilestone(RunLifecycle::Reporter reporter);
+  void abort();
   double getStartTimestamp(double timestamp) const;
 
   void pause(double timestamp);
@@ -53,7 +56,10 @@ class AnimationProgressProvider final : public KeyframeProgressProvider, public 
   EasingFunction easingFunction_;
   std::shared_ptr<KeyframeEasingConfigs> keyframeEasingConfigs_;
 
-  AnimationProgressState state_ = AnimationProgressState::Pending;
+  // Survives resetProgress, so the replay updateSettings performs reports
+  // neither a restart nor iterations reported before.
+  RunLifecycle lifecycle_;
+
   unsigned currentIteration_ = 1;
   double previousIterationsDuration_ = 0;
   double pauseTimestamp_ = 0;
@@ -61,7 +67,7 @@ class AnimationProgressProvider final : public KeyframeProgressProvider, public 
 
   double getTotalPausedTime(double timestamp) const;
   bool shouldFinish(double timestamp) const;
-  AnimationProgressState computeState(double timestamp) const;
+  RunStage computeStage(double timestamp) const;
 
   double updateIterationProgress(double currentIterationElapsedTime);
   double applyAnimationDirection(double iterationProgress) const;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.h
@@ -38,7 +38,7 @@ class AnimationProgressProvider final : public KeyframeProgressProvider, public 
   double getKeyframeProgress(double fromOffset, double toOffset) const override;
 
   AnimationProgressState getState() const;
-  void onMilestone(RunLifecycle::Reporter reporter);
+  void setMilestoneReporter(RunLifecycle::Reporter reporter);
   void abort();
   double getStartTimestamp(double timestamp) const;
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.h
@@ -67,7 +67,7 @@ class AnimationProgressProvider final : public KeyframeProgressProvider, public 
 
   double getTotalPausedTime(double timestamp) const;
   bool shouldFinish(double timestamp) const;
-  RunStage computeStage(double timestamp) const;
+  RunPhase computePhase(double timestamp) const;
 
   double updateIterationProgress(double currentIterationElapsedTime);
   double applyAnimationDirection(double iterationProgress) const;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.h
@@ -56,8 +56,8 @@ class AnimationProgressProvider final : public KeyframeProgressProvider, public 
   EasingFunction easingFunction_;
   std::shared_ptr<KeyframeEasingConfigs> keyframeEasingConfigs_;
 
-  // Survives resetProgress, so the replay updateSettings performs reports
-  // neither a restart nor iterations reported before.
+  // Survives resetProgress: the replay updateSettings performs re-times the run
+  // rather than starting a new one, so its phase carries over.
   RunLifecycle lifecycle_;
 
   unsigned currentIteration_ = 1;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/RunLifecycle.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/RunLifecycle.cpp
@@ -9,8 +9,8 @@ void RunLifecycle::setMilestoneReporter(Reporter reporter) {
 }
 
 void RunLifecycle::reachPhase(const RunPhase phase, const unsigned iteration) {
-  // An abort ends the run for good. Removal from the loop is only enqueued, so
-  // a frame already in flight can still phase an aborted run.
+  // Removal from the loop is only enqueued, so a frame already in flight can
+  // still tick a run that was just aborted.
   if (aborted_) {
     return;
   }
@@ -52,9 +52,8 @@ void RunLifecycle::reachPhase(const RunPhase phase, const unsigned iteration) {
 }
 
 void RunLifecycle::abort() {
-  // A run that already told its owner it ended is past the point where a cancel
-  // applies. This tracks the report rather than the phase because a reporter
-  // can abort part way through a phase change that has yet to reach its end.
+  // Tracks the report rather than the phase: a reporter can abort part way
+  // through a phase change that has not reached its end yet.
   if (aborted_ || endReported_) {
     return;
   }
@@ -81,9 +80,8 @@ bool RunLifecycle::hasEnded() const {
 }
 
 void RunLifecycle::reportIterationBoundary(const unsigned iteration) {
-  // The boundary is against the iteration of the previous sample, not the
-  // furthest the run has ever got, and one sample reports one boundary however
-  // many it stepped over.
+  // Against the previous sample, not the furthest the run has ever got, and
+  // one sample reports one boundary however many it stepped over.
   if (phase_ != RunPhase::Active || iteration == iteration_) {
     return;
   }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/RunLifecycle.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/RunLifecycle.cpp
@@ -5,7 +5,7 @@
 
 namespace reanimated::css {
 
-void RunLifecycle::onMilestone(Reporter reporter) {
+void RunLifecycle::setMilestoneReporter(Reporter reporter) {
   reporter_ = std::move(reporter);
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/RunLifecycle.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/RunLifecycle.cpp
@@ -29,9 +29,13 @@ void RunLifecycle::reachPosition(const RunStage stage, const unsigned repeat) {
 }
 
 void RunLifecycle::abort() {
-  if (aborted_ || hasEnded() || reported_ == rank(RunStage::None)) {
+  if (aborted_ || hasEnded()) {
     return;
   }
+
+  // A run exists from the moment it is created, even while it waits out its
+  // delay, so one aborted before its first position still reports that much.
+  enterStagesUpTo(rank(RunStage::Created));
 
   aborted_ = true;
   report(RunMilestone::Aborted);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/RunLifecycle.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/RunLifecycle.cpp
@@ -77,12 +77,18 @@ bool RunLifecycle::hasEnded() const {
 }
 
 void RunLifecycle::reportIterationBoundary(const unsigned iteration) {
-  // One sample reports one boundary however many the run stepped over.
-  if (phase_ != RunPhase::Active || iteration <= iteration_) {
+  // The boundary is against the iteration of the previous sample, not the
+  // furthest the run has ever got, and one sample reports one boundary however
+  // many it stepped over.
+  if (phase_ != RunPhase::Active || iteration == iteration_) {
     return;
   }
+
+  // Re-timing a run can drop it back an iteration, and the boundary it crossed
+  // is then the end of the one it landed in rather than the start.
+  const auto time = iteration < iteration_ ? MilestoneTime::IterationEnd : MilestoneTime::IterationStart;
   iteration_ = iteration;
-  report(RunMilestone::Repeated, MilestoneTime::IterationBoundary);
+  report(RunMilestone::Repeated, time);
 }
 
 void RunLifecycle::report(const RunMilestone milestone, const MilestoneTime time) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/RunLifecycle.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/RunLifecycle.cpp
@@ -55,16 +55,20 @@ bool RunLifecycle::hasEnded() const {
 }
 
 void RunLifecycle::enterStagesUpTo(const std::size_t target) {
-  // A reporter may abort from inside a milestone, which ends the ladder here.
+  // A reporter may abort from inside a milestone, which leaves the run on the
+  // stage it aborted at.
   while (reported_ < target && !aborted_) {
     report(static_cast<RunMilestone>(++reported_));
   }
 }
 
 void RunLifecycle::report(const RunMilestone milestone) const {
-  if (reporter_) {
-    reporter_(milestone);
+  // An abort is the last thing a run reports, including when a reporter
+  // triggers it from inside an earlier milestone.
+  if (!reporter_ || (aborted_ && milestone != RunMilestone::Aborted)) {
+    return;
   }
+  reporter_(milestone);
 }
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/RunLifecycle.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/RunLifecycle.cpp
@@ -33,8 +33,7 @@ void RunLifecycle::abort() {
     return;
   }
 
-  // A run exists from the moment it is created, even while it waits out its
-  // delay, so one aborted before its first position still reports that much.
+  // A run exists from creation, so an early abort still reports Created.
   enterStagesUpTo(rank(RunStage::Created));
 
   aborted_ = true;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/RunLifecycle.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/RunLifecycle.cpp
@@ -59,9 +59,13 @@ void RunLifecycle::abort() {
     return;
   }
 
-  // A run exists from creation, so an early abort still reports it first.
+  // A run exists from creation, so an early abort still reports it first. That
+  // report can abort the run itself, leaving nothing for this call to do.
   if (phase_ == RunPhase::Idle) {
     reachPhase(RunPhase::Before);
+    if (aborted_) {
+      return;
+    }
   }
 
   aborted_ = true;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/RunLifecycle.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/RunLifecycle.cpp
@@ -10,6 +10,12 @@ void RunLifecycle::setMilestoneReporter(Reporter reporter) {
 }
 
 void RunLifecycle::reachPosition(const RunStage stage, const unsigned repeat) {
+  // An abort ends the run for good. Removal from the loop is only enqueued, so
+  // a frame already in flight can still position an aborted run.
+  if (aborted_) {
+    return;
+  }
+
   const auto target = rank(stage);
 
   // Longer settings pull a finished run back so it can reach the end again.
@@ -49,7 +55,8 @@ bool RunLifecycle::hasEnded() const {
 }
 
 void RunLifecycle::enterStagesUpTo(const std::size_t target) {
-  while (reported_ < target) {
+  // A reporter may abort from inside a milestone, which ends the ladder here.
+  while (reported_ < target && !aborted_) {
     report(static_cast<RunMilestone>(++reported_));
   }
 }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/RunLifecycle.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/RunLifecycle.cpp
@@ -1,6 +1,5 @@
 #include <reanimated/CSS/progress/RunLifecycle.h>
 
-#include <algorithm>
 #include <utility>
 
 namespace reanimated::css {
@@ -9,66 +8,99 @@ void RunLifecycle::setMilestoneReporter(Reporter reporter) {
   reporter_ = std::move(reporter);
 }
 
-void RunLifecycle::reachPosition(const RunStage stage, const unsigned repeat) {
+void RunLifecycle::reachPhase(const RunPhase phase, const unsigned iteration) {
   // An abort ends the run for good. Removal from the loop is only enqueued, so
-  // a frame already in flight can still position an aborted run.
+  // a frame already in flight can still phase an aborted run.
   if (aborted_) {
     return;
   }
 
-  const auto target = rank(stage);
-
-  // Longer settings pull a finished run back so it can reach the end again.
-  if (target < reported_ && hasEnded()) {
-    reported_ = target;
+  if (phase == phase_) {
+    reportIterationBoundary(iteration);
+    return;
   }
 
-  enterStagesUpTo(std::min(target, rank(RunStage::Started)));
+  const auto from = std::exchange(phase_, phase);
+  // Boundaries the run stepped over outside its active phase are not reported.
+  iteration_ = iteration;
 
-  // One position reports one repeat however many the run stepped over.
-  if (hasStarted() && repeat > repeat_) {
-    repeat_ = repeat;
-    report(RunMilestone::Repeated);
+  if (from == RunPhase::After) {
+    // Re-entering a finished run starts it again, timed at the end of the
+    // interval it had already reached.
+    report(RunMilestone::Started, MilestoneTime::IntervalEnd);
+    if (phase == RunPhase::Before) {
+      report(RunMilestone::Ended, MilestoneTime::IntervalStart);
+    }
+    return;
   }
 
-  enterStagesUpTo(target);
+  if (from == RunPhase::Active) {
+    report(RunMilestone::Ended, phase == RunPhase::After ? MilestoneTime::IntervalEnd : MilestoneTime::IntervalStart);
+    return;
+  }
+
+  if (from == RunPhase::Idle) {
+    report(RunMilestone::Created, MilestoneTime::IntervalStart);
+  }
+  if (phase == RunPhase::Before) {
+    return;
+  }
+  report(RunMilestone::Started, MilestoneTime::IntervalStart);
+  if (phase == RunPhase::After) {
+    report(RunMilestone::Ended, MilestoneTime::IntervalEnd);
+  }
 }
 
 void RunLifecycle::abort() {
-  if (aborted_ || hasEnded()) {
+  // A run that already told its owner it ended is past the point where a cancel
+  // applies. This tracks the report rather than the phase because a reporter
+  // can abort part way through a phase change that has yet to reach its end.
+  if (aborted_ || endReported_) {
     return;
   }
 
-  // A run exists from creation, so an early abort still reports Created.
-  enterStagesUpTo(rank(RunStage::Created));
+  // A run exists from creation, so an early abort still reports it first.
+  if (phase_ == RunPhase::Idle) {
+    reachPhase(RunPhase::Before);
+  }
 
   aborted_ = true;
-  report(RunMilestone::Aborted);
+  report(RunMilestone::Aborted, MilestoneTime::ActiveTime);
 }
 
 bool RunLifecycle::hasStarted() const {
-  return reported_ >= rank(RunStage::Started);
+  return phase_ == RunPhase::Active || phase_ == RunPhase::After;
 }
 
 bool RunLifecycle::hasEnded() const {
-  return reported_ == rank(RunStage::Ended);
+  return phase_ == RunPhase::After;
 }
 
-void RunLifecycle::enterStagesUpTo(const std::size_t target) {
-  // A reporter may abort from inside a milestone, which leaves the run on the
-  // stage it aborted at.
-  while (reported_ < target && !aborted_) {
-    report(static_cast<RunMilestone>(++reported_));
-  }
-}
-
-void RunLifecycle::report(const RunMilestone milestone) const {
-  // An abort is the last thing a run reports, including when a reporter
-  // triggers it from inside an earlier milestone.
-  if (!reporter_ || (aborted_ && milestone != RunMilestone::Aborted)) {
+void RunLifecycle::reportIterationBoundary(const unsigned iteration) {
+  // One sample reports one boundary however many the run stepped over.
+  if (phase_ != RunPhase::Active || iteration <= iteration_) {
     return;
   }
-  reporter_(milestone);
+  iteration_ = iteration;
+  report(RunMilestone::Repeated, MilestoneTime::IterationBoundary);
+}
+
+void RunLifecycle::report(const RunMilestone milestone, const MilestoneTime time) {
+  // An abort is the last thing a run reports, including when a reporter
+  // triggers it from inside an earlier milestone.
+  if (aborted_ && milestone != RunMilestone::Aborted) {
+    return;
+  }
+
+  if (milestone == RunMilestone::Ended) {
+    endReported_ = true;
+  } else if (milestone == RunMilestone::Started) {
+    endReported_ = false;
+  }
+
+  if (reporter_) {
+    reporter_(milestone, time);
+  }
 }
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/RunLifecycle.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/RunLifecycle.cpp
@@ -1,0 +1,60 @@
+#include <reanimated/CSS/progress/RunLifecycle.h>
+
+#include <algorithm>
+#include <utility>
+
+namespace reanimated::css {
+
+void RunLifecycle::onMilestone(Reporter reporter) {
+  reporter_ = std::move(reporter);
+}
+
+void RunLifecycle::reachPosition(const RunStage stage, const unsigned repeat) {
+  const auto target = rank(stage);
+
+  // Longer settings pull a finished run back so it can reach the end again.
+  if (target < reported_ && hasEnded()) {
+    reported_ = target;
+  }
+
+  enterStagesUpTo(std::min(target, rank(RunStage::Started)));
+
+  // One position reports one repeat however many the run stepped over.
+  if (hasStarted() && repeat > repeat_) {
+    repeat_ = repeat;
+    report(RunMilestone::Repeated);
+  }
+
+  enterStagesUpTo(target);
+}
+
+void RunLifecycle::abort() {
+  if (aborted_ || hasEnded() || reported_ == rank(RunStage::None)) {
+    return;
+  }
+
+  aborted_ = true;
+  report(RunMilestone::Aborted);
+}
+
+bool RunLifecycle::hasStarted() const {
+  return reported_ >= rank(RunStage::Started);
+}
+
+bool RunLifecycle::hasEnded() const {
+  return reported_ == rank(RunStage::Ended);
+}
+
+void RunLifecycle::enterStagesUpTo(const std::size_t target) {
+  while (reported_ < target) {
+    report(static_cast<RunMilestone>(++reported_));
+  }
+}
+
+void RunLifecycle::report(const RunMilestone milestone) const {
+  if (reporter_) {
+    reporter_(milestone);
+  }
+}
+
+} // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/RunLifecycle.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/RunLifecycle.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+
+namespace reanimated::css {
+
+enum class RunStage : std::uint8_t { None, Created, Started, Ended };
+
+/// Stage values share their rank with RunStage so the ladder can report a
+/// stage without translating it.
+enum class RunMilestone : std::uint8_t {
+  Created = static_cast<std::uint8_t>(RunStage::Created),
+  Started = static_cast<std::uint8_t>(RunStage::Started),
+  Ended = static_cast<std::uint8_t>(RunStage::Ended),
+  Repeated,
+  Aborted,
+};
+
+/// Reports each milestone of a run once, in the order it is reached. Knows
+/// nothing about animations or transitions: the owner maps milestones to its
+/// own events, and a kind without repeats never passes one.
+class RunLifecycle {
+ public:
+  using Reporter = std::function<void(RunMilestone)>;
+
+  void onMilestone(Reporter reporter);
+  void reachPosition(RunStage stage, unsigned repeat = 1);
+  void abort();
+
+  bool hasStarted() const;
+  bool hasEnded() const;
+
+ private:
+  static constexpr std::size_t rank(RunStage stage) {
+    return static_cast<std::size_t>(stage);
+  }
+
+  void report(RunMilestone milestone) const;
+  void enterStagesUpTo(std::size_t target);
+
+  std::size_t reported_{rank(RunStage::None)};
+  unsigned repeat_{1};
+  bool aborted_{false};
+  Reporter reporter_;
+};
+
+} // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/RunLifecycle.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/RunLifecycle.h
@@ -25,7 +25,7 @@ class RunLifecycle {
  public:
   using Reporter = std::function<void(RunMilestone)>;
 
-  void onMilestone(Reporter reporter);
+  void setMilestoneReporter(Reporter reporter);
   void reachPosition(RunStage stage, unsigned repeat = 1);
   void abort();
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/RunLifecycle.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/RunLifecycle.h
@@ -1,47 +1,45 @@
 #pragma once
 
-#include <cstddef>
 #include <cstdint>
 #include <functional>
 
 namespace reanimated::css {
 
-enum class RunStage : std::uint8_t { None, Created, Started, Ended };
+/// The phases a run moves through, named after the CSS event tables. A run is
+/// Idle before it exists, Before while its delay has yet to pass, Active while
+/// it produces values, and After once it is done.
+enum class RunPhase : std::uint8_t { Idle, Before, Active, After };
 
-/// Stage values share their rank with RunStage so the ladder can report a
-/// stage without translating it.
-enum class RunMilestone : std::uint8_t {
-  Created = static_cast<std::uint8_t>(RunStage::Created),
-  Started = static_cast<std::uint8_t>(RunStage::Started),
-  Ended = static_cast<std::uint8_t>(RunStage::Ended),
-  Repeated,
-  Aborted,
-};
+enum class RunMilestone : std::uint8_t { Created, Started, Ended, Repeated, Aborted };
 
-/// Reports each milestone of a run once, in the order it is reached. Knows
-/// nothing about animations or transitions: the owner maps milestones to its
-/// own events, and a kind without repeats never passes one.
+/// Which of the run's times a milestone carries. The same milestone reports a
+/// different one depending on the phase change that produced it, so the owner
+/// cannot derive this from the milestone alone.
+enum class MilestoneTime : std::uint8_t { IntervalStart, IntervalEnd, IterationBoundary, ActiveTime };
+
+/// Reports the milestones a run crosses, following the phase change tables in
+/// css-animations-2 and css-transitions-2. Both tables agree on the phase
+/// changes and the times, so this knows nothing about animations or
+/// transitions: the owner maps milestones to its own events, and a kind
+/// without iterations never passes one.
 class RunLifecycle {
  public:
-  using Reporter = std::function<void(RunMilestone)>;
+  using Reporter = std::function<void(RunMilestone, MilestoneTime)>;
 
   void setMilestoneReporter(Reporter reporter);
-  void reachPosition(RunStage stage, unsigned repeat = 1);
+  void reachPhase(RunPhase phase, unsigned iteration = 1);
   void abort();
 
   bool hasStarted() const;
   bool hasEnded() const;
 
  private:
-  static constexpr std::size_t rank(RunStage stage) {
-    return static_cast<std::size_t>(stage);
-  }
+  void report(RunMilestone milestone, MilestoneTime time);
+  void reportIterationBoundary(unsigned iteration);
 
-  void report(RunMilestone milestone) const;
-  void enterStagesUpTo(std::size_t target);
-
-  std::size_t reported_{rank(RunStage::None)};
-  unsigned repeat_{1};
+  RunPhase phase_{RunPhase::Idle};
+  unsigned iteration_{1};
+  bool endReported_{false};
   bool aborted_{false};
   Reporter reporter_;
 };

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/RunLifecycle.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/RunLifecycle.h
@@ -15,7 +15,7 @@ enum class RunMilestone : std::uint8_t { Created, Started, Ended, Repeated, Abor
 /// Which of the run's times a milestone carries. The same milestone reports a
 /// different one depending on the phase change that produced it, so the owner
 /// cannot derive this from the milestone alone.
-enum class MilestoneTime : std::uint8_t { IntervalStart, IntervalEnd, IterationBoundary, ActiveTime };
+enum class MilestoneTime : std::uint8_t { IntervalStart, IntervalEnd, IterationStart, IterationEnd, ActiveTime };
 
 /// Reports the milestones a run crosses, following the phase change tables in
 /// css-animations-2 and css-transitions-2. Both tables agree on the phase


### PR DESCRIPTION
`RunLifecycle` tracks which phase a run is in and reports the milestones each phase change crosses. It knows nothing about animations or transitions: the owner maps `Created`, `Started`, `Ended`, `Repeated` and `Aborted` to its own events.

The phase changes come straight from the tables in [css-animations-2](https://drafts.csswg.org/css-animations-2/#event-dispatch) and [css-transitions-2](https://drafts.csswg.org/css-transitions-2/#event-dispatch), which agree on every row. That includes the rows that move a run backwards, which a style update reaches by re-timing a run that is already going or already finished.

A milestone can be reached by more than one phase change, and the time it carries differs: a start is the interval start entering from a delay and the interval end re-entering after finishing. Hence `MilestoneTime`, used by the owners in #10070 and #10120.

Pausing also moves out of the progress state, fixing an animation created with `playState: Paused` reporting `animationstart` while still paused and never once it actually started.

Nothing registers a reporter yet. First step of the CSS animation callbacks series.
