### PR TITLE
chore(repo): verify app formatting in CI

### DIFF
--- a/apps/common-app/package.json
+++ b/apps/common-app/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "",
-    "lint": "eslint . --flag v10_config_lookup_from_file",
+    "lint": "eslint . --flag v10_config_lookup_from_file && yarn run --top-level oxfmt --check .",
     "format": "yarn run --top-level oxfmt .",
     "circular-dependency-check": "yarn madge --extensions js,jsx,ts,tsx --circular src",
     "type:check": "yarn type:check:native && yarn type:check:web",

--- a/apps/common-app/runtime-tests/ReJest/TestRunner/CallTrackerRegistry.ts
+++ b/apps/common-app/runtime-tests/ReJest/TestRunner/CallTrackerRegistry.ts
@@ -3,9 +3,9 @@ import { createSynchronizable } from 'react-native-worklets';
 import type { TrackerCallCount } from '../types';
 
 let callCallTrackerRegistryJS: Record<string, number> = {};
-const callCallTrackerRegistryUI = createSynchronizable<
-  Record<string, number>
->({});
+const callCallTrackerRegistryUI = createSynchronizable<Record<string, number>>(
+  {}
+);
 function callTrackerJS(name: string) {
   if (!callCallTrackerRegistryJS[name]) {
     callCallTrackerRegistryJS[name] = 0;

--- a/apps/common-app/runtime-tests/ReJest/utils/remoteReporter.ts
+++ b/apps/common-app/runtime-tests/ReJest/utils/remoteReporter.ts
@@ -35,9 +35,7 @@ export interface RemoteReporterOptions {
   library: string;
   declaredSuites: DeclaredSuite[];
   onStatus: (message: string) => void;
-  onStart: (params: {
-    only?: string[];
-  }) => Promise<RunSummary | void>;
+  onStart: (params: { only?: string[] }) => Promise<RunSummary | void>;
 }
 
 interface StartMessage {
@@ -94,8 +92,7 @@ export function runWithRemoteReporter({
   }
 
   const ws = socket;
-  const originalConsole: Partial<Record<ConsoleLevel, typeof console.log>> =
-    {};
+  const originalConsole: Partial<Record<ConsoleLevel, typeof console.log>> = {};
   let consolePatched = false;
   let runStarted = false;
   let runFinishedEnvelopeSent = false;
@@ -189,10 +186,7 @@ export function runWithRemoteReporter({
     runFinishedEnvelopeSent = true;
     safeSend(envelope);
     setTimeout(() => {
-      if (
-        ws.readyState === 1 ||
-        ws.readyState === 0
-      ) {
+      if (ws.readyState === 1 || ws.readyState === 0) {
         try {
           ws.close();
         } catch {

--- a/apps/common-app/runtime-tests/ReJest/utils/stringFormatUtils.ts
+++ b/apps/common-app/runtime-tests/ReJest/utils/stringFormatUtils.ts
@@ -136,9 +136,7 @@ export function formatTestName(
   if (Array.isArray(variableObject)) {
     variableObject.forEach((value, index) => {
       // python-like syntax ${1} {2}
-      testName = testName
-        .split('${' + index + '}')
-        .join(valueToString(value));
+      testName = testName.split('${' + index + '}').join(valueToString(value));
     });
   }
   if (typeof variableObject === 'object') {
@@ -147,9 +145,7 @@ export function formatTestName(
       // Typical object literal syntax
       testName = testName
         .split('${' + k + '}')
-        .join(
-          valueToString(variableObject[k as keyof typeof variableObject])
-        );
+        .join(valueToString(variableObject[k as keyof typeof variableObject]));
     });
   }
 

--- a/apps/common-app/src/apps/reanimated/examples/SuspenseLayoutAnimationCrashExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/SuspenseLayoutAnimationCrashExample.tsx
@@ -4,13 +4,13 @@ import React, {
   useReducer,
   useRef,
   useState,
-} from "react";
-import { Button, Text, View } from "react-native";
+} from 'react';
+import { Button, Text, View } from 'react-native';
 import Animated, {
   FadeIn,
   FadeOut,
   LinearTransition,
-} from "react-native-reanimated";
+} from 'react-native-reanimated';
 
 // Minimal reproduction of a Fabric mounting crash caused by Reanimated's
 // legacy LayoutAnimationsProxy (EXC_BAD_ACCESS at 0x18 on RN 0.83 /
@@ -35,7 +35,7 @@ const SUSPEND_MS = 150;
 
 const cache = new Map<
   string,
-  { status: "pending" | "done"; promise: Promise<void> }
+  { status: 'pending' | 'done'; promise: Promise<void> }
 >();
 
 function useSuspendedData(key: string) {
@@ -45,15 +45,15 @@ function useSuspendedData(key: string) {
       setTimeout(() => {
         const e = cache.get(key);
         if (e) {
-          e.status = "done";
+          e.status = 'done';
         }
         resolve();
       }, SUSPEND_MS);
     });
-    entry = { status: "pending", promise };
+    entry = { status: 'pending', promise };
     cache.set(key, entry);
   }
-  if (entry.status === "pending") {
+  if (entry.status === 'pending') {
     // eslint-disable-next-line
     throw entry.promise;
   }
@@ -89,22 +89,19 @@ function Item({
     <Animated.View
       layout={LinearTransition.duration(250)}
       entering={FadeIn.duration(200)}
-      exiting={FadeOut.duration(800)}
-    >
+      exiting={FadeOut.duration(800)}>
       {swapped ? (
         <Animated.View
           key="a"
           entering={FadeIn.duration(200)}
-          exiting={FadeOut.duration(600)}
-        >
+          exiting={FadeOut.duration(600)}>
           <Text>{`${id} · A · mode ${mode}`}</Text>
         </Animated.View>
       ) : (
         <Animated.View
           key="b"
           entering={FadeIn.duration(200)}
-          exiting={FadeOut.duration(600)}
-        >
+          exiting={FadeOut.duration(600)}>
           <Text>{`${id} · B · mode ${mode}`}</Text>
         </Animated.View>
       )}
@@ -130,8 +127,7 @@ function Skeleton() {
   return (
     <Animated.View
       entering={FadeIn.duration(150)}
-      exiting={FadeOut.duration(400)}
-    >
+      exiting={FadeOut.duration(400)}>
       <Text>Loading…</Text>
     </Animated.View>
   );
@@ -141,7 +137,7 @@ export default function SuspenseLayoutAnimationCrashExample() {
   const [mode, nextMode] = useReducer((m: number) => m + 1, 0);
   const [swapped, setSwapped] = useState(false);
   const interval = useRef<ReturnType<typeof setInterval> | undefined>(
-    undefined,
+    undefined
   );
 
   useEffect(() => () => clearInterval(interval.current), []);

--- a/apps/fabric-example/index.runtimeTests.self-tests.js
+++ b/apps/fabric-example/index.runtimeTests.self-tests.js
@@ -3,4 +3,7 @@ import SelfTestsAutoRunApp from 'common-app/runtime-tests/self-tests/AutoRunApp'
 
 const RUNTIME_TESTS_APP_NAME = 'FabricExampleRuntimeTests';
 
-AppRegistry.registerComponent(RUNTIME_TESTS_APP_NAME, () => SelfTestsAutoRunApp);
+AppRegistry.registerComponent(
+  RUNTIME_TESTS_APP_NAME,
+  () => SelfTestsAutoRunApp
+);

--- a/apps/fabric-example/index.runtimeTests.worklets.js
+++ b/apps/fabric-example/index.runtimeTests.worklets.js
@@ -3,7 +3,4 @@ import WorkletsAutoRunApp from 'common-app/runtime-tests/worklets/AutoRunApp';
 
 const RUNTIME_TESTS_APP_NAME = 'FabricExampleRuntimeTests';
 
-AppRegistry.registerComponent(
-  RUNTIME_TESTS_APP_NAME,
-  () => WorkletsAutoRunApp
-);
+AppRegistry.registerComponent(RUNTIME_TESTS_APP_NAME, () => WorkletsAutoRunApp);

--- a/apps/fabric-example/package.json
+++ b/apps/fabric-example/package.json
@@ -8,7 +8,7 @@
     "ios": "react-native run-ios",
     "start": "react-native start",
     "format": "yarn run --top-level oxfmt .",
-    "lint": "eslint . --max-warnings 0",
+    "lint": "eslint . --max-warnings 0 && yarn run --top-level oxfmt --check .",
     "type:check": "tsc --noEmit",
     "runtime-tests": "node ./scripts/runtime-tests-server.js --launch",
     "runtime-tests:server": "node ./scripts/runtime-tests-server.js"

--- a/apps/fabric-example/scripts/runtime-tests-server.js
+++ b/apps/fabric-example/scripts/runtime-tests-server.js
@@ -523,7 +523,8 @@ async function appPath() {
   const entries = JSON.parse(stdout.slice(stdout.indexOf('[')));
   const entry =
     entries.find(
-      (candidate) => candidate.buildSettings.WRAPPER_NAME === 'FabricExample.app'
+      (candidate) =>
+        candidate.buildSettings.WRAPPER_NAME === 'FabricExample.app'
     ) ?? entries[0];
   const { TARGET_BUILD_DIR, WRAPPER_NAME } = entry.buildSettings;
   return path.join(TARGET_BUILD_DIR, WRAPPER_NAME);
@@ -549,16 +550,12 @@ async function installAndLaunch(udid) {
   console.log(
     `[runtime-tests] launching ${BUNDLE_ID} with RUNTIME_TESTS_LIBRARY=${LIBRARY}`
   );
-  await run(
-    'xcrun',
-    ['simctl', 'launch', udid, BUNDLE_ID],
-    {
-      env: {
-        ...process.env,
-        SIMCTL_CHILD_RUNTIME_TESTS_LIBRARY: LIBRARY,
-      },
-    }
-  );
+  await run('xcrun', ['simctl', 'launch', udid, BUNDLE_ID], {
+    env: {
+      ...process.env,
+      SIMCTL_CHILD_RUNTIME_TESTS_LIBRARY: LIBRARY,
+    },
+  });
 }
 
 function sdkTool(dir, name) {

--- a/apps/macos-example/package.json
+++ b/apps/macos-example/package.json
@@ -6,7 +6,7 @@
     "macos": "react-native run-macos",
     "build": "cd macos && bundle install && bundle exec pod update --no-repo-update",
     "format": "yarn run --top-level oxfmt .",
-    "lint": "eslint . --max-warnings 0",
+    "lint": "eslint . --max-warnings 0 && yarn run --top-level oxfmt --check .",
     "start": "react-native start",
     "type:check": "tsc --noEmit"
   },

--- a/apps/next-example/package.json
+++ b/apps/next-example/package.json
@@ -11,7 +11,7 @@
     "start": "next start",
     "e2e": "start-server-and-test \"next start\" http://localhost:3000 \"cypress open --e2e\"",
     "e2e:headless": "start-server-and-test \"next start\" http://localhost:3000 \"cypress run --e2e\"",
-    "lint": "eslint --max-warnings=0 .",
+    "lint": "eslint --max-warnings=0 . && yarn run --top-level oxfmt --check .",
     "format": "yarn run --top-level oxfmt ."
   },
   "dependencies": {

--- a/apps/tvos-example/package.json
+++ b/apps/tvos-example/package.json
@@ -6,7 +6,7 @@
     "build": "cd ios && bundle install && bundle exec pod update --no-repo-update",
     "android": "react-native run-android --active-arch-only",
     "ios": "react-native run-ios",
-    "lint": "eslint . --max-warnings 0",
+    "lint": "eslint . --max-warnings 0 && yarn run --top-level oxfmt --check .",
     "format": "yarn run --top-level oxfmt .",
     "start": "react-native start",
     "test": "jest",

--- a/apps/web-example/package.json
+++ b/apps/web-example/package.json
@@ -9,7 +9,7 @@
     "production": "yarn expo export -p web && yarn serve dist --single",
     "format": "yarn run --top-level oxfmt .",
     "build": "",
-    "lint": "eslint . --max-warnings 0",
+    "lint": "eslint . --max-warnings 0 && yarn run --top-level oxfmt --check .",
     "type:check": "tsc --noEmit",
     "test:e2e": "node scripts/run-e2e.mjs",
     "test:e2e:ui": "node scripts/run-e2e.mjs --ui",


### PR DESCRIPTION
> [!NOTE] **This PR description is AI-generated.**

## Summary

App workspaces only ran ESLint in their `lint` scripts, and `eslint-config-prettier` turns off every formatting rule, so nothing verified `oxfmt` formatting under `apps/` — `lint:root` skips it too, since `.prettiereslintignore` excludes `apps/`.

I appended `yarn run --top-level oxfmt --check .` to the `lint` script of all six app workspaces, mirroring `packages/react-native-worklets` in `lint:js` and both docs workspaces in `lint`. Invoking it from each app directory keeps that app's own `.prettierignore` in effect, so generated `*.snapshot.ts` files and `apps/fabric-example/ios` stay excluded.

I reformatted the seven files that had already drifted: four in `apps/common-app`, three in `apps/fabric-example`.

`.github/workflows/example-typescript-check-and-lint.yml` runs `yarn lint` for `apps/common-app` and `apps/tvos-example`, so those are enforced now; the other four apps sit behind pre-existing TODOs in that workflow's matrix and pick the check up once those entries are re-enabled.

## Test plan

`yarn lint` passes in all six app workspaces, `yarn type:check` passes in `apps/common-app` and `apps/tvos-example`, and `yarn lint:root` still passes.
