### PR TITLE
test(worklets): stop asserting unguaranteed timer order on the UI Runtime

### DIFF
--- a/apps/common-app/runtime-tests/worklets/tests/runLoop/setInterval.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/runLoop/setInterval.test.tsx
@@ -267,36 +267,75 @@ describe('Test setInterval', () => {
     }
   );
 
-  test.each([RuntimeKind.UI, RuntimeKind.Worker])(
-    'intervals order of execution, inverted scheduled order, runtime: **%s**',
-    async (runtimeKind) => {
-      // Arrange
-      const [notification1, notification2] = ['callback1', 'callback2'];
-      const [confirmedOrder, order] = createOrderConstraint();
+  test(`intervals order of execution, inverted scheduled order, runtime: **${RuntimeKind.Worker}**`, async () => {
+    // Arrange
+    const [notification1, notification2] = ['callback1', 'callback2'];
+    const [confirmedOrder, order] = createOrderConstraint();
 
-      // Act
-      await render(
-        <DispatchTestComponent
-          worklet={() => {
-            'worklet';
-            const handle1 = setInterval(() => {
-              order(2, notification2);
-              clearInterval(handle1);
-            }, 70);
-            const handle2 = setInterval(() => {
-              order(1, notification1);
-              clearInterval(handle2);
-            }, 50);
-          }}
-          runtimeKind={runtimeKind}
-        />
+    // Act
+    await render(
+      <DispatchTestComponent
+        worklet={() => {
+          'worklet';
+          const handle1 = setInterval(() => {
+            order(2, notification2);
+            clearInterval(handle1);
+          }, 70);
+          const handle2 = setInterval(() => {
+            order(1, notification1);
+            clearInterval(handle2);
+          }, 50);
+        }}
+        runtimeKind={RuntimeKind.Worker}
+      />
+    );
+
+    // Assert
+    await waitForNotifications([notification1, notification2]);
+    expect(confirmedOrder.value).toBe(2);
+  });
+
+  test(`intervals order of execution, inverted scheduled order, runtime: **${RuntimeKind.UI}**`, async () => {
+    // Arrange
+    const [notification1, notification2] = ['callback1', 'callback2'];
+    const [confirmedOrder, order] = createOrderConstraint();
+    const [bothIntervalsWereDue, markBothIntervalsWereDue] =
+      createTestValue<boolean>(false);
+    const shorterDelay = 50;
+    const longerDelay = 70;
+
+    // Act
+    await render(
+      <DispatchTestComponent
+        worklet={() => {
+          'worklet';
+          const scheduledAt = performance.now();
+          const handle1 = setInterval(() => {
+            order(2, notification2);
+            clearInterval(handle1);
+          }, longerDelay);
+          const handle2 = setInterval(() => {
+            markBothIntervalsWereDue(
+              performance.now() - scheduledAt >= longerDelay
+            );
+            order(1, notification1);
+            clearInterval(handle2);
+          }, shorterDelay);
+        }}
+        runtimeKind={RuntimeKind.UI}
+      />
+    );
+
+    // Assert
+    await waitForNotifications([notification1, notification2]);
+    if (bothIntervalsWereDue.value) {
+      expect(confirmedOrder.value === 2 || confirmedOrder.value === -1).toBe(
+        true
       );
-
-      // Assert
-      await waitForNotifications([notification1, notification2]);
+    } else {
       expect(confirmedOrder.value).toBe(2);
     }
-  );
+  });
 
   test.each([RuntimeKind.UI, RuntimeKind.Worker])(
     'intervals order of execution, nested timeouts, runtime: **%s**',

--- a/apps/common-app/runtime-tests/worklets/tests/runLoop/setTimeout.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/runLoop/setTimeout.test.tsx
@@ -225,34 +225,71 @@ describe('Test setTimeout', () => {
     }
   );
 
-  test.each([RuntimeKind.UI, RuntimeKind.Worker])(
-    'timeouts order of execution, inverted scheduled order, runtime: **%s**',
-    async (runtimeKind) => {
-      // Arrange
-      const [notification1, notification2] = ['callback1', 'callback2'];
-      const [confirmedOrder, order] = createOrderConstraint();
+  test(`timeouts order of execution, inverted scheduled order, runtime: **${RuntimeKind.Worker}**`, async () => {
+    // Arrange
+    const [notification1, notification2] = ['callback1', 'callback2'];
+    const [confirmedOrder, order] = createOrderConstraint();
 
-      // Act
-      await render(
-        <DispatchTestComponent
-          worklet={() => {
-            'worklet';
-            setTimeout(() => {
-              order(2, notification2);
-            }, 70);
-            setTimeout(() => {
-              order(1, notification1);
-            }, 50);
-          }}
-          runtimeKind={runtimeKind}
-        />
+    // Act
+    await render(
+      <DispatchTestComponent
+        worklet={() => {
+          'worklet';
+          setTimeout(() => {
+            order(2, notification2);
+          }, 70);
+          setTimeout(() => {
+            order(1, notification1);
+          }, 50);
+        }}
+        runtimeKind={RuntimeKind.Worker}
+      />
+    );
+
+    // Assert
+    await waitForNotifications([notification1, notification2]);
+    expect(confirmedOrder.value).toBe(2);
+  });
+
+  test(`timeouts order of execution, inverted scheduled order, runtime: **${RuntimeKind.UI}**`, async () => {
+    // Arrange
+    const [notification1, notification2] = ['callback1', 'callback2'];
+    const [confirmedOrder, order] = createOrderConstraint();
+    const [bothTimeoutsWereDue, markBothTimeoutsWereDue] =
+      createTestValue<boolean>(false);
+    const shorterDelay = 50;
+    const longerDelay = 70;
+
+    // Act
+    await render(
+      <DispatchTestComponent
+        worklet={() => {
+          'worklet';
+          const scheduledAt = performance.now();
+          setTimeout(() => {
+            order(2, notification2);
+          }, longerDelay);
+          setTimeout(() => {
+            markBothTimeoutsWereDue(
+              performance.now() - scheduledAt >= longerDelay
+            );
+            order(1, notification1);
+          }, shorterDelay);
+        }}
+        runtimeKind={RuntimeKind.UI}
+      />
+    );
+
+    // Assert
+    await waitForNotifications([notification1, notification2]);
+    if (bothTimeoutsWereDue.value) {
+      expect(confirmedOrder.value === 2 || confirmedOrder.value === -1).toBe(
+        true
       );
-
-      // Assert
-      await waitForNotifications([notification1, notification2]);
+    } else {
       expect(confirmedOrder.value).toBe(2);
     }
-  );
+  });
 
   test.each([RuntimeKind.UI, RuntimeKind.Worker])(
     'timeouts order of execution, nested timeouts, runtime: **%s**',


### PR DESCRIPTION
## Summary

On the UI Runtime `setTimeout` (and therefore `setInterval`) is polyfilled with `requestAnimationFrame` which doesn't guarantee order of execution based on the delay timings.

i.e. if first a 30ms delay task was ordered and then a 20ms task, and then due to UI hang 50ms have passed, the tasks won't fire in 20ms->30ms order but in the scheduling order, so 30ms->20ms

I amended the tests to cover that nuance, since they were flaky sometimes.

## Test plan

"run loop" runtime tests pass
