### PR TITLE
docs: Add CSS pseudo selectors page

### DIFF
--- a/docs/docs-reanimated/docs/css-transitions/overview.mdx
+++ b/docs/docs-reanimated/docs/css-transitions/overview.mdx
@@ -71,6 +71,7 @@ When you need frame-by-frame control (gesture-driven or scroll-driven interactio
 - A CSS transition animates a style property when its value changes between renders.
 - You need [`transitionProperty`](/docs/css-transitions/transition-property) to say what to watch and [`transitionDuration`](/docs/css-transitions/transition-duration) to say how long it takes.
 - Transitions run on [Animated components](/docs/fundamentals/glossary#animated-component) and react to state or prop changes, not to shared value updates.
+- Interaction states like hovering, pressing, and focus don't need React state at all - [Pseudo Selectors](/docs/css-transitions/pseudo-selectors) transition on them directly.
 - Use CSS transitions for state-driven animations, and [`useAnimatedStyle`](/docs/core/useAnimatedStyle) for gesture-driven or orchestrated ones.
 
 ## What's next?
@@ -82,5 +83,7 @@ Now that you've got the basics, explore the individual properties to fine-tune y
 - [`transitionTimingFunction`](/docs/css-transitions/transition-timing-function)
 - [`transitionDelay`](/docs/css-transitions/transition-delay)
 - [`transitionBehavior`](/docs/css-transitions/transition-behavior)
+
+Want a style to react to hovering, pressing, or focus without wiring up any state? See [Pseudo Selectors](/docs/css-transitions/pseudo-selectors).
 
 Looking for animations that play on their own or loop through multiple steps? Head over to [CSS Animations](/docs/css-animations/overview).

--- a/docs/docs-reanimated/docs/css-transitions/pseudo-selectors.mdx
+++ b/docs/docs-reanimated/docs/css-transitions/pseudo-selectors.mdx
@@ -1,0 +1,243 @@
+---
+sidebar_position: 7
+---
+
+# Pseudo Selectors
+
+Pseudo selectors let you transition a style property based on an interaction state - **hovered**, **pressed**, or **focused** - without ever putting that state in React.
+
+import PseudoSelectorsBasic from '@site/src/examples/css-transitions/PseudoSelectorsBasic';
+import PseudoSelectorsBasicSrc from '!!raw-loader!@site/src/examples/css-transitions/PseudoSelectorsBasic';
+
+<InteractiveExample src={PseudoSelectorsBasicSrc} component={PseudoSelectorsBasic} label="Hover or press the box"/>
+
+Instead of writing the pseudo state as a selector that wraps a whole style block, like you would in CSS on the web, you write it _inside_ the property it affects:
+
+```jsx
+<Animated.View
+  style={{
+    // highlight-start
+    backgroundColor: {
+      default: '#b58df1',
+      ':hover': '#82cab2',
+    },
+    // highlight-end
+    transitionDuration: 300,
+  }}
+/>
+```
+
+There's no `useState` and no `onPressIn`/`onPressOut` here. Reanimated watches for the interaction itself, and when the state changes it transitions the property between the values you gave it - all off the JavaScript thread, without re-rendering your component.
+
+## Reference
+
+```javascript
+function App() {
+  return (
+    <Animated.View
+      style={{
+        // highlight-start
+        opacity: {
+          default: 0.6,
+          ':hover': 1,
+        },
+        // highlight-end
+        transitionDuration: 300,
+      }}
+    />
+  );
+}
+```
+
+<details>
+  <summary>Type definitions</summary>
+
+  ```typescript
+  type NativePseudoSelectorKey =
+    | ':hover'
+    | ':active'
+    | ':active-deepest'
+    | ':focus'
+    | ':focus-within';
+
+  type CSSPseudoSelectorKey =
+    | 'default'
+    | NativePseudoSelectorKey
+    | WebPseudoSelectorKey; // web-only selectors, see the table below
+
+  type CSSPseudoValue<T> = RequireAtLeastOne<{
+    [K in CSSPseudoSelectorKey]?: T;
+  }>;
+
+  type StyleWithPseudoValues<TStyle extends object> = {
+    [K in keyof TStyle]: TStyle[K] | CSSPseudoValue<TStyle[K]>;
+  };
+  ```
+</details>
+
+### Values
+
+#### `default`
+
+The value used when none of the listed selectors match - the resting state of the property.
+
+```typescript
+backgroundColor: {
+  default: '#b58df1',
+  ':hover': '#82cab2',
+},
+```
+
+#### `<pseudo selector>`
+
+The value used while that selector matches. You can list as many selectors as you want for a single property.
+
+```typescript
+transform: {
+  default: [{ scale: 1 }],
+  ':hover': [{ scale: 1.1 }],
+  ':active': [{ scale: 0.9 }],
+},
+```
+
+## How it works
+
+You write the property as an object: the keys are `default` and the selectors you care about, and the values are what the property should be in each of those states. Reanimated attaches the matching native listeners (a hover recognizer, a press recognizer, focus notifications) to the view, and swaps between the values as those listeners fire.
+
+Two things follow from that:
+
+1. **Timing comes from the component's transition settings.** Pseudo selectors animate as CSS transitions, so [`transitionDuration`](/docs/css-transitions/transition-duration), [`transitionTimingFunction`](/docs/css-transitions/transition-timing-function), and [`transitionDelay`](/docs/css-transitions/transition-delay) are read from the top level of the style, not from inside the pseudo object.
+1. **Nothing re-renders.** Hovering or pressing doesn't trigger a React render, so JavaScript work can't get in the way of the animation.
+
+When several selectors match at once, the one later in this list wins:
+
+```
+:focus-within  <  :focus  <  :hover  <  :active  <  :active-deepest
+```
+
+## Available selectors
+
+Five selectors describe interaction states that exist on every platform.
+
+### `:hover`
+
+Matches while a pointer - a mouse, a trackpad, or a stylus - sits over the element.
+
+import PseudoSelectorsHover from '@site/src/examples/css-transitions/PseudoSelectorsHover';
+import PseudoSelectorsHoverSrc from '!!raw-loader!@site/src/examples/css-transitions/PseudoSelectorsHover';
+
+<InteractiveExample src={PseudoSelectorsHoverSrc} component={PseudoSelectorsHover} label="Hover any box"/>
+
+:::note
+
+A finger isn't a pointer, so on touch devices `:hover` follows the model mobile browsers use: a tap commits the hover state, and a later touch somewhere else (or a scroll) clears it. A stylus is a real pointer, so it hovers just like a mouse. When you want press feedback that behaves the same on every input, reach for `:active`.
+
+:::
+
+### `:active`
+
+Matches while the element is held down. A press also activates every ancestor that declares `:active`.
+
+import PseudoSelectorsActive from '@site/src/examples/css-transitions/PseudoSelectorsActive';
+import PseudoSelectorsActiveSrc from '!!raw-loader!@site/src/examples/css-transitions/PseudoSelectorsActive';
+
+<InteractiveExample src={PseudoSelectorsActiveSrc} component={PseudoSelectorsActive} label="Press and hold the button"/>
+
+### `:active-deepest`
+
+The same press, but only the innermost element under the finger matches - it never travels up to ancestors.
+
+Both stacks below are a card wrapping a button, and in each one the card and the button declare the same selector. Press each button to see the difference:
+
+import PseudoSelectorsActiveDeepest from '@site/src/examples/css-transitions/PseudoSelectorsActiveDeepest';
+import PseudoSelectorsActiveDeepestSrc from '!!raw-loader!@site/src/examples/css-transitions/PseudoSelectorsActiveDeepest';
+
+<InteractiveExample src={PseudoSelectorsActiveDeepestSrc} component={PseudoSelectorsActiveDeepest} label="Press both buttons and watch the cards"/>
+
+### `:focus`
+
+Matches while the element itself has focus - most often a `TextInput` the user is typing into.
+
+import PseudoSelectorsFocus from '@site/src/examples/css-transitions/PseudoSelectorsFocus';
+import PseudoSelectorsFocusSrc from '!!raw-loader!@site/src/examples/css-transitions/PseudoSelectorsFocus';
+
+<InteractiveExample src={PseudoSelectorsFocusSrc} component={PseudoSelectorsFocus} label="Tap a field to focus it"/>
+
+:::note
+
+What counts as focused is each platform's own idea of focus. On iOS it's a text input being edited, and nothing else. On Android and on the web it's the full focus system, so anything focusable matches - a `View` with `focusable`, or an element reached with a keyboard or a D-pad. On the web that also means clicking a `Pressable` focuses it, and its `:focus` style stays on until focus moves somewhere else.
+
+:::
+
+### `:focus-within`
+
+Matches while the element _or anything inside it_ has focus, following the same platform rules as `:focus`.
+
+import PseudoSelectorsFocusWithin from '@site/src/examples/css-transitions/PseudoSelectorsFocusWithin';
+import PseudoSelectorsFocusWithinSrc from '!!raw-loader!@site/src/examples/css-transitions/PseudoSelectorsFocusWithin';
+
+<InteractiveExample src={PseudoSelectorsFocusWithinSrc} component={PseudoSelectorsFocusWithin} label="Focus a field to light up the card"/>
+
+### Web-only selectors
+
+The web supports many more selectors, like `:focus-visible`, `:disabled` and `:first-child`. Android and iOS ignore them with a warning in development builds - see [Supported selectors by platform](#supported-selectors-by-platform) for the full list.
+
+## Combining selectors
+
+A single property can list several selectors, and different properties on the same component can respond to different ones. Because timing lives at the top level, you can also give each property its own duration by lining up [`transitionProperty`](/docs/css-transitions/transition-property) with [`transitionDuration`](/docs/css-transitions/transition-duration):
+
+import PseudoSelectorsCombined from '@site/src/examples/css-transitions/PseudoSelectorsCombined';
+import PseudoSelectorsCombinedSrc from '!!raw-loader!@site/src/examples/css-transitions/PseudoSelectorsCombined';
+
+<InteractiveExample src={PseudoSelectorsCombinedSrc} component={PseudoSelectorsCombined} label="Hover the button, then press it"/>
+
+The button drifts between colors over 600ms, but snaps down in 100ms when pressed. `backgroundColor` lists both `:hover` and `:active`, and pressing wins over hovering because `:active` sits later in the priority list.
+
+## Animating SVG components
+
+Pseudo selectors work on [`react-native-svg`](https://github.com/software-mansion/react-native-svg) components too. Put the pseudo objects for SVG attributes like `fill` or `r` in `style`, and keep the resting geometry on the props themselves so the shape still renders before any interaction. For everything else about animating SVG, see [Animating SVG](/docs/guides/animating-svg).
+
+import PseudoSelectorsSvg from '@site/src/examples/css-transitions/PseudoSelectorsSvg';
+import PseudoSelectorsSvgSrc from '!!raw-loader!@site/src/examples/css-transitions/PseudoSelectorsSvg';
+
+<InteractiveExample src={PseudoSelectorsSvgSrc} component={PseudoSelectorsSvg} label="Hover the circles"/>
+
+Reanimated hit-tests the front-most element, so when SVG shapes overlap only the one on top reacts.
+
+## Remarks
+
+- Set `transitionDuration` when you want the change animated. Without any transition settings the pseudo value still applies, it just switches over immediately, exactly like a transition of `0`.
+
+- `default` is optional. Leaving it out is a fine way to animate back to a property's own default value. What it won't do is bring back a value from your `StyleSheet`: once `backgroundColor` has a pseudo object, that object owns the property, and any `backgroundColor` from an earlier style in the array is dropped. Write the resting value as `default` instead.
+
+- Transition settings can't go inside a pseudo object. `transitionDuration`, `transitionTimingFunction`, and `transitionDelay` describe the component, not a single state.
+
+- While a selector matches, its properties win. A re-render or a regular transition can't override a value that a pseudo selector is currently applying.
+
+- Pseudo selectors are a feature of CSS styles. They don't work in [`useAnimatedStyle`](/docs/core/useAnimatedStyle), where the animation is driven by [shared values](/docs/fundamentals/glossary#shared-value) instead.
+
+- Every selector other than the five cross-platform ones is supported on the web only. Android and iOS ignore them, with a warning in development builds.
+
+- Not every style property can be animated. See [Supported style properties](/docs/guides/supported-properties) for the full list.
+
+## Supported selectors by platform
+
+| Selector                                                                     | Android | iOS | Web |
+| ---------------------------------------------------------------------------- | ------- | --- | --- |
+| `:hover`                                                                     | ✅      | ✅  | ✅  |
+| `:active`                                                                    | ✅      | ✅  | ✅  |
+| `:active-deepest`                                                            | ✅      | ✅  | ✅  |
+| `:focus`                                                                     | ✅      | ✅  | ✅  |
+| `:focus-within`                                                              | ✅      | ✅  | ✅  |
+| `:focus-visible`                                                             | ❌      | ❌  | ✅  |
+| `:link`, `:visited`, `:any-link`, `:target`                                  | ❌      | ❌  | ✅  |
+| `:disabled`, `:enabled`, `:checked`, `:indeterminate`, `:default`            | ❌      | ❌  | ✅  |
+| `:required`, `:optional`, `:valid`, `:invalid`, `:in-range`, `:out-of-range` | ❌      | ❌  | ✅  |
+| `:read-only`, `:read-write`, `:placeholder-shown`, `:autofill`               | ❌      | ❌  | ✅  |
+| `:first-child`, `:last-child`, `:only-child`, `:empty`                       | ❌      | ❌  | ✅  |
+| `:first-of-type`, `:last-of-type`, `:only-of-type`                           | ❌      | ❌  | ✅  |
+| `:root`, `:fullscreen`                                                       | ❌      | ❌  | ✅  |
+
+## Platform compatibility
+
+<PlatformCompatibility android ios web/>

--- a/docs/docs-reanimated/src/examples/css-transitions/PseudoSelectorsActive.tsx
+++ b/docs/docs-reanimated/src/examples/css-transitions/PseudoSelectorsActive.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import Animated from 'react-native-reanimated';
+
+const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <AnimatedPressable
+        style={[
+          styles.button,
+          {
+            // highlight-start
+            backgroundColor: { default: '#b58df1', ':active': '#82cab2' },
+            transform: { default: [{ scale: 1 }], ':active': [{ scale: 0.9 }] },
+            // highlight-end
+            transitionDuration: 250,
+          },
+        ]}>
+        <Text style={styles.label}>Press and hold me</Text>
+      </AnimatedPressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: '100%',
+  },
+  button: {
+    alignItems: 'center',
+    borderRadius: 12,
+    justifyContent: 'center',
+    marginVertical: 64,
+    paddingHorizontal: 32,
+    paddingVertical: 20,
+  },
+  label: {
+    color: 'white',
+    fontWeight: 'bold',
+    userSelect: 'none',
+  },
+});

--- a/docs/docs-reanimated/src/examples/css-transitions/PseudoSelectorsActiveDeepest.tsx
+++ b/docs/docs-reanimated/src/examples/css-transitions/PseudoSelectorsActiveDeepest.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import Animated from 'react-native-reanimated';
+
+const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      {/* The card reacts too, because `:active` propagates up the tree. */}
+      <Animated.View
+        style={[
+          styles.card,
+          {
+            // highlight-start
+            backgroundColor: {
+              default: '#b58df133',
+              ':active': '#b58df199',
+            },
+            // highlight-end
+            transitionDuration: 250,
+          },
+        ]}>
+        <AnimatedPressable
+          style={[
+            styles.button,
+            {
+              backgroundColor: { default: '#b58df1', ':active': '#782aeb' },
+              transitionDuration: 250,
+            },
+          ]}>
+          <Text style={styles.label}>:active</Text>
+        </AnimatedPressable>
+      </Animated.View>
+
+      {/* Only the pressed button reacts - the card stays as it is. */}
+      <Animated.View
+        style={[
+          styles.card,
+          {
+            // highlight-start
+            backgroundColor: {
+              default: '#82cab233',
+              ':active-deepest': '#82cab299',
+            },
+            // highlight-end
+            transitionDuration: 250,
+          },
+        ]}>
+        <AnimatedPressable
+          style={[
+            styles.button,
+            {
+              backgroundColor: {
+                default: '#82cab2',
+                ':active-deepest': '#38806a',
+              },
+              transitionDuration: 250,
+            },
+          ]}>
+          <Text style={styles.label}>:active-deepest</Text>
+        </AnimatedPressable>
+      </Animated.View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: '100%',
+    gap: 16,
+    marginVertical: 48,
+  },
+  card: {
+    borderRadius: 16,
+    padding: 24,
+  },
+  button: {
+    alignItems: 'center',
+    borderRadius: 10,
+    paddingHorizontal: 20,
+    paddingVertical: 16,
+  },
+  label: {
+    color: 'white',
+    fontWeight: 'bold',
+    userSelect: 'none',
+  },
+});

--- a/docs/docs-reanimated/src/examples/css-transitions/PseudoSelectorsBasic.tsx
+++ b/docs/docs-reanimated/src/examples/css-transitions/PseudoSelectorsBasic.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import Animated from 'react-native-reanimated';
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <Animated.View
+        style={[
+          styles.box,
+          {
+            // highlight-start
+            backgroundColor: {
+              default: '#b58df1',
+              ':hover': '#82cab2',
+            },
+            transform: {
+              default: [{ scale: 1 }],
+              ':active': [{ scale: 0.9 }],
+            },
+            // highlight-end
+            transitionDuration: 300,
+          },
+        ]}>
+        <Text style={styles.label}>Hover or press me</Text>
+      </Animated.View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: '100%',
+  },
+  box: {
+    alignItems: 'center',
+    borderRadius: 16,
+    height: 140,
+    justifyContent: 'center',
+    margin: 64,
+    padding: 16,
+    width: 140,
+  },
+  label: {
+    color: 'white',
+    fontWeight: 'bold',
+    textAlign: 'center',
+    userSelect: 'none',
+  },
+});

--- a/docs/docs-reanimated/src/examples/css-transitions/PseudoSelectorsCombined.tsx
+++ b/docs/docs-reanimated/src/examples/css-transitions/PseudoSelectorsCombined.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import Animated from 'react-native-reanimated';
+
+const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <AnimatedPressable
+        style={[
+          styles.button,
+          {
+            // highlight-start
+            backgroundColor: {
+              default: '#b58df1',
+              ':hover': '#82cab2',
+              ':active': '#fa7f7c',
+            },
+            transform: { default: [{ scale: 1 }], ':active': [{ scale: 0.9 }] },
+            transitionProperty: ['backgroundColor', 'transform'],
+            transitionDuration: [600, 100],
+            // highlight-end
+          },
+        ]}>
+        <Text style={styles.label}>Hover, then press</Text>
+      </AnimatedPressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: '100%',
+  },
+  button: {
+    alignItems: 'center',
+    borderRadius: 12,
+    justifyContent: 'center',
+    marginVertical: 64,
+    paddingHorizontal: 32,
+    paddingVertical: 20,
+  },
+  label: {
+    color: 'white',
+    fontWeight: 'bold',
+    userSelect: 'none',
+  },
+});

--- a/docs/docs-reanimated/src/examples/css-transitions/PseudoSelectorsFocus.tsx
+++ b/docs/docs-reanimated/src/examples/css-transitions/PseudoSelectorsFocus.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { StyleSheet, TextInput, View } from 'react-native';
+import Animated from 'react-native-reanimated';
+
+const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <AnimatedTextInput
+        placeholder="Tap to focus"
+        placeholderTextColor="#33488e"
+        style={[
+          styles.input,
+          {
+            // highlight-next-line
+            backgroundColor: { default: '#87cce8', ':focus': '#ffe780' },
+            transitionDuration: 250,
+          },
+        ]}
+      />
+      <AnimatedTextInput
+        placeholder="Tap to focus"
+        placeholderTextColor="#33488e"
+        style={[
+          styles.input,
+          {
+            // highlight-next-line
+            backgroundColor: { default: '#87cce8', ':focus': '#82cab2' },
+            transitionDuration: 250,
+          },
+        ]}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: '100%',
+    gap: 16,
+  },
+  input: {
+    borderColor: '#001a72',
+    borderRadius: 10,
+    borderWidth: 3,
+    color: '#001a72',
+    height: 48,
+    paddingHorizontal: 16,
+    width: 240,
+  },
+});

--- a/docs/docs-reanimated/src/examples/css-transitions/PseudoSelectorsFocusWithin.tsx
+++ b/docs/docs-reanimated/src/examples/css-transitions/PseudoSelectorsFocusWithin.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { StyleSheet, TextInput, View } from 'react-native';
+import Animated from 'react-native-reanimated';
+
+const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <Animated.View
+        style={[
+          styles.card,
+          {
+            // highlight-start
+            backgroundColor: {
+              default: '#b58df122',
+              ':focus-within': '#b58df1aa',
+            },
+            borderColor: { default: '#001a72', ':focus-within': '#782aeb' },
+            // highlight-end
+            transitionDuration: 350,
+          },
+        ]}>
+        <AnimatedTextInput
+          placeholder="Username"
+          placeholderTextColor="#33488e"
+          style={[
+            styles.input,
+            {
+              borderColor: { default: '#001a72', ':focus': '#782aeb' },
+              transitionDuration: 250,
+            },
+          ]}
+        />
+        <AnimatedTextInput
+          placeholder="Password"
+          placeholderTextColor="#33488e"
+          secureTextEntry
+          style={[
+            styles.input,
+            {
+              borderColor: { default: '#001a72', ':focus': '#782aeb' },
+              transitionDuration: 250,
+            },
+          ]}
+        />
+      </Animated.View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: '100%',
+  },
+  card: {
+    borderRadius: 16,
+    borderWidth: 2,
+    gap: 12,
+    marginVertical: 48,
+    padding: 24,
+  },
+  input: {
+    backgroundColor: '#87cce8',
+    borderRadius: 10,
+    borderWidth: 3,
+    color: '#001a72',
+    height: 44,
+    paddingHorizontal: 16,
+    width: 220,
+  },
+});

--- a/docs/docs-reanimated/src/examples/css-transitions/PseudoSelectorsHover.tsx
+++ b/docs/docs-reanimated/src/examples/css-transitions/PseudoSelectorsHover.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import Animated from 'react-native-reanimated';
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <Animated.View
+        style={[
+          styles.box,
+          {
+            // highlight-next-line
+            backgroundColor: { default: '#b58df1', ':hover': '#fa7f7c' },
+            transitionDuration: 400,
+          },
+        ]}>
+        <Text style={styles.label}>color</Text>
+      </Animated.View>
+
+      <Animated.View
+        style={[
+          styles.box,
+          {
+            backgroundColor: '#82cab2',
+            // highlight-next-line
+            borderRadius: { default: 8, ':hover': 40 },
+            transitionDuration: 400,
+          },
+        ]}>
+        <Text style={styles.label}>radius</Text>
+      </Animated.View>
+
+      <Animated.View
+        style={[
+          styles.box,
+          {
+            backgroundColor: '#87cce8',
+            // highlight-next-line
+            transform: { default: [{ scale: 1 }], ':hover': [{ scale: 1.2 }] },
+            transitionDuration: 400,
+          },
+        ]}>
+        <Text style={styles.label}>scale</Text>
+      </Animated.View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: '100%',
+    gap: 24,
+  },
+  box: {
+    alignItems: 'center',
+    borderRadius: 8,
+    height: 80,
+    justifyContent: 'center',
+    marginVertical: 64,
+    width: 80,
+  },
+  label: {
+    color: 'white',
+    fontWeight: 'bold',
+    userSelect: 'none',
+  },
+});

--- a/docs/docs-reanimated/src/examples/css-transitions/PseudoSelectorsSvg.tsx
+++ b/docs/docs-reanimated/src/examples/css-transitions/PseudoSelectorsSvg.tsx
@@ -1,0 +1,56 @@
+import type React from 'react';
+import { StyleSheet, View } from 'react-native';
+import Animated from 'react-native-reanimated';
+import type { CircleProps } from 'react-native-svg';
+import { Circle, Svg } from 'react-native-svg';
+
+// react-native-svg accepts `style`, but its prop types don't declare it yet.
+const AnimatedCircle = Animated.createAnimatedComponent(
+  Circle
+) as React.ComponentType<CircleProps & { style?: object }>;
+
+const CIRCLES = [
+  { cx: '20%', color: '#fa7f7c' },
+  { cx: '50%', color: '#b58df1' },
+  { cx: '80%', color: '#82cab2' },
+];
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <Svg style={styles.svg}>
+        {CIRCLES.map(({ cx, color }) => (
+          // Base geometry stays on the props so the circle renders at rest.
+          <AnimatedCircle
+            key={cx}
+            cx={cx}
+            cy="50%"
+            r={28}
+            fill={color}
+            style={{
+              // highlight-start
+              fill: { default: color, ':hover': '#ffe780' },
+              r: { default: 28, ':hover': 44 },
+              // highlight-end
+              transitionDuration: 400,
+            }}
+          />
+        ))}
+      </Svg>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: '100%',
+  },
+  svg: {
+    height: 140,
+    marginVertical: 48,
+    width: '100%',
+  },
+});


### PR DESCRIPTION
Documents CSS pseudo selectors, which had no docs coverage until now.

https://github.com/user-attachments/assets/5e1f903a-276f-4fda-84a4-2224c107cf2d

