### PR TITLE
feat: deliver batched CSS events to JS

### DIFF
--- a/packages/react-native-reanimated/src/ReanimatedModule/NativeReanimated.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/NativeReanimated.ts
@@ -19,6 +19,7 @@ import type {
 } from '../commonTypes';
 import type {
   CSSAnimationUpdates,
+  CSSEventHandler,
   CSSPseudoStyleConfig,
   CSSTransitionConfig,
   NormalizedCSSAnimationKeyframesConfig,
@@ -183,6 +184,10 @@ See https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooti
     this.#reanimatedModuleProxy.setViewStyle(viewTag, style);
   }
 
+  setCSSEventHandler(handler: CSSEventHandler) {
+    this.#reanimatedModuleProxy.setCSSEventHandler(handler);
+  }
+
   markNodeAsRemovable(shadowNodeWrapper: ShadowNodeWrapper) {
     this.#reanimatedModuleProxy.markNodeAsRemovable(shadowNodeWrapper);
   }
@@ -269,6 +274,7 @@ class DummyReanimatedModuleProxy implements ReanimatedModuleProxy {
 
   unsubscribeFromKeyboardEvents(): void {}
   setViewStyle(): void {}
+  setCSSEventHandler(): void {}
   markNodeAsRemovable(): void {}
   unmarkNodeAsRemovable(): void {}
   registerCSSKeyframes(): void {}

--- a/packages/react-native-reanimated/src/ReanimatedModule/js-reanimated/JSReanimated.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/js-reanimated/JSReanimated.ts
@@ -18,6 +18,7 @@ import type {
 import { SensorType } from '../../commonTypes';
 import type {
   CSSAnimationUpdates,
+  CSSEventHandler,
   CSSTransitionConfig,
   NormalizedCSSAnimationKeyframesConfig,
 } from '../../css/native';
@@ -278,6 +279,12 @@ class JSReanimated implements IReanimatedModule {
   setViewStyle(_viewTag: number, _style: StyleProps): void {
     throw new Error(
       '[Reanimated] setViewStyle is not available in JSReanimated.'
+    );
+  }
+
+  setCSSEventHandler(_handler: CSSEventHandler): void {
+    throw new Error(
+      '[Reanimated] `setCSSEventHandler` is not available in JSReanimated.'
     );
   }
 

--- a/packages/react-native-reanimated/src/ReanimatedModule/reanimatedModuleProxy.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/reanimatedModuleProxy.ts
@@ -13,6 +13,7 @@ import type {
 } from '../commonTypes';
 import type {
   CSSAnimationUpdates,
+  CSSEventHandler,
   CSSPseudoStyleConfig,
   CSSTransitionConfig,
   NormalizedCSSAnimationKeyframesConfig,
@@ -62,6 +63,9 @@ export interface ReanimatedModuleProxy {
   setShouldAnimateExitingForTag(viewTag: number, shouldAnimate: boolean): void;
 
   setViewStyle(viewTag: number, style: StyleProps): void;
+
+  /** Registers the single handler receiving every CSS event batch. */
+  setCSSEventHandler(handler: CSSEventHandler): void;
 
   markNodeAsRemovable(shadowNodeWrapper: ShadowNodeWrapper): void;
   unmarkNodeAsRemovable(viewTag: number): void;

--- a/packages/react-native-reanimated/src/css/native/events/CSSCallbacksRegistry.ts
+++ b/packages/react-native-reanimated/src/css/native/events/CSSCallbacksRegistry.ts
@@ -2,11 +2,9 @@
 import type { CSSEventSubscriber, NativeCSSEvent } from './types';
 
 /**
- * Routes CSS events emitted by the native side to the JS objects interested in
- * a given view.
- *
- * Nested animated components can share a single view tag, so every tag keeps a
- * set of subscribers instead of a single one.
+ * Routes CSS events emitted by the native side to the objects interested in a
+ * given view. Nested animated components can share a view tag, so every tag
+ * keeps a set of subscribers rather than a single one.
  */
 class CSSCallbacksRegistry {
   private readonly subscribersByTag_ = new Map<

--- a/packages/react-native-reanimated/src/css/native/events/CSSCallbacksRegistry.ts
+++ b/packages/react-native-reanimated/src/css/native/events/CSSCallbacksRegistry.ts
@@ -42,7 +42,15 @@ class CSSCallbacksRegistry {
       }
 
       for (const subscriber of subscribers) {
-        subscriber.handleCSSEvent(event);
+        try {
+          subscriber.handleCSSEvent(event);
+        } catch (error) {
+          // A batch carries events for unrelated views, so the error is
+          // reported the way an uncaught one would be anyway. That keeps a
+          // broken callback fatal without starving the views queued behind it.
+          // @ts-expect-error React Native's `ErrorUtils` are hidden from the global scope.
+          globalThis.ErrorUtils.reportFatalError(error);
+        }
       }
     }
   }

--- a/packages/react-native-reanimated/src/css/native/events/CSSCallbacksRegistry.ts
+++ b/packages/react-native-reanimated/src/css/native/events/CSSCallbacksRegistry.ts
@@ -1,5 +1,4 @@
 'use strict';
-import { logger } from '../../../common';
 import type { CSSEventSubscriber, NativeCSSEvent } from './types';
 
 /**
@@ -44,26 +43,14 @@ class CSSCallbacksRegistry {
         continue;
       }
 
-      // Snapshot the subscribers as a user callback can mount or unmount views.
-      for (const subscriber of Array.from(subscribers)) {
-        this.deliver(subscriber, event);
+      for (const subscriber of subscribers) {
+        subscriber.handleCSSEvent(event);
       }
     }
   }
 
   clear(): void {
     this.subscribersByTag_.clear();
-  }
-
-  private deliver(subscriber: CSSEventSubscriber, event: NativeCSSEvent): void {
-    try {
-      subscriber.handleCSSEvent(event);
-    } catch (error) {
-      // A throwing user callback must not drop the rest of the batch.
-      logger.error(
-        `A CSS "${event.type}" callback threw an error: ${String(error)}`
-      );
-    }
   }
 }
 

--- a/packages/react-native-reanimated/src/css/native/events/CSSCallbacksRegistry.ts
+++ b/packages/react-native-reanimated/src/css/native/events/CSSCallbacksRegistry.ts
@@ -1,0 +1,72 @@
+'use strict';
+import { logger } from '../../../common';
+import type { CSSEventSubscriber, NativeCSSEvent } from './types';
+
+/**
+ * Routes CSS events emitted by the native side to the JS objects interested in
+ * a given view.
+ *
+ * Nested animated components can share a single view tag, so every tag keeps a
+ * set of subscribers instead of a single one.
+ */
+class CSSCallbacksRegistry {
+  private readonly subscribersByTag_ = new Map<
+    number,
+    Set<CSSEventSubscriber>
+  >();
+
+  register(viewTag: number, subscriber: CSSEventSubscriber): void {
+    const subscribers = this.subscribersByTag_.get(viewTag);
+    if (subscribers) {
+      subscribers.add(subscriber);
+    } else {
+      this.subscribersByTag_.set(viewTag, new Set([subscriber]));
+    }
+  }
+
+  unregister(viewTag: number, subscriber: CSSEventSubscriber): void {
+    const subscribers = this.subscribersByTag_.get(viewTag);
+    if (!subscribers) {
+      return;
+    }
+
+    subscribers.delete(subscriber);
+    if (subscribers.size === 0) {
+      this.subscribersByTag_.delete(viewTag);
+    }
+  }
+
+  dispatch(events: NativeCSSEvent[]): void {
+    for (const event of events) {
+      const subscribers = this.subscribersByTag_.get(event.tag);
+      if (!subscribers) {
+        // An event can outlive the view it was emitted for.
+        continue;
+      }
+
+      // Snapshot the subscribers as a user callback can mount or unmount views.
+      for (const subscriber of Array.from(subscribers)) {
+        this.deliver(subscriber, event);
+      }
+    }
+  }
+
+  clear(): void {
+    this.subscribersByTag_.clear();
+  }
+
+  private deliver(subscriber: CSSEventSubscriber, event: NativeCSSEvent): void {
+    try {
+      subscriber.handleCSSEvent(event);
+    } catch (error) {
+      // A throwing user callback must not drop the rest of the batch.
+      logger.error(
+        `A CSS "${event.type}" callback threw an error: ${String(error)}`
+      );
+    }
+  }
+}
+
+const cssCallbacksRegistry = new CSSCallbacksRegistry();
+
+export default cssCallbacksRegistry;

--- a/packages/react-native-reanimated/src/css/native/events/__tests__/CSSCallbacksRegistry.test.ts
+++ b/packages/react-native-reanimated/src/css/native/events/__tests__/CSSCallbacksRegistry.test.ts
@@ -104,15 +104,58 @@ describe('cssCallbacksRegistry', () => {
     expect(sub.handleCSSEvent).not.toHaveBeenCalled();
   });
 
-  test('an error thrown by a subscriber reaches the caller', () => {
-    const throwing = subscriber(
-      jest.fn(() => {
-        throw new Error('[Reanimated] boom');
-      })
-    );
-    cssCallbacksRegistry.register(1, throwing);
+  describe('a throwing subscriber', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const errorUtils = (globalThis as any).ErrorUtils;
+    let reportFatalError: jest.SpyInstance;
 
-    expect(() => cssCallbacksRegistry.dispatch([event(1)])).toThrow('boom');
+    const throwing = () =>
+      subscriber(
+        jest.fn(() => {
+          throw new Error('[Reanimated] boom');
+        })
+      );
+
+    beforeEach(() => {
+      reportFatalError = jest
+        .spyOn(errorUtils, 'reportFatalError')
+        .mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+      reportFatalError.mockRestore();
+    });
+
+    test('is reported as a fatal error', () => {
+      cssCallbacksRegistry.register(1, throwing());
+
+      cssCallbacksRegistry.dispatch([event(1)]);
+
+      expect(reportFatalError).toHaveBeenCalledTimes(1);
+      expect(reportFatalError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: '[Reanimated] boom' })
+      );
+    });
+
+    test('does not stop the other subscribers of the same view', () => {
+      const healthy = subscriber();
+      cssCallbacksRegistry.register(1, throwing());
+      cssCallbacksRegistry.register(1, healthy);
+
+      cssCallbacksRegistry.dispatch([event(1)]);
+
+      expect(healthy.handleCSSEvent).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not starve the events of unrelated views in the batch', () => {
+      const other = subscriber();
+      cssCallbacksRegistry.register(1, throwing());
+      cssCallbacksRegistry.register(2, other);
+
+      cssCallbacksRegistry.dispatch([event(1), event(2)]);
+
+      expect(other.handleCSSEvent).toHaveBeenCalledTimes(1);
+    });
   });
 
   test('a subscriber unregistering itself while dispatching does not break the batch', () => {

--- a/packages/react-native-reanimated/src/css/native/events/__tests__/CSSCallbacksRegistry.test.ts
+++ b/packages/react-native-reanimated/src/css/native/events/__tests__/CSSCallbacksRegistry.test.ts
@@ -1,0 +1,154 @@
+'use strict';
+import cssCallbacksRegistry from '../CSSCallbacksRegistry';
+import type { CSSEventSubscriber, NativeCSSEvent } from '../types';
+
+const event = (tag: number, name = 'anim'): NativeCSSEvent => ({
+  tag,
+  type: 'animationEnd',
+  name,
+  elapsedTime: 1,
+});
+
+const subscriber = (
+  handleCSSEvent: jest.Mock = jest.fn()
+): CSSEventSubscriber & { handleCSSEvent: jest.Mock } => ({ handleCSSEvent });
+
+describe('cssCallbacksRegistry', () => {
+  beforeEach(() => {
+    cssCallbacksRegistry.clear();
+  });
+
+  test('delivers an event to the subscriber registered for its tag', () => {
+    const sub = subscriber();
+    cssCallbacksRegistry.register(1, sub);
+
+    cssCallbacksRegistry.dispatch([event(1)]);
+
+    expect(sub.handleCSSEvent).toHaveBeenCalledWith(event(1));
+  });
+
+  test('delivers an event to every subscriber sharing a tag', () => {
+    const outer = subscriber();
+    const inner = subscriber();
+    cssCallbacksRegistry.register(1, outer);
+    cssCallbacksRegistry.register(1, inner);
+
+    cssCallbacksRegistry.dispatch([event(1)]);
+
+    expect(outer.handleCSSEvent).toHaveBeenCalledTimes(1);
+    expect(inner.handleCSSEvent).toHaveBeenCalledTimes(1);
+  });
+
+  test('registering the same subscriber twice delivers the event once', () => {
+    const sub = subscriber();
+    cssCallbacksRegistry.register(1, sub);
+    cssCallbacksRegistry.register(1, sub);
+
+    cssCallbacksRegistry.dispatch([event(1)]);
+
+    expect(sub.handleCSSEvent).toHaveBeenCalledTimes(1);
+  });
+
+  test('routes each event to the subscribers of its own tag', () => {
+    const first = subscriber();
+    const second = subscriber();
+    cssCallbacksRegistry.register(1, first);
+    cssCallbacksRegistry.register(2, second);
+
+    cssCallbacksRegistry.dispatch([event(2)]);
+
+    expect(first.handleCSSEvent).not.toHaveBeenCalled();
+    expect(second.handleCSSEvent).toHaveBeenCalledTimes(1);
+  });
+
+  test('unregistering one subscriber keeps the others attached', () => {
+    const outer = subscriber();
+    const inner = subscriber();
+    cssCallbacksRegistry.register(1, outer);
+    cssCallbacksRegistry.register(1, inner);
+
+    cssCallbacksRegistry.unregister(1, outer);
+    cssCallbacksRegistry.dispatch([event(1)]);
+
+    expect(outer.handleCSSEvent).not.toHaveBeenCalled();
+    expect(inner.handleCSSEvent).toHaveBeenCalledTimes(1);
+  });
+
+  test('drops the tag entry once its last subscriber is unregistered', () => {
+    const sub = subscriber();
+    cssCallbacksRegistry.register(1, sub);
+    cssCallbacksRegistry.unregister(1, sub);
+
+    // @ts-expect-error - reading a private field to assert there is no leak
+    expect(cssCallbacksRegistry.subscribersByTag_.has(1)).toBe(false);
+  });
+
+  test('unregistering an unknown tag or subscriber is a no-op', () => {
+    const sub = subscriber();
+    cssCallbacksRegistry.register(1, sub);
+
+    expect(() => {
+      cssCallbacksRegistry.unregister(2, sub);
+      cssCallbacksRegistry.unregister(1, subscriber());
+    }).not.toThrow();
+
+    cssCallbacksRegistry.dispatch([event(1)]);
+    expect(sub.handleCSSEvent).toHaveBeenCalledTimes(1);
+  });
+
+  test('an event for an unknown tag is silently ignored', () => {
+    const sub = subscriber();
+    cssCallbacksRegistry.register(1, sub);
+
+    expect(() => cssCallbacksRegistry.dispatch([event(99)])).not.toThrow();
+    expect(sub.handleCSSEvent).not.toHaveBeenCalled();
+  });
+
+  test('a throwing subscriber does not stop the rest of the batch', () => {
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    const throwing = subscriber(
+      jest.fn(() => {
+        throw new Error('[Reanimated] boom');
+      })
+    );
+    const healthy = subscriber();
+    cssCallbacksRegistry.register(1, throwing);
+    cssCallbacksRegistry.register(2, healthy);
+
+    cssCallbacksRegistry.dispatch([event(1), event(2), event(1)]);
+
+    expect(throwing.handleCSSEvent).toHaveBeenCalledTimes(2);
+    expect(healthy.handleCSSEvent).toHaveBeenCalledTimes(1);
+    expect(consoleError).toHaveBeenCalledTimes(2);
+
+    consoleError.mockRestore();
+  });
+
+  test('a subscriber unregistering itself while dispatching does not break the batch', () => {
+    const first: CSSEventSubscriber = {
+      handleCSSEvent: jest.fn(() => {
+        cssCallbacksRegistry.unregister(1, first);
+      }),
+    };
+    const second = subscriber();
+    cssCallbacksRegistry.register(1, first);
+    cssCallbacksRegistry.register(1, second);
+
+    cssCallbacksRegistry.dispatch([event(1)]);
+
+    expect(second.handleCSSEvent).toHaveBeenCalledTimes(1);
+  });
+
+  test('clear drops every subscription', () => {
+    const sub = subscriber();
+    cssCallbacksRegistry.register(1, sub);
+
+    cssCallbacksRegistry.clear();
+    cssCallbacksRegistry.dispatch([event(1)]);
+
+    expect(sub.handleCSSEvent).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react-native-reanimated/src/css/native/events/__tests__/CSSCallbacksRegistry.test.ts
+++ b/packages/react-native-reanimated/src/css/native/events/__tests__/CSSCallbacksRegistry.test.ts
@@ -104,27 +104,15 @@ describe('cssCallbacksRegistry', () => {
     expect(sub.handleCSSEvent).not.toHaveBeenCalled();
   });
 
-  test('a throwing subscriber does not stop the rest of the batch', () => {
-    const consoleError = jest
-      .spyOn(console, 'error')
-      .mockImplementation(() => undefined);
-
+  test('an error thrown by a subscriber reaches the caller', () => {
     const throwing = subscriber(
       jest.fn(() => {
         throw new Error('[Reanimated] boom');
       })
     );
-    const healthy = subscriber();
     cssCallbacksRegistry.register(1, throwing);
-    cssCallbacksRegistry.register(2, healthy);
 
-    cssCallbacksRegistry.dispatch([event(1), event(2), event(1)]);
-
-    expect(throwing.handleCSSEvent).toHaveBeenCalledTimes(2);
-    expect(healthy.handleCSSEvent).toHaveBeenCalledTimes(1);
-    expect(consoleError).toHaveBeenCalledTimes(2);
-
-    consoleError.mockRestore();
+    expect(() => cssCallbacksRegistry.dispatch([event(1)])).toThrow('boom');
   });
 
   test('a subscriber unregistering itself while dispatching does not break the batch', () => {

--- a/packages/react-native-reanimated/src/css/native/events/index.ts
+++ b/packages/react-native-reanimated/src/css/native/events/index.ts
@@ -1,0 +1,3 @@
+'use strict';
+export { default as cssCallbacksRegistry } from './CSSCallbacksRegistry';
+export type { CSSEventHandler } from './types';

--- a/packages/react-native-reanimated/src/css/native/events/types.ts
+++ b/packages/react-native-reanimated/src/css/native/events/types.ts
@@ -1,0 +1,32 @@
+'use strict';
+
+type CSSAnimationEventType =
+  | 'animationStart'
+  | 'animationEnd'
+  | 'animationIteration'
+  | 'animationCancel';
+
+type CSSTransitionEventType =
+  | 'transitionRun'
+  | 'transitionStart'
+  | 'transitionEnd'
+  | 'transitionCancel';
+
+type CSSEventType = CSSAnimationEventType | CSSTransitionEventType;
+
+/** A single CSS event as it comes from the native side. */
+export type NativeCSSEvent = {
+  tag: number;
+  type: CSSEventType;
+  /** Animation name for animation events, RN property name for transitions. */
+  name: string;
+  /** Already converted to seconds by the native side. */
+  elapsedTime: number;
+};
+
+export type CSSEventHandler = (events: NativeCSSEvent[]) => void;
+
+/** Receives the CSS events addressed to a single view tag. */
+export interface CSSEventSubscriber {
+  handleCSSEvent(event: NativeCSSEvent): void;
+}

--- a/packages/react-native-reanimated/src/css/native/events/types.ts
+++ b/packages/react-native-reanimated/src/css/native/events/types.ts
@@ -14,7 +14,6 @@ type CSSTransitionEventType =
 
 type CSSEventType = CSSAnimationEventType | CSSTransitionEventType;
 
-/** A single CSS event as it comes from the native side. */
 export type NativeCSSEvent = {
   tag: number;
   type: CSSEventType;
@@ -26,7 +25,6 @@ export type NativeCSSEvent = {
 
 export type CSSEventHandler = (events: NativeCSSEvent[]) => void;
 
-/** Receives the CSS events addressed to a single view tag. */
 export interface CSSEventSubscriber {
   handleCSSEvent(event: NativeCSSEvent): void;
 }

--- a/packages/react-native-reanimated/src/css/native/index.ts
+++ b/packages/react-native-reanimated/src/css/native/index.ts
@@ -1,4 +1,5 @@
 'use strict';
+export * from './events';
 export * from './keyframes';
 export * from './managers';
 export * from './normalization';

--- a/packages/react-native-reanimated/src/css/native/proxy.ts
+++ b/packages/react-native-reanimated/src/css/native/proxy.ts
@@ -1,6 +1,7 @@
 'use strict';
 import type { ShadowNodeWrapper, StyleProps } from '../../commonTypes';
 import { ReanimatedModule } from '../../ReanimatedModule';
+import type { CSSEventHandler } from './events';
 import type {
   CSSAnimationUpdates,
   CSSPseudoStyleConfig,
@@ -12,6 +13,12 @@ import type {
 
 export function setViewStyle(viewTag: number, style: StyleProps) {
   ReanimatedModule.setViewStyle(viewTag, style);
+}
+
+// EVENTS
+
+export function setCSSEventHandler(handler: CSSEventHandler) {
+  ReanimatedModule.setCSSEventHandler(handler);
 }
 
 export function markNodeAsRemovable(shadowNodeWrapper: ShadowNodeWrapper) {

--- a/packages/react-native-reanimated/src/initializers.native.ts
+++ b/packages/react-native-reanimated/src/initializers.native.ts
@@ -6,6 +6,8 @@ import {
   toggleSlowAnimationsOnUIRuntime,
 } from 'react-native-worklets';
 
+import { cssCallbacksRegistry } from './css/native/events';
+import { setCSSEventHandler } from './css/native/proxy';
 import { initSvgCssSupport } from './css/svg';
 import { getStaticFeatureFlag } from './featureFlags';
 import type { IReanimatedModule } from './ReanimatedModule';
@@ -18,6 +20,7 @@ export function initializeReanimatedModule(
       '[Reanimated] Tried to initialize Reanimated without a valid ReanimatedModule'
     );
   }
+  setCSSEventHandler((events) => cssCallbacksRegistry.dispatch(events));
   if (getStaticFeatureFlag('EXPERIMENTAL_CSS_ANIMATIONS_FOR_SVG_COMPONENTS')) {
     initSvgCssSupport();
   }

--- a/packages/react-native-reanimated/src/initializers.native.ts
+++ b/packages/react-native-reanimated/src/initializers.native.ts
@@ -6,8 +6,7 @@ import {
   toggleSlowAnimationsOnUIRuntime,
 } from 'react-native-worklets';
 
-import { cssCallbacksRegistry } from './css/native/events';
-import { setCSSEventHandler } from './css/native/proxy';
+import { cssCallbacksRegistry, setCSSEventHandler } from './css/native';
 import { initSvgCssSupport } from './css/svg';
 import { getStaticFeatureFlag } from './featureFlags';
 import type { IReanimatedModule } from './ReanimatedModule';


### PR DESCRIPTION
The JS half of the CSS events channel: a registry that receives batched events from native and hands each one to the subscribers listening for that view tag, plus the module plumbing that installs the handler.

Subscription is keyed by view tag rather than by object identity, since nested animated components can share a tag. An event can outlive the view it was emitted for, so an event for a tag nobody listens to is dropped.

A batch carries events for unrelated views, so a throwing subscriber is reported through `ErrorUtils.reportFatalError` rather than left to unwind. The error stays fatal, as an uncaught one would be, without starving the views queued behind it in the same batch.
