### PR TITLE
feat: Keep platform-driven CSS transition values alive across React Native writes

### DIFF
--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionReconciler.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionReconciler.kt
@@ -1,0 +1,42 @@
+package com.swmansion.reanimated.css
+
+import android.view.View
+import android.view.ViewTreeObserver
+
+/**
+ * Platform transitions animate the same View property React Native writes, so a
+ * commit touching the view overwrites the running animation - and on Android
+ * Fabric re-applies the whole props blob, so any prop changing is enough.
+ *
+ * Every writer (a Fabric mount, the synchronous props path, the animation backend)
+ * runs on the UI thread earlier in the frame, so re-asserting just before the frame
+ * is drawn covers all of them without knowing which one ran.
+ *
+ * One listener per window, not per view: getViewTreeObserver returns the window's
+ * observer, so registering per view would run [repair] once per animating view.
+ */
+internal class CSSPlatformTransitionReconciler(
+    private val repair: () -> Unit,
+) {
+    private val observers = HashMap<ViewTreeObserver, ViewTreeObserver.OnPreDrawListener>()
+
+    fun track(view: View) {
+        val observer = view.viewTreeObserver
+        if (!observer.isAlive || observers.containsKey(observer)) return
+
+        val listener =
+            ViewTreeObserver.OnPreDrawListener {
+                repair()
+                true
+            }
+        observer.addOnPreDrawListener(listener)
+        observers[observer] = listener
+    }
+
+    fun untrackAll() {
+        observers.forEach { (observer, listener) ->
+            if (observer.isAlive) observer.removeOnPreDrawListener(listener)
+        }
+        observers.clear()
+    }
+}

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionReconciler.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionReconciler.kt
@@ -4,43 +4,36 @@ import android.view.View
 import android.view.ViewTreeObserver
 
 /**
- * Platform transitions animate the same View property React Native writes, so a commit
- * touching the view overwrites the running animation - and on Android Fabric re-applies
- * the whole props blob, so any prop changing is enough.
+ * A platform transition animates the property React Native itself writes, so a commit can
+ * overwrite it mid-flight. Re-asserting just before the frame is drawn covers every writer -
+ * a Fabric mount, the synchronous props path, the animation backend - without knowing which
+ * one ran, since they all run earlier in the same frame.
  *
- * Every writer (a Fabric mount, the synchronous props path, the animation backend) runs on
- * the UI thread earlier in the frame, so re-asserting just before the frame is drawn covers
- * all of them without knowing which one ran.
- *
- * One listener per window, not per view: getViewTreeObserver returns the window's observer.
- * Each listener retires itself once [repair] reports nothing left to hold, so a cancel that
- * momentarily empties the registry cannot deregister a still-needed listener.
+ * [repair] returns whether anything is still animating.
  */
 internal class CSSPlatformTransitionReconciler(
     private val repair: () -> Boolean,
 ) {
-    private val observers = HashMap<ViewTreeObserver, ViewTreeObserver.OnPreDrawListener>()
+    /** Keyed by window: getViewTreeObserver is per window, not per view. */
+    private val tracked = HashSet<ViewTreeObserver>()
 
     fun track(view: View) {
         val observer = view.viewTreeObserver
-        if (!observer.isAlive || observers.containsKey(observer)) return
+        if (!observer.isAlive || !tracked.add(observer)) return
 
-        val listener =
+        observer.addOnPreDrawListener(
             object : ViewTreeObserver.OnPreDrawListener {
                 override fun onPreDraw(): Boolean {
-                    if (!repair()) retire(observer, this)
+                    // Retiring here rather than when the registry empties: cancelling an
+                    // animator runs its end callback part way through installing the
+                    // replacement, when the registry is briefly empty.
+                    if (!repair()) {
+                        if (observer.isAlive) observer.removeOnPreDrawListener(this)
+                        tracked.remove(observer)
+                    }
                     return true
                 }
-            }
-        observer.addOnPreDrawListener(listener)
-        observers[observer] = listener
-    }
-
-    private fun retire(
-        observer: ViewTreeObserver,
-        listener: ViewTreeObserver.OnPreDrawListener,
-    ) {
-        if (observer.isAlive) observer.removeOnPreDrawListener(listener)
-        observers.remove(observer)
+            },
+        )
     }
 }

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionReconciler.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionReconciler.kt
@@ -4,19 +4,20 @@ import android.view.View
 import android.view.ViewTreeObserver
 
 /**
- * Platform transitions animate the same View property React Native writes, so a
- * commit touching the view overwrites the running animation - and on Android
- * Fabric re-applies the whole props blob, so any prop changing is enough.
+ * Platform transitions animate the same View property React Native writes, so a commit
+ * touching the view overwrites the running animation - and on Android Fabric re-applies
+ * the whole props blob, so any prop changing is enough.
  *
- * Every writer (a Fabric mount, the synchronous props path, the animation backend)
- * runs on the UI thread earlier in the frame, so re-asserting just before the frame
- * is drawn covers all of them without knowing which one ran.
+ * Every writer (a Fabric mount, the synchronous props path, the animation backend) runs on
+ * the UI thread earlier in the frame, so re-asserting just before the frame is drawn covers
+ * all of them without knowing which one ran.
  *
- * One listener per window, not per view: getViewTreeObserver returns the window's
- * observer, so registering per view would run [repair] once per animating view.
+ * One listener per window, not per view: getViewTreeObserver returns the window's observer.
+ * Each listener retires itself once [repair] reports nothing left to hold, so a cancel that
+ * momentarily empties the registry cannot deregister a still-needed listener.
  */
 internal class CSSPlatformTransitionReconciler(
-    private val repair: () -> Unit,
+    private val repair: () -> Boolean,
 ) {
     private val observers = HashMap<ViewTreeObserver, ViewTreeObserver.OnPreDrawListener>()
 
@@ -25,18 +26,21 @@ internal class CSSPlatformTransitionReconciler(
         if (!observer.isAlive || observers.containsKey(observer)) return
 
         val listener =
-            ViewTreeObserver.OnPreDrawListener {
-                repair()
-                true
+            object : ViewTreeObserver.OnPreDrawListener {
+                override fun onPreDraw(): Boolean {
+                    if (!repair()) retire(observer, this)
+                    return true
+                }
             }
         observer.addOnPreDrawListener(listener)
         observers[observer] = listener
     }
 
-    fun untrackAll() {
-        observers.forEach { (observer, listener) ->
-            if (observer.isAlive) observer.removeOnPreDrawListener(listener)
-        }
-        observers.clear()
+    private fun retire(
+        observer: ViewTreeObserver,
+        listener: ViewTreeObserver.OnPreDrawListener,
+    ) {
+        if (observer.isAlive) observer.removeOnPreDrawListener(listener)
+        observers.remove(observer)
     }
 }

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionReconciler.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionReconciler.kt
@@ -4,12 +4,9 @@ import android.view.View
 import android.view.ViewTreeObserver
 
 /**
- * A platform transition animates the property React Native itself writes, so a commit can
- * overwrite it mid-flight. Re-asserting just before the frame is drawn covers every writer -
- * a Fabric mount, the synchronous props path, the animation backend - without knowing which
- * one ran, since they all run earlier in the same frame.
- *
- * [repair] returns whether anything is still animating.
+ * React writes the same property the animator drives, so a commit can overwrite it mid-flight.
+ * Re-asserting just before the draw covers every writer without knowing which one ran, since
+ * they all run earlier in the frame. [repair] returns whether anything is still animating.
  */
 internal class CSSPlatformTransitionReconciler(
     private val repair: () -> Boolean,
@@ -29,9 +26,8 @@ internal class CSSPlatformTransitionReconciler(
                 override fun onPreDraw(): Boolean {
                     if (repair()) return true
 
-                    // Retiring here rather than when the registry empties: cancelling an
-                    // animator runs its end callback part way through installing the
-                    // replacement, when the registry is briefly empty.
+                    // Retire here, not when the registry empties: a cancel fires its end
+                    // callback mid-replacement, when the registry is briefly empty.
                     if (observer.isAlive) observer.removeOnPreDrawListener(this)
                     tracked.remove(observer)
                     return true

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionReconciler.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionReconciler.kt
@@ -18,19 +18,22 @@ internal class CSSPlatformTransitionReconciler(
     private val tracked = HashSet<ViewTreeObserver>()
 
     fun track(view: View) {
+        // A window torn down mid-animation never draws again, so its listener never retires.
+        tracked.removeAll { !it.isAlive }
+
         val observer = view.viewTreeObserver
         if (!observer.isAlive || !tracked.add(observer)) return
 
         observer.addOnPreDrawListener(
             object : ViewTreeObserver.OnPreDrawListener {
                 override fun onPreDraw(): Boolean {
+                    if (repair()) return true
+
                     // Retiring here rather than when the registry empties: cancelling an
                     // animator runs its end callback part way through installing the
                     // replacement, when the registry is briefly empty.
-                    if (!repair()) {
-                        if (observer.isAlive) observer.removeOnPreDrawListener(this)
-                        tracked.remove(observer)
-                    }
+                    if (observer.isAlive) observer.removeOnPreDrawListener(this)
+                    tracked.remove(observer)
                     return true
                 }
             },

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
@@ -19,6 +19,7 @@ internal class CSSPlatformTransitionsManager(
     private val animationTimestamp: () -> Long,
 ) {
     private val animators = HashMap<Key, ObjectAnimator>()
+    private val reconciler = CSSPlatformTransitionReconciler(::repairClobberedValues)
     private val startTokens = HashMap<Key, Long>()
 
     private var nextStartToken = 0L
@@ -76,6 +77,7 @@ internal class CSSPlatformTransitionsManager(
             val key = Key(viewTag, propertyName)
             startTokens.remove(key)
             animators.remove(key)?.cancel()
+            if (animators.isEmpty()) reconciler.untrackAll()
         }
     }
 
@@ -124,6 +126,7 @@ internal class CSSPlatformTransitionsManager(
             object : AnimatorListenerAdapter() {
                 override fun onAnimationEnd(animation: Animator) {
                     if (animators[key] === animation) animators.remove(key)
+                    if (animators.isEmpty()) reconciler.untrackAll()
                 }
             },
         )
@@ -137,6 +140,17 @@ internal class CSSPlatformTransitionsManager(
         }
         animator.start()
         animators[key] = animator
+        reconciler.track(view)
+    }
+
+    /** Re-asserts the animator's own value wherever a commit overwrote it. */
+    private fun repairClobberedValues() {
+        animators.forEach { (key, animator) ->
+            val view = animator.target as? View ?: return@forEach
+            val writer = cssPropertyWriterFor(key.propertyName) ?: return@forEach
+            val current = animator.animatedValue as? Float ?: return@forEach
+            if (writer.get(view) != current) writer.setValue(view, current)
+        }
     }
 
     /** PathInterpolator flattens its curve on construction, so cache it. Type is in the key

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
@@ -30,15 +30,15 @@ internal class CSSPlatformTransitionsManager(
         val propertyName: String,
     )
 
-    /**
-     * ObjectAnimator leaves its animated value uninitialised until its first frame, which a
-     * start delay defers, so [startValue] is what the property must show until then.
-     */
     private class RunningTransition(
         val animator: ObjectAnimator,
+        val writer: FloatProperty<View>,
         val startValue: Float,
     ) {
-        /** What the animation should be showing right now. */
+        /**
+         * ObjectAnimator leaves its animated value uninitialised until its first frame, which
+         * a start delay defers, so until then the property must show the start value.
+         */
         fun currentValue(): Float = if (animator.isRunning) animator.animatedValue as Float else startValue
     }
 
@@ -149,17 +149,17 @@ internal class CSSPlatformTransitionsManager(
             animator.setCurrentFraction((elapsedMs / durationMs).toFloat().coerceIn(0f, 1f))
         }
         animator.start()
-        animators[key] = RunningTransition(animator, startValue)
+        animators[key] = RunningTransition(animator, writer, startValue)
         reconciler.track(view)
     }
 
-    /** Re-asserts the animator's own value wherever a commit overwrote it. */
+    /** Re-asserts each animator's own value wherever a commit overwrote it. */
     private fun repairClobberedValues(): Boolean {
-        animators.forEach { (key, running) ->
+        animators.values.forEach { running ->
+            // target is held weakly, so read the View through it rather than keeping one.
             val view = running.animator.target as? View ?: return@forEach
-            val writer = cssPropertyWriterFor(key.propertyName) ?: return@forEach
             val current = running.currentValue()
-            if (writer.get(view) != current) writer.setValue(view, current)
+            if (running.writer.get(view) != current) running.writer.setValue(view, current)
         }
         return animators.isNotEmpty()
     }

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
@@ -35,10 +35,7 @@ internal class CSSPlatformTransitionsManager(
         val writer: FloatProperty<View>,
         val startValue: Float,
     ) {
-        /**
-         * ObjectAnimator leaves its animated value uninitialised until its first frame, which
-         * a start delay defers, so until then the property must show the start value.
-         */
+        /** Uninitialised until the first frame, which a start delay defers, so show startValue. */
         fun currentValue(): Float = if (animator.isRunning) animator.animatedValue as Float else startValue
     }
 

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
@@ -18,7 +18,7 @@ internal class CSSPlatformTransitionsManager(
     private val reactContext: WeakReference<ReactApplicationContext>,
     private val animationTimestamp: () -> Long,
 ) {
-    private val animators = HashMap<Key, ObjectAnimator>()
+    private val animators = HashMap<Key, RunningTransition>()
     private val reconciler = CSSPlatformTransitionReconciler(::repairClobberedValues)
     private val startTokens = HashMap<Key, Long>()
 
@@ -29,6 +29,18 @@ internal class CSSPlatformTransitionsManager(
         val viewTag: Int,
         val propertyName: String,
     )
+
+    /**
+     * ObjectAnimator leaves its animated value uninitialised until its first frame, which a
+     * start delay defers, so [startValue] is what the property must show until then.
+     */
+    private class RunningTransition(
+        val animator: ObjectAnimator,
+        val startValue: Float,
+    ) {
+        /** What the animation should be showing right now. */
+        fun currentValue(): Float = if (animator.isRunning) animator.animatedValue as Float else startValue
+    }
 
     private data class InterpolatorKey(
         val type: Int,
@@ -76,8 +88,7 @@ internal class CSSPlatformTransitionsManager(
         UiThreadUtil.runOnUiThread {
             val key = Key(viewTag, propertyName)
             startTokens.remove(key)
-            animators.remove(key)?.cancel()
-            if (animators.isEmpty()) reconciler.untrackAll()
+            animators.remove(key)?.animator?.cancel()
         }
     }
 
@@ -113,7 +124,7 @@ internal class CSSPlatformTransitionsManager(
         // Resume from what is on screen; fromValue is the committed style, which would snap back.
         val interrupted = animators.remove(key)
         val startValue = if (interrupted != null) writer.get(view) else fromValue.toFloat()
-        interrupted?.cancel()
+        interrupted?.animator?.cancel()
 
         // ObjectAnimator writes nothing until its first frame, so the view would show the
         // already-committed target for the whole delay.
@@ -125,8 +136,7 @@ internal class CSSPlatformTransitionsManager(
         animator.addListener(
             object : AnimatorListenerAdapter() {
                 override fun onAnimationEnd(animation: Animator) {
-                    if (animators[key] === animation) animators.remove(key)
-                    if (animators.isEmpty()) reconciler.untrackAll()
+                    if (animators[key]?.animator === animation) animators.remove(key)
                 }
             },
         )
@@ -139,18 +149,19 @@ internal class CSSPlatformTransitionsManager(
             animator.setCurrentFraction((elapsedMs / durationMs).toFloat().coerceIn(0f, 1f))
         }
         animator.start()
-        animators[key] = animator
+        animators[key] = RunningTransition(animator, startValue)
         reconciler.track(view)
     }
 
     /** Re-asserts the animator's own value wherever a commit overwrote it. */
-    private fun repairClobberedValues() {
-        animators.forEach { (key, animator) ->
-            val view = animator.target as? View ?: return@forEach
+    private fun repairClobberedValues(): Boolean {
+        animators.forEach { (key, running) ->
+            val view = running.animator.target as? View ?: return@forEach
             val writer = cssPropertyWriterFor(key.propertyName) ?: return@forEach
-            val current = animator.animatedValue as? Float ?: return@forEach
+            val current = running.currentValue()
             if (writer.get(view) != current) writer.setValue(view, current)
         }
+        return animators.isNotEmpty()
     }
 
     /** PathInterpolator flattens its curve on construction, so cache it. Type is in the key


### PR DESCRIPTION
A platform transition animates the same `View` property React Native writes, so any commit touching that view overwrites the running animation. On Android Fabric re-applies the whole props blob, so it is enough for any prop on the view to change.

This PR adds a pre-draw listener that re-applies styles from running animators to ensure that the animation takes effect and is not overridden by RN.

Stacked on #10090.