### PR TITLE
ci: name branch commit-check step for readability

### DIFF
--- a/.github/workflows/check-branch-changes.yml
+++ b/.github/workflows/check-branch-changes.yml
@@ -24,7 +24,8 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.branch }}
 
-      - id: commit_check
+      - name: Check for commits in the last 24 hours
+        id: commit_check
         run: |
           COUNT=$(git log --oneline --since='24 hours ago' | wc -l)
           echo "Found $COUNT commits in the last 24 hours on branch ${{ inputs.branch }}"


### PR DESCRIPTION
## Problem

In `.github/workflows/check-branch-changes.yml`, the `commit_check` helper `run` step is unnamed and longer than **300 characters**. In the GitHub Actions UI that collapses into a generic label, which hurts readability when recent-commit detection fails.

## Changes

Semantics are unchanged: same step `id`, same `GITHUB_OUTPUT` keys, and the same job output wiring (`steps.commit_check.outputs.has_changes`).

- Add `name: Check for commits in the last 24 hours` to `id: commit_check`

## Test plan
- [ ] Confirm callers still use `needs.check.outputs.has_changes` / `steps.commit_check.outputs.has_changes`
- [ ] Confirm the step shows the new name in the Actions UI
