### PR TITLE
chore(Worklets): remove leftover RCTBundleConsumer imports

### DIFF
--- a/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.h
+++ b/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.h
@@ -6,22 +6,7 @@
 
 #import <worklets/NativeModules/WorkletsModuleProxy.h>
 
-#if __has_include(<React/RCTBundleConsumer.h>)
-// Bundle mode
-#import <React/NSBigStringBuffer.h>
-#import <React/RCTBundleConsumer.h>
-#endif // __has_include(<React/RCTBundleConsumer.h>)
-
-@interface WorkletsModule : RCTEventEmitter <
-                                NativeWorkletsModuleSpec,
-                                RCTCallInvokerModule,
-                                RCTInvalidating
-#if __has_include(<React/RCTBundleConsumer.h>)
-                                // Bundle mode
-                                ,
-                                RCTBundleConsumer
-#endif // __has_include(<React/RCTBundleConsumer.h>)
-                                >
+@interface WorkletsModule : RCTEventEmitter <NativeWorkletsModuleSpec, RCTCallInvokerModule, RCTInvalidating>
 
 - (std::shared_ptr<worklets::WorkletsModuleProxy>)getWorkletsModuleProxy;
 


### PR DESCRIPTION
## Summary

It's dead code leftover from prototyping Bundle Mode.

## Test plan

CI
