### PR TITLE
feat: report CSS transition events from the engine

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSLoopTransition.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSLoopTransition.cpp
@@ -24,6 +24,10 @@ double CSSLoopTransition::getMinDelay(double timestamp) const {
   return progressProvider_.getMinDelay(timestamp);
 }
 
+void CSSLoopTransition::onMilestone(MilestoneReporter reporter) {
+  progressProvider_.onMilestone(std::move(reporter));
+}
+
 bool CSSLoopTransition::update(const double timestamp, OperationsLoop &loop) {
   progressProvider_.update(timestamp);
   onUpdate_(viewTag_);
@@ -70,6 +74,17 @@ void CSSLoopTransition::updateSettings(
 
   // Update the settings saved in progress provider
   progressProvider_.setPropertySettings(changedPropertiesSettings);
+}
+
+void CSSLoopTransition::trackProperties(
+    const PropertiesSettingsMap &propertiesSettings,
+    const std::vector<std::string> &propertyNames,
+    const double timestamp) {
+  progressProvider_.setPropertySettings(propertiesSettings);
+  for (const auto &propertyName : propertyNames) {
+    // The platform gets no reversing state, so it always runs the full duration.
+    progressProvider_.runProgressProvider(propertyName, false, timestamp);
+  }
 }
 
 folly::dynamic CSSLoopTransition::computeCurrentStyle(const std::shared_ptr<const ShadowNode> &shadowNode) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSLoopTransition.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSLoopTransition.cpp
@@ -24,8 +24,8 @@ double CSSLoopTransition::getMinDelay(double timestamp) const {
   return progressProvider_.getMinDelay(timestamp);
 }
 
-void CSSLoopTransition::onMilestone(MilestoneReporter reporter) {
-  progressProvider_.onMilestone(std::move(reporter));
+void CSSLoopTransition::setMilestoneReporter(MilestoneReporter reporter) {
+  progressProvider_.setMilestoneReporter(std::move(reporter));
 }
 
 bool CSSLoopTransition::update(const double timestamp, OperationsLoop &loop) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSLoopTransition.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSLoopTransition.cpp
@@ -159,6 +159,10 @@ void CSSLoopTransition::handleChangedProperties(
   }
 }
 
+void CSSLoopTransition::abort(const double timestamp) {
+  progressProvider_.abort(timestamp);
+}
+
 void CSSLoopTransition::removeProperties(const std::vector<std::string> &propertyNames, const double timestamp) {
   styleInterpolator_.removeProperties(propertyNames);
   progressProvider_.removeProperties(propertyNames, timestamp);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSLoopTransition.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSLoopTransition.h
@@ -17,6 +17,8 @@ namespace reanimated::css {
 class CSSLoopTransition : public OperationsLoop::LoopOperation, public std::enable_shared_from_this<CSSLoopTransition> {
  public:
   using OnUpdateCallback = std::function<void(Tag)>;
+  /// Reports a milestone of one transitioning property, with its elapsed time.
+  using MilestoneReporter = TransitionProgressProvider::MilestoneReporter;
 
   CSSLoopTransition(
       Tag viewTag,
@@ -25,6 +27,8 @@ class CSSLoopTransition : public OperationsLoop::LoopOperation, public std::enab
       OnUpdateCallback onUpdate);
 
   double getMinDelay(double timestamp) const;
+
+  void onMilestone(MilestoneReporter reporter);
 
   bool update(double timestamp, OperationsLoop &loop) override;
 
@@ -43,6 +47,12 @@ class CSSLoopTransition : public OperationsLoop::LoopOperation, public std::enab
   void updateSettings(
       const PropertiesSettingsMap &changedPropertiesSettings,
       const std::vector<std::string> &removedProperties,
+      double timestamp);
+
+  /// Tracks the lifecycle of properties whose rendering is routed to the platform.
+  void trackProperties(
+      const PropertiesSettingsMap &propertiesSettings,
+      const std::vector<std::string> &propertyNames,
       double timestamp);
 
   folly::dynamic computeCurrentStyle(const std::shared_ptr<const ShadowNode> &shadowNode);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSLoopTransition.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSLoopTransition.h
@@ -28,7 +28,7 @@ class CSSLoopTransition : public OperationsLoop::LoopOperation, public std::enab
 
   double getMinDelay(double timestamp) const;
 
-  void onMilestone(MilestoneReporter reporter);
+  void setMilestoneReporter(MilestoneReporter reporter);
 
   bool update(double timestamp, OperationsLoop &loop) override;
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSLoopTransition.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSLoopTransition.h
@@ -57,6 +57,9 @@ class CSSLoopTransition : public OperationsLoop::LoopOperation, public std::enab
 
   folly::dynamic computeCurrentStyle(const std::shared_ptr<const ShadowNode> &shadowNode);
 
+  /// Reports a cancel for every property still transitioning.
+  void abort(double timestamp);
+
   void removeProperties(const std::vector<std::string> &propertyNames, double timestamp);
 
  private:

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.cpp
@@ -21,6 +21,12 @@ CSSTransition::CSSTransition(
 
 CSSTransition::~CSSTransition() {
   platformTransitionProxy_->cancelAll(getViewTag(), routing_.platform);
+  if (loopTransition_) {
+    // The loop co-owns the transition and removal is only enqueued, so a frame
+    // already in flight can still tick it after we are gone. Drop the reporter
+    // so that tick has nothing to call back into.
+    loopTransition_->onMilestone(nullptr);
+  }
 }
 
 TransitionProperties CSSTransition::getProperties() const {
@@ -39,21 +45,51 @@ folly::dynamic CSSTransition::run(jsi::Runtime &rt, CSSTransitionConfig &&config
   }
 
   auto loopConfig = platformTransitionProxy_->processConfig(rt, getViewTag(), config, routing_, timestamp);
-  if (loopConfig.empty()) {
+
+  const auto platformRuns = platformRunProperties(config);
+  const bool hasTrackedRemovals = eventMask_ != 0 && loopTransition_ && !config.removedProperties.empty();
+  if (loopConfig.empty() && platformRuns.empty() && !hasTrackedRemovals) {
     return folly::dynamic::object();
   }
 
   auto &loopTransition = ensureLoopTransition();
   loopTransition.updateSettings(loopConfig.changedPropertiesSettings, loopConfig.removedProperties, timestamp);
 
-  // Settings-only configs reconfigure without running.
-  if (!loopConfig.hasValueUpdates()) {
-    return folly::dynamic::object();
+  if (hasTrackedRemovals) {
+    // Platform-side removals never reach the loop config.
+    loopTransition.removeProperties(config.removedProperties);
   }
 
-  auto initialUpdate = loopTransition.run(rt, shadowNode_, loopConfig.changedProperties, lastUpdates, timestamp);
-  scheduleLoop(timestamp);
+  if (!platformRuns.empty()) {
+    PropertiesSettingsMap platformSettings;
+    for (const auto &propertyName : platformRuns) {
+      platformSettings.emplace(propertyName, config.changedPropertiesSettings.at(propertyName));
+    }
+    loopTransition.trackProperties(platformSettings, platformRuns, timestamp);
+  }
+
+  folly::dynamic initialUpdate = folly::dynamic::object();
+  // Settings-only configs reconfigure without running.
+  if (loopConfig.hasValueUpdates()) {
+    initialUpdate = loopTransition.run(rt, shadowNode_, loopConfig.changedProperties, lastUpdates, timestamp);
+  }
+  if (loopConfig.hasValueUpdates() || !platformRuns.empty()) {
+    scheduleLoop(timestamp);
+  }
   return initialUpdate;
+}
+
+std::vector<std::string> CSSTransition::platformRunProperties(const CSSTransitionConfig &config) const {
+  std::vector<std::string> result;
+  if (eventMask_ == 0) {
+    return result;
+  }
+  for (const auto &[propertyName, value] : config.changedProperties) {
+    if (routing_.platform.contains(propertyName)) {
+      result.push_back(propertyName);
+    }
+  }
+  return result;
 }
 
 folly::dynamic CSSTransition::run(
@@ -114,8 +150,63 @@ CSSLoopTransition &CSSTransition::ensureLoopTransition() {
         shadowNode_->getComponentName(),
         viewStylesRepository_,
         [&observer = observer_](Tag viewTag) { observer.onTransitionUpdate(viewTag); });
+    observeMilestones(*loopTransition_);
   }
   return *loopTransition_;
+}
+
+void CSSTransition::setEventMask(const CSSEventMask eventMask) {
+  if (eventMask == eventMask_) {
+    return;
+  }
+  eventMask_ = eventMask;
+
+  if (loopTransition_) {
+    observeMilestones(*loopTransition_);
+  }
+}
+
+void CSSTransition::observeMilestones(CSSLoopTransition &loopTransition) {
+  if (eventMask_ == 0) {
+    loopTransition.onMilestone(nullptr);
+    return;
+  }
+
+  loopTransition.onMilestone(
+      [this](const RunMilestone milestone, const std::string &propertyName, const double elapsedTime) {
+        reportMilestone(milestone, propertyName, elapsedTime);
+      });
+}
+
+void CSSTransition::reportMilestone(
+    const RunMilestone milestone,
+    const std::string &propertyName,
+    const double elapsedTime) {
+  switch (milestone) {
+    case RunMilestone::Created:
+      emitEvent(CSSEventType::TransitionRun, propertyName, elapsedTime);
+      break;
+    case RunMilestone::Started:
+      emitEvent(CSSEventType::TransitionStart, propertyName, elapsedTime);
+      break;
+    case RunMilestone::Ended:
+      emitEvent(CSSEventType::TransitionEnd, propertyName, elapsedTime);
+      break;
+    case RunMilestone::Aborted:
+      emitEvent(CSSEventType::TransitionCancel, propertyName, elapsedTime);
+      break;
+    case RunMilestone::Repeated:
+      // A transition runs once, so it never repeats.
+      break;
+  }
+}
+
+void CSSTransition::emitEvent(const CSSEventType type, const std::string &propertyName, const double elapsedTime)
+    const {
+  if (!hasListener(eventMask_, type)) {
+    return;
+  }
+  observer_.onTransitionEvent(shadowNode_->getTag(), propertyName, type, elapsedTime);
 }
 
 void CSSTransition::scheduleLoop(const double timestamp) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.cpp
@@ -56,7 +56,6 @@ folly::dynamic CSSTransition::run(jsi::Runtime &rt, CSSTransitionConfig &&config
   loopTransition.updateSettings(loopConfig.changedPropertiesSettings, loopConfig.removedProperties, timestamp);
 
   if (hasTrackedRemovals) {
-    // Platform-side removals never reach the loop config.
     loopTransition.removeProperties(config.removedProperties);
   }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.cpp
@@ -119,6 +119,8 @@ void CSSTransition::setPseudoLockedProperties(TransitionProperties properties) {
 
 void CSSTransition::cancel() {
   if (loopTransition_) {
+    // Report the cancel before the operation goes away, as animations do.
+    loopTransition_->abort(loop_->resolveTimestamp());
     loop_->remove(loopTransition_);
   }
   platformTransitionProxy_->cancelAll(getViewTag(), routing_.platform);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.cpp
@@ -60,6 +60,9 @@ folly::dynamic CSSTransition::run(jsi::Runtime &rt, CSSTransitionConfig &&config
   }
 
   if (!platformRuns.empty()) {
+    // TODO: add support for events reported by the platform itself; until
+    // then the lifecycle of platform-routed properties temporarily runs on
+    // the loop path.
     PropertiesSettingsMap platformSettings;
     for (const auto &propertyName : platformRuns) {
       platformSettings.emplace(propertyName, config.changedPropertiesSettings.at(propertyName));

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.cpp
@@ -46,52 +46,48 @@ folly::dynamic CSSTransition::run(jsi::Runtime &rt, CSSTransitionConfig &&config
 
   auto loopConfig = platformTransitionProxy_->processConfig(rt, getViewTag(), config, routing_, timestamp);
 
-  const auto platformRuns = platformRunProperties(config);
-  const bool hasTrackedRemovals = eventMask_ != 0 && loopTransition_ && !config.removedProperties.empty();
-  if (loopConfig.empty() && platformRuns.empty() && !hasTrackedRemovals) {
+  if (!loopConfig.empty()) {
+    ensureLoopTransition().updateSettings(
+        loopConfig.changedPropertiesSettings, loopConfig.removedProperties, timestamp);
+  }
+  trackPlatformLifecycles(config, timestamp);
+
+  // Settings-only configs reconfigure without running.
+  if (!loopConfig.hasValueUpdates()) {
     return folly::dynamic::object();
   }
 
-  auto &loopTransition = ensureLoopTransition();
-  loopTransition.updateSettings(loopConfig.changedPropertiesSettings, loopConfig.removedProperties, timestamp);
-
-  if (hasTrackedRemovals) {
-    loopTransition.removeProperties(config.removedProperties);
-  }
-
-  if (!platformRuns.empty()) {
-    // TODO: add support for events reported by the platform itself; until
-    // then the lifecycle of platform-routed properties temporarily runs on
-    // the loop path.
-    PropertiesSettingsMap platformSettings;
-    for (const auto &propertyName : platformRuns) {
-      platformSettings.emplace(propertyName, config.changedPropertiesSettings.at(propertyName));
-    }
-    loopTransition.trackProperties(platformSettings, platformRuns, timestamp);
-  }
-
-  folly::dynamic initialUpdate = folly::dynamic::object();
-  // Settings-only configs reconfigure without running.
-  if (loopConfig.hasValueUpdates()) {
-    initialUpdate = loopTransition.run(rt, shadowNode_, loopConfig.changedProperties, lastUpdates, timestamp);
-  }
-  if (loopConfig.hasValueUpdates() || !platformRuns.empty()) {
-    scheduleLoop(timestamp);
-  }
+  auto initialUpdate =
+      ensureLoopTransition().run(rt, shadowNode_, loopConfig.changedProperties, lastUpdates, timestamp);
+  scheduleLoop(timestamp);
   return initialUpdate;
 }
 
-std::vector<std::string> CSSTransition::platformRunProperties(const CSSTransitionConfig &config) const {
-  std::vector<std::string> result;
+// TODO: add support for events reported by the platform itself; until then
+// the lifecycle of platform-routed properties temporarily runs on the loop path.
+void CSSTransition::trackPlatformLifecycles(const CSSTransitionConfig &config, const double timestamp) {
   if (eventMask_ == 0) {
-    return result;
+    return;
   }
+
+  if (loopTransition_ && !config.removedProperties.empty()) {
+    loopTransition_->removeProperties(config.removedProperties, timestamp);
+  }
+
+  PropertiesSettingsMap propertiesSettings;
+  std::vector<std::string> propertyNames;
   for (const auto &[propertyName, value] : config.changedProperties) {
     if (routing_.platform.contains(propertyName)) {
-      result.push_back(propertyName);
+      propertyNames.push_back(propertyName);
+      propertiesSettings.emplace(propertyName, config.changedPropertiesSettings.at(propertyName));
     }
   }
-  return result;
+  if (propertyNames.empty()) {
+    return;
+  }
+
+  ensureLoopTransition().trackProperties(propertiesSettings, propertyNames, timestamp);
+  scheduleLoop(timestamp);
 }
 
 folly::dynamic CSSTransition::run(

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.cpp
@@ -25,7 +25,7 @@ CSSTransition::~CSSTransition() {
     // The loop co-owns the transition and removal is only enqueued, so a frame
     // already in flight can still tick it after we are gone. Drop the reporter
     // so that tick has nothing to call back into.
-    loopTransition_->onMilestone(nullptr);
+    loopTransition_->setMilestoneReporter(nullptr);
   }
 }
 
@@ -166,11 +166,11 @@ void CSSTransition::setEventMask(const CSSEventMask eventMask) {
 
 void CSSTransition::observeMilestones(CSSLoopTransition &loopTransition) {
   if (eventMask_ == 0) {
-    loopTransition.onMilestone(nullptr);
+    loopTransition.setMilestoneReporter(nullptr);
     return;
   }
 
-  loopTransition.onMilestone(
+  loopTransition.setMilestoneReporter(
       [this](const RunMilestone milestone, const std::string &propertyName, const double elapsedTime) {
         reportMilestone(milestone, propertyName, elapsedTime);
       });

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.h
@@ -3,6 +3,7 @@
 #include <reanimated/CSS/configs/CSSTransitionConfig.h>
 #include <reanimated/CSS/core/transition/CSSLoopTransition.h>
 #include <reanimated/CSS/core/transition/CSSPlatformTransitionProxy.h>
+#include <reanimated/CSS/events/CSSEvent.h>
 #include <reanimated/CSS/misc/ViewStylesRepository.h>
 #include <reanimated/Fabric/updates/OperationsLoop.h>
 
@@ -22,6 +23,8 @@ class CSSTransition {
    public:
     virtual ~Observer() = default;
     virtual void onTransitionUpdate(Tag viewTag) = 0;
+    virtual void
+    onTransitionEvent(Tag viewTag, const std::string &propertyName, CSSEventType type, double elapsedTimeMs) = 0;
   };
 
   CSSTransition(
@@ -59,6 +62,8 @@ class CSSTransition {
 
   void setPseudoLockedProperties(TransitionProperties properties);
 
+  void setEventMask(CSSEventMask eventMask);
+
  private:
   const std::shared_ptr<const ShadowNode> shadowNode_;
   const std::shared_ptr<ViewStylesRepository> viewStylesRepository_;
@@ -70,8 +75,15 @@ class CSSTransition {
   TransitionProperties pseudoLockedProperties_;
   std::shared_ptr<CSSLoopTransition> loopTransition_;
 
+  CSSEventMask eventMask_{0};
+
   CSSLoopTransition &ensureLoopTransition();
   void scheduleLoop(double timestamp);
+  /// Changed properties the platform renders whose lifecycle we still track.
+  std::vector<std::string> platformRunProperties(const CSSTransitionConfig &config) const;
+  void observeMilestones(CSSLoopTransition &loopTransition);
+  void reportMilestone(RunMilestone milestone, const std::string &propertyName, double elapsedTime);
+  void emitEvent(CSSEventType type, const std::string &propertyName, double elapsedTime) const;
 };
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.h
@@ -79,8 +79,7 @@ class CSSTransition {
 
   CSSLoopTransition &ensureLoopTransition();
   void scheduleLoop(double timestamp);
-  /// Changed properties the platform renders whose lifecycle we still track.
-  std::vector<std::string> platformRunProperties(const CSSTransitionConfig &config) const;
+  void trackPlatformLifecycles(const CSSTransitionConfig &config, double timestamp);
   void observeMilestones(CSSLoopTransition &loopTransition);
   void reportMilestone(RunMilestone milestone, const std::string &propertyName, double elapsedTime);
   void emitEvent(CSSEventType type, const std::string &propertyName, double elapsedTime) const;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSTransitionsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSTransitionsRegistry.cpp
@@ -13,8 +13,12 @@ namespace reanimated::css {
 CSSTransitionsRegistry::CSSTransitionsRegistry(
     const std::shared_ptr<ViewStylesRepository> &viewStylesRepository,
     const std::shared_ptr<OperationsLoop> &loop,
-    const std::shared_ptr<CSSPlatformTransitionProxy> &platformTransitionProxy)
-    : viewStylesRepository_(viewStylesRepository), loop_(loop), platformTransitionProxy_(platformTransitionProxy) {}
+    const std::shared_ptr<CSSPlatformTransitionProxy> &platformTransitionProxy,
+    const std::shared_ptr<CSSEventsEmitter> &eventsEmitter)
+    : viewStylesRepository_(viewStylesRepository),
+      loop_(loop),
+      platformTransitionProxy_(platformTransitionProxy),
+      eventsEmitter_(eventsEmitter) {}
 
 bool CSSTransitionsRegistry::needsFlush() const {
   react_native_assert(UpdatesRegistryManager::isLockedByCurrentThread());
@@ -29,6 +33,13 @@ void CSSTransitionsRegistry::updateConfigOrRun(
   const auto &transition = getOrCreateTransition(shadowNode);
   auto initialUpdate = transition->run(rt, std::move(config), getUpdatesFromRegistry(transition->getViewTag()));
   recordInitialUpdate(transition, initialUpdate);
+}
+
+void CSSTransitionsRegistry::setEventMask(
+    const std::shared_ptr<const ShadowNode> &shadowNode,
+    const CSSEventMask eventMask) {
+  react_native_assert(UpdatesRegistryManager::isLockedByCurrentThread());
+  getOrCreateTransition(shadowNode)->setEventMask(eventMask);
 }
 
 void CSSTransitionsRegistry::run(
@@ -154,6 +165,15 @@ CSSTransitionsRegistry::TransitionObserver::TransitionObserver(CSSTransitionsReg
 void CSSTransitionsRegistry::TransitionObserver::onTransitionUpdate(const Tag viewTag) {
   react_native_assert(UpdatesRegistryManager::isLockedByCurrentThread());
   owner_.updatedTags_.insert(viewTag);
+}
+
+void CSSTransitionsRegistry::TransitionObserver::onTransitionEvent(
+    const Tag viewTag,
+    const std::string &propertyName,
+    const CSSEventType type,
+    const double elapsedTimeMs) {
+  react_native_assert(UpdatesRegistryManager::isLockedByCurrentThread());
+  owner_.eventsEmitter_->emit(createCSSEvent(viewTag, type, propertyName, elapsedTimeMs));
 }
 
 void CSSTransitionsRegistry::removeTag(const Tag viewTag) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSTransitionsRegistry.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSTransitionsRegistry.h
@@ -2,6 +2,7 @@
 
 #include <reanimated/CSS/configs/CSSTransitionConfig.h>
 #include <reanimated/CSS/core/transition/CSSTransition.h>
+#include <reanimated/CSS/events/CSSEventsEmitter.h>
 #include <reanimated/CSS/misc/ViewStylesRepository.h>
 #include <reanimated/Fabric/updates/OperationsLoop.h>
 #include <reanimated/Fabric/updates/UpdatesRegistry.h>
@@ -17,7 +18,8 @@ class CSSTransitionsRegistry : public UpdatesRegistry {
   CSSTransitionsRegistry(
       const std::shared_ptr<ViewStylesRepository> &viewStylesRepository,
       const std::shared_ptr<OperationsLoop> &loop,
-      const std::shared_ptr<CSSPlatformTransitionProxy> &platformTransitionProxy);
+      const std::shared_ptr<CSSPlatformTransitionProxy> &platformTransitionProxy,
+      const std::shared_ptr<CSSEventsEmitter> &eventsEmitter);
 
   bool needsFlush() const;
 
@@ -26,6 +28,8 @@ class CSSTransitionsRegistry : public UpdatesRegistry {
       jsi::Runtime &rt,
       const std::shared_ptr<const ShadowNode> &shadowNode,
       CSSTransitionConfig &&config);
+
+  void setEventMask(const std::shared_ptr<const ShadowNode> &shadowNode, CSSEventMask eventMask);
   void run(const std::shared_ptr<const ShadowNode> &shadowNode, const PropertyValueDynamicDiffsMap &propertyDiffs);
 
   void setPseudoLockedProperties(Tag viewTag, const TransitionProperties &properties);
@@ -49,6 +53,8 @@ class CSSTransitionsRegistry : public UpdatesRegistry {
    public:
     explicit TransitionObserver(CSSTransitionsRegistry &owner);
     void onTransitionUpdate(Tag viewTag) override;
+    void onTransitionEvent(Tag viewTag, const std::string &propertyName, CSSEventType type, double elapsedTimeMs)
+        override;
 
    private:
     CSSTransitionsRegistry &owner_;
@@ -57,6 +63,7 @@ class CSSTransitionsRegistry : public UpdatesRegistry {
   const std::shared_ptr<ViewStylesRepository> viewStylesRepository_;
   const std::shared_ptr<OperationsLoop> loop_;
   const std::shared_ptr<CSSPlatformTransitionProxy> platformTransitionProxy_;
+  const std::shared_ptr<CSSEventsEmitter> eventsEmitter_;
 
   TransitionObserver transitionObserver_{*this};
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -225,7 +225,8 @@ ReanimatedModuleProxy::ReanimatedModuleProxy(
           std::make_shared<CSSPlatformTransitionProxy>(
               platformDepMethodsHolder.cssCanRouteProperty,
               platformDepMethodsHolder.cssApplyTransition,
-              platformDepMethodsHolder.cssRemoveTransition))),
+              platformDepMethodsHolder.cssRemoveTransition),
+          cssEventsEmitter_)),
       pseudoStylesRegistry_(std::make_shared<PseudoStylesRegistry>(
           platformDepMethodsHolder.attachPseudoSelector,
           platformDepMethodsHolder.detachPseudoSelector,
@@ -600,11 +601,14 @@ void ReanimatedModuleProxy::setCSSEventHandler(jsi::Runtime &rt, const jsi::Valu
 void ReanimatedModuleProxy::runCSSTransition(
     jsi::Runtime &rt,
     const jsi::Value &shadowNodeWrapper,
-    const jsi::Value &transitionConfig) {
+    const jsi::Value &transitionConfig,
+    const jsi::Value &eventMask) {
   auto shadowNode = shadowNodeFromValue(rt, shadowNodeWrapper);
   auto config = parseCSSTransitionConfig(rt, shadowNode->getComponentName(), transitionConfig);
 
   auto lock = updatesRegistryManager_->lock();
+  // Subscribed before the run so the first `transitionrun` already has a listener.
+  cssTransitionsRegistry_->setEventMask(shadowNode, static_cast<CSSEventMask>(eventMask.asNumber()));
   cssTransitionsRegistry_->updateConfigOrRun(rt, shadowNode, std::move(config));
 }
 
@@ -1573,16 +1577,16 @@ jsi::Object ReanimatedModuleProxy::toOptimizedObject(jsi::Runtime &rt) {
         strongThis->unregisterCSSAnimations(at<0>(args));
       });
 
-  addMethod<2>(
+  addMethod<3>(
       rt,
       obj,
       "runCSSTransition",
-      [weakThis = weak_from_this()](jsi::Runtime &rt, const jsi::Value &, const jsi::Value(&args)[2]) {
+      [weakThis = weak_from_this()](jsi::Runtime &rt, const jsi::Value &, const jsi::Value(&args)[3]) {
         auto strongThis = weakThis.lock();
         if (!strongThis) {
           return;
         }
-        strongThis->runCSSTransition(rt, at<0>(args), at<1>(args));
+        strongThis->runCSSTransition(rt, at<0>(args), at<1>(args), at<2>(args));
       });
 
   addMethod<1>(

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
@@ -144,7 +144,11 @@ class ReanimatedModuleProxy : public std::enable_shared_from_this<ReanimatedModu
 
   void setCSSEventHandler(jsi::Runtime &rt, const jsi::Value &handler);
 
-  void runCSSTransition(jsi::Runtime &rt, const jsi::Value &shadowNodeWrapper, const jsi::Value &transitionConfig);
+  void runCSSTransition(
+      jsi::Runtime &rt,
+      const jsi::Value &shadowNodeWrapper,
+      const jsi::Value &transitionConfig,
+      const jsi::Value &eventMask);
   void unregisterCSSTransition(jsi::Runtime &rt, const jsi::Value &viewTag);
 
   void registerPseudoStyles(jsi::Runtime &rt, const jsi::Value &shadowNodeWrapper, const jsi::Value &config);

--- a/packages/react-native-reanimated/src/ReanimatedModule/NativeReanimated.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/NativeReanimated.ts
@@ -233,11 +233,13 @@ See https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooti
 
   runCSSTransition(
     shadowNodeWrapper: ShadowNodeWrapper,
-    transitionConfig: CSSTransitionConfig
+    transitionConfig: CSSTransitionConfig,
+    eventMask: number
   ): void {
     this.#reanimatedModuleProxy.runCSSTransition(
       shadowNodeWrapper,
-      transitionConfig
+      transitionConfig,
+      eventMask
     );
   }
 

--- a/packages/react-native-reanimated/src/ReanimatedModule/js-reanimated/JSReanimated.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/js-reanimated/JSReanimated.ts
@@ -337,7 +337,8 @@ class JSReanimated implements IReanimatedModule {
 
   runCSSTransition(
     _shadowNodeWrapper: ShadowNodeWrapper,
-    _transitionConfig: CSSTransitionConfig
+    _transitionConfig: CSSTransitionConfig,
+    _eventMask: number
   ): void {
     throw new Error(
       '[Reanimated] `runCSSTransition` is not available in JSReanimated.'

--- a/packages/react-native-reanimated/src/ReanimatedModule/reanimatedModuleProxy.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/reanimatedModuleProxy.ts
@@ -91,7 +91,8 @@ export interface ReanimatedModuleProxy {
 
   runCSSTransition(
     shadowNodeWrapper: ShadowNodeWrapper,
-    transitionConfig: CSSTransitionConfig
+    transitionConfig: CSSTransitionConfig,
+    eventMask: number
   ): void;
 
   unregisterCSSTransition(viewTag: number): void;

--- a/packages/react-native-reanimated/src/css/native/managers/CSSTransitionsManager.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/CSSTransitionsManager.ts
@@ -64,7 +64,9 @@ export default class CSSTransitionsManager implements ICSSTransitionsManager {
     );
 
     if (Object.keys(config).length) {
-      runCSSTransition(this.shadowNodeWrapper, config);
+      // TODO: the mask is always empty because transition callbacks do not
+      // reach this manager yet; they should subscribe the view here.
+      runCSSTransition(this.shadowNodeWrapper, config, 0);
       this.hasTransition = true;
     }
 

--- a/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSTransitionsManager.test.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSTransitionsManager.test.ts
@@ -69,40 +69,56 @@ describe('CSSTransitionsManager', () => {
         manager.update(DEFAULT_TRANSITION_CONFIG, { opacity: 0 });
         manager.update(DEFAULT_TRANSITION_CONFIG, { opacity: 1 });
 
-        expect(runCSSTransition).toHaveBeenCalledWith(shadowNodeWrapper, {
-          opacity: {
-            ...DEFAULT_SETTINGS,
-            value: [0, 1],
+        expect(runCSSTransition).toHaveBeenCalledWith(
+          shadowNodeWrapper,
+          {
+            opacity: {
+              ...DEFAULT_SETTINGS,
+              value: [0, 1],
+            },
           },
-        });
+          0
+        );
       });
 
       test('all changed properties when transitionProperty is "all"', () => {
         manager.update(ALL_CONFIG, { opacity: 0, width: 100, height: 100 });
         manager.update(ALL_CONFIG, { opacity: 1, width: 200, height: 100 });
 
-        expect(runCSSTransition).toHaveBeenCalledWith(shadowNodeWrapper, {
-          opacity: { ...DEFAULT_SETTINGS, value: [0, 1] },
-          width: { ...DEFAULT_SETTINGS, value: [100, 200] },
-        });
+        expect(runCSSTransition).toHaveBeenCalledWith(
+          shadowNodeWrapper,
+          {
+            opacity: { ...DEFAULT_SETTINGS, value: [0, 1] },
+            width: { ...DEFAULT_SETTINGS, value: [100, 200] },
+          },
+          0
+        );
       });
 
       test('newly added property when transitionProperty is "all"', () => {
         manager.update(ALL_CONFIG, { opacity: 0 });
         manager.update(ALL_CONFIG, { opacity: 0, width: 100 });
 
-        expect(runCSSTransition).toHaveBeenCalledWith(shadowNodeWrapper, {
-          width: { ...DEFAULT_SETTINGS, value: [undefined, 100] },
-        });
+        expect(runCSSTransition).toHaveBeenCalledWith(
+          shadowNodeWrapper,
+          {
+            width: { ...DEFAULT_SETTINGS, value: [undefined, 100] },
+          },
+          0
+        );
       });
 
       test('removed property when transitionProperty is "all"', () => {
         manager.update(ALL_CONFIG, { opacity: 0, width: 100 });
         manager.update(ALL_CONFIG, { opacity: 0 });
 
-        expect(runCSSTransition).toHaveBeenCalledWith(shadowNodeWrapper, {
-          width: { ...DEFAULT_SETTINGS, value: [100, undefined] },
-        });
+        expect(runCSSTransition).toHaveBeenCalledWith(
+          shadowNodeWrapper,
+          {
+            width: { ...DEFAULT_SETTINGS, value: [100, undefined] },
+          },
+          0
+        );
       });
 
       test('for newly added property when transitionProperty changes at the same time', () => {
@@ -118,9 +134,13 @@ describe('CSSTransitionsManager', () => {
         manager.update(config1, { opacity: 0 }); // width undefined
         manager.update(config2, { opacity: 0, width: 100 });
 
-        expect(runCSSTransition).toHaveBeenCalledWith(shadowNodeWrapper, {
-          width: { ...DEFAULT_SETTINGS, value: [undefined, 100] },
-        });
+        expect(runCSSTransition).toHaveBeenCalledWith(
+          shadowNodeWrapper,
+          {
+            width: { ...DEFAULT_SETTINGS, value: [undefined, 100] },
+          },
+          0
+        );
       });
 
       describe('cleanup when property is removed from config', () => {
@@ -148,9 +168,13 @@ describe('CSSTransitionsManager', () => {
               nextProps
             );
 
-            expect(runCSSTransition).toHaveBeenCalledWith(shadowNodeWrapper, {
-              opacity: null,
-            });
+            expect(runCSSTransition).toHaveBeenCalledWith(
+              shadowNodeWrapper,
+              {
+                opacity: null,
+              },
+              0
+            );
           });
         });
       });
@@ -167,13 +191,17 @@ describe('CSSTransitionsManager', () => {
           { opacity: 1 }
         );
 
-        expect(runCSSTransition).toHaveBeenCalledWith(shadowNodeWrapper, {
-          opacity: {
-            ...DEFAULT_SETTINGS,
-            duration: 500,
-            value: [0, 1],
+        expect(runCSSTransition).toHaveBeenCalledWith(
+          shadowNodeWrapper,
+          {
+            opacity: {
+              ...DEFAULT_SETTINGS,
+              duration: 500,
+              value: [0, 1],
+            },
           },
-        });
+          0
+        );
       });
 
       test('handles partial updates with multiple properties', () => {
@@ -186,9 +214,13 @@ describe('CSSTransitionsManager', () => {
         // Only opacity changes
         manager.update(config, { opacity: 1, width: 100 });
 
-        expect(runCSSTransition).toHaveBeenCalledWith(shadowNodeWrapper, {
-          opacity: { ...DEFAULT_SETTINGS, value: [0, 1] },
-        });
+        expect(runCSSTransition).toHaveBeenCalledWith(
+          shadowNodeWrapper,
+          {
+            opacity: { ...DEFAULT_SETTINGS, value: [0, 1] },
+          },
+          0
+        );
       });
 
       test('does not trigger transition when a disallowed prop is removed from props', () => {
@@ -231,9 +263,13 @@ describe('CSSTransitionsManager', () => {
         // opacity is now effectively removed by normalization pruning
         manager.update(afterConfig, { opacity: 1, width: 100 });
 
-        expect(runCSSTransition).toHaveBeenCalledWith(shadowNodeWrapper, {
-          opacity: null,
-        });
+        expect(runCSSTransition).toHaveBeenCalledWith(
+          shadowNodeWrapper,
+          {
+            opacity: null,
+          },
+          0
+        );
       });
 
       describe('detach via null config', () => {

--- a/packages/react-native-reanimated/src/css/native/proxy.ts
+++ b/packages/react-native-reanimated/src/css/native/proxy.ts
@@ -74,9 +74,14 @@ export function unregisterCSSAnimations(viewTag: number) {
 
 export function runCSSTransition(
   shadowNodeWrapper: ShadowNodeWrapper,
-  transitionConfig: CSSTransitionConfig
+  transitionConfig: CSSTransitionConfig,
+  eventMask: number
 ) {
-  ReanimatedModule.runCSSTransition(shadowNodeWrapper, transitionConfig);
+  ReanimatedModule.runCSSTransition(
+    shadowNodeWrapper,
+    transitionConfig,
+    eventMask
+  );
 }
 
 export function unregisterCSSTransition(viewTag: number) {


### PR DESCRIPTION
Emits CSS transition events from the engine and delivers them through the shared CSS events channel: transitionrun, transitionstart, transitionend and transitioncancel.

Properties whose rendering is routed to a platform transition temporarily track their lifecycle on the loop clock, so their events fire from common code until the platform can report its own. The subscription mask travels as a separate runCSSTransition argument rather than inside the config, where every key is read as a CSS property name. The mask is always empty for now because transition callbacks do not reach the transitions manager yet.

