### PR TITLE
feat(Worklets): bring Bundle Mode script loading on par with React Native

### DIFF
--- a/packages/react-native-worklets/android/src/main/cpp/worklets/android/JScriptBufferWrapper.cpp
+++ b/packages/react-native-worklets/android/src/main/cpp/worklets/android/JScriptBufferWrapper.cpp
@@ -25,21 +25,13 @@ jni::local_ref<JScriptBufferWrapper::jhybriddata> JScriptBufferWrapper::initHybr
 
 jni::local_ref<JScriptBufferWrapper::jhybriddata> JScriptBufferWrapper::initHybridFromFile(
     jni::alias_ref<jhybridobject> jThis, // NOLINT //(performance-unnecessary-value-param)
-    const std::string &fileName) {
+    const std::string &fileName,
+    const std::string &sourceURL) {
   std::shared_ptr<const ScriptBuffer> script;
   RecoverableError::runRethrowingAsRecoverable<std::system_error>([&fileName, &script]() {
     auto bigString = JSBigFileString::fromPath(fileName);
     script = std::make_shared<ScriptBuffer>(std::move(bigString));
   });
-  return makeCxxInstance(std::move(script), fileName);
-}
-
-jni::local_ref<JScriptBufferWrapper::jhybriddata> JScriptBufferWrapper::initHybridFromString(
-    jni::alias_ref<jhybridobject> jThis, // NOLINT //(performance-unnecessary-value-param)
-    const std::string &scriptStr,
-    const std::string &sourceURL) {
-  auto bigString = std::make_shared<JSBigStdString>(scriptStr);
-  auto script = std::make_shared<ScriptBuffer>(std::move(bigString));
   return makeCxxInstance(std::move(script), sourceURL);
 }
 
@@ -60,7 +52,6 @@ void JScriptBufferWrapper::registerNatives() {
   registerHybrid({
       makeNativeMethod("initHybridFromAssets", JScriptBufferWrapper::initHybridFromAssets),
       makeNativeMethod("initHybridFromFile", JScriptBufferWrapper::initHybridFromFile),
-      makeNativeMethod("initHybridFromString", JScriptBufferWrapper::initHybridFromString),
   });
 }
 } // namespace worklets

--- a/packages/react-native-worklets/android/src/main/cpp/worklets/android/JScriptBufferWrapper.h
+++ b/packages/react-native-worklets/android/src/main/cpp/worklets/android/JScriptBufferWrapper.h
@@ -31,11 +31,8 @@ class JScriptBufferWrapper : public jni::HybridClass<JScriptBufferWrapper> {
       jni::alias_ref<jhybridobject> jThis,
       jni::alias_ref<JAssetManager::javaobject> assetManager,
       const std::string &assetURL);
-  static jni::local_ref<JScriptBufferWrapper::jhybriddata> initHybridFromFile(
-      jni::alias_ref<jhybridobject> jThis,
-      const std::string &fileName);
   static jni::local_ref<JScriptBufferWrapper::jhybriddata>
-  initHybridFromString(jni::alias_ref<jhybridobject> jThis, const std::string &script, const std::string &sourceURL);
+  initHybridFromFile(jni::alias_ref<jhybridobject> jThis, const std::string &fileName, const std::string &sourceURL);
 
   friend HybridBase;
 

--- a/packages/react-native-worklets/android/src/main/java/com/swmansion/worklets/ScriptBufferWrapper.kt
+++ b/packages/react-native-worklets/android/src/main/java/com/swmansion/worklets/ScriptBufferWrapper.kt
@@ -68,12 +68,14 @@ class ScriptBufferWrapper(
 
     companion object {
         private const val DEV_BUNDLE_FILE_NAME = "WorkletsDevBundle.js"
+        private const val CONNECT_TIMEOUT_MS = 5_000
 
         private fun downloadScriptToFile(
             url: String,
             outputFile: File,
         ) {
             val connection = URL(url).openConnection() as HttpURLConnection
+            connection.connectTimeout = CONNECT_TIMEOUT_MS
             try {
                 val statusCode =
                     try {

--- a/packages/react-native-worklets/android/src/main/java/com/swmansion/worklets/ScriptBufferWrapper.kt
+++ b/packages/react-native-worklets/android/src/main/java/com/swmansion/worklets/ScriptBufferWrapper.kt
@@ -1,13 +1,15 @@
 package com.swmansion.worklets
 
 import android.annotation.SuppressLint
+import android.content.Context
 import android.content.res.AssetManager
-import android.os.Build
 import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip
 import com.facebook.proguard.annotations.DoNotStripAny
+import org.json.JSONException
+import org.json.JSONObject
+import java.io.File
 import java.io.IOException
-import java.io.InputStream
 import java.net.HttpURLConnection
 import java.net.URL
 import java.nio.charset.StandardCharsets
@@ -17,13 +19,18 @@ import java.nio.charset.StandardCharsets
 @SuppressLint("MissingNativeLoadLibrary")
 @DoNotStripAny
 class ScriptBufferWrapper(
-    uri: String,
-    assetManager: AssetManager,
+    uri: String?,
+    context: Context,
 ) {
     @field:DoNotStrip
     private val mHybridData: HybridData
 
     init {
+        checkNotNull(uri) {
+            "[Worklets] No script URL provided. Make sure the packager is running or you have " +
+                "embedded a JS bundle in your application bundle."
+        }
+
         val filePrefix = "file://"
         val absPathPrefix = "/"
         val assetsPrefix = "assets://"
@@ -32,23 +39,19 @@ class ScriptBufferWrapper(
             when {
                 uri.startsWith(filePrefix) -> {
                     val fileName = uri.substring(filePrefix.length)
-                    initHybridFromFile(fileName)
+                    initHybridFromFile(fileName, fileName)
                 }
                 uri.startsWith(assetsPrefix) -> {
                     val assetURL = uri.substring(assetsPrefix.length)
-                    initHybridFromAssets(assetManager, assetURL)
+                    initHybridFromAssets(context.assets, assetURL)
                 }
                 uri.startsWith(absPathPrefix) -> {
-                    initHybridFromFile(uri)
+                    initHybridFromFile(uri, uri)
                 }
                 else -> {
-                    val scriptContent =
-                        try {
-                            downloadScript(uri)
-                        } catch (e: IOException) {
-                            throw RuntimeException(e)
-                        }
-                    initHybridFromString(scriptContent, uri)
+                    val bundleFile = File(context.cacheDir, DEV_BUNDLE_FILE_NAME)
+                    downloadScriptToFile(uri, bundleFile)
+                    initHybridFromFile(bundleFile.absolutePath, uri)
                 }
             }
     }
@@ -58,45 +61,73 @@ class ScriptBufferWrapper(
         assetURL: String,
     ): HybridData
 
-    private external fun initHybridFromFile(fileName: String): HybridData
-
-    private external fun initHybridFromString(
-        script: String,
-        url: String,
+    private external fun initHybridFromFile(
+        fileName: String,
+        sourceURL: String,
     ): HybridData
 
     companion object {
-        private fun downloadScript(url: String): String {
-            val scriptUrl = URL(url)
-            val connection = scriptUrl.openConnection() as HttpURLConnection
+        private const val DEV_BUNDLE_FILE_NAME = "WorkletsDevBundle.js"
+
+        private fun downloadScriptToFile(
+            url: String,
+            outputFile: File,
+        ) {
+            val connection = URL(url).openConnection() as HttpURLConnection
             try {
-                val content: ByteArray
-
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                    content = connection.inputStream.readAllBytes()
-                } else {
-                    content = readBytes(connection.inputStream)
+                val statusCode =
+                    try {
+                        connection.responseCode
+                    } catch (e: IOException) {
+                        throw RuntimeException("[Worklets] Could not connect to development server.\n", e)
+                    }
+                if (statusCode != 200) {
+                    throw RuntimeException(serverErrorMessage(url, statusCode, connection))
                 }
-
-                return String(content, StandardCharsets.UTF_8)
+                try {
+                    val tmpFile = File(outputFile.path + ".tmp")
+                    connection.inputStream.use { input ->
+                        tmpFile.outputStream().use { output -> input.copyTo(output) }
+                    }
+                    if (!tmpFile.renameTo(outputFile)) {
+                        throw IOException("Couldn't rename $tmpFile to $outputFile")
+                    }
+                } catch (e: IOException) {
+                    throw RuntimeException(
+                        "[Worklets] Failed to store worklets bundle from URL $url: ${e.message}",
+                        e,
+                    )
+                }
             } finally {
                 connection.disconnect()
             }
         }
 
-        /** Reads all bytes from an InputStream into a byte array for SDKs below 33. */
-        private fun readBytes(inputStream: InputStream): ByteArray {
-            val bufferSize = 4096
-            try {
-                val byteBuffer = java.io.ByteArrayOutputStream()
-                val buffer = ByteArray(bufferSize)
-                var len: Int
-                while (inputStream.read(buffer).also { len = it } != -1) {
-                    byteBuffer.write(buffer, 0, len)
-                }
-                return byteBuffer.toByteArray()
-            } finally {
-                inputStream.close()
+        private fun serverErrorMessage(
+            url: String,
+            statusCode: Int,
+            connection: HttpURLConnection,
+        ): String {
+            val body = connection.errorStream?.use { String(it.readBytes(), StandardCharsets.UTF_8) }
+            val metroMessage = parseMetroError(body)
+            if (metroMessage != null) {
+                return "[Worklets] $metroMessage"
+            }
+            return "[Worklets] The development server returned response error code: $statusCode\n\n" +
+                "URL: $url\n\n" +
+                "Body:\n$body"
+        }
+
+        private fun parseMetroError(body: String?): String? {
+            if (body.isNullOrEmpty()) {
+                return null
+            }
+            return try {
+                val json = JSONObject(body)
+                val fileName = json.getString("filename").substringAfterLast('/')
+                "${json.getString("message")}\n  at $fileName:${json.getInt("lineNumber")}:${json.getInt("column")}"
+            } catch (e: JSONException) {
+                null
             }
         }
     }

--- a/packages/react-native-worklets/android/src/networking/com/swmansion/worklets/WorkletsModule.kt
+++ b/packages/react-native-worklets/android/src/networking/com/swmansion/worklets/WorkletsModule.kt
@@ -71,11 +71,9 @@ class WorkletsModule(
         val jsContext = checkNotNull(context.javaScriptContextHolder).get()
         val jsCallInvokerHolder = context.jsCallInvokerHolder as CallInvokerHolderImpl
 
-        val sourceURL = context.sourceURL
-
         val scriptBufferWrapper: ScriptBufferWrapper? =
             if (bundleModeEnabled) {
-                ScriptBufferWrapper(sourceURL!!, context.assets)
+                ScriptBufferWrapper(context.sourceURL, context)
             } else {
                 null
             }

--- a/packages/react-native-worklets/android/src/no-networking/com/swmansion/worklets/WorkletsModule.kt
+++ b/packages/react-native-worklets/android/src/no-networking/com/swmansion/worklets/WorkletsModule.kt
@@ -67,11 +67,9 @@ class WorkletsModule(
         val jsContext = checkNotNull(context.javaScriptContextHolder).get()
         val jsCallInvokerHolder = context.jsCallInvokerHolder as CallInvokerHolderImpl
 
-        val sourceURL = context.sourceURL
-
         val scriptBufferWrapper: ScriptBufferWrapper? =
             if (bundleModeEnabled) {
-                ScriptBufferWrapper(sourceURL!!, context.assets)
+                ScriptBufferWrapper(context.sourceURL, context)
             } else {
                 null
             }

--- a/packages/react-native-worklets/apple/worklets/apple/ScriptLoader.h
+++ b/packages/react-native-worklets/apple/worklets/apple/ScriptLoader.h
@@ -1,0 +1,11 @@
+#import <Foundation/Foundation.h>
+
+#import <worklets/Tools/ScriptBuffer.h>
+
+#import <memory>
+
+namespace worklets {
+
+std::shared_ptr<const ScriptBuffer> getScript(NSURL *url);
+
+} // namespace worklets

--- a/packages/react-native-worklets/apple/worklets/apple/ScriptLoader.mm
+++ b/packages/react-native-worklets/apple/worklets/apple/ScriptLoader.mm
@@ -1,0 +1,124 @@
+#import <worklets/apple/ScriptLoader.h>
+
+namespace worklets {
+namespace {
+
+class NSDataScript : public JSBigString {
+ public:
+  explicit NSDataScript(NSData *data) : data_(data), size_([data length]) {}
+
+  bool isAscii() const override
+  {
+    return false;
+  }
+
+  const char *c_str() const override
+  {
+    return static_cast<const char *>(data_.bytes);
+  }
+
+  size_t size() const override
+  {
+    return size_;
+  }
+
+ private:
+  NSData *data_;
+  size_t size_;
+};
+
+NSData *loadScriptFromFile(NSURL *url)
+{
+  NSError *error;
+  NSData *data = [NSData dataWithContentsOfFile:url.path options:NSDataReadingMappedIfSafe error:&error];
+
+  if (data == nil) [[unlikely]] {
+    NSString *errorMsg = [NSString stringWithFormat:@"[Worklets] Failed to load worklets bundle from file %@: %@",
+                                                    url.path,
+                                                    error.localizedDescription];
+    NSLog(@"%@", errorMsg);
+    throw std::runtime_error([errorMsg UTF8String]);
+  }
+
+  return data;
+}
+
+NSData *downloadScript(NSURL *url)
+{
+  dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+  __block NSData *data = nil;
+  __block NSURLResponse *response = nil;
+  __block NSError *error = nil;
+
+  NSURLSessionDataTask *task = [[NSURLSession sharedSession]
+        dataTaskWithURL:url
+      completionHandler:^(NSData *taskData, NSURLResponse *taskResponse, NSError *taskError) {
+        data = taskData;
+        response = taskResponse;
+        error = taskError;
+        dispatch_semaphore_signal(semaphore);
+      }];
+  [task resume];
+  dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
+
+  if (error != nil) [[unlikely]] {
+    NSString *errorMsg;
+    if ([error.domain isEqualToString:NSURLErrorDomain]) {
+      errorMsg = @"[Worklets] Could not connect to development server.\n";
+    } else {
+      errorMsg = [NSString stringWithFormat:@"[Worklets] Failed to load worklets bundle from URL %@: %@",
+                                            url,
+                                            error.localizedDescription];
+    }
+    NSLog(@"%@", errorMsg);
+    throw std::runtime_error([errorMsg UTF8String]);
+  }
+
+  NSInteger statusCode =
+      [response isKindOfClass:[NSHTTPURLResponse class]] ? [(NSHTTPURLResponse *)response statusCode] : 200;
+  if (statusCode != 200) [[unlikely]] {
+    NSString *description = nil;
+    NSDictionary *jsonError = data != nil ? [NSJSONSerialization JSONObjectWithData:data options:0 error:nil] : nil;
+    if ([jsonError isKindOfClass:[NSDictionary class]] && [jsonError[@"message"] isKindOfClass:[NSString class]] &&
+        [jsonError[@"message"] length] > 0) {
+      description = jsonError[@"message"];
+    } else {
+      description = [NSString stringWithFormat:@"Received status code %ld while fetching the bundle", (long)statusCode];
+    }
+    NSString *errorMsg =
+        [NSString stringWithFormat:@"[Worklets] Failed to load worklets bundle from URL %@: %@", url, description];
+    NSLog(@"%@", errorMsg);
+    throw std::runtime_error([errorMsg UTF8String]);
+  }
+
+  NSString *mimeType = response.MIMEType;
+  if (![mimeType isEqualToString:@"application/javascript"] && ![mimeType isEqualToString:@"text/javascript"])
+      [[unlikely]] {
+    NSString *errorMsg = [NSString
+        stringWithFormat:
+            @"[Worklets] Expected MIME-Type of the worklets bundle to be 'application/javascript' or 'text/javascript', but got '%@'",
+            mimeType];
+    NSLog(@"%@", errorMsg);
+    throw std::runtime_error([errorMsg UTF8String]);
+  }
+
+  return data;
+}
+
+} // namespace
+
+std::shared_ptr<const ScriptBuffer> getScript(NSURL *url)
+{
+  if (url == nil) [[unlikely]] {
+    NSString *errorMsg =
+        @"[Worklets] No script URL provided. Make sure the packager is running or you have embedded a "
+        @"JS bundle in your application bundle.";
+    NSLog(@"%@", errorMsg);
+    throw std::runtime_error([errorMsg UTF8String]);
+  }
+
+  NSData *data = url.isFileURL ? loadScriptFromFile(url) : downloadScript(url);
+  return std::make_shared<const ScriptBuffer>(std::make_shared<const NSDataScript>(data));
+}
+
+} // namespace worklets

--- a/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.mm
+++ b/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.mm
@@ -7,7 +7,10 @@
 #import <worklets/apple/AssertJavaScriptQueue.h>
 #import <worklets/apple/AssertTurboModuleManagerQueue.h>
 #import <worklets/apple/IOSUIScheduler.h>
+#import <worklets/apple/ScriptLoader.h>
 #import <worklets/apple/WorkletsModule.h>
+
+#import <Foundation/Foundation.h>
 
 #import <React/RCTBridge+Private.h>
 #import <React/RCTCallInvoker.h>
@@ -64,7 +67,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule : (BOOL)bundleModeEnab
 
   if (bundleModeEnabled) {
     NSURL *url = bundleManager_.bundleURL;
-    script = [self getScript:url];
+    script = getScript(url);
     sourceURL = [[url absoluteString] UTF8String];
   }
 
@@ -125,21 +128,6 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(toggleSlowAnimationsOnUIRuntime)
 {
   AssertJavaScriptQueue();
   return std::make_shared<facebook::react::NativeWorkletsModuleSpecJSI>(params);
-}
-
-- (std::shared_ptr<const ScriptBuffer>)getScript:(NSURL *)url
-{
-  NSData *data = [NSData dataWithContentsOfURL:url];
-
-  if (!data) [[unlikely]] {
-    NSString *errorMsg = [NSString stringWithFormat:@"[Worklets] Failed to load worklets bundle from URL: %@", url];
-    NSLog(@"%@", errorMsg);
-    throw std::runtime_error([errorMsg UTF8String]);
-  }
-
-  auto str = std::string(reinterpret_cast<const char *>([data bytes]), [data length]);
-  auto bigString = std::make_shared<const JSBigStdString>(str);
-  return std::make_shared<const ScriptBuffer>(bigString);
 }
 
 - (std::shared_ptr<RuntimeBindings>)getRuntimeBindings:(jsi::Runtime &)rnRuntime


### PR DESCRIPTION
## Summary

In Bundle Mode we loaded the script through in-memory copies - on iOS the whole bundle ended up in a `std::string` that stayed resident and dirty for the app's lifetime, and on Android a dev-server bundle passed through a Java `String` and two more copies on its way through JNI.

I brought the loading on par with React Native's own loaders: local bundles are now mmapped (`NSDataReadingMappedIfSafe` on iOS, the same call `RCTJavaScriptLoader` uses; on Android dev-server downloads stream to a cache file loaded through `JSBigFileString`, like `JSBundleLoader` does), and dev-server fetches check the HTTP status, surface the error message Metro returns as JSON.

## Test plan

Bundle Mode works on iOS and Android both in development and production.
