### PR TITLE
fix: forward the default of pseudo selector values in animatedProps

### DIFF
--- a/packages/react-native-reanimated/__tests__/pseudoAnimatedProps.test.tsx
+++ b/packages/react-native-reanimated/__tests__/pseudoAnimatedProps.test.tsx
@@ -1,0 +1,41 @@
+import { render } from '@testing-library/react-native';
+import { View } from 'react-native';
+
+import Animated from '../src';
+
+const AnimatedView = Animated.createAnimatedComponent(View);
+
+describe('pseudo selector values in animatedProps', () => {
+  it('forwards the default value instead of the raw pseudo object', () => {
+    const { getByTestId } = render(
+      <AnimatedView
+        animatedProps={{
+          fill: { default: 'rgb(255,0,0)', ':hover': 'rgb(255,255,0)' },
+          transitionDuration: '100ms',
+        }}
+        testID="subject"
+      />
+    );
+
+    expect(getByTestId('subject').props.fill).toBe('rgb(255,0,0)');
+  });
+
+  it('omits a pseudo value that has no default', () => {
+    const { getByTestId } = render(
+      <AnimatedView
+        animatedProps={{ fill: { ':hover': 'rgb(255,255,0)' } }}
+        testID="subject"
+      />
+    );
+
+    expect(getByTestId('subject').props.fill).toBeUndefined();
+  });
+
+  it('forwards plain animatedProps values unchanged', () => {
+    const { getByTestId } = render(
+      <AnimatedView animatedProps={{ fill: 'rgb(0,0,255)' }} testID="subject" />
+    );
+
+    expect(getByTestId('subject').props.fill).toBe('rgb(0,0,255)');
+  });
+});

--- a/packages/react-native-reanimated/__tests__/pseudoAnimatedProps.test.tsx
+++ b/packages/react-native-reanimated/__tests__/pseudoAnimatedProps.test.tsx
@@ -1,7 +1,7 @@
 import { render } from '@testing-library/react-native';
 import { View } from 'react-native';
 
-import Animated from '../src';
+import Animated, { makeMutable } from '../src';
 
 const AnimatedView = Animated.createAnimatedComponent(View);
 
@@ -37,5 +37,14 @@ describe('pseudo selector values in animatedProps', () => {
     );
 
     expect(getByTestId('subject').props.fill).toBe('rgb(0,0,255)');
+  });
+
+  it('does not mistake a shared value for a pseudo selector object', () => {
+    const sharedValue = makeMutable('rgb(0,0,255)');
+    const { getByTestId } = render(
+      <AnimatedView animatedProps={{ fill: sharedValue }} testID="subject" />
+    );
+
+    expect(getByTestId('subject').props.fill).toBe(sharedValue);
   });
 });

--- a/packages/react-native-reanimated/src/createAnimatedComponent/PropsFilter.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/PropsFilter.tsx
@@ -2,7 +2,7 @@
 
 import { initialUpdaterRun } from '../animation';
 import type { StyleProps } from '../commonTypes';
-import { isCSSConfigProp } from '../css/utils';
+import { isCSSConfigProp, isPseudoSelectorValue } from '../css/utils';
 import type { AnimatedStyleHandle } from '../hook/commonTypes';
 import { isSharedValue } from '../isSharedValue';
 import { WorkletEventHandler } from '../WorkletEventHandler';
@@ -108,9 +108,19 @@ export class PropsFilter implements IPropsFilter {
           }
         } else {
           for (const animatedPropKey in animatedProps) {
-            if (!isCSSConfigProp(animatedPropKey)) {
-              props[animatedPropKey] = animatedProps[animatedPropKey];
+            if (isCSSConfigProp(animatedPropKey)) {
+              continue;
             }
+            const animatedPropValue = animatedProps[animatedPropKey];
+            if (isPseudoSelectorValue(animatedPropValue)) {
+              // Forward only the resting value; pseudo states are driven by
+              // the CSS manager, like pseudo values in style are.
+              if (animatedPropValue.default !== undefined) {
+                props[animatedPropKey] = animatedPropValue.default;
+              }
+              continue;
+            }
+            props[animatedPropKey] = animatedPropValue;
           }
         }
       });


### PR DESCRIPTION
A pseudo selector object passed through `animatedProps` was forwarded to the component verbatim. On web the raw object ended up stringified into the DOM attribute (`fill="[object Object]"`), so the element rendered with a broken resting value while only the pseudo-state CSS rule worked. This contradicted the animating-SVG guide, which documents `animatedProps` as the way to drive SVG props.

The `style` path already replaces a pseudo object with its `default` value before forwarding; this applies the same rule to `animatedProps`. A value with no `default` is omitted, matching the style path. Native also benefits: the component receives the correct resting value on the first frame instead of a raw object.

Verified in a browser against a bundled build: before, the circle rendered `fill="[object Object]"` (computed black); after, the resting fill is correct, `:hover` still transitions, and unhover reverts.