### PR TITLE
perf: Intern easings and route properties by id across the transition JNI

### DIFF
--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
@@ -31,10 +31,52 @@ PlatformEasing toPlatformEasing(const css::EasingConfig &easingConfig) {
   return {PlatformEasing::Type::Linear, {}, {}};
 }
 
+/// Must match cssPropertyWriterFor on the Kotlin side.
+std::optional<int> platformPropertyId(const std::string &propertyName) {
+  if (propertyName == "opacity") {
+    return 0;
+  }
+  return std::nullopt;
+}
+
+constexpr size_t kMaxInternedEasings = 256;
+
 } // namespace
 
-CSSPlatformTransitions::CSSPlatformTransitions(AnimateFunction animate, RemoveFunction remove)
-    : animate_(std::move(animate)), remove_(std::move(remove)) {}
+std::size_t CSSPlatformTransitions::EasingKeyHash::operator()(const EasingKey &key) const {
+  std::size_t seed = std::hash<int>{}(key.type);
+  const auto combine = [&seed](const float value) {
+    seed ^= std::hash<float>{}(value) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+  };
+  for (const float value : key.pointsX) {
+    combine(value);
+  }
+  for (const float value : key.pointsY) {
+    combine(value);
+  }
+  return seed;
+}
+
+CSSPlatformTransitions::CSSPlatformTransitions(
+    AnimateFunction animate,
+    RemoveFunction remove,
+    DefineEasingFunction defineEasing)
+    : animate_(std::move(animate)), remove_(std::move(remove)), defineEasing_(std::move(defineEasing)) {}
+
+std::optional<int> CSSPlatformTransitions::easingIdFor(const PlatformEasing &easing) {
+  EasingKey key{static_cast<std::uint8_t>(easing.type), easing.pointsX, easing.pointsY};
+  const auto it = easingIds_.find(key);
+  if (it != easingIds_.end()) {
+    return it->second;
+  }
+  if (easingIds_.size() >= kMaxInternedEasings) {
+    return std::nullopt;
+  }
+  const int easingId = static_cast<int>(easingIds_.size());
+  defineEasing_(easingId, static_cast<int>(easing.type), easing.pointsX, easing.pointsY);
+  easingIds_.emplace(std::move(key), easingId);
+  return easingId;
+}
 
 const CSSPlatformTransitions::ActiveTransition *CSSPlatformTransitions::activeTransitionFor(
     const Tag viewTag,
@@ -58,6 +100,11 @@ bool CSSPlatformTransitions::applyTransition(
   const auto *from = std::get_if<double>(&fromValue);
   const auto *to = std::get_if<double>(&toValue);
   if (from == nullptr || to == nullptr) {
+    return false;
+  }
+
+  const auto propertyId = platformPropertyId(propertyName);
+  if (!propertyId) {
     return false;
   }
 
@@ -91,14 +138,19 @@ bool CSSPlatformTransitions::applyTransition(
     adjustedStart = active->adjustedEnd;
   }
 
+  const auto easingId = easingIdFor(toPlatformEasing(resolvedSettings.easingConfig));
+  if (!easingId) {
+    return false;
+  }
+
   if (!animate_(
           static_cast<int>(viewTag),
-          propertyName,
+          *propertyId,
           *from,
           *to,
           reversing.duration,
           reversing.startTimestamp,
-          toPlatformEasing(resolvedSettings.easingConfig),
+          *easingId,
           settings == nullptr)) {
     return false;
   }
@@ -115,7 +167,11 @@ void CSSPlatformTransitions::removeTransition(const Tag viewTag, const std::stri
       active_.erase(propertiesIt);
     }
   }
-  remove_(static_cast<int>(viewTag), propertyName);
+  // A property that never resolves to an id was never routed, so there is
+  // nothing to remove on the platform side.
+  if (const auto propertyId = platformPropertyId(propertyName)) {
+    remove_(static_cast<int>(viewTag), *propertyId);
+  }
 }
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
@@ -31,19 +31,26 @@ class CSSPlatformTransitions {
  public:
   /// Returns false when the view can't carry the animation, in which case the
   /// property falls back to the loop. A `persistent` transition has no committed
-  /// style behind it, so its value must outlive the animation itself.
+  /// style behind it, so its value must outlive the animation itself. The call is
+  /// all-primitive - the easing curve is pre-registered under `easingId` and the
+  /// property under `propertyId` - so the hot per-transition JNI hop allocates
+  /// nothing.
   using AnimateFunction = std::function<bool(
       int viewTag,
-      const std::string &propertyName,
+      int propertyId,
       double fromValue,
       double toValue,
       double durationMs,
       double startTimestampMs,
-      const PlatformEasing &easing,
+      int easingId,
       bool persistent)>;
-  using RemoveFunction = std::function<void(int viewTag, const std::string &propertyName)>;
+  using RemoveFunction = std::function<void(int viewTag, int propertyId)>;
 
-  CSSPlatformTransitions(AnimateFunction animate, RemoveFunction remove);
+  /// Registers an easing curve once; later transitions reference it by id.
+  using DefineEasingFunction =
+      std::function<void(int easingId, int type, const std::vector<float> &pointsX, const std::vector<float> &pointsY)>;
+
+  CSSPlatformTransitions(AnimateFunction animate, RemoveFunction remove, DefineEasingFunction defineEasing);
 
   /// A null `settings` marks the pseudo-selector toggle path, which carries none of
   /// its own and reuses whatever the last config apply stored. A settings-only config
@@ -66,11 +73,30 @@ class CSSPlatformTransitions {
     css::CSSTransitionPropertySettings settings;
   };
 
+  struct EasingKey {
+    std::uint8_t type;
+    std::vector<float> pointsX;
+    std::vector<float> pointsY;
+
+    bool operator==(const EasingKey &other) const = default;
+  };
+
+  struct EasingKeyHash {
+    std::size_t operator()(const EasingKey &key) const;
+  };
+
   const ActiveTransition *activeTransitionFor(Tag viewTag, const std::string &propertyName) const;
 
+  /// Interns the curve, registering it on first sight. Returns nullopt once the
+  /// table is full (an app computing easing points at runtime could otherwise grow
+  /// it forever); such transitions fall back to the loop, which plays any easing.
+  std::optional<int> easingIdFor(const PlatformEasing &easing);
+
   std::unordered_map<Tag, std::unordered_map<std::string, ActiveTransition>> active_;
+  std::unordered_map<EasingKey, int, EasingKeyHash> easingIds_;
   AnimateFunction animate_;
   RemoveFunction remove_;
+  DefineEasingFunction defineEasing_;
 };
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
@@ -251,45 +251,45 @@ void NativeProxy::attachPseudoSelector(Tag tag, PseudoSelector selector, std::fu
 
 bool NativeProxy::cssAnimateTransition(
     const int viewTag,
-    const std::string &propertyName,
+    const int propertyId,
     const double fromValue,
     const double toValue,
     const double durationMs,
     const double startTimestampMs,
-    const PlatformEasing &easing,
+    const int easingId,
     const bool persistent) {
-  static const auto method = getJniMethod<jboolean(
-      int,
-      jni::alias_ref<jni::JString>,
-      double,
-      double,
-      double,
-      double,
-      int,
-      jni::alias_ref<jni::JArrayFloat>,
-      jni::alias_ref<jni::JArrayFloat>,
-      jboolean)>("cssAnimateTransition");
-  auto jPointsX = jni::JArrayFloat::newArray(easing.pointsX.size());
-  jPointsX->setRegion(0, easing.pointsX.size(), easing.pointsX.data());
-  auto jPointsY = jni::JArrayFloat::newArray(easing.pointsY.size());
-  jPointsY->setRegion(0, easing.pointsY.size(), easing.pointsY.data());
+  static const auto method =
+      getJniMethod<jboolean(int, int, double, double, double, double, int, jboolean)>("cssAnimateTransition");
   return method(
              javaPart_.get(),
              viewTag,
-             jni::make_jstring(propertyName),
+             propertyId,
              fromValue,
              toValue,
              durationMs,
              startTimestampMs,
-             static_cast<int>(easing.type),
-             jPointsX,
-             jPointsY,
+             easingId,
              static_cast<jboolean>(persistent)) != JNI_FALSE;
 }
 
-void NativeProxy::cssRemoveTransition(const int viewTag, const std::string &propertyName) {
-  static const auto method = getJniMethod<void(int, jni::alias_ref<jni::JString>)>("cssRemoveTransition");
-  method(javaPart_.get(), viewTag, jni::make_jstring(propertyName));
+void NativeProxy::cssRemoveTransition(const int viewTag, const int propertyId) {
+  static const auto method = getJniMethod<void(int, int)>("cssRemoveTransition");
+  method(javaPart_.get(), viewTag, propertyId);
+}
+
+void NativeProxy::cssDefineEasing(
+    const int easingId,
+    const int type,
+    const std::vector<float> &pointsX,
+    const std::vector<float> &pointsY) {
+  static const auto method =
+      getJniMethod<void(int, int, jni::alias_ref<jni::JArrayFloat>, jni::alias_ref<jni::JArrayFloat>)>(
+          "cssDefineEasing");
+  auto jPointsX = jni::JArrayFloat::newArray(pointsX.size());
+  jPointsX->setRegion(0, pointsX.size(), pointsX.data());
+  auto jPointsY = jni::JArrayFloat::newArray(pointsY.size());
+  jPointsY->setRegion(0, pointsY.size(), pointsY.data());
+  method(javaPart_.get(), easingId, type, jPointsX, jPointsY);
 }
 
 void NativeProxy::detachPseudoSelector(Tag tag, PseudoSelector selector) {
@@ -378,7 +378,9 @@ PlatformDepMethodsHolder NativeProxy::getPlatformDependentMethods() {
   // the constructor's member-initializer list, where a member would still be raw
   // memory.
   auto cssPlatformTransitions = std::make_shared<CSSPlatformTransitions>(
-      bindThis(&NativeProxy::cssAnimateTransition), bindThis(&NativeProxy::cssRemoveTransition));
+      bindThis(&NativeProxy::cssAnimateTransition),
+      bindThis(&NativeProxy::cssRemoveTransition),
+      bindThis(&NativeProxy::cssDefineEasing));
 
   auto cssCanRouteProperty = css::CSSCanRoutePropertyFunction(&css::canRouteCSSProperty);
 

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
@@ -76,14 +76,15 @@ class NativeProxy : public jni::HybridClass<NativeProxy>, std::enable_shared_fro
   void detachPseudoSelector(Tag tag, PseudoSelector selector);
   bool cssAnimateTransition(
       int viewTag,
-      const std::string &propertyName,
+      int propertyId,
       double fromValue,
       double toValue,
       double durationMs,
       double startTimestampMs,
-      const PlatformEasing &easing,
+      int easingId,
       bool persistent);
-  void cssRemoveTransition(int viewTag, const std::string &propertyName);
+  void cssRemoveTransition(int viewTag, int propertyId);
+  void cssDefineEasing(int easingId, int type, const std::vector<float> &pointsX, const std::vector<float> &pointsY);
 
   /***
    * Wraps a method of `NativeProxy` in a function object capturing `this`

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
@@ -268,37 +268,43 @@ open class NativeProxy {
     }
 
     @DoNotStrip
+    fun cssDefineEasing(
+        easingId: Int,
+        easingType: Int,
+        easingPointsX: FloatArray,
+        easingPointsY: FloatArray,
+    ) {
+        cssPlatformTransitionsManager.defineEasing(easingId, easingType, easingPointsX, easingPointsY)
+    }
+
+    @DoNotStrip
     fun cssAnimateTransition(
         viewTag: Int,
-        propertyName: String,
+        propertyId: Int,
         fromValue: Double,
         toValue: Double,
         durationMs: Double,
         startTimestampMs: Double,
-        easingType: Int,
-        easingPointsX: FloatArray,
-        easingPointsY: FloatArray,
+        easingId: Int,
         persistent: Boolean,
     ): Boolean =
         cssPlatformTransitionsManager.animateTransition(
             viewTag,
-            propertyName,
+            propertyId,
             fromValue,
             toValue,
             durationMs,
             startTimestampMs,
-            easingType,
-            easingPointsX,
-            easingPointsY,
+            easingId,
             persistent,
         )
 
     @DoNotStrip
     fun cssRemoveTransition(
         viewTag: Int,
-        propertyName: String,
+        propertyId: Int,
     ) {
-        cssPlatformTransitionsManager.removeTransition(viewTag, propertyName)
+        cssPlatformTransitionsManager.removeTransition(viewTag, propertyId)
     }
 
     @DoNotStrip

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
@@ -24,11 +24,13 @@ internal class CSSPlatformTransitionsManager(
     /** Monotonic so a token is never reused, even after its entry is dropped. */
     private var nextStartToken = 0L
 
-    /** Access-ordered and capped: runtime-computed easing points would otherwise grow it forever. */
-    private val interpolators =
-        object : LinkedHashMap<InterpolatorKey, TimeInterpolator>(16, 0.75f, true) {
-            override fun removeEldestEntry(eldest: MutableMap.MutableEntry<InterpolatorKey, TimeInterpolator>): Boolean = size > 64
-        }
+    /**
+     * Indexed by the easing id the C++ interner assigned. Copy-on-append keeps reads
+     * lock-free: defines are rare (once per distinct easing) and a define always
+     * happens before the first animate call that references the id.
+     */
+    @Volatile
+    private var easings = arrayOfNulls<TimeInterpolator>(0)
 
     private var pumping = false
 
@@ -92,7 +94,7 @@ internal class CSSPlatformTransitionsManager(
 
     private data class Key(
         val viewTag: Int,
-        val propertyName: String,
+        val propertyId: Int,
     )
 
     private class RunningTransition(
@@ -115,43 +117,36 @@ internal class CSSPlatformTransitionsManager(
     }
 
     private sealed class Command {
+        abstract val key: Key
+
         class Start(
-            val viewTag: Int,
-            val propertyName: String,
+            override val key: Key,
             val writer: FloatProperty<View>,
             val fromValue: Double,
             val toValue: Double,
             val durationMs: Double,
             val startTimestampMs: Double,
-            val easingType: Int,
-            val pointsX: FloatArray,
-            val pointsY: FloatArray,
+            val interpolator: TimeInterpolator,
             val persistent: Boolean,
         ) : Command()
 
         class Remove(
-            val viewTag: Int,
-            val propertyName: String,
+            override val key: Key,
         ) : Command()
     }
 
-    /**
-     * FloatArray equals is identity, so a data class or Pair key would never hit the
-     * cache (every JNI call carries fresh arrays); the point arrays must be compared
-     * by content.
-     */
-    private class InterpolatorKey(
-        private val type: Int,
-        private val pointsX: FloatArray,
-        private val pointsY: FloatArray,
+    /** PathInterpolator flattens its curve natively on construction, so build once per id. */
+    fun defineEasing(
+        easingId: Int,
+        easingType: Int,
+        easingPointsX: FloatArray,
+        easingPointsY: FloatArray,
     ) {
-        override fun equals(other: Any?): Boolean =
-            other is InterpolatorKey &&
-                type == other.type &&
-                pointsX.contentEquals(other.pointsX) &&
-                pointsY.contentEquals(other.pointsY)
-
-        override fun hashCode(): Int = 31 * (31 * type + pointsX.contentHashCode()) + pointsY.contentHashCode()
+        val interpolator = CSSEasing.interpolator(easingType, easingPointsX, easingPointsY)
+        val current = easings
+        val grown = if (easingId < current.size) current.copyOf() else current.copyOf(easingId + 1)
+        grown[easingId] = interpolator
+        easings = grown
     }
 
     /**
@@ -162,17 +157,16 @@ internal class CSSPlatformTransitionsManager(
      */
     fun animateTransition(
         viewTag: Int,
-        propertyName: String,
+        propertyId: Int,
         fromValue: Double,
         toValue: Double,
         durationMs: Double,
         startTimestampMs: Double,
-        easingType: Int,
-        easingPointsX: FloatArray,
-        easingPointsY: FloatArray,
+        easingId: Int,
         persistent: Boolean,
     ): Boolean {
-        val writer = cssPropertyWriterFor(propertyName) ?: return false
+        val writer = cssPropertyWriterFor(propertyId) ?: return false
+        val interpolator = easings.getOrNull(easingId) ?: return false
         val context = reactContext.get() ?: return false
         // Refusing sends the property to the loop, which resolves the final style without
         // animating. The animator duration scale is otherwise not applied: platform
@@ -182,16 +176,13 @@ internal class CSSPlatformTransitionsManager(
 
         enqueue(
             Command.Start(
-                viewTag,
-                propertyName,
+                Key(viewTag, propertyId),
                 writer,
                 fromValue,
                 toValue,
                 durationMs,
                 startTimestampMs,
-                easingType,
-                easingPointsX,
-                easingPointsY,
+                interpolator,
                 persistent,
             ),
         )
@@ -200,9 +191,9 @@ internal class CSSPlatformTransitionsManager(
 
     fun removeTransition(
         viewTag: Int,
-        propertyName: String,
+        propertyId: Int,
     ) {
-        enqueue(Command.Remove(viewTag, propertyName))
+        enqueue(Command.Remove(Key(viewTag, propertyId)))
     }
 
     /**
@@ -231,12 +222,7 @@ internal class CSSPlatformTransitionsManager(
 
     private fun hasPendingCommand(key: Key): Boolean =
         synchronized(commandLock) {
-            pendingCommands.any { command ->
-                when (command) {
-                    is Command.Start -> command.viewTag == key.viewTag && command.propertyName == key.propertyName
-                    is Command.Remove -> command.viewTag == key.viewTag && command.propertyName == key.propertyName
-                }
-            }
+            pendingCommands.any { it.key == key }
         }
 
     private fun flushCommands() {
@@ -257,14 +243,13 @@ internal class CSSPlatformTransitionsManager(
     }
 
     private fun beginTransition(command: Command.Start) {
-        val key = Key(command.viewTag, command.propertyName)
+        val key = command.key
         // Claiming a fresh token invalidates any retry still queued for this key, so a
         // superseded request cannot start on a later frame.
         val token = ++nextStartToken
         startTokens[key] = token
         beginWhenMounted(key, token, command.startTimestampMs + command.durationMs, command.persistent) {
-            viewForTag(command.viewTag)?.also { view ->
-                val interpolator = interpolatorFor(command.easingType, command.pointsX, command.pointsY)
+            viewForTag(key.viewTag)?.also { view ->
                 start(
                     view,
                     key,
@@ -273,7 +258,7 @@ internal class CSSPlatformTransitionsManager(
                     command.toValue,
                     command.durationMs,
                     command.startTimestampMs,
-                    interpolator,
+                    command.interpolator,
                     command.persistent,
                 )
             } != null
@@ -281,7 +266,7 @@ internal class CSSPlatformTransitionsManager(
     }
 
     private fun dropTransition(command: Command.Remove) {
-        val key = Key(command.viewTag, command.propertyName)
+        val key = command.key
         // Also drops any queued retry for this key.
         startTokens.remove(key)
         val dropped = transitions.remove(key) ?: return
@@ -384,20 +369,6 @@ internal class CSSPlatformTransitionsManager(
             running.writer.setValue(view, running.current)
         }
         return transitions.isNotEmpty()
-    }
-
-    /**
-     * PathInterpolator flattens its curve natively on construction, so cache it. The
-     * type is part of the key because different families can share a point list:
-     * linear(0.5, 1) and cubicBezier(0, 1, 0.5, 1) both normalize to [0,1],[0.5,1].
-     */
-    private fun interpolatorFor(
-        type: Int,
-        pointsX: FloatArray,
-        pointsY: FloatArray,
-    ): TimeInterpolator {
-        val key = InterpolatorKey(type, pointsX, pointsY)
-        return interpolators.getOrPut(key) { CSSEasing.interpolator(type, pointsX, pointsY) }
     }
 
     private fun viewForTag(viewTag: Int): View? =

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPropertyWriter.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPropertyWriter.kt
@@ -7,10 +7,12 @@ import android.view.View
  * The View property React Native itself writes for a CSS property. Animating the
  * same field RN writes means a commit can overwrite a running animation, which the
  * pre-draw reconciliation repairs.
+ *
+ * Ids must match `platformPropertyId` in CSSPlatformTransitions.cpp.
  */
-internal fun cssPropertyWriterFor(propertyName: String): FloatProperty<View>? =
-    when (propertyName) {
-        "opacity" -> AlphaProperty
+internal fun cssPropertyWriterFor(propertyId: Int): FloatProperty<View>? =
+    when (propertyId) {
+        0 -> AlphaProperty
         else -> null
     }
 


### PR DESCRIPTION
Makes the hot per-transition JNI call all-primitive. Easing curves are registered once per distinct curve (`cssDefineEasing`) and referenced by id afterwards, and properties map to compile-time int ids on both sides, so starting a transition no longer allocates a `jstring` and two `jfloatArray`s per call - at heavy churn (hundreds of views re-rendering many times per second) that removed tens of thousands of transient Java objects per second from the GC.

The Kotlin interpolator cache disappears with it: the interpolator is resolved once when the easing is defined and carried in the start command. The intern table is capped; an app computing easing points at runtime past the cap falls back to the loop path through the existing demotion contract, which plays any easing.

Commands now carry their `(viewTag, propertyId)` key directly, so pending-command checks and the flush dispatch read as one-liners.
