### PR TITLE
fix: alternating animations settle on the wrong keyframe

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.cpp
@@ -1,5 +1,7 @@
 #include <reanimated/CSS/progress/AnimationProgressProvider.h>
 
+#include <algorithm>
+#include <cmath>
 #include <memory>
 #include <utility>
 
@@ -155,6 +157,13 @@ double AnimationProgressProvider::updateIterationProgress(const double currentIt
 
   if (deltaIterations > 0) {
     currentIteration_ += deltaIterations;
+    // The animation finishes within its last iteration, so the counter must not
+    // run past it. Without this the final frame reports one iteration too many,
+    // which flips the direction of alternating animations.
+    const double lastIteration = std::max(1.0, std::ceil(iterationCount_));
+    if (iterationCount_ >= 0 && currentIteration_ > lastIteration) {
+      currentIteration_ = static_cast<unsigned>(lastIteration);
+    }
     previousIterationsDuration_ = (currentIteration_ - 1) * duration_;
   }
 


### PR DESCRIPTION
`alternate` and `alternate-reverse` settled on the wrong keyframe when fill mode `forwards` was enabled. This PR fixes the issue.

## Example

The following example shows comparison of how it looks after animations complete.

<img width="1765" height="844" alt="reanimated-10075-three-way" src="https://github.com/user-attachments/assets/f8ea22c2-6fa9-476a-b637-2a8fa23cee57" />
