### PR TITLE
feat: report the lifecycle milestones a transition crosses

### DIFF
--- a/apps/common-app/src/apps/css/examples/animations/routes/index.ts
+++ b/apps/common-app/src/apps/css/examples/animations/routes/index.ts
@@ -54,6 +54,10 @@ const routes = {
     CardComponent: routeCards.MiscellaneousCard,
     name: 'Miscellaneous',
     routes: {
+      AnimationCallbacks: {
+        Component: miscellaneous.AnimationCallbacks,
+        name: 'Animation Callbacks',
+      },
       ChangingAnimation: {
         Component: miscellaneous.ChangingAnimation,
         name: 'Changing Animation',

--- a/apps/common-app/src/apps/css/examples/animations/screens/miscellaneous/AnimationCallbacks.tsx
+++ b/apps/common-app/src/apps/css/examples/animations/screens/miscellaneous/AnimationCallbacks.tsx
@@ -1,0 +1,186 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { FlatList, StyleSheet, View } from 'react-native';
+import type { CSSAnimationProperties } from 'react-native-reanimated';
+import Animated, { css } from 'react-native-reanimated';
+
+import { Button, Screen, Section, Text } from '@/apps/css/components';
+import { colors, flex, radius, sizes, spacing } from '@/theme';
+
+const pulse = css.keyframes({
+  '0%, 100%': {
+    transform: [{ scale: 1 }],
+  },
+  '50%': {
+    transform: [{ scale: 1.5 }],
+  },
+});
+
+const FINITE: CSSAnimationProperties = {
+  animationDelay: '500ms',
+  animationDuration: '1s',
+  animationIterationCount: 3,
+  animationName: pulse,
+};
+
+const INFINITE: CSSAnimationProperties = {
+  animationDuration: '1s',
+  animationIterationCount: 'infinite',
+  animationName: pulse,
+};
+
+type LoggedEvent = {
+  id: number;
+  label: string;
+};
+
+export default function AnimationCallbacks() {
+  const [events, setEvents] = useState<Array<LoggedEvent>>([]);
+  const [animation, setAnimation] = useState<CSSAnimationProperties | null>(
+    FINITE
+  );
+  const [isMounted, setIsMounted] = useState(true);
+
+  const log = useCallback((type: string, elapsedTime: number) => {
+    setEvents((current) => [
+      ...current,
+      { id: current.length, label: `${type} at ${elapsedTime.toFixed(2)}s` },
+    ]);
+  }, []);
+
+  // A queued re-attach would otherwise land after a cancel and undo it.
+  const restartFrame = useRef<number | null>(null);
+
+  const cancelPendingRestart = useCallback(() => {
+    if (restartFrame.current !== null) {
+      cancelAnimationFrame(restartFrame.current);
+      restartFrame.current = null;
+    }
+  }, []);
+
+  useEffect(() => cancelPendingRestart, [cancelPendingRestart]);
+
+  const restart = useCallback(
+    (properties: CSSAnimationProperties) => {
+      cancelPendingRestart();
+      setEvents([]);
+      setIsMounted(true);
+      // Detaching first guarantees a fresh animation rather than a settings
+      // update on the running one.
+      setAnimation(null);
+      restartFrame.current = requestAnimationFrame(() => {
+        restartFrame.current = null;
+        setAnimation(properties);
+      });
+    },
+    [cancelPendingRestart]
+  );
+
+  const cancel = useCallback(() => {
+    cancelPendingRestart();
+    setAnimation(null);
+  }, [cancelPendingRestart]);
+
+  const unmount = useCallback(() => {
+    cancelPendingRestart();
+    setIsMounted(false);
+  }, [cancelPendingRestart]);
+
+  return (
+    <Screen style={styles.screen}>
+      <Section
+        description="Animation lifecycle callbacks fired by the **native** CSS engine. `elapsedTime` is reported in **seconds**."
+        title="Animation Callbacks">
+        <View style={styles.content}>
+          <View style={styles.buttons}>
+            <Button
+              style={flex.grow}
+              title="Finite (3x)"
+              onPress={() => restart(FINITE)}
+            />
+            <Button
+              style={flex.grow}
+              title="Infinite"
+              onPress={() => restart(INFINITE)}
+            />
+            <Button style={flex.grow} title="Cancel" onPress={cancel} />
+            <Button style={flex.grow} title="Unmount" onPress={unmount} />
+            <Button
+              style={flex.grow}
+              title="Clear log"
+              onPress={() => setEvents([])}
+            />
+          </View>
+
+          <View style={styles.preview}>
+            {isMounted && (
+              <Animated.View
+                style={[
+                  styles.box,
+                  animation,
+                  {
+                    onAnimationCancel: ({ elapsedTime }) =>
+                      log('cancel', elapsedTime),
+                    onAnimationEnd: ({ elapsedTime }) =>
+                      log('end', elapsedTime),
+                    onAnimationIteration: ({ elapsedTime }) =>
+                      log('iteration', elapsedTime),
+                    onAnimationStart: ({ elapsedTime }) =>
+                      log('start', elapsedTime),
+                  },
+                ]}
+              />
+            )}
+          </View>
+        </View>
+      </Section>
+
+      <Section description="In order of arrival" title="Event Log" fill>
+        <FlatList
+          contentContainerStyle={styles.logContent}
+          data={events}
+          keyExtractor={(event) => String(event.id)}
+          ListEmptyComponent={<Text variant="subHeading2">No events yet</Text>}
+          renderItem={({ item }) => <Text variant="body1">{item.label}</Text>}
+          style={styles.log}
+        />
+      </Section>
+    </Screen>
+  );
+}
+
+const styles = StyleSheet.create({
+  box: {
+    backgroundColor: colors.primary,
+    borderRadius: radius.sm,
+    height: sizes.md,
+    width: sizes.md,
+  },
+  buttons: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.xxs,
+    justifyContent: 'space-between',
+  },
+  content: {
+    gap: spacing.xs,
+  },
+  log: {
+    backgroundColor: colors.background2,
+    borderRadius: radius.sm,
+    flex: 1,
+  },
+  logContent: {
+    gap: spacing.xxxs,
+    padding: spacing.xs,
+  },
+  preview: {
+    ...flex.center,
+    backgroundColor: colors.background2,
+    borderRadius: radius.md,
+    height: sizes.xxl,
+  },
+  screen: {
+    gap: spacing.sm,
+    padding: spacing.sm,
+  },
+});

--- a/apps/common-app/src/apps/css/examples/animations/screens/miscellaneous/index.ts
+++ b/apps/common-app/src/apps/css/examples/animations/screens/miscellaneous/index.ts
@@ -1,9 +1,11 @@
+import AnimationCallbacks from './AnimationCallbacks';
 import ChangingAnimation from './ChangingAnimation';
 import KeyframeTimingFunctions from './KeyframeTimingFunctions';
 import MultipleAnimations from './MultipleAnimations';
 import UpdatingAnimationSettings from './UpdatingAnimationSettings';
 
 export default {
+  AnimationCallbacks,
   ChangingAnimation,
   KeyframeTimingFunctions,
   MultipleAnimations,

--- a/packages/react-native-reanimated/CHANGELOG.md
+++ b/packages/react-native-reanimated/CHANGELOG.md
@@ -10,4 +10,6 @@
 
 ### 🐛 Bug fixes
 
+- Fix `EXC_BAD_ACCESS` crash in `-[REANodesManager performOperations]` when called before the `_performOperations` block is registered on iOS. ([#10229](https://github.com/software-mansion/react-native-reanimated/pull/10229) by [@tomekzaw](https://github.com/tomekzaw))
+
 ### 💡 Others

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/definitions.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/definitions.h
@@ -4,13 +4,17 @@
 #include <jsi/jsi.h>
 #include <string>
 #include <unordered_set>
+#include <variant>
 #include <vector>
 
 namespace reanimated::css {
 
 using namespace facebook;
 
-using PropertyPath = std::vector<std::string>;
+/// A record key (e.g. "boxShadow") or an index into an array-typed property
+/// (e.g. the 0 in boxShadow[0]).
+using PropertyPathSegment = std::variant<std::string, size_t>;
+using PropertyPath = std::vector<PropertyPathSegment>;
 using TransitionProperties = std::unordered_set<std::string>;
 
 using EasingFunction = std::function<double(double)>;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSLoopTransition.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSLoopTransition.cpp
@@ -62,10 +62,11 @@ folly::dynamic CSSLoopTransition::run(
 
 void CSSLoopTransition::updateSettings(
     const PropertiesSettingsMap &changedPropertiesSettings,
-    const std::vector<std::string> &removedProperties) {
+    const std::vector<std::string> &removedProperties,
+    const double timestamp) {
 
   // Remove interpolators and progress providers for no longer transitioned props
-  removeProperties(removedProperties);
+  removeProperties(removedProperties, timestamp);
 
   // Update the settings saved in progress provider
   progressProvider_.setPropertySettings(changedPropertiesSettings);
@@ -93,7 +94,7 @@ void CSSLoopTransition::handleChangedProperties(
     const auto allowDiscrete = progressProvider_.getPropertySettings(propertyName).allowDiscrete;
 
     if (!allowDiscrete && isDiscreteProperty(propertyName, componentName_)) {
-      removeProperty(propertyName);
+      removeProperty(propertyName, timestamp);
       continue;
     }
 
@@ -125,7 +126,7 @@ void CSSLoopTransition::handleChangedProperties(
     const auto allowDiscrete = progressProvider_.getPropertySettings(propertyName).allowDiscrete;
 
     if (!allowDiscrete && isDiscreteProperty(propertyName, componentName_)) {
-      removeProperty(propertyName);
+      removeProperty(propertyName, timestamp);
       continue;
     }
 
@@ -143,14 +144,14 @@ void CSSLoopTransition::handleChangedProperties(
   }
 }
 
-void CSSLoopTransition::removeProperties(const std::vector<std::string> &propertyNames) {
+void CSSLoopTransition::removeProperties(const std::vector<std::string> &propertyNames, const double timestamp) {
   styleInterpolator_.removeProperties(propertyNames);
-  progressProvider_.removeProperties(propertyNames);
+  progressProvider_.removeProperties(propertyNames, timestamp);
 }
 
-void CSSLoopTransition::removeProperty(const std::string &propertyName) {
+void CSSLoopTransition::removeProperty(const std::string &propertyName, const double timestamp) {
   styleInterpolator_.removeProperty(propertyName);
-  progressProvider_.removeProperty(propertyName);
+  progressProvider_.removeProperty(propertyName, timestamp);
 }
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSLoopTransition.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSLoopTransition.h
@@ -42,11 +42,12 @@ class CSSLoopTransition : public OperationsLoop::LoopOperation, public std::enab
       double timestamp);
   void updateSettings(
       const PropertiesSettingsMap &changedPropertiesSettings,
-      const std::vector<std::string> &removedProperties);
+      const std::vector<std::string> &removedProperties,
+      double timestamp);
 
   folly::dynamic computeCurrentStyle(const std::shared_ptr<const ShadowNode> &shadowNode);
 
-  void removeProperties(const std::vector<std::string> &propertyNames);
+  void removeProperties(const std::vector<std::string> &propertyNames, double timestamp);
 
  private:
   const Tag viewTag_;
@@ -66,7 +67,7 @@ class CSSLoopTransition : public OperationsLoop::LoopOperation, public std::enab
       const PropertyValueDynamicDiffsMap &propertiesDiffs,
       const folly::dynamic &lastUpdateValue,
       double timestamp);
-  void removeProperty(const std::string &propertyName);
+  void removeProperty(const std::string &propertyName, double timestamp);
 };
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.cpp
@@ -24,8 +24,10 @@ bool CSSPlatformTransitionProxy::apply(
     const PlatformValue &fromValue,
     const PlatformValue &toValue,
     const CSSTransitionPropertySettings *settings,
+    const bool persistent,
     const double timestamp) const {
-  return applyTransition_ && applyTransition_(viewTag, propertyName, fromValue, toValue, settings, timestamp);
+  return applyTransition_ &&
+      applyTransition_(viewTag, propertyName, fromValue, toValue, settings, persistent, timestamp);
 }
 
 void CSSPlatformTransitionProxy::remove(const Tag viewTag, const std::string &propertyName) const {
@@ -57,7 +59,8 @@ CSSTransitionConfig CSSPlatformTransitionProxy::processConfig(
     bool routable = canRoute(propertyName, settings.easingConfig);
     if (routable && hasValue) {
       const auto values = parsePlatformValues(rt, propertyName, valueIt->second.first, valueIt->second.second);
-      routable = values && apply(viewTag, propertyName, values->first, values->second, &settings, timestamp);
+      // React commits the config path's target, so there is nothing to hold afterwards.
+      routable = values && apply(viewTag, propertyName, values->first, values->second, &settings, false, timestamp);
     } else if (routable) {
       // Settings-only: stay on the platform only if already animating there.
       routable = routing.platform.contains(propertyName);
@@ -102,6 +105,7 @@ CSSTransitionConfig CSSPlatformTransitionProxy::processConfig(
 PropertyValueDynamicDiffsMap CSSPlatformTransitionProxy::processDynamicDiffs(
     const Tag viewTag,
     const PropertyValueDynamicDiffsMap &propertyDiffs,
+    const TransitionProperties &pseudoLockedProperties,
     CSSTransitionRouting &routing,
     const double timestamp) const {
   PropertyValueDynamicDiffsMap loopDiffs;
@@ -110,7 +114,9 @@ PropertyValueDynamicDiffsMap CSSPlatformTransitionProxy::processDynamicDiffs(
     // still express the toggled value; otherwise it migrates to the loop.
     if (routing.platform.contains(propertyName)) {
       const auto values = parsePlatformValues(propertyName, propertyDiff.first, propertyDiff.second);
-      if (values && apply(viewTag, propertyName, values->first, values->second, nullptr, timestamp)) {
+      // Releasing the last selector targets the committed style, which needs no hold.
+      const bool persistent = pseudoLockedProperties.contains(propertyName);
+      if (values && apply(viewTag, propertyName, values->first, values->second, nullptr, persistent, timestamp)) {
         continue;
       }
       routing.platform.erase(propertyName);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.h
@@ -21,13 +21,15 @@ using namespace react;
 using CSSCanRoutePropertyFunction = std::function<bool(const std::string &propertyName, const EasingConfig &easing)>;
 /// Animates a routed property natively; a false return falls back to the loop.
 /// `settings` is null on the pseudo-selector toggle path, where the backend reuses
-/// the settings captured at config-apply time and holds the animation persistently.
+/// the settings captured at config-apply time. `persistent` means the target has no
+/// committed style behind it, so the backend must hold the value past the animation.
 using CSSApplyTransitionFunction = std::function<bool(
     Tag viewTag,
     const std::string &propertyName,
     const PlatformValue &fromValue,
     const PlatformValue &toValue,
     const CSSTransitionPropertySettings *settings,
+    bool persistent,
     double timestamp)>;
 /// Cancels the property's native transition and drops its platform-side state.
 using CSSRemoveTransitionFunction = std::function<void(Tag viewTag, const std::string &propertyName)>;
@@ -61,9 +63,11 @@ class CSSPlatformTransitionProxy {
 
   /// Re-routes pseudo-selector toggle diffs: a property the platform can no longer
   /// express migrates to the loop. Updates `routing`, returns the loop diffs.
+  /// Only a property still pseudo-locked after the toggle needs its value held.
   PropertyValueDynamicDiffsMap processDynamicDiffs(
       Tag viewTag,
       const PropertyValueDynamicDiffsMap &propertyDiffs,
+      const TransitionProperties &pseudoLockedProperties,
       CSSTransitionRouting &routing,
       double timestamp) const;
 
@@ -78,6 +82,7 @@ class CSSPlatformTransitionProxy {
       const PlatformValue &fromValue,
       const PlatformValue &toValue,
       const CSSTransitionPropertySettings *settings,
+      bool persistent,
       double timestamp) const;
   void remove(Tag viewTag, const std::string &propertyName) const;
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.cpp
@@ -61,7 +61,8 @@ folly::dynamic CSSTransition::run(
     const folly::dynamic &lastUpdates) {
   const auto timestamp = loop_->resolveTimestamp();
 
-  auto loopDiffs = platformTransitionProxy_->processDynamicDiffs(getViewTag(), propertyDiffs, routing_, timestamp);
+  auto loopDiffs = platformTransitionProxy_->processDynamicDiffs(
+      getViewTag(), propertyDiffs, pseudoLockedProperties_, routing_, timestamp);
   if (loopDiffs.empty() && !loopTransition_) {
     return folly::dynamic::object();
   }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.cpp
@@ -44,7 +44,7 @@ folly::dynamic CSSTransition::run(jsi::Runtime &rt, CSSTransitionConfig &&config
   }
 
   auto &loopTransition = ensureLoopTransition();
-  loopTransition.updateSettings(loopConfig.changedPropertiesSettings, loopConfig.removedProperties);
+  loopTransition.updateSettings(loopConfig.changedPropertiesSettings, loopConfig.removedProperties, timestamp);
 
   // Settings-only configs reconfigure without running.
   if (!loopConfig.hasValueUpdates()) {
@@ -90,7 +90,7 @@ void CSSTransition::cancel() {
   platformTransitionProxy_->cancelAll(getViewTag(), routing_.platform);
 }
 
-void CSSTransition::removeProperties(const std::vector<std::string> &propertyNames) {
+void CSSTransition::removeProperties(const std::vector<std::string> &propertyNames, const double timestamp) {
   TransitionProperties platformProperties;
   for (const auto &propertyName : propertyNames) {
     if (routing_.platform.erase(propertyName) > 0) {
@@ -103,7 +103,7 @@ void CSSTransition::removeProperties(const std::vector<std::string> &propertyNam
     platformTransitionProxy_->cancelAll(getViewTag(), platformProperties);
   }
   if (loopTransition_) {
-    loopTransition_->removeProperties(propertyNames);
+    loopTransition_->removeProperties(propertyNames, timestamp);
   }
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.h
@@ -55,7 +55,7 @@ class CSSTransition {
   void cancel();
   /// Drops the properties from the transition, so neither the loop nor a native animation keeps
   /// writing them once their value has been evicted from the updates registry.
-  void removeProperties(const std::vector<std::string> &propertyNames);
+  void removeProperties(const std::vector<std::string> &propertyNames, double timestamp);
 
   void setPseudoLockedProperties(TransitionProperties properties);
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/PropertyInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/PropertyInterpolator.cpp
@@ -2,7 +2,9 @@
 #include <reanimated/Compat/WorkletsApi.h>
 
 #include <memory>
+#include <string>
 #include <utility>
+#include <variant>
 
 namespace reanimated::css {
 
@@ -16,14 +18,19 @@ bool PropertyInterpolatorFactory::isDiscreteProperty() const {
 }
 
 std::string PropertyInterpolator::getPropertyPathString() const {
-  if (propertyPath_.empty()) {
-    return "";
+  std::string result;
+
+  for (const auto &segment : propertyPath_) {
+    if (const auto *arrayIndex = std::get_if<size_t>(&segment)) {
+      result += "[" + std::to_string(*arrayIndex) + "]";
+    } else {
+      if (!result.empty()) {
+        result += ".";
+      }
+      result += std::get<std::string>(segment);
+    }
   }
 
-  std::string result = propertyPath_[0];
-  for (size_t i = 1; i < propertyPath_.size(); ++i) {
-    result += "." + propertyPath_[i];
-  }
   return result;
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.cpp
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <string>
+#include <variant>
 
 namespace reanimated::css {
 
@@ -128,12 +129,16 @@ folly::dynamic ViewStylesRepository::getStyleProp(const Tag tag, const PropertyP
 folly::dynamic ViewStylesRepository::getPropertyValue(const folly::dynamic &value, const PropertyPath &propertyPath) {
   const folly::dynamic *currentValue = &value;
 
-  for (size_t i = 0; i < propertyPath.size(); ++i) {
-    if (currentValue->isNull() || currentValue->empty()) {
-      return {};
+  for (const auto &segment : propertyPath) {
+    if (const auto *arrayIndex = std::get_if<size_t>(&segment)) {
+      if (!currentValue->isArray() || *arrayIndex >= currentValue->size()) {
+        return {};
+      }
+      currentValue = &(*currentValue)[*arrayIndex];
+      continue;
     }
 
-    const auto &propName = propertyPath[i];
+    const auto &propName = std::get<std::string>(segment);
 
     if (!currentValue->isObject()) {
       return {};
@@ -150,22 +155,7 @@ folly::dynamic ViewStylesRepository::getPropertyValue(const folly::dynamic &valu
         return {};
       }
 
-      if (i + 1 >= propertyPath.size()) {
-        return transform;
-      }
-
-      const std::string &transformPropName = propertyPath[i + 1];
-
-      for (const auto &transformEntry : transform) {
-        if (transformEntry.isObject()) {
-          auto transformPropIt = transformEntry.find(transformPropName);
-          if (transformPropIt != transformEntry.items().end()) {
-            return transformPropIt->second;
-          }
-        }
-      }
-
-      return {};
+      return transform;
     }
 
     auto propIt = currentValue->find(propName);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
@@ -54,8 +54,6 @@ ReversingState TransitionPropertyProgressProvider::getReversingState() const {
 
 void TransitionPropertyProgressProvider::onMilestone(RunLifecycle::Reporter reporter) {
   lifecycle_.onMilestone(std::move(reporter));
-  // Reports the stage already reached, so a provider observed right at
-  // creation reports Created. Stages crossed earlier are not replayed.
   lifecycle_.reachPosition(computeStage());
 }
 
@@ -71,7 +69,6 @@ void TransitionPropertyProgressProvider::update(const double timestamp) {
 
 RunStage TransitionPropertyProgressProvider::computeStage() const {
   switch (getState()) {
-    // Pending means created but still waiting out its delay.
     case TransitionProgressState::Pending:
       return RunStage::Created;
     case TransitionProgressState::Running:
@@ -198,8 +195,6 @@ void TransitionProgressProvider::runProgressProvider(
       provider = createReversingShorteningProgressProvider(timestamp, settings, *progressProvider);
     }
 
-    // Taking over a still-running property interrupts it; aborting an ended
-    // one is a no-op, so it is not cancelled retroactively.
     progressProvider->abort(timestamp);
   }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
@@ -87,7 +87,8 @@ double TransitionPropertyProgressProvider::elapsedTimeAt(const MilestoneTime tim
       return duration_;
     case MilestoneTime::ActiveTime:
       return std::max(0.0, cancelTimestamp_ - (creationTimestamp_ + delay_));
-    case MilestoneTime::IterationBoundary:
+    case MilestoneTime::IterationStart:
+    case MilestoneTime::IterationEnd:
       // A transition has no iterations, so it never reaches a boundary.
       return 0;
   }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
@@ -81,17 +81,13 @@ RunStage TransitionPropertyProgressProvider::computeStage() const {
 
 double TransitionPropertyProgressProvider::elapsedTimeAt(const RunMilestone milestone) const {
   switch (milestone) {
-    case RunMilestone::Created:
-    case RunMilestone::Started:
-      return 0;
     case RunMilestone::Ended:
       return duration_;
     case RunMilestone::Aborted:
       return std::max(0.0, cancelTimestamp_ - (creationTimestamp_ + delay_));
-    case RunMilestone::Repeated:
+    default:
       return 0;
   }
-  return 0;
 }
 
 TransitionProgressState TransitionPropertyProgressProvider::getState() const {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
@@ -213,18 +213,20 @@ void TransitionProgressProvider::runProgressProvider(
   observeProperty(propertyName, *provider);
 }
 
-void TransitionProgressProvider::removeProperties(const std::vector<std::string> &propertyNames) {
+void TransitionProgressProvider::removeProperties(
+    const std::vector<std::string> &propertyNames,
+    const double timestamp) {
   for (const auto &propertyName : propertyNames) {
-    removeProperty(propertyName);
+    removeProperty(propertyName, timestamp);
   }
 }
 
-void TransitionProgressProvider::removeProperty(const std::string &propertyName) {
+void TransitionProgressProvider::removeProperty(const std::string &propertyName, const double timestamp) {
   const auto it = propertyProgressProviders_.find(propertyName);
   if (it == propertyProgressProviders_.end()) {
     return;
   }
-  it->second->abort(lastTimestamp_);
+  it->second->abort(timestamp);
   propertyProgressProviders_.erase(it);
 }
 
@@ -245,7 +247,6 @@ void TransitionProgressProvider::discardFinishedProgressProviders() {
 }
 
 void TransitionProgressProvider::update(const double timestamp) {
-  lastTimestamp_ = timestamp;
   removedProperties_.clear();
 
   for (const auto &[propertyName, propertyProgressProvider] : propertyProgressProviders_) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
@@ -58,6 +58,10 @@ void TransitionPropertyProgressProvider::setMilestoneReporter(RunLifecycle::Repo
 }
 
 void TransitionPropertyProgressProvider::abort(const double timestamp) {
+  // A cancel can arrive at a timestamp the provider has not been ticked to, and
+  // the run still owes the milestones it crossed in between. Advancing first
+  // also lets a run that has since finished report its end instead of a cancel.
+  update(timestamp);
   cancelTimestamp_ = timestamp;
   lifecycle_.abort();
 }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
@@ -54,7 +54,7 @@ ReversingState TransitionPropertyProgressProvider::getReversingState() const {
 
 void TransitionPropertyProgressProvider::setMilestoneReporter(RunLifecycle::Reporter reporter) {
   lifecycle_.setMilestoneReporter(std::move(reporter));
-  lifecycle_.reachPosition(computeStage());
+  lifecycle_.reachPhase(computePhase());
 }
 
 void TransitionPropertyProgressProvider::abort(const double timestamp) {
@@ -64,36 +64,36 @@ void TransitionPropertyProgressProvider::abort(const double timestamp) {
 
 void TransitionPropertyProgressProvider::update(const double timestamp) {
   TimeProgressProvider::update(timestamp);
-  lifecycle_.reachPosition(computeStage());
+  lifecycle_.reachPhase(computePhase());
 }
 
-RunStage TransitionPropertyProgressProvider::computeStage() const {
+RunPhase TransitionPropertyProgressProvider::computePhase() const {
   switch (getState()) {
     case TransitionProgressState::Pending:
-      return RunStage::Created;
+      return RunPhase::Before;
     case TransitionProgressState::Running:
-      return RunStage::Started;
+      return RunPhase::Active;
     case TransitionProgressState::Idle:
-      return RunStage::Ended;
+      return RunPhase::After;
   }
-  return RunStage::None;
+  return RunPhase::Idle;
 }
 
-double TransitionPropertyProgressProvider::elapsedTimeAt(const RunMilestone milestone) const {
-  switch (milestone) {
-    case RunMilestone::Created:
-    case RunMilestone::Started:
-      return startElapsedTime();
-    case RunMilestone::Ended:
+double TransitionPropertyProgressProvider::elapsedTimeAt(const MilestoneTime time) const {
+  switch (time) {
+    case MilestoneTime::IntervalStart:
+      return intervalStart();
+    case MilestoneTime::IntervalEnd:
       return duration_;
-    case RunMilestone::Aborted:
+    case MilestoneTime::ActiveTime:
       return std::max(0.0, cancelTimestamp_ - (creationTimestamp_ + delay_));
-    default:
+    case MilestoneTime::IterationBoundary:
+      // A transition has no iterations, so it never reaches a boundary.
       return 0;
   }
 }
 
-double TransitionPropertyProgressProvider::startElapsedTime() const {
+double TransitionPropertyProgressProvider::intervalStart() const {
   // A negative delay starts the transition partway through, and the web reports
   // that offset capped to the duration.
   return std::min(std::max(0.0, -delay_), duration_);
@@ -176,9 +176,10 @@ void TransitionProgressProvider::observeProperty(
   }
 
   // The lambda lives inside the provider, so capturing it by reference is safe.
-  provider.setMilestoneReporter([this, propertyName, &provider](const RunMilestone milestone) {
-    reporter_(milestone, propertyName, provider.elapsedTimeAt(milestone));
-  });
+  provider.setMilestoneReporter(
+      [this, propertyName, &provider](const RunMilestone milestone, const MilestoneTime time) {
+        reporter_(milestone, propertyName, provider.elapsedTimeAt(time));
+      });
 }
 
 void TransitionProgressProvider::runProgressProvider(

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
@@ -219,6 +219,12 @@ void TransitionProgressProvider::removeProperty(const std::string &propertyName)
   propertyProgressProviders_.erase(it);
 }
 
+void TransitionProgressProvider::abort(const double timestamp) {
+  for (const auto &[_, provider] : propertyProgressProviders_) {
+    provider->abort(timestamp);
+  }
+}
+
 void TransitionProgressProvider::discardFinishedProgressProviders() {
   for (auto it = propertyProgressProviders_.begin(); it != propertyProgressProviders_.end();) {
     if (it->second->getState() == TransitionProgressState::Idle) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
@@ -2,6 +2,7 @@
 
 #include <reanimated/CSS/utils/reversingShortening.h>
 
+#include <algorithm>
 #include <limits>
 #include <memory>
 #include <string>
@@ -49,6 +50,51 @@ double TransitionPropertyProgressProvider::getRemainingDelay(const double timest
 
 ReversingState TransitionPropertyProgressProvider::getReversingState() const {
   return {reversingShorteningFactor_, creationTimestamp_ + delay_, duration_, delay_, easing_};
+}
+
+void TransitionPropertyProgressProvider::onMilestone(RunLifecycle::Reporter reporter) {
+  lifecycle_.onMilestone(std::move(reporter));
+  // Reports the stage already reached, so a provider observed right at
+  // creation reports Created. Stages crossed earlier are not replayed.
+  lifecycle_.reachPosition(computeStage());
+}
+
+void TransitionPropertyProgressProvider::abort(const double timestamp) {
+  cancelTimestamp_ = timestamp;
+  lifecycle_.abort();
+}
+
+void TransitionPropertyProgressProvider::update(const double timestamp) {
+  TimeProgressProvider::update(timestamp);
+  lifecycle_.reachPosition(computeStage());
+}
+
+RunStage TransitionPropertyProgressProvider::computeStage() const {
+  switch (getState()) {
+    // Pending means created but still waiting out its delay.
+    case TransitionProgressState::Pending:
+      return RunStage::Created;
+    case TransitionProgressState::Running:
+      return RunStage::Started;
+    case TransitionProgressState::Idle:
+      return RunStage::Ended;
+  }
+  return RunStage::None;
+}
+
+double TransitionPropertyProgressProvider::elapsedTimeAt(const RunMilestone milestone) const {
+  switch (milestone) {
+    case RunMilestone::Created:
+    case RunMilestone::Started:
+      return 0;
+    case RunMilestone::Ended:
+      return duration_;
+    case RunMilestone::Aborted:
+      return std::max(0.0, cancelTimestamp_ - (creationTimestamp_ + delay_));
+    case RunMilestone::Repeated:
+      return 0;
+  }
+  return 0;
 }
 
 TransitionProgressState TransitionPropertyProgressProvider::getState() const {
@@ -111,6 +157,28 @@ std::unordered_set<std::string> TransitionProgressProvider::getRemovedProperties
   return removedProperties_;
 }
 
+void TransitionProgressProvider::onMilestone(MilestoneReporter reporter) {
+  reporter_ = std::move(reporter);
+
+  for (const auto &[propertyName, propertyProgressProvider] : propertyProgressProviders_) {
+    observeProperty(propertyName, *propertyProgressProvider);
+  }
+}
+
+void TransitionProgressProvider::observeProperty(
+    const std::string &propertyName,
+    TransitionPropertyProgressProvider &provider) {
+  if (!reporter_) {
+    provider.onMilestone(nullptr);
+    return;
+  }
+
+  // The lambda lives inside the provider, so capturing it by reference is safe.
+  provider.onMilestone([this, propertyName, &provider](const RunMilestone milestone) {
+    reporter_(milestone, propertyName, provider.elapsedTimeAt(milestone));
+  });
+}
+
 void TransitionProgressProvider::runProgressProvider(
     const std::string &propertyName,
     const bool isReversed,
@@ -119,6 +187,7 @@ void TransitionProgressProvider::runProgressProvider(
   const auto settings = getPropertySettings(propertyName);
 
   const auto providerIt = propertyProgressProviders_.find(propertyName);
+  std::shared_ptr<TransitionPropertyProgressProvider> provider;
 
   if (providerIt != propertyProgressProviders_.end()) {
     const auto &progressProvider = providerIt->second;
@@ -126,27 +195,37 @@ void TransitionProgressProvider::runProgressProvider(
 
     if (isReversed && progressProvider->getState() != TransitionProgressState::Idle) {
       // Create reversing shortening progress provider for interrupted reversing transition
-      propertyProgressProviders_.insert_or_assign(
-          propertyName, createReversingShorteningProgressProvider(timestamp, settings, *progressProvider));
-      return;
+      provider = createReversingShorteningProgressProvider(timestamp, settings, *progressProvider);
     }
+
+    // Taking over a still-running property interrupts it; aborting an ended
+    // one is a no-op, so it is not cancelled retroactively.
+    progressProvider->abort(timestamp);
   }
 
-  // Create progress provider with the new settings
-  propertyProgressProviders_.insert_or_assign(
-      propertyName,
-      std::make_shared<TransitionPropertyProgressProvider>(
-          timestamp, settings.duration, settings.delay, settings.easingConfig));
+  if (!provider) {
+    // Create progress provider with the new settings
+    provider = std::make_shared<TransitionPropertyProgressProvider>(
+        timestamp, settings.duration, settings.delay, settings.easingConfig);
+  }
+
+  propertyProgressProviders_.insert_or_assign(propertyName, provider);
+  observeProperty(propertyName, *provider);
 }
 
 void TransitionProgressProvider::removeProperties(const std::vector<std::string> &propertyNames) {
   for (const auto &propertyName : propertyNames) {
-    propertyProgressProviders_.erase(propertyName);
+    removeProperty(propertyName);
   }
 }
 
 void TransitionProgressProvider::removeProperty(const std::string &propertyName) {
-  propertyProgressProviders_.erase(propertyName);
+  const auto it = propertyProgressProviders_.find(propertyName);
+  if (it == propertyProgressProviders_.end()) {
+    return;
+  }
+  it->second->abort(lastTimestamp_);
+  propertyProgressProviders_.erase(it);
 }
 
 void TransitionProgressProvider::discardFinishedProgressProviders() {
@@ -160,6 +239,7 @@ void TransitionProgressProvider::discardFinishedProgressProviders() {
 }
 
 void TransitionProgressProvider::update(const double timestamp) {
+  lastTimestamp_ = timestamp;
   removedProperties_.clear();
 
   for (const auto &[propertyName, propertyProgressProvider] : propertyProgressProviders_) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
@@ -52,8 +52,8 @@ ReversingState TransitionPropertyProgressProvider::getReversingState() const {
   return {reversingShorteningFactor_, creationTimestamp_ + delay_, duration_, delay_, easing_};
 }
 
-void TransitionPropertyProgressProvider::onMilestone(RunLifecycle::Reporter reporter) {
-  lifecycle_.onMilestone(std::move(reporter));
+void TransitionPropertyProgressProvider::setMilestoneReporter(RunLifecycle::Reporter reporter) {
+  lifecycle_.setMilestoneReporter(std::move(reporter));
   lifecycle_.reachPosition(computeStage());
 }
 
@@ -150,7 +150,7 @@ std::unordered_set<std::string> TransitionProgressProvider::getRemovedProperties
   return removedProperties_;
 }
 
-void TransitionProgressProvider::onMilestone(MilestoneReporter reporter) {
+void TransitionProgressProvider::setMilestoneReporter(MilestoneReporter reporter) {
   reporter_ = std::move(reporter);
 
   for (const auto &[propertyName, propertyProgressProvider] : propertyProgressProviders_) {
@@ -162,12 +162,12 @@ void TransitionProgressProvider::observeProperty(
     const std::string &propertyName,
     TransitionPropertyProgressProvider &provider) {
   if (!reporter_) {
-    provider.onMilestone(nullptr);
+    provider.setMilestoneReporter(nullptr);
     return;
   }
 
   // The lambda lives inside the provider, so capturing it by reference is safe.
-  provider.onMilestone([this, propertyName, &provider](const RunMilestone milestone) {
+  provider.setMilestoneReporter([this, propertyName, &provider](const RunMilestone milestone) {
     reporter_(milestone, propertyName, provider.elapsedTimeAt(milestone));
   });
 }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
@@ -81,6 +81,9 @@ RunStage TransitionPropertyProgressProvider::computeStage() const {
 
 double TransitionPropertyProgressProvider::elapsedTimeAt(const RunMilestone milestone) const {
   switch (milestone) {
+    case RunMilestone::Created:
+    case RunMilestone::Started:
+      return startElapsedTime();
     case RunMilestone::Ended:
       return duration_;
     case RunMilestone::Aborted:
@@ -88,6 +91,12 @@ double TransitionPropertyProgressProvider::elapsedTimeAt(const RunMilestone mile
     default:
       return 0;
   }
+}
+
+double TransitionPropertyProgressProvider::startElapsedTime() const {
+  // A negative delay starts the transition partway through, and the web reports
+  // that offset capped to the duration.
+  return std::min(std::max(0.0, -delay_), duration_);
 }
 
 TransitionProgressState TransitionPropertyProgressProvider::getState() const {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.h
@@ -52,6 +52,7 @@ class TransitionPropertyProgressProvider final : public KeyframeProgressProvider
   // The lifecycle reports an abort without a timestamp, so abort() leaves one here.
   double cancelTimestamp_ = 0;
 
+  double startElapsedTime() const;
   double getElapsedTime(double timestamp) const;
   RunStage computeStage() const;
 };

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.h
@@ -2,6 +2,7 @@
 
 #include <reanimated/CSS/configs/CSSTransitionConfig.h>
 #include <reanimated/CSS/progress/KeyframeProgressProvider.h>
+#include <reanimated/CSS/progress/RunLifecycle.h>
 #include <reanimated/CSS/progress/TimeProgressProvider.h>
 #include <reanimated/CSS/utils/props.h>
 #include <reanimated/CSS/utils/reversingShortening.h>
@@ -32,6 +33,13 @@ class TransitionPropertyProgressProvider final : public KeyframeProgressProvider
   ReversingState getReversingState() const;
   TransitionProgressState getState() const;
 
+  /// Time the property has run by the given milestone, in milliseconds.
+  double elapsedTimeAt(RunMilestone milestone) const;
+
+  void onMilestone(RunLifecycle::Reporter reporter);
+  void abort(double timestamp);
+  void update(double timestamp) override;
+
  protected:
   std::optional<double> calculateRawProgress(double timestamp) override;
 
@@ -40,7 +48,12 @@ class TransitionPropertyProgressProvider final : public KeyframeProgressProvider
   EasingFunction easingFunction_;
   double reversingShorteningFactor_ = 1;
 
+  RunLifecycle lifecycle_;
+  // The lifecycle reports an abort without a timestamp, so abort() leaves one here.
+  double cancelTimestamp_ = 0;
+
   double getElapsedTime(double timestamp) const;
+  RunStage computeStage() const;
 };
 
 using TransitionPropertyProgressProviders =
@@ -48,10 +61,15 @@ using TransitionPropertyProgressProviders =
 
 class TransitionProgressProvider final {
  public:
+  /// Reports a milestone of one property, with the time elapsed by then.
+  using MilestoneReporter = std::function<void(RunMilestone, const std::string &property, double elapsedTime)>;
+
   TransitionProgressState getState() const;
   double getMinDelay(double timestamp) const;
   TransitionPropertyProgressProviders getPropertyProgressProviders() const;
   std::unordered_set<std::string> getRemovedProperties() const;
+
+  void onMilestone(MilestoneReporter reporter);
 
   void runProgressProvider(const std::string &propertyName, bool isReversed, double timestamp);
   void removeProperties(const std::vector<std::string> &propertyNames);
@@ -63,6 +81,11 @@ class TransitionProgressProvider final {
 
  private:
   TransitionPropertyProgressProviders propertyProgressProviders_;
+  MilestoneReporter reporter_;
+  // removeProperty() reports a cancel, which needs a timestamp its caller does not supply.
+  double lastTimestamp_ = 0;
+
+  void observeProperty(const std::string &propertyName, TransitionPropertyProgressProvider &provider);
 
   // TO DO: currently never cleaned by design - if the property has already been transitioned in the past, we might want
   // to reuse the config (run without settings in the config).

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.h
@@ -36,7 +36,7 @@ class TransitionPropertyProgressProvider final : public KeyframeProgressProvider
   /// Time the property has run by the given milestone, in milliseconds.
   double elapsedTimeAt(RunMilestone milestone) const;
 
-  void onMilestone(RunLifecycle::Reporter reporter);
+  void setMilestoneReporter(RunLifecycle::Reporter reporter);
   void abort(double timestamp);
   void update(double timestamp) override;
 
@@ -69,7 +69,7 @@ class TransitionProgressProvider final {
   TransitionPropertyProgressProviders getPropertyProgressProviders() const;
   std::unordered_set<std::string> getRemovedProperties() const;
 
-  void onMilestone(MilestoneReporter reporter);
+  void setMilestoneReporter(MilestoneReporter reporter);
 
   void runProgressProvider(const std::string &propertyName, bool isReversed, double timestamp);
   void removeProperties(const std::vector<std::string> &propertyNames);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.h
@@ -72,6 +72,7 @@ class TransitionProgressProvider final {
   void setMilestoneReporter(MilestoneReporter reporter);
 
   void runProgressProvider(const std::string &propertyName, bool isReversed, double timestamp);
+  void abort(double timestamp);
   void removeProperties(const std::vector<std::string> &propertyNames);
   void removeProperty(const std::string &propertyName);
   void discardFinishedProgressProviders();

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.h
@@ -34,7 +34,7 @@ class TransitionPropertyProgressProvider final : public KeyframeProgressProvider
   TransitionProgressState getState() const;
 
   /// Time the property has run by the given milestone, in milliseconds.
-  double elapsedTimeAt(RunMilestone milestone) const;
+  double elapsedTimeAt(MilestoneTime time) const;
 
   void setMilestoneReporter(RunLifecycle::Reporter reporter);
   void abort(double timestamp);
@@ -52,9 +52,9 @@ class TransitionPropertyProgressProvider final : public KeyframeProgressProvider
   // The lifecycle reports an abort without a timestamp, so abort() leaves one here.
   double cancelTimestamp_ = 0;
 
-  double startElapsedTime() const;
+  double intervalStart() const;
   double getElapsedTime(double timestamp) const;
-  RunStage computeStage() const;
+  RunPhase computePhase() const;
 };
 
 using TransitionPropertyProgressProviders =

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.h
@@ -74,8 +74,8 @@ class TransitionProgressProvider final {
 
   void runProgressProvider(const std::string &propertyName, bool isReversed, double timestamp);
   void abort(double timestamp);
-  void removeProperties(const std::vector<std::string> &propertyNames);
-  void removeProperty(const std::string &propertyName);
+  void removeProperties(const std::vector<std::string> &propertyNames, double timestamp);
+  void removeProperty(const std::string &propertyName, double timestamp);
   void discardFinishedProgressProviders();
   void update(double timestamp);
   void setPropertySettings(const PropertiesSettingsMap &changedPropertiesSettings);
@@ -84,8 +84,6 @@ class TransitionProgressProvider final {
  private:
   TransitionPropertyProgressProviders propertyProgressProviders_;
   MilestoneReporter reporter_;
-  // removeProperty() reports a cancel, which needs a timestamp its caller does not supply.
-  double lastTimestamp_ = 0;
 
   void observeProperty(const std::string &propertyName, TransitionPropertyProgressProvider &provider);
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSTransitionsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSTransitionsRegistry.cpp
@@ -98,7 +98,7 @@ void CSSTransitionsRegistry::reconcilePseudoStyledProperties(
   if (!evictedProperties.empty()) {
     // An in-flight transition would otherwise re-emit the evicted value on its next tick and
     // pin the property again.
-    transition->removeProperties(evictedProperties);
+    transition->removeProperties(evictedProperties, loop_->resolveTimestamp());
     setInUpdatesRegistry(transition->getShadowNodeFamily(), updates);
   }
   if (!corrections.empty()) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/interpolators.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/interpolators.cpp
@@ -28,7 +28,7 @@ std::shared_ptr<PropertyInterpolator> createPropertyInterpolator(
     const InterpolatorFactoriesArray &factories,
     const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) {
   PropertyPath newPath = propertyPath;
-  newPath.emplace_back(std::to_string(arrayIndex));
+  newPath.emplace_back(arrayIndex);
 
   return factories[arrayIndex % factories.size()]->create(newPath, viewStylesRepository);
 }

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
@@ -53,6 +53,7 @@ bool CSSPlatformTransitions::applyTransition(
     const css::PlatformValue &fromValue,
     const css::PlatformValue &toValue,
     const css::CSSTransitionPropertySettings *settings,
+    const bool persistent,
     const double timestamp) {
   // Only scalars are routed today (opacity); anything else stays on the loop.
   const auto *from = std::get_if<double>(&fromValue);
@@ -99,7 +100,7 @@ bool CSSPlatformTransitions::applyTransition(
           reversing.duration,
           reversing.startTimestamp,
           toPlatformEasing(resolvedSettings.easingConfig),
-          settings == nullptr)) {
+          persistent)) {
     return false;
   }
 

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
@@ -54,6 +54,7 @@ class CSSPlatformTransitions {
       const css::PlatformValue &fromValue,
       const css::PlatformValue &toValue,
       const css::CSSTransitionPropertySettings *settings,
+      bool persistent,
       double timestamp);
 
   void removeTransition(Tag viewTag, const std::string &propertyName);

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
@@ -139,6 +139,7 @@ open class NativeProxy {
             return
         }
         pseudoSelectorManager.invalidate()
+        cssPlatformTransitionsManager.invalidate()
         if (mHybridData.isValid) {
             invalidateCpp()
         }

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
@@ -256,6 +256,7 @@ open class NativeProxy {
         intBuffer: IntArray,
         doubleBuffer: DoubleArray,
     ) {
+        cssPlatformTransitionsManager.onPropsWrittenSynchronously()
         SynchronousPropsBufferParser.parse(intBuffer, doubleBuffer) { viewTag, props ->
             if (BuildConfig.IS_REACT_NATIVE_86_OR_NEWER) {
                 try {

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionReconciler.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionReconciler.kt
@@ -12,27 +12,47 @@ internal class CSSPlatformTransitionReconciler(
     private val repair: () -> Boolean,
 ) {
     /** Keyed by window: getViewTreeObserver is per window, not per view. */
-    private val tracked = HashSet<ViewTreeObserver>()
+    private val tracked = HashMap<ViewTreeObserver, ViewTreeObserver.OnPreDrawListener>()
 
     fun track(view: View) {
         // A window torn down mid-animation never draws again, so its listener never retires.
-        tracked.removeAll { !it.isAlive }
+        tracked.keys.removeAll { !it.isAlive }
+
+        // A detached view hands out a temporary observer that is killed once the view attaches
+        // and its listeners are merged into the window's, leaving nothing to remove them from.
+        if (!view.isAttachedToWindow) return
 
         val observer = view.viewTreeObserver
-        if (!observer.isAlive || !tracked.add(observer)) return
+        if (!observer.isAlive || tracked.containsKey(observer)) return
 
-        observer.addOnPreDrawListener(
+        val listener =
             object : ViewTreeObserver.OnPreDrawListener {
                 override fun onPreDraw(): Boolean {
                     if (repair()) return true
 
                     // Retire here, not when the registry empties: a cancel fires its end
                     // callback mid-replacement, when the registry is briefly empty.
-                    if (observer.isAlive) observer.removeOnPreDrawListener(this)
-                    tracked.remove(observer)
+                    retire(observer, this)
                     return true
                 }
-            },
-        )
+            }
+        tracked[observer] = listener
+        observer.addOnPreDrawListener(listener)
+    }
+
+    /** The listeners live on the window, which outlives the React context. */
+    fun invalidate() {
+        tracked.forEach { (observer, listener) ->
+            if (observer.isAlive) observer.removeOnPreDrawListener(listener)
+        }
+        tracked.clear()
+    }
+
+    private fun retire(
+        observer: ViewTreeObserver,
+        listener: ViewTreeObserver.OnPreDrawListener,
+    ) {
+        if (observer.isAlive) observer.removeOnPreDrawListener(listener)
+        tracked.remove(observer)
     }
 }

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
@@ -8,7 +8,10 @@ import android.util.FloatProperty
 import android.view.Choreographer
 import android.view.View
 import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.UIManager
+import com.facebook.react.bridge.UIManagerListener
 import com.facebook.react.bridge.UiThreadUtil
+import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.fabric.FabricUIManager
 import com.facebook.react.uimanager.IllegalViewOperationException
 import java.lang.ref.WeakReference
@@ -19,6 +22,34 @@ internal class CSSPlatformTransitionsManager(
     private val animationTimestamp: () -> Long,
 ) {
     private val animators = HashMap<Key, RunningTransition>()
+
+    /**
+     * React can overwrite an animated value only on frames where it wrote props, so the
+     * pre-draw repair is skipped on all others. Everything here runs on the UI thread.
+     */
+    private var reactWroteSinceLastDraw = true
+
+    @OptIn(UnstableReactNativeAPI::class)
+    private val mountListener =
+        object : UIManagerListener {
+            override fun willDispatchViewUpdates(uiManager: UIManager) = Unit
+
+            override fun willMountItems(uiManager: UIManager) = Unit
+
+            override fun didMountItems(uiManager: UIManager) {
+                reactWroteSinceLastDraw = true
+            }
+
+            override fun didDispatchMountItems(uiManager: UIManager) = Unit
+
+            override fun didScheduleMountItems(uiManager: UIManager) = Unit
+        }
+
+    init {
+        @OptIn(UnstableReactNativeAPI::class)
+        fabricUIManager.addUIManagerEventListener(mountListener)
+    }
+
     private val reconciler = CSSPlatformTransitionReconciler(::repairClobberedValues)
     private val startTokens = HashMap<Key, Long>()
 
@@ -106,6 +137,8 @@ internal class CSSPlatformTransitionsManager(
         // Set before posting: a start already queued would otherwise register a new
         // animator and listener behind the cleanup.
         invalidated = true
+        @OptIn(UnstableReactNativeAPI::class)
+        fabricUIManager.removeUIManagerEventListener(mountListener)
         UiThreadUtil.runOnUiThread {
             startTokens.clear()
             // Snapshot first: cancel() runs onAnimationEnd, which reads the map.
@@ -200,8 +233,15 @@ internal class CSSPlatformTransitionsManager(
         reconciler.track(view)
     }
 
+    /** Synchronous prop writes run their mount item inline, so no listener reports them. */
+    fun onPropsWrittenSynchronously() {
+        reactWroteSinceLastDraw = true
+    }
+
     /** Re-asserts each animator's own value wherever a commit overwrote it. */
     private fun repairClobberedValues(): Boolean {
+        if (!reactWroteSinceLastDraw) return animators.isNotEmpty()
+        reactWroteSinceLastDraw = false
         animators.values.forEach { running ->
             // target is held weakly, so read the View through it rather than keeping one.
             val view = running.animator.target as? View ?: return@forEach

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
@@ -22,6 +22,9 @@ internal class CSSPlatformTransitionsManager(
     private val reconciler = CSSPlatformTransitionReconciler(::repairClobberedValues)
     private val startTokens = HashMap<Key, Long>()
 
+    @Volatile
+    private var invalidated = false
+
     private var nextStartToken = 0L
     private val interpolators = HashMap<InterpolatorKey, TimeInterpolator>()
 
@@ -75,12 +78,14 @@ internal class CSSPlatformTransitionsManager(
         easingPointsY: FloatArray,
         persistent: Boolean,
     ): Boolean {
+        if (invalidated) return false
         val writer = cssPropertyWriterFor(propertyName) ?: return false
         val context = reactContext.get() ?: return false
         val scale = DurationScale.effectiveScale(context)
         if (scale <= 0f) return false
 
         UiThreadUtil.runOnUiThread {
+            if (invalidated) return@runOnUiThread
             val key = Key(viewTag, propertyName)
             // A fresh token invalidates any retry still queued for this key.
             val token = ++nextStartToken
@@ -94,6 +99,21 @@ internal class CSSPlatformTransitionsManager(
             }
         }
         return true
+    }
+
+    /** Animators keep ticking on their own, so a dead context has to stop them. */
+    fun invalidate() {
+        // Set before posting: a start already queued would otherwise register a new
+        // animator and listener behind the cleanup.
+        invalidated = true
+        UiThreadUtil.runOnUiThread {
+            startTokens.clear()
+            // Snapshot first: cancel() runs onAnimationEnd, which reads the map.
+            val running = animators.values.toList()
+            animators.clear()
+            running.forEach { it.animator.cancel() }
+            reconciler.invalidate()
+        }
     }
 
     fun removeTransition(

--- a/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.h
@@ -18,13 +18,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithSurfacePresenter:(RCTSurfacePresenter *)surfacePresenter;
 
 /// Animates the property natively and remembers its settings for later toggles.
-/// A null `settings` marks the toggle path: the stored settings are reused and the
-/// animation is held persistently. Returns NO when there are none to reuse.
+/// A null `settings` marks the toggle path, where the stored settings are reused;
+/// returns NO when there are none. `persistent` holds the value past the animation.
 - (BOOL)applyTransitionForTag:(facebook::react::Tag)viewTag
                  propertyName:(const std::string &)propertyName
                     fromValue:(const reanimated::css::PlatformValue &)fromValue
                       toValue:(const reanimated::css::PlatformValue &)toValue
                      settings:(nullable const reanimated::css::CSSTransitionPropertySettings *)settings
+                   persistent:(BOOL)persistent
                     timestamp:(double)timestamp;
 
 - (void)removeTransitionForTag:(facebook::react::Tag)viewTag propertyName:(const std::string &)propertyName;

--- a/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.mm
@@ -73,17 +73,18 @@ struct ActiveTransition {
                     fromValue:(const PlatformValue &)fromValue
                       toValue:(const PlatformValue &)toValue
                      settings:(const CSSTransitionPropertySettings *)settings
+                   persistent:(BOOL)persistent
                     timestamp:(double)timestamp
 {
   const ActiveTransition *active = [self activeTransitionForTag:viewTag propertyName:propertyName];
 
-  // The toggle path has no settings of its own and holds its value indefinitely.
-  const BOOL persistent = settings == nullptr;
-  if (persistent && active == nullptr) {
+  // The toggle path has no settings of its own, so it reuses the stored ones.
+  const BOOL reusesStoredSettings = settings == nullptr;
+  if (reusesStoredSettings && active == nullptr) {
     return NO;
   }
   // Copy: the active entry is re-assigned below.
-  const CSSTransitionPropertySettings resolvedSettings = persistent ? active->settings : *settings;
+  const CSSTransitionPropertySettings resolvedSettings = reusesStoredSettings ? active->settings : *settings;
 
   // Targeting the in-flight transition's start value means this is a reversal.
   const bool isReversal = active != nullptr && active->adjustedStart && toValue == *active->adjustedStart;

--- a/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.mm
@@ -125,7 +125,11 @@ using namespace facebook::react;
 - (void)performOperations
 {
   RCTAssertMainQueue();
-  _performOperations(); // calls ReanimatedModuleProxy::performOperations
+  REAPerformOperations performOperations = _performOperations;
+  if (performOperations == nil) {
+    return;
+  }
+  performOperations(); // calls ReanimatedModuleProxy::performOperations
 }
 
 - (void)dispatchEvent:(id<RCTEvent>)event

--- a/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.mm
@@ -140,12 +140,14 @@ css::CSSApplyTransitionFunction makeCSSApplyTransition(REACSSPlatformTransitions
              const css::PlatformValue &fromValue,
              const css::PlatformValue &toValue,
              const css::CSSTransitionPropertySettings *settings,
+             bool persistent,
              double timestamp) {
     return [platformTransitions applyTransitionForTag:viewTag
                                          propertyName:propertyName
                                             fromValue:fromValue
                                               toValue:toValue
                                              settings:settings
+                                           persistent:persistent
                                             timestamp:timestamp];
   };
 }

--- a/packages/react-native-reanimated/src/css/native/events/CSSCallbacksRegistry.ts
+++ b/packages/react-native-reanimated/src/css/native/events/CSSCallbacksRegistry.ts
@@ -5,39 +5,59 @@ import type { CSSEventSubscriber, NativeCSSEvent } from './types';
  * Routes CSS events emitted by the native side to the objects interested in a
  * given view. Nested animated components can share a view tag, so every tag
  * keeps a set of subscribers rather than a single one.
+ *
+ * A view that unmounts is retired instead of unregistered: it stops being a
+ * subscriber, but still hears the batch after, because the engine emits its
+ * cancel as it tears down and that batch arrives once the view is gone.
  */
 class CSSCallbacksRegistry {
-  private readonly subscribersByTag_ = new Map<
+  private readonly subscribersByTag = new Map<
     number,
     Set<CSSEventSubscriber>
   >();
+  private retiringByTag = new Map<number, Set<CSSEventSubscriber>>();
 
   register(viewTag: number, subscriber: CSSEventSubscriber): void {
-    const subscribers = this.subscribersByTag_.get(viewTag);
-    if (subscribers) {
-      subscribers.add(subscriber);
-    } else {
-      this.subscribersByTag_.set(viewTag, new Set([subscriber]));
-    }
+    this.retiringByTag.get(viewTag)?.delete(subscriber);
+    addSubscriber(this.subscribersByTag, viewTag, subscriber);
   }
 
   unregister(viewTag: number, subscriber: CSSEventSubscriber): void {
-    const subscribers = this.subscribersByTag_.get(viewTag);
+    const subscribers = this.subscribersByTag.get(viewTag);
     if (!subscribers) {
       return;
     }
 
     subscribers.delete(subscriber);
     if (subscribers.size === 0) {
-      this.subscribersByTag_.delete(viewTag);
+      this.subscribersByTag.delete(viewTag);
     }
   }
 
+  /**
+   * Unregistering now, rather than after the batch it still hears, is what lets
+   * a view that mounts again stay subscribed by simply registering.
+   */
+  retire(viewTag: number, subscriber: CSSEventSubscriber): void {
+    this.unregister(viewTag, subscriber);
+    addSubscriber(this.retiringByTag, viewTag, subscriber);
+  }
+
   dispatch(events: NativeCSSEvent[]): void {
+    // Taken up front, so a view retired by a callback in this batch hears the
+    // next one rather than this one.
+    const retiring = this.retiringByTag;
+    this.retiringByTag = new Map();
+
     for (const event of events) {
-      const subscribers = this.subscribersByTag_.get(event.tag);
+      const subscribers = subscribersFor(
+        event.tag,
+        this.subscribersByTag,
+        retiring
+      );
+
+      // Absent once the event outlives the view it was emitted for.
       if (!subscribers) {
-        // An event can outlive the view it was emitted for.
         continue;
       }
 
@@ -45,9 +65,8 @@ class CSSCallbacksRegistry {
         try {
           subscriber.handleCSSEvent(event);
         } catch (error) {
-          // A batch carries events for unrelated views, so the error is
-          // reported the way an uncaught one would be anyway. That keeps a
-          // broken callback fatal without starving the views queued behind it.
+          // Reported the way an uncaught error would be anyway, so one broken
+          // callback stays fatal without starving the views queued behind it.
           // @ts-expect-error React Native's `ErrorUtils` are hidden from the global scope.
           globalThis.ErrorUtils.reportFatalError(error);
         }
@@ -56,8 +75,37 @@ class CSSCallbacksRegistry {
   }
 
   clear(): void {
-    this.subscribersByTag_.clear();
+    this.subscribersByTag.clear();
+    this.retiringByTag.clear();
   }
+}
+
+function addSubscriber(
+  byTag: Map<number, Set<CSSEventSubscriber>>,
+  viewTag: number,
+  subscriber: CSSEventSubscriber
+): void {
+  const subscribers = byTag.get(viewTag);
+  if (subscribers) {
+    subscribers.add(subscriber);
+  } else {
+    byTag.set(viewTag, new Set([subscriber]));
+  }
+}
+
+/** One set, because a view that registers again while retiring is in both. */
+function subscribersFor(
+  viewTag: number,
+  subscribed: Map<number, Set<CSSEventSubscriber>>,
+  retiring: Map<number, Set<CSSEventSubscriber>>
+): Set<CSSEventSubscriber> | undefined {
+  const current = subscribed.get(viewTag);
+  const retired = retiring.get(viewTag);
+
+  if (!retired) {
+    return current;
+  }
+  return current ? new Set([...current, ...retired]) : retired;
 }
 
 const cssCallbacksRegistry = new CSSCallbacksRegistry();

--- a/packages/react-native-reanimated/src/css/native/events/__tests__/CSSCallbacksRegistry.test.ts
+++ b/packages/react-native-reanimated/src/css/native/events/__tests__/CSSCallbacksRegistry.test.ts
@@ -80,7 +80,7 @@ describe('cssCallbacksRegistry', () => {
     cssCallbacksRegistry.unregister(1, sub);
 
     // @ts-expect-error - reading a private field to assert there is no leak
-    expect(cssCallbacksRegistry.subscribersByTag_.has(1)).toBe(false);
+    expect(cssCallbacksRegistry.subscribersByTag.has(1)).toBe(false);
   });
 
   test('unregistering an unknown tag or subscriber is a no-op', () => {
@@ -181,5 +181,82 @@ describe('cssCallbacksRegistry', () => {
     cssCallbacksRegistry.dispatch([event(1)]);
 
     expect(sub.handleCSSEvent).not.toHaveBeenCalled();
+  });
+
+  describe('retire', () => {
+    test('a retired subscriber still hears the batch emitted during teardown', () => {
+      const sub = subscriber();
+      cssCallbacksRegistry.register(1, sub);
+      cssCallbacksRegistry.retire(1, sub);
+
+      cssCallbacksRegistry.dispatch([event(1)]);
+
+      expect(sub.handleCSSEvent).toHaveBeenCalledTimes(1);
+    });
+
+    test('and stops hearing from the batch after that', () => {
+      const sub = subscriber();
+      cssCallbacksRegistry.register(1, sub);
+      cssCallbacksRegistry.retire(1, sub);
+
+      cssCallbacksRegistry.dispatch([event(1)]);
+      cssCallbacksRegistry.dispatch([event(1)]);
+
+      expect(sub.handleCSSEvent).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not disturb a subscriber still attached to the same tag', () => {
+      const outer = subscriber();
+      const inner = subscriber();
+      cssCallbacksRegistry.register(1, outer);
+      cssCallbacksRegistry.register(1, inner);
+      cssCallbacksRegistry.retire(1, outer);
+
+      cssCallbacksRegistry.dispatch([event(1)]);
+      cssCallbacksRegistry.dispatch([event(1)]);
+
+      expect(outer.handleCSSEvent).toHaveBeenCalledTimes(1);
+      expect(inner.handleCSSEvent).toHaveBeenCalledTimes(2);
+    });
+
+    // A frozen view is retired and then mounted again on the same manager.
+    test('a subscriber that registers again stays subscribed', () => {
+      const sub = subscriber();
+      cssCallbacksRegistry.register(1, sub);
+      cssCallbacksRegistry.retire(1, sub);
+      cssCallbacksRegistry.register(1, sub);
+
+      cssCallbacksRegistry.dispatch([event(1)]);
+      cssCallbacksRegistry.dispatch([event(1)]);
+
+      expect(sub.handleCSSEvent).toHaveBeenCalledTimes(2);
+    });
+
+    test('and hears the batch it registered again for exactly once', () => {
+      const sub = subscriber();
+      cssCallbacksRegistry.register(1, sub);
+      cssCallbacksRegistry.retire(1, sub);
+      cssCallbacksRegistry.register(1, sub);
+
+      cssCallbacksRegistry.dispatch([event(1)]);
+
+      expect(sub.handleCSSEvent).toHaveBeenCalledTimes(1);
+    });
+
+    test('and hears it once even when registered again mid batch', () => {
+      const remounted = subscriber();
+      const remounting: CSSEventSubscriber = {
+        handleCSSEvent: jest.fn(() => {
+          cssCallbacksRegistry.register(1, remounted);
+        }),
+      };
+      cssCallbacksRegistry.register(1, remounting);
+      cssCallbacksRegistry.register(1, remounted);
+      cssCallbacksRegistry.retire(1, remounted);
+
+      cssCallbacksRegistry.dispatch([event(1)]);
+
+      expect(remounted.handleCSSEvent).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/react-native-reanimated/src/css/native/events/__tests__/mask.test.ts
+++ b/packages/react-native-reanimated/src/css/native/events/__tests__/mask.test.ts
@@ -1,0 +1,17 @@
+'use strict';
+import { getAnimationEventMaskFromProps } from '../mask';
+import { CSS_EVENT_MASK } from '../types';
+
+describe('getAnimationEventMaskFromProps', () => {
+  test('returns an empty mask when no prop is present', () => {
+    expect(getAnimationEventMaskFromProps([])).toBe(0);
+  });
+
+  test('combines the bits of every present prop', () => {
+    expect(
+      getAnimationEventMaskFromProps(
+        new Set(['onAnimationStart', 'onAnimationCancel'] as const)
+      )
+    ).toBe(CSS_EVENT_MASK.animationStart | CSS_EVENT_MASK.animationCancel);
+  });
+});

--- a/packages/react-native-reanimated/src/css/native/events/index.ts
+++ b/packages/react-native-reanimated/src/css/native/events/index.ts
@@ -1,3 +1,14 @@
 'use strict';
 export { default as cssCallbacksRegistry } from './CSSCallbacksRegistry';
-export type { CSSEventHandler } from './types';
+export {
+  ANIMATION_CALLBACK_PROP_BY_EVENT_TYPE,
+  getAnimationEventMaskFromProps,
+} from './mask';
+export type {
+  CSSAnimationEventType,
+  CSSEventHandler,
+  CSSEventSubscriber,
+  CSSEventType,
+  NativeCSSEvent,
+} from './types';
+export { CSS_EVENT_MASK } from './types';

--- a/packages/react-native-reanimated/src/css/native/events/mask.ts
+++ b/packages/react-native-reanimated/src/css/native/events/mask.ts
@@ -1,0 +1,35 @@
+'use strict';
+import type { CSSAnimationCallbackProp } from '../../types';
+import type { CSSAnimationEventType } from './types';
+import { CSS_EVENT_MASK } from './types';
+
+export const ANIMATION_CALLBACK_PROP_BY_EVENT_TYPE = {
+  animationStart: 'onAnimationStart',
+  animationEnd: 'onAnimationEnd',
+  animationIteration: 'onAnimationIteration',
+  animationCancel: 'onAnimationCancel',
+} as const satisfies Record<CSSAnimationEventType, CSSAnimationCallbackProp>;
+
+type PropByEventType = typeof ANIMATION_CALLBACK_PROP_BY_EVENT_TYPE;
+
+/** Inverse of the table above, so the pairing is written down only once. */
+type EventTypeByProp = {
+  [T in keyof PropByEventType as PropByEventType[T]]: T;
+};
+
+const EVENT_TYPE_BY_PROP = Object.fromEntries(
+  Object.entries(ANIMATION_CALLBACK_PROP_BY_EVENT_TYPE).map(([type, prop]) => [
+    prop,
+    type,
+  ])
+) as EventTypeByProp;
+
+export function getAnimationEventMaskFromProps(
+  props: Iterable<CSSAnimationCallbackProp>
+): number {
+  let mask = 0;
+  for (const prop of props) {
+    mask |= CSS_EVENT_MASK[EVENT_TYPE_BY_PROP[prop]];
+  }
+  return mask;
+}

--- a/packages/react-native-reanimated/src/css/native/events/types.ts
+++ b/packages/react-native-reanimated/src/css/native/events/types.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-type CSSAnimationEventType =
+export type CSSAnimationEventType =
   | 'animationStart'
   | 'animationEnd'
   | 'animationIteration'
@@ -12,7 +12,7 @@ type CSSTransitionEventType =
   | 'transitionEnd'
   | 'transitionCancel';
 
-type CSSEventType = CSSAnimationEventType | CSSTransitionEventType;
+export type CSSEventType = CSSAnimationEventType | CSSTransitionEventType;
 
 export type NativeCSSEvent = {
   tag: number;
@@ -28,3 +28,18 @@ export type CSSEventHandler = (events: NativeCSSEvent[]) => void;
 export interface CSSEventSubscriber {
   handleCSSEvent(event: NativeCSSEvent): void;
 }
+
+/**
+ * Bit requested for each event type. The native side emits an event only when
+ * its bit is set, so these values must stay in sync with the C++ ones.
+ */
+export const CSS_EVENT_MASK = {
+  animationStart: 1 << 0,
+  animationEnd: 1 << 1,
+  animationIteration: 1 << 2,
+  animationCancel: 1 << 3,
+  transitionRun: 1 << 4,
+  transitionStart: 1 << 5,
+  transitionEnd: 1 << 6,
+  transitionCancel: 1 << 7,
+} as const satisfies Record<CSSEventType, number>;

--- a/packages/react-native-reanimated/src/css/native/managers/CSSAnimationsManager.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/CSSAnimationsManager.ts
@@ -28,6 +28,7 @@ export default class CSSAnimationsManager implements ICSSAnimationsManager {
   private readonly compoundComponentName: string;
 
   private attachedAnimations: ProcessedAnimation[] = [];
+  private appliedEventMask = 0;
 
   constructor(
     shadowNodeWrapper: ShadowNodeWrapper,
@@ -39,7 +40,10 @@ export default class CSSAnimationsManager implements ICSSAnimationsManager {
     this.compoundComponentName = compoundComponentName;
   }
 
-  update(animationProperties: ExistingCSSAnimationProperties | null): void {
+  update(
+    animationProperties: ExistingCSSAnimationProperties | null,
+    eventMask = 0
+  ): void {
     if (!animationProperties) {
       this.detach();
       return;
@@ -60,11 +64,10 @@ export default class CSSAnimationsManager implements ICSSAnimationsManager {
         return;
       }
 
-      applyCSSAnimations(
-        this.shadowNodeWrapper,
-        this.compoundComponentName,
-        animationUpdates
-      );
+      this.apply(animationUpdates, eventMask);
+    } else if (eventMask !== this.appliedEventMask) {
+      // Only the mask changed, but the native side still has to learn about it.
+      this.apply({}, eventMask);
     }
   }
 
@@ -72,11 +75,20 @@ export default class CSSAnimationsManager implements ICSSAnimationsManager {
     this.unregisterKeyframesUsage();
   }
 
+  private apply(animationUpdates: CSSAnimationUpdates, eventMask: number) {
+    this.appliedEventMask = eventMask;
+    applyCSSAnimations(this.shadowNodeWrapper, this.compoundComponentName, {
+      ...animationUpdates,
+      eventMask,
+    });
+  }
+
   private detach() {
     if (this.attachedAnimations.length > 0) {
       unregisterCSSAnimations(this.viewTag);
       this.unregisterKeyframesUsage();
       this.attachedAnimations = [];
+      this.appliedEventMask = 0;
     }
   }
 

--- a/packages/react-native-reanimated/src/css/native/managers/CSSCallbacksManager.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/CSSCallbacksManager.ts
@@ -39,6 +39,16 @@ export default class CSSCallbacksManager
     return this.eventMask;
   }
 
+  /**
+   * Unsubscribes without dropping the callbacks, so a cancel already emitted
+   * for the unmounting view still reaches the user.
+   */
+  retire(): void {
+    if (this.viewTag !== -1) {
+      cssCallbacksRegistry.retire(this.viewTag, this);
+    }
+  }
+
   handleCSSEvent(event: NativeCSSEvent): void {
     // TODO: transition events arrive here too and are dropped, so transition
     // callbacks never fire on native. They should reach the user once the

--- a/packages/react-native-reanimated/src/css/native/managers/CSSCallbacksManager.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/CSSCallbacksManager.ts
@@ -1,0 +1,72 @@
+'use strict';
+import { CSSCallbackStore } from '../../models';
+import type { CSSAnimationCallbackProp, CSSAnimationEvent } from '../../types';
+import type {
+  CSSAnimationEventType,
+  CSSEventSubscriber,
+  CSSEventType,
+  NativeCSSEvent,
+} from '../events';
+import {
+  ANIMATION_CALLBACK_PROP_BY_EVENT_TYPE as CALLBACK_PROP_BY_EVENT_TYPE,
+  cssCallbacksRegistry,
+  getAnimationEventMaskFromProps,
+} from '../events';
+
+const CALLBACK_PROPS: CSSAnimationCallbackProp[] = Object.values(
+  CALLBACK_PROP_BY_EVENT_TYPE
+);
+
+// Every CSS event for a view reaches this manager, so the table doubles as the
+// check for whether the kind is one it owns.
+const isAnimationEventType = (
+  type: CSSEventType
+): type is CSSAnimationEventType => type in CALLBACK_PROP_BY_EVENT_TYPE;
+
+export default class CSSCallbacksManager
+  extends CSSCallbackStore<CSSAnimationCallbackProp, CSSAnimationEvent>
+  implements CSSEventSubscriber
+{
+  private readonly viewTag: number;
+  private eventMask = 0;
+
+  constructor(viewTag: number) {
+    super(CALLBACK_PROPS);
+    this.viewTag = viewTag;
+  }
+
+  getMask(): number {
+    return this.eventMask;
+  }
+
+  handleCSSEvent(event: NativeCSSEvent): void {
+    // TODO: transition events arrive here too and are dropped, so transition
+    // callbacks never fire on native. They should reach the user once the
+    // native side emits them.
+    if (!isAnimationEventType(event.type)) {
+      return;
+    }
+
+    this.invoke(CALLBACK_PROP_BY_EVENT_TYPE[event.type], {
+      animationName: event.name,
+      elapsedTime: event.elapsedTime,
+    });
+  }
+
+  protected onPresenceChanged(
+    _added: readonly CSSAnimationCallbackProp[],
+    _removed: readonly CSSAnimationCallbackProp[],
+    present: ReadonlySet<CSSAnimationCallbackProp>
+  ): void {
+    this.eventMask = getAnimationEventMaskFromProps(present);
+
+    if (this.viewTag === -1) {
+      return;
+    }
+    if (present.size > 0) {
+      cssCallbacksRegistry.register(this.viewTag, this);
+    } else {
+      cssCallbacksRegistry.unregister(this.viewTag, this);
+    }
+  }
+}

--- a/packages/react-native-reanimated/src/css/native/managers/CSSManager.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/CSSManager.ts
@@ -104,7 +104,7 @@ export default class CSSManager implements ICSSManager {
   }
 
   unmountCleanup(): void {
-    this.cssCallbacksManager?.detach();
+    this.cssCallbacksManager?.retire();
     this.cssAnimationsManager.unmountCleanup();
     this.cssTransitionsManager.unmountCleanup();
     this.cssPseudoStylesManager.unmountCleanup();

--- a/packages/react-native-reanimated/src/css/native/managers/CSSManager.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/CSSManager.ts
@@ -6,11 +6,12 @@ import {
 } from '../../../common';
 import type { ShadowNodeWrapper } from '../../../commonTypes';
 import type { ViewInfo } from '../../../createAnimatedComponent/commonTypes';
-import type { CSSStyle } from '../../types';
+import type { CSSAnimationCallbacks, CSSStyle } from '../../types';
 import type { ICSSManager } from '../../types/interfaces';
 import { filterCSSAndStyleProperties } from '../../utils';
 import { setViewStyle } from '../proxy';
 import CSSAnimationsManager from './CSSAnimationsManager';
+import CSSCallbacksManager from './CSSCallbacksManager';
 import CSSPseudoStylesManager from './CSSPseudoStylesManager';
 import CSSTransitionsManager from './CSSTransitionsManager';
 
@@ -18,6 +19,7 @@ export default class CSSManager implements ICSSManager {
   private readonly cssAnimationsManager: CSSAnimationsManager;
   private readonly cssTransitionsManager: CSSTransitionsManager;
   private readonly cssPseudoStylesManager: CSSPseudoStylesManager;
+  private cssCallbacksManager: CSSCallbacksManager | null = null;
   private readonly viewTag: number;
   private readonly propsBuilder: ReturnType<typeof getPropsBuilder>;
   /**
@@ -59,10 +61,14 @@ export default class CSSManager implements ICSSManager {
       animationProperties,
       transitionProperties,
       pseudoStylesBySelector,
-      ,
+      animationCallbacks,
       ,
       filteredStyle,
     ] = filterCSSAndStyleProperties(style);
+
+    // Synced before either manager runs so a cancel emitted while detaching
+    // still reaches the user.
+    const eventMask = this.syncCallbacks(animationCallbacks);
 
     const hasAnimation = animationProperties !== null;
     const hasTransition = transitionProperties !== null;
@@ -88,7 +94,7 @@ export default class CSSManager implements ICSSManager {
       setViewStyle(this.viewTag, normalizedStyle);
     }
 
-    this.cssAnimationsManager.update(animationProperties);
+    this.cssAnimationsManager.update(animationProperties, eventMask);
     this.cssPseudoStylesManager.update(
       pseudoStylesBySelector,
       transitionProperties
@@ -98,8 +104,21 @@ export default class CSSManager implements ICSSManager {
   }
 
   unmountCleanup(): void {
+    this.cssCallbacksManager?.detach();
     this.cssAnimationsManager.unmountCleanup();
     this.cssTransitionsManager.unmountCleanup();
     this.cssPseudoStylesManager.unmountCleanup();
+  }
+
+  private syncCallbacks(callbacks: CSSAnimationCallbacks | null): number {
+    if (!this.cssCallbacksManager) {
+      if (!callbacks) {
+        return 0;
+      }
+      this.cssCallbacksManager = new CSSCallbacksManager(this.viewTag);
+    }
+
+    this.cssCallbacksManager.sync(callbacks ?? {});
+    return this.cssCallbacksManager.getMask();
   }
 }

--- a/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSAnimationsManager.test.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSAnimationsManager.test.ts
@@ -4,6 +4,7 @@ import type { ShadowNodeWrapper } from '../../../../commonTypes';
 import { ANIMATION_NAME_PREFIX } from '../../../constants';
 import { CSSKeyframesRuleBase } from '../../../models';
 import type { CSSAnimationProperties } from '../../../types';
+import { CSS_EVENT_MASK } from '../../events';
 import { cssKeyframesRegistry, CSSKeyframesRuleImpl } from '../../keyframes';
 import { normalizeSingleCSSAnimationSettings } from '../../normalization';
 import {
@@ -70,6 +71,7 @@ describe('CSSAnimationsManager', () => {
             newAnimationSettings: {
               0: normalizeSingleCSSAnimationSettings(animationProperties),
             },
+            eventMask: 0,
           }
         );
 
@@ -106,6 +108,7 @@ describe('CSSAnimationsManager', () => {
             settingsUpdates: {
               0: { duration: 3000, timingFunction: 'ease-in', delay: 0 },
             },
+            eventMask: 0,
           }
         );
         expect(unregisterCSSAnimations).not.toHaveBeenCalled();
@@ -140,6 +143,7 @@ describe('CSSAnimationsManager', () => {
             newAnimationSettings: {
               0: normalizeSingleCSSAnimationSettings(newAnimationProperties),
             },
+            eventMask: 0,
           }
         );
         expect(unregisterCSSAnimations).not.toHaveBeenCalled();
@@ -290,6 +294,7 @@ describe('CSSAnimationsManager', () => {
                 0: expect.objectContaining({ duration: 2000 }),
                 1: expect.objectContaining({ duration: 2000 }),
               },
+              eventMask: 0,
             }
           );
 
@@ -304,6 +309,7 @@ describe('CSSAnimationsManager', () => {
             COMPOUND_COMPONENT_NAME,
             {
               animationNames: [animation2Name, animation1Name],
+              eventMask: 0,
             }
           );
         });
@@ -324,6 +330,7 @@ describe('CSSAnimationsManager', () => {
                 0: expect.objectContaining({ duration: 2000 }),
                 1: expect.objectContaining({ duration: 500 }),
               },
+              eventMask: 0,
             }
           );
 
@@ -342,6 +349,7 @@ describe('CSSAnimationsManager', () => {
                 0: { duration: 2000 },
                 1: { duration: 500 },
               },
+              eventMask: 0,
             }
           );
         });
@@ -392,6 +400,48 @@ describe('CSSAnimationsManager', () => {
         expect(unregisterCSSAnimations).not.toHaveBeenCalled();
         expect(applyCSSAnimations).not.toHaveBeenCalled();
       });
+    });
+  });
+
+  describe('event mask', () => {
+    const ANIMATION = {
+      animationName: { from: { opacity: 0 } },
+      animationDuration: '2s',
+    } satisfies CSSAnimationProperties;
+
+    test('sends the requested mask alongside the animation', () => {
+      manager.update(ANIMATION, CSS_EVENT_MASK.animationEnd);
+
+      expect(applyCSSAnimations).toHaveBeenLastCalledWith(
+        shadowNodeWrapper,
+        COMPOUND_COMPONENT_NAME,
+        expect.objectContaining({ eventMask: CSS_EVENT_MASK.animationEnd })
+      );
+    });
+
+    test('sends the new mask when only the mask changes', () => {
+      manager.update(ANIMATION, CSS_EVENT_MASK.animationEnd);
+      manager.update(
+        ANIMATION,
+        CSS_EVENT_MASK.animationEnd | CSS_EVENT_MASK.animationStart
+      );
+
+      expect(applyCSSAnimations).toHaveBeenCalledTimes(2);
+      expect(applyCSSAnimations).toHaveBeenLastCalledWith(
+        shadowNodeWrapper,
+        COMPOUND_COMPONENT_NAME,
+        {
+          eventMask:
+            CSS_EVENT_MASK.animationEnd | CSS_EVENT_MASK.animationStart,
+        }
+      );
+    });
+
+    test('does not re-apply when the mask is unchanged', () => {
+      manager.update(ANIMATION, CSS_EVENT_MASK.animationEnd);
+      manager.update(ANIMATION, CSS_EVENT_MASK.animationEnd);
+
+      expect(applyCSSAnimations).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSCallbacksManager.test.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSCallbacksManager.test.ts
@@ -1,0 +1,168 @@
+'use strict';
+import type { CSSEventType, NativeCSSEvent } from '../../events';
+import { CSS_EVENT_MASK, cssCallbacksRegistry } from '../../events';
+import CSSCallbacksManager from '../CSSCallbacksManager';
+
+const VIEW_TAG = 1;
+
+const event = (
+  type: CSSEventType,
+  overrides: Partial<NativeCSSEvent> = {}
+): NativeCSSEvent => ({
+  tag: VIEW_TAG,
+  type,
+  name: 'fadeIn',
+  elapsedTime: 0.25,
+  ...overrides,
+});
+
+describe('CSSCallbacksManager', () => {
+  let manager: CSSCallbacksManager;
+
+  beforeEach(() => {
+    cssCallbacksRegistry.clear();
+    manager = new CSSCallbacksManager(VIEW_TAG);
+  });
+
+  describe('mask', () => {
+    test('is recomputed from the latest callbacks, not accumulated', () => {
+      manager.sync({ onAnimationEnd: jest.fn(), onAnimationStart: jest.fn() });
+      manager.sync({ onAnimationEnd: jest.fn() });
+
+      expect(manager.getMask()).toBe(CSS_EVENT_MASK.animationEnd);
+    });
+
+    test('is empty again after detach', () => {
+      manager.sync({ onAnimationEnd: jest.fn() });
+      manager.detach();
+
+      expect(manager.getMask()).toBe(0);
+    });
+  });
+
+  describe('event delivery', () => {
+    test('maps the native payload to the public animation event', () => {
+      const onAnimationEnd = jest.fn();
+      manager.sync({ onAnimationEnd });
+
+      cssCallbacksRegistry.dispatch([
+        event('animationEnd', { name: 'pulse', elapsedTime: 1.5 }),
+      ]);
+
+      expect(onAnimationEnd).toHaveBeenCalledWith({
+        animationName: 'pulse',
+        elapsedTime: 1.5,
+      });
+    });
+
+    test('routes every animation event type to its own callback', () => {
+      const callbacks = {
+        onAnimationStart: jest.fn(),
+        onAnimationEnd: jest.fn(),
+        onAnimationIteration: jest.fn(),
+        onAnimationCancel: jest.fn(),
+      };
+      manager.sync(callbacks);
+
+      cssCallbacksRegistry.dispatch([
+        event('animationStart'),
+        event('animationEnd'),
+        event('animationIteration'),
+        event('animationCancel'),
+      ]);
+
+      expect(callbacks.onAnimationStart).toHaveBeenCalledTimes(1);
+      expect(callbacks.onAnimationEnd).toHaveBeenCalledTimes(1);
+      expect(callbacks.onAnimationIteration).toHaveBeenCalledTimes(1);
+      expect(callbacks.onAnimationCancel).toHaveBeenCalledTimes(1);
+    });
+
+    test('ignores transition events', () => {
+      const onAnimationEnd = jest.fn();
+      manager.sync({ onAnimationEnd });
+
+      cssCallbacksRegistry.dispatch([event('transitionEnd')]);
+
+      expect(onAnimationEnd).not.toHaveBeenCalled();
+    });
+
+    test('invokes the callback from the latest sync', () => {
+      const first = jest.fn();
+      const second = jest.fn();
+      manager.sync({ onAnimationEnd: first });
+      manager.sync({ onAnimationEnd: second });
+
+      cssCallbacksRegistry.dispatch([event('animationEnd')]);
+
+      expect(first).not.toHaveBeenCalled();
+      expect(second).toHaveBeenCalledTimes(1);
+    });
+
+    test('stops delivering once the callback is removed', () => {
+      const onAnimationEnd = jest.fn();
+      manager.sync({ onAnimationEnd });
+      manager.sync({});
+
+      cssCallbacksRegistry.dispatch([event('animationEnd')]);
+
+      expect(onAnimationEnd).not.toHaveBeenCalled();
+    });
+
+    test('stops delivering after detach and resumes after a new sync', () => {
+      const onAnimationEnd = jest.fn();
+      manager.sync({ onAnimationEnd });
+      manager.detach();
+
+      cssCallbacksRegistry.dispatch([event('animationEnd')]);
+      expect(onAnimationEnd).not.toHaveBeenCalled();
+
+      manager.sync({ onAnimationEnd });
+      cssCallbacksRegistry.dispatch([event('animationEnd')]);
+      expect(onAnimationEnd).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('registration', () => {
+    test('adding a second callback does not duplicate delivery', () => {
+      const onAnimationStart = jest.fn();
+
+      manager.sync({ onAnimationStart });
+      manager.sync({ onAnimationStart, onAnimationEnd: jest.fn() });
+
+      cssCallbacksRegistry.dispatch([event('animationStart')]);
+
+      expect(onAnimationStart).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not register a view that has no tag yet', () => {
+      const registerSpy = jest.spyOn(cssCallbacksRegistry, 'register');
+      const tagless = new CSSCallbacksManager(-1);
+
+      const onAnimationEnd = jest.fn();
+      tagless.sync({ onAnimationEnd });
+
+      expect(registerSpy).not.toHaveBeenCalled();
+      expect(tagless.getMask()).toBe(CSS_EVENT_MASK.animationEnd);
+
+      cssCallbacksRegistry.dispatch([event('animationEnd', { tag: -1 })]);
+      expect(onAnimationEnd).not.toHaveBeenCalled();
+
+      registerSpy.mockRestore();
+    });
+
+    test('keeps nested components with the same tag independent', () => {
+      const outer = jest.fn();
+      const inner = jest.fn();
+      const otherManager = new CSSCallbacksManager(VIEW_TAG);
+
+      manager.sync({ onAnimationEnd: outer });
+      otherManager.sync({ onAnimationEnd: inner });
+      manager.detach();
+
+      cssCallbacksRegistry.dispatch([event('animationEnd')]);
+
+      expect(outer).not.toHaveBeenCalled();
+      expect(inner).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSManager.test.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSManager.test.ts
@@ -140,14 +140,16 @@ describe('CSSManager', () => {
       expect(onAnimationCancel).not.toHaveBeenCalled();
     });
 
-    test('stops delivering events after unmount cleanup', () => {
-      const onAnimationEnd = jest.fn();
-      manager.update({ ...ANIMATION, onAnimationEnd });
+    test('delivers the cancel the engine emits while the view unmounts', () => {
+      const onAnimationCancel = jest.fn();
+      manager.update({ ...ANIMATION, onAnimationCancel });
+      // The engine emits the cancel during cleanup, but its batch is dispatched
+      // after cleanup has already returned.
       manager.unmountCleanup();
 
-      cssCallbacksRegistry.dispatch([event('animationEnd')]);
+      cssCallbacksRegistry.dispatch([event('animationCancel')]);
 
-      expect(onAnimationEnd).not.toHaveBeenCalled();
+      expect(onAnimationCancel).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSManager.test.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSManager.test.ts
@@ -1,5 +1,6 @@
 'use strict';
 import type { ShadowNodeWrapper } from '../../../../commonTypes';
+import { cssCallbacksRegistry } from '../../events';
 import { setViewStyle } from '../../proxy';
 import CSSManager from '../CSSManager';
 
@@ -73,5 +74,80 @@ describe('CSSManager', () => {
     });
 
     expect(setViewStyle).not.toHaveBeenCalled();
+  });
+
+  describe('animation callbacks', () => {
+    const ANIMATION = {
+      animationName: { from: { opacity: 0 } },
+      animationDuration: '2s',
+    } as const;
+
+    const event = (type: 'animationEnd' | 'animationCancel') => ({
+      tag: viewTag,
+      type,
+      name: 'fadeIn',
+      elapsedTime: 2,
+    });
+
+    beforeEach(() => {
+      cssCallbacksRegistry.clear();
+    });
+
+    test('delivers a native event to the provided callback', () => {
+      const onAnimationEnd = jest.fn();
+      manager.update({ ...ANIMATION, onAnimationEnd });
+
+      cssCallbacksRegistry.dispatch([event('animationEnd')]);
+
+      expect(onAnimationEnd).toHaveBeenCalledWith({
+        animationName: 'fadeIn',
+        elapsedTime: 2,
+      });
+    });
+
+    test('starts delivering when a callback appears after the first update', () => {
+      const onAnimationEnd = jest.fn();
+      manager.update(ANIMATION);
+      manager.update({ ...ANIMATION, onAnimationEnd });
+
+      cssCallbacksRegistry.dispatch([event('animationEnd')]);
+
+      expect(onAnimationEnd).toHaveBeenCalledWith({
+        animationName: 'fadeIn',
+        elapsedTime: 2,
+      });
+    });
+
+    test('keeps delivering events while the animation detaches', () => {
+      const onAnimationCancel = jest.fn();
+      manager.update({ ...ANIMATION, onAnimationCancel });
+      manager.update({ onAnimationCancel });
+
+      cssCallbacksRegistry.dispatch([event('animationCancel')]);
+
+      expect(onAnimationCancel).toHaveBeenCalledTimes(1);
+    });
+
+    test('drops a cancel emitted for an animation removed together with its callbacks', () => {
+      const onAnimationCancel = jest.fn();
+      manager.update({ ...ANIMATION, onAnimationCancel });
+      // The animation and its callbacks go away in the same update, so the
+      // native side may still emit a cancel using the mask it had before.
+      manager.update({});
+
+      cssCallbacksRegistry.dispatch([event('animationCancel')]);
+
+      expect(onAnimationCancel).not.toHaveBeenCalled();
+    });
+
+    test('stops delivering events after unmount cleanup', () => {
+      const onAnimationEnd = jest.fn();
+      manager.update({ ...ANIMATION, onAnimationEnd });
+      manager.unmountCleanup();
+
+      cssCallbacksRegistry.dispatch([event('animationEnd')]);
+
+      expect(onAnimationEnd).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/react-native-reanimated/src/css/native/types/animation.ts
+++ b/packages/react-native-reanimated/src/css/native/types/animation.ts
@@ -52,4 +52,5 @@ export type CSSAnimationUpdates = {
     number,
     Partial<NormalizedSingleCSSAnimationSettings>
   >;
+  eventMask?: number;
 };


### PR DESCRIPTION
Reports the milestones each transitioning property crosses, so the CSS engine can turn them into transition events. Nothing consumes them yet.

Transitions run per property, so the lifecycle lives on the property progress provider and every milestone is tagged with the property name. The run lifecycle is reused unchanged: Created maps to transitionrun, Started to transitionstart, Ended to transitionend and an abort to transitioncancel; a transition never repeats.

Which time a milestone carries follows the phase change that produced it, per [css-transitions-2](https://drafts.csswg.org/css-transitions-2/#event-dispatch). A cancel advances the property to its own timestamp first, so a removal landing after the transition finished reports the end rather than a cancel.

Stacked on #10071.
