### PR TITLE
feat: batch CSS events and deliver them to JS

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/events/CSSEvent.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/events/CSSEvent.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <react/renderer/core/ReactPrimitives.h>
+
+#include <cstdint>
+#include <string>
+#include <utility>
+
+namespace reanimated::css {
+
+/// Event kinds a view can subscribe to. The ordinal is the bit index in
+/// `CSSEventMask`, so the JS side must keep its bitmask constants in sync.
+enum class CSSEventType : std::uint8_t {
+  AnimationStart = 0,
+  AnimationEnd = 1,
+  AnimationIteration = 2,
+  AnimationCancel = 3,
+  TransitionRun = 4,
+  TransitionStart = 5,
+  TransitionEnd = 6,
+  TransitionCancel = 7,
+};
+
+using CSSEventMask = std::uint8_t;
+
+constexpr bool hasListener(const CSSEventMask mask, const CSSEventType type) {
+  return (mask & (1U << static_cast<std::uint8_t>(type))) != 0;
+}
+
+struct CSSEvent {
+  facebook::react::Tag viewTag;
+  CSSEventType type;
+  /// Animation name for animation events, RN property name for transition ones.
+  std::string name;
+  /// Seconds, matching the public `elapsedTime` contract shared with web.
+  double elapsedTime;
+};
+
+inline CSSEvent createCSSEvent(
+    const facebook::react::Tag viewTag,
+    const CSSEventType type,
+    std::string name,
+    const double elapsedTimeMs) {
+  return CSSEvent{viewTag, type, std::move(name), elapsedTimeMs / 1000};
+}
+
+} // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/events/CSSEvent.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/events/CSSEvent.h
@@ -1,8 +1,10 @@
 #pragma once
 
+#include <react/debug/react_native_assert.h>
 #include <react/renderer/core/ReactPrimitives.h>
 
 #include <cstdint>
+#include <limits>
 #include <string>
 #include <utility>
 
@@ -24,8 +26,11 @@ enum class CSSEventType : std::uint8_t {
 
 using CSSEventMask = std::uint8_t;
 
-constexpr bool hasListener(const CSSEventMask mask, const CSSEventType type) {
-  return (mask & (1U << static_cast<std::uint8_t>(type))) != 0;
+inline bool hasListener(const CSSEventMask mask, const CSSEventType type) {
+  const auto bit = static_cast<std::uint8_t>(type);
+  // A type that does not fit the mask would silently never have a listener.
+  react_native_assert(bit < std::numeric_limits<CSSEventMask>::digits);
+  return (mask & (1U << bit)) != 0;
 }
 
 struct CSSEvent {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/events/CSSEvent.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/events/CSSEvent.h
@@ -9,7 +9,8 @@
 namespace reanimated::css {
 
 /// Event kinds a view can subscribe to. The ordinal is the bit index in
-/// `CSSEventMask`, so the JS side must keep its bitmask constants in sync.
+/// `CSSEventMask`, so the JS side must keep its bitmask constants in sync, and
+/// a new kind has to fit the mask as well as the switches over this enum.
 enum class CSSEventType : std::uint8_t {
   AnimationStart = 0,
   AnimationEnd = 1,

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/events/CSSEventsEmitter.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/events/CSSEventsEmitter.cpp
@@ -60,12 +60,9 @@ void CSSEventsEmitter::invalidate() {
   std::lock_guard<std::mutex> lock(mutex_);
   emitFunction_.reset();
   pending_.clear();
-  drainRequested_ = false;
 }
 
 void CSSEventsEmitter::emit(CSSEvent event) {
-  bool shouldScheduleDrain;
-
   {
     std::lock_guard<std::mutex> lock(mutex_);
     // Buffering before the handler is installed, or after it is gone, would
@@ -74,15 +71,17 @@ void CSSEventsEmitter::emit(CSSEvent event) {
       return;
     }
     pending_.push_back(std::move(event));
-    shouldScheduleDrain = !drainRequested_ || pending_.size() % kDrainRetryBacklog == 0;
-    drainRequested_ = true;
   }
 
   // Scheduled after unlocking: `emit` already holds the updates registry lock,
   // and reaching into the scheduler under both is how lock cycles start.
-  if (shouldScheduleDrain) {
-    scheduleDrain();
-  }
+  //
+  // One request per event rather than one per batch. A request can be dropped
+  // before it runs, since the runtime scheduler clears its queue on a task
+  // error, and there is no signal for that: anything that remembers a request
+  // is outstanding strands the buffer for good. Delivery is still batched, as
+  // the first drain to run takes every pending event and the rest find none.
+  scheduleDrain();
 }
 
 void CSSEventsEmitter::scheduleDrain() {
@@ -99,7 +98,6 @@ void CSSEventsEmitter::drain(jsi::Runtime &rt) {
 
   {
     std::lock_guard<std::mutex> lock(mutex_);
-    drainRequested_ = false;
     events.swap(pending_);
     emitFunction = emitFunction_;
   }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/events/CSSEventsEmitter.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/events/CSSEventsEmitter.cpp
@@ -29,7 +29,6 @@ const char *cssEventTypeName(const CSSEventType type) {
     case CSSEventType::TransitionCancel:
       return "transitionCancel";
   }
-  return "";
 }
 
 jsi::Array eventsToJSIArray(jsi::Runtime &rt, const std::vector<CSSEvent> &events) {
@@ -65,17 +64,28 @@ void CSSEventsEmitter::invalidate() {
 }
 
 void CSSEventsEmitter::emit(CSSEvent event) {
-  std::lock_guard<std::mutex> lock(mutex_);
-  pending_.push_back(std::move(event));
-  requestDrain();
+  bool shouldScheduleDrain;
+
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    // Buffering before the handler is installed, or after it is gone, would
+    // grow `pending_` for events that can never be delivered.
+    if (!emitFunction_) {
+      return;
+    }
+    pending_.push_back(std::move(event));
+    shouldScheduleDrain = !drainRequested_ || pending_.size() % kDrainRetryBacklog == 0;
+    drainRequested_ = true;
+  }
+
+  // Scheduled after unlocking: `emit` already holds the updates registry lock,
+  // and reaching into the scheduler under both is how lock cycles start.
+  if (shouldScheduleDrain) {
+    scheduleDrain();
+  }
 }
 
-void CSSEventsEmitter::requestDrain() {
-  if (drainRequested_ || !emitFunction_) {
-    return;
-  }
-  drainRequested_ = true;
-
+void CSSEventsEmitter::scheduleDrain() {
   jsInvoker_->invokeAsync([weakThis = weak_from_this()](jsi::Runtime &rt) {
     if (const auto strongThis = weakThis.lock()) {
       strongThis->drain(rt);
@@ -90,14 +100,15 @@ void CSSEventsEmitter::drain(jsi::Runtime &rt) {
   {
     std::lock_guard<std::mutex> lock(mutex_);
     drainRequested_ = false;
-    if (pending_.empty() || !emitFunction_) {
-      pending_.clear();
-      return;
-    }
-    events = std::exchange(pending_, {});
+    events.swap(pending_);
     emitFunction = emitFunction_;
   }
 
+  if (events.empty() || !emitFunction) {
+    return;
+  }
+
+  // Called unlocked so a callback that synchronously emits again cannot deadlock.
   emitFunction->call(rt, eventsToJSIArray(rt, events));
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/events/CSSEventsEmitter.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/events/CSSEventsEmitter.cpp
@@ -1,0 +1,104 @@
+#include <reanimated/CSS/events/CSSEventsEmitter.h>
+
+#include <utility>
+#include <vector>
+
+namespace reanimated::css {
+
+using namespace facebook;
+
+namespace {
+
+/// Wire name of the event, matching the string union on the JS side.
+const char *cssEventTypeName(const CSSEventType type) {
+  switch (type) {
+    case CSSEventType::AnimationStart:
+      return "animationStart";
+    case CSSEventType::AnimationEnd:
+      return "animationEnd";
+    case CSSEventType::AnimationIteration:
+      return "animationIteration";
+    case CSSEventType::AnimationCancel:
+      return "animationCancel";
+    case CSSEventType::TransitionRun:
+      return "transitionRun";
+    case CSSEventType::TransitionStart:
+      return "transitionStart";
+    case CSSEventType::TransitionEnd:
+      return "transitionEnd";
+    case CSSEventType::TransitionCancel:
+      return "transitionCancel";
+  }
+  return "";
+}
+
+jsi::Array eventsToJSIArray(jsi::Runtime &rt, const std::vector<CSSEvent> &events) {
+  jsi::Array result(rt, events.size());
+
+  for (size_t i = 0; i < events.size(); i++) {
+    const auto &event = events[i];
+    jsi::Object jsEvent(rt);
+    jsEvent.setProperty(rt, "tag", jsi::Value(static_cast<int>(event.viewTag)));
+    jsEvent.setProperty(rt, "type", jsi::String::createFromUtf8(rt, cssEventTypeName(event.type)));
+    jsEvent.setProperty(rt, "name", jsi::String::createFromUtf8(rt, event.name));
+    jsEvent.setProperty(rt, "elapsedTime", jsi::Value(event.elapsedTime));
+    result.setValueAtIndex(rt, i, std::move(jsEvent));
+  }
+
+  return result;
+}
+
+} // namespace
+
+CSSEventsEmitter::CSSEventsEmitter(const std::shared_ptr<react::CallInvoker> &jsInvoker) : jsInvoker_(jsInvoker) {}
+
+void CSSEventsEmitter::setEmitFunction(std::shared_ptr<jsi::Function> emitFunction) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  emitFunction_ = std::move(emitFunction);
+}
+
+void CSSEventsEmitter::invalidate() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  emitFunction_.reset();
+  pending_.clear();
+  drainRequested_ = false;
+}
+
+void CSSEventsEmitter::emit(CSSEvent event) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  pending_.push_back(std::move(event));
+  requestDrain();
+}
+
+void CSSEventsEmitter::requestDrain() {
+  if (drainRequested_ || !emitFunction_) {
+    return;
+  }
+  drainRequested_ = true;
+
+  jsInvoker_->invokeAsync([weakThis = weak_from_this()](jsi::Runtime &rt) {
+    if (const auto strongThis = weakThis.lock()) {
+      strongThis->drain(rt);
+    }
+  });
+}
+
+void CSSEventsEmitter::drain(jsi::Runtime &rt) {
+  std::vector<CSSEvent> events;
+  std::shared_ptr<jsi::Function> emitFunction;
+
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    drainRequested_ = false;
+    if (pending_.empty() || !emitFunction_) {
+      pending_.clear();
+      return;
+    }
+    events = std::exchange(pending_, {});
+    emitFunction = emitFunction_;
+  }
+
+  emitFunction->call(rt, eventsToJSIArray(rt, events));
+}
+
+} // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/events/CSSEventsEmitter.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/events/CSSEventsEmitter.h
@@ -5,7 +5,6 @@
 #include <ReactCommon/CallInvoker.h>
 #include <jsi/jsi.h>
 
-#include <cstddef>
 #include <memory>
 #include <mutex>
 #include <vector>
@@ -28,19 +27,11 @@ class CSSEventsEmitter : public std::enable_shared_from_this<CSSEventsEmitter> {
   void emit(CSSEvent event);
 
  private:
-  /// A drain request can be dropped before it runs (the runtime scheduler
-  /// clears its queue on a task error when
-  /// `enableRuntimeSchedulerQueueClearingOnError` is on), which would leave
-  /// `drainRequested_` latched with no drain left to clear it. Re-request once
-  /// the backlog says the request never arrived.
-  static constexpr std::size_t kDrainRetryBacklog = 64;
-
   const std::shared_ptr<facebook::react::CallInvoker> jsInvoker_;
 
   std::mutex mutex_;
   std::shared_ptr<facebook::jsi::Function> emitFunction_;
   std::vector<CSSEvent> pending_;
-  bool drainRequested_{false};
 
   void scheduleDrain();
   void drain(facebook::jsi::Runtime &rt);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/events/CSSEventsEmitter.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/events/CSSEventsEmitter.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <reanimated/CSS/events/CSSEvent.h>
+
+#include <ReactCommon/CallInvoker.h>
+#include <jsi/jsi.h>
+
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+#include <vector>
+
+namespace reanimated::css {
+
+/// Batches CSS animation and transition events and delivers them to JS.
+///
+/// Whether a view listens for an event is decided by its owner before emitting,
+/// so this only batches. Events are produced on the UI thread with registry
+/// locks held, so `emit` buffers and asks the JS thread for a drain, and the JS
+/// function is only ever called from that drain.
+class CSSEventsEmitter : public std::enable_shared_from_this<CSSEventsEmitter> {
+ public:
+  explicit CSSEventsEmitter(const std::shared_ptr<facebook::react::CallInvoker> &jsInvoker);
+
+  void setEmitFunction(std::shared_ptr<facebook::jsi::Function> emitFunction);
+  void invalidate();
+
+  void emit(CSSEvent event);
+
+ private:
+  const std::shared_ptr<facebook::react::CallInvoker> jsInvoker_;
+
+  mutable std::mutex mutex_;
+  std::shared_ptr<facebook::jsi::Function> emitFunction_;
+  std::vector<CSSEvent> pending_;
+  bool drainRequested_{false};
+
+  void requestDrain();
+  void drain(facebook::jsi::Runtime &rt);
+};
+
+} // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/events/CSSEventsEmitter.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/events/CSSEventsEmitter.h
@@ -5,9 +5,9 @@
 #include <ReactCommon/CallInvoker.h>
 #include <jsi/jsi.h>
 
+#include <cstddef>
 #include <memory>
 #include <mutex>
-#include <unordered_map>
 #include <vector>
 
 namespace reanimated::css {
@@ -15,9 +15,9 @@ namespace reanimated::css {
 /// Batches CSS animation and transition events and delivers them to JS.
 ///
 /// Whether a view listens for an event is decided by its owner before emitting,
-/// so this only batches. Events are produced on the UI thread with registry
-/// locks held, so `emit` buffers and asks the JS thread for a drain, and the JS
-/// function is only ever called from that drain.
+/// so this only batches. `emit` runs on both the UI and the JS thread with the
+/// updates registry lock held, so it buffers and asks the JS thread for a
+/// drain, and the JS function is only ever called from that drain.
 class CSSEventsEmitter : public std::enable_shared_from_this<CSSEventsEmitter> {
  public:
   explicit CSSEventsEmitter(const std::shared_ptr<facebook::react::CallInvoker> &jsInvoker);
@@ -28,14 +28,21 @@ class CSSEventsEmitter : public std::enable_shared_from_this<CSSEventsEmitter> {
   void emit(CSSEvent event);
 
  private:
+  /// A drain request can be dropped before it runs (the runtime scheduler
+  /// clears its queue on a task error when
+  /// `enableRuntimeSchedulerQueueClearingOnError` is on), which would leave
+  /// `drainRequested_` latched with no drain left to clear it. Re-request once
+  /// the backlog says the request never arrived.
+  static constexpr std::size_t kDrainRetryBacklog = 64;
+
   const std::shared_ptr<facebook::react::CallInvoker> jsInvoker_;
 
-  mutable std::mutex mutex_;
+  std::mutex mutex_;
   std::shared_ptr<facebook::jsi::Function> emitFunction_;
   std::vector<CSSEvent> pending_;
   bool drainRequested_{false};
 
-  void requestDrain();
+  void scheduleDrain();
   void drain(facebook::jsi::Runtime &rt);
 };
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -394,6 +394,8 @@ ReanimatedModuleProxy::~ReanimatedModuleProxy() {
   // event handler registry and frame callbacks store some JSI values from UI
   // runtime, so they have to go away before we tear down the runtime
   eventHandlerRegistry_.reset();
+  // The emitter holds a function from the RN runtime and is still reachable
+  // from a frame in flight, so stop it before that runtime goes away.
   cssEventsEmitter_->invalidate();
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -212,6 +212,7 @@ ReanimatedModuleProxy::ReanimatedModuleProxy(
           updatesRegistryManager_)),
       animatedPropsRegistry_(std::make_shared<AnimatedPropsRegistry>()),
       viewStylesRepository_(std::make_shared<ViewStylesRepository>(staticPropsRegistry_, animatedPropsRegistry_)),
+      cssEventsEmitter_(std::make_shared<CSSEventsEmitter>(jsCallInvoker)),
       cssAnimationKeyframesRegistry_(std::make_shared<CSSKeyframesRegistry>()),
       cssAnimationsRegistry_(std::make_shared<CSSAnimationsRegistry>(
           operationsLoop_,
@@ -393,6 +394,7 @@ ReanimatedModuleProxy::~ReanimatedModuleProxy() {
   // event handler registry and frame callbacks store some JSI values from UI
   // runtime, so they have to go away before we tear down the runtime
   eventHandlerRegistry_.reset();
+  cssEventsEmitter_->invalidate();
 }
 
 jsi::Value ReanimatedModuleProxy::registerEventHandler(
@@ -586,6 +588,10 @@ void ReanimatedModuleProxy::applyCSSAnimations(
 void ReanimatedModuleProxy::unregisterCSSAnimations(const jsi::Value &viewTag) {
   auto lock = updatesRegistryManager_->lock();
   cssAnimationsRegistry_->remove(viewTag.asNumber());
+}
+
+void ReanimatedModuleProxy::setCSSEventHandler(jsi::Runtime &rt, const jsi::Value &handler) {
+  cssEventsEmitter_->setEmitFunction(std::make_shared<jsi::Function>(handler.asObject(rt).asFunction(rt)));
 }
 
 void ReanimatedModuleProxy::runCSSTransition(
@@ -1538,6 +1544,18 @@ jsi::Object ReanimatedModuleProxy::toOptimizedObject(jsi::Runtime &rt) {
           return;
         }
         strongThis->applyCSSAnimations(rt, at<0>(args), at<1>(args), at<2>(args));
+      });
+
+  addMethod<1>(
+      rt,
+      obj,
+      "setCSSEventHandler",
+      [weakThis = weak_from_this()](jsi::Runtime &rt, const jsi::Value &, const jsi::Value(&args)[1]) {
+        auto strongThis = weakThis.lock();
+        if (!strongThis) {
+          return;
+        }
+        strongThis->setCSSEventHandler(rt, at<0>(args));
       });
 
   addMethod<1>(

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
@@ -8,6 +8,7 @@
 #include <reanimated/AnimatedSensor/AnimatedSensorModule.h>
 #include <reanimated/CSS/core/CSSAnimation.h>
 #include <reanimated/CSS/core/transition/CSSTransition.h>
+#include <reanimated/CSS/events/CSSEventsEmitter.h>
 #include <reanimated/CSS/misc/ViewStylesRepository.h>
 #include <reanimated/CSS/registries/CSSAnimationsRegistry.h>
 #include <reanimated/CSS/registries/CSSKeyframesRegistry.h>
@@ -141,6 +142,8 @@ class ReanimatedModuleProxy : public std::enable_shared_from_this<ReanimatedModu
       const jsi::Value &animationUpdates);
   void unregisterCSSAnimations(const jsi::Value &viewTag);
 
+  void setCSSEventHandler(jsi::Runtime &rt, const jsi::Value &handler);
+
   void runCSSTransition(jsi::Runtime &rt, const jsi::Value &shadowNodeWrapper, const jsi::Value &transitionConfig);
   void unregisterCSSTransition(jsi::Runtime &rt, const jsi::Value &viewTag);
 
@@ -244,6 +247,7 @@ class ReanimatedModuleProxy : public std::enable_shared_from_this<ReanimatedModu
   const std::shared_ptr<OperationsLoop> operationsLoop_;
   const std::shared_ptr<AnimatedPropsRegistry> animatedPropsRegistry_;
   const std::shared_ptr<ViewStylesRepository> viewStylesRepository_;
+  const std::shared_ptr<css::CSSEventsEmitter> cssEventsEmitter_;
   const std::shared_ptr<CSSKeyframesRegistry> cssAnimationKeyframesRegistry_;
   const std::shared_ptr<CSSAnimationsRegistry> cssAnimationsRegistry_;
   const std::shared_ptr<CSSTransitionsRegistry> cssTransitionsRegistry_;


### PR DESCRIPTION
The transport for CSS events: a buffer that batches whatever is emitted and hands it to JS in one call, plus the JSI entrypoint that installs the receiving function.

Nothing emits yet, so this is inert on its own. #10070 adds the animation side.

Emitting buffers the event and asks the JS thread to drain, so however many events land before the drain runs arrive in a single JS call. That keeps the JS call off the UI thread and out of the registry lock. A drain is requested per event rather than latched per batch: a request can be dropped before it runs, and there is no signal for that, so anything remembering that one is outstanding would strand the buffer for good. `elapsedTime` is converted to seconds once, matching the contract already shipped on web.

The event type ordinals are the bit indices of the subscription mask, so the JS constants have to stay in sync with them. The four transition values are reserved and unemitted until CSS transitions land.
