### PR TITLE
refactor(worklets): remove deprecated WorkletRuntime sync API

### DIFF
--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/MemoryManager.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/MemoryManager.cpp
@@ -7,7 +7,7 @@
 namespace worklets {
 void MemoryManager::loadAllCustomSerializables(const std::shared_ptr<WorkletRuntime> &runtime) {
   std::lock_guard lock(customSerializationDataMutex_);
-  runtime->executeSync([&](jsi::Runtime &rt) -> jsi::Value {
+  runtime->runSync([&](jsi::Runtime &rt) -> jsi::Value {
     const auto registry = getCustomSerializationRegistry(rt);
     for (const auto &data : customSerializationData_) {
       loadCustomSerializable(rt, registry, data);
@@ -20,7 +20,7 @@ void MemoryManager::loadCustomSerializable(
     const std::shared_ptr<WorkletRuntime> &runtime,
     const SerializationData &data) {
   std::lock_guard lock(customSerializationDataMutex_);
-  runtime->executeSync([this, data](jsi::Runtime &rt) -> jsi::Value {
+  runtime->runSync([this, data](jsi::Runtime &rt) -> jsi::Value {
     const auto registry = getCustomSerializationRegistry(rt);
     loadCustomSerializable(rt, registry, data);
     return jsi::Value::undefined();

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.cpp
@@ -312,27 +312,4 @@ std::weak_ptr<WorkletRuntime> WorkletRuntime::getWeakRuntimeFromJSIRuntime(jsi::
   return weakHolder->weakRuntime;
 }
 
-/* #region deprecated */
-
-void WorkletRuntime::runAsyncGuarded(const std::shared_ptr<SerializableWorklet> &worklet) {
-  schedule(worklet);
-}
-
-jsi::Value WorkletRuntime::executeSync(jsi::Runtime &caller, const jsi::Value &worklet) const {
-  auto serializableWorklet = extractSerializableOrThrow<SerializableWorklet>(
-      caller, worklet, "[Worklets] Only worklets can be executed synchronously on UI runtime.");
-  auto result = runSyncSerialized(serializableWorklet);
-  return result->toJSValue(caller);
-}
-
-jsi::Value WorkletRuntime::executeSync(std::function<jsi::Value(jsi::Runtime &)> &&job) const {
-  return runSync(job);
-}
-
-jsi::Value WorkletRuntime::executeSync(const std::function<jsi::Value(jsi::Runtime &)> &job) const {
-  return runSync(job);
-}
-
-/* #endregion */
-
 } // namespace worklets

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.h
@@ -176,27 +176,6 @@ class WorkletRuntime : public jsi::HostObject, public std::enable_shared_from_th
 
   void init(const std::shared_ptr<JSIWorkletsModuleProxy> &jsiWorkletsModuleProxy);
 
-  /* #region deprecated */
-
-  /** @deprecated Use `runSync` instead. */
-  template <typename... Args>
-  jsi::Value runGuarded(const std::shared_ptr<SerializableWorklet> &worklet, Args &&...args) const {
-    return runSync(worklet, std::forward<Args>(args)...);
-  }
-
-  /** @deprecated Use `schedule` instead. */
-  void runAsyncGuarded(const std::shared_ptr<SerializableWorklet> &worklet);
-
-  /** @deprecated Use `runSyncSerialized` and extract to `jsi::Value` with
-   * `extractSerializableOrThrow` instead. */
-  jsi::Value executeSync(jsi::Runtime &rt, const jsi::Value &worklet) const;
-  /** @deprecated Use `runSync` instead. */
-  jsi::Value executeSync(std::function<jsi::Value(jsi::Runtime &)> &&job) const;
-  /** @deprecated Use `runSync` instead. */
-  jsi::Value executeSync(const std::function<jsi::Value(jsi::Runtime &)> &job) const;
-
-  /* #endregion */
-
   /**
    * Retrieves a weak reference to the WorkletRuntime associated with the
    * provided jsi::Runtime.


### PR DESCRIPTION
> [!NOTE] **This PR description is AI-generated.**

## Summary

Extracted from #10085.

`WorkletRuntime` kept a `deprecated` region with `runGuarded`, `runAsyncGuarded`, and three `executeSync` overloads that duplicated the current `runSync` / `schedule` API.

`runGuarded` and `runAsyncGuarded` had no callers, and the two `executeSync` call sites in `MemoryManager` already forwarded through `executeSync` to `runSync`, so I repointed them at `runSync` and removed the region. No behavior change.

## Test plan

CI passes.
