### PR TITLE
chore: rename RawProgressProvider to TimeProgressProvider

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.cpp
@@ -15,7 +15,7 @@ AnimationProgressProvider::AnimationProgressProvider(
     const AnimationDirection direction,
     EasingFunction easingFunction,
     const std::shared_ptr<KeyframeEasingConfigs> &keyframeEasingConfigs)
-    : RawProgressProvider(timestamp, duration, delay),
+    : TimeProgressProvider(timestamp, duration, delay),
       iterationCount_(iterationCount),
       direction_(direction),
       easingFunction_(std::move(easingFunction)),
@@ -81,12 +81,12 @@ void AnimationProgressProvider::play(const double timestamp) {
 }
 
 void AnimationProgressProvider::update(const double timestamp) {
-  RawProgressProvider::update(timestamp);
+  TimeProgressProvider::update(timestamp);
   state_ = computeState(timestamp);
 }
 
 void AnimationProgressProvider::resetProgress() {
-  RawProgressProvider::resetProgress();
+  TimeProgressProvider::resetProgress();
   currentIteration_ = 1;
   previousIterationsDuration_ = 0;
   state_ = AnimationProgressState::Pending;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.h
@@ -4,7 +4,7 @@
 #include <reanimated/CSS/configs/CSSKeyframesConfig.h>
 #include <reanimated/CSS/easing/EasingFunctions.h>
 #include <reanimated/CSS/progress/KeyframeProgressProvider.h>
-#include <reanimated/CSS/progress/RawProgressProvider.h>
+#include <reanimated/CSS/progress/TimeProgressProvider.h>
 
 #include <memory>
 
@@ -17,7 +17,7 @@ enum class AnimationProgressState : std::uint8_t {
   Finished
 };
 
-class AnimationProgressProvider final : public KeyframeProgressProvider, public RawProgressProvider {
+class AnimationProgressProvider final : public KeyframeProgressProvider, public TimeProgressProvider {
  public:
   AnimationProgressProvider(
       double timestamp,

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TimeProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TimeProgressProvider.cpp
@@ -1,23 +1,23 @@
-#include <reanimated/CSS/progress/RawProgressProvider.h>
+#include <reanimated/CSS/progress/TimeProgressProvider.h>
 
 namespace reanimated::css {
 
-RawProgressProvider::RawProgressProvider(const double timestamp, const double duration, const double delay)
+TimeProgressProvider::TimeProgressProvider(const double timestamp, const double duration, const double delay)
     : duration_(duration), delay_(delay), creationTimestamp_(timestamp) {}
 
-void RawProgressProvider::setDuration(double duration) {
+void TimeProgressProvider::setDuration(double duration) {
   duration_ = duration;
 }
 
-void RawProgressProvider::setDelay(double delay) {
+void TimeProgressProvider::setDelay(double delay) {
   delay_ = delay;
 }
 
-void RawProgressProvider::resetProgress() {
+void TimeProgressProvider::resetProgress() {
   rawProgress_.reset();
 }
 
-void RawProgressProvider::update(const double timestamp) {
+void TimeProgressProvider::update(const double timestamp) {
   lastTimestamp_ = timestamp;
 
   if (timestamp - creationTimestamp_ < delay_) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TimeProgressProvider.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TimeProgressProvider.h
@@ -4,9 +4,9 @@
 
 namespace reanimated::css {
 
-class RawProgressProvider {
+class TimeProgressProvider {
  public:
-  RawProgressProvider(double timestamp, double duration, double delay);
+  TimeProgressProvider(double timestamp, double duration, double delay);
 
   void setDuration(double duration);
   void setDelay(double delay);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
@@ -17,7 +17,7 @@ TransitionPropertyProgressProvider::TransitionPropertyProgressProvider(
     const double duration,
     const double delay,
     EasingConfig easing)
-    : RawProgressProvider(timestamp, duration, delay),
+    : TimeProgressProvider(timestamp, duration, delay),
       easing_(std::move(easing)),
       easingFunction_(getEasingFunctionFromConfig(easing_)) {}
 
@@ -27,7 +27,7 @@ TransitionPropertyProgressProvider::TransitionPropertyProgressProvider(
     const double delay,
     EasingConfig easing,
     const double reversingShorteningFactor)
-    : RawProgressProvider(timestamp, duration, delay),
+    : TimeProgressProvider(timestamp, duration, delay),
       easing_(std::move(easing)),
       easingFunction_(getEasingFunctionFromConfig(easing_)),
       reversingShorteningFactor_(reversingShorteningFactor) {}
@@ -53,7 +53,7 @@ ReversingState TransitionPropertyProgressProvider::getReversingState() const {
 
 TransitionProgressState TransitionPropertyProgressProvider::getState() const {
   // rawProgress_ is empty until the property's delay has passed
-  // (RawProgressProvider::update resets it while timestamp < creationTimestamp + delay)
+  // (TimeProgressProvider::update resets it while timestamp < creationTimestamp + delay)
   if (!rawProgress_.has_value()) {
     return TransitionProgressState::Pending;
   }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.h
@@ -2,7 +2,7 @@
 
 #include <reanimated/CSS/configs/CSSTransitionConfig.h>
 #include <reanimated/CSS/progress/KeyframeProgressProvider.h>
-#include <reanimated/CSS/progress/RawProgressProvider.h>
+#include <reanimated/CSS/progress/TimeProgressProvider.h>
 #include <reanimated/CSS/utils/props.h>
 #include <reanimated/CSS/utils/reversingShortening.h>
 
@@ -16,7 +16,7 @@ namespace reanimated::css {
 
 enum class TransitionProgressState : std::uint8_t { Idle, Pending, Running };
 
-class TransitionPropertyProgressProvider final : public KeyframeProgressProvider, public RawProgressProvider {
+class TransitionPropertyProgressProvider final : public KeyframeProgressProvider, public TimeProgressProvider {
  public:
   TransitionPropertyProgressProvider(double timestamp, double duration, double delay, EasingConfig easing);
   TransitionPropertyProgressProvider(


### PR DESCRIPTION
`RawProgressProvider` is entirely time-driven: it is constructed from a timestamp, owns the duration, delay and creation timestamp, and gates on the frame clock. The name said nothing about that, which matters now that progress sources not driven by the frame clock are coming, such as a platform animation owning its own clock.

Rename only. `Raw` stays on `calculateRawProgress`, where it still means "before direction and easing". Inheritance is unchanged: `KeyframeProgressProvider` is what a consumer reads, `TimeProgressProvider` is what drives it, and the two stay independent so a provider that is not time-driven can implement one without the other.
