### PR TITLE
feat: CSS transition callbacks on native

### DIFF
--- a/packages/react-native-reanimated/src/css/native/events/index.ts
+++ b/packages/react-native-reanimated/src/css/native/events/index.ts
@@ -3,9 +3,10 @@ export { default as cssCallbacksRegistry } from './CSSCallbacksRegistry';
 export {
   ANIMATION_CALLBACK_PROP_BY_EVENT_TYPE,
   getAnimationEventMaskFromProps,
+  getTransitionEventMaskFromProps,
+  TRANSITION_CALLBACK_PROP_BY_EVENT_TYPE,
 } from './mask';
 export type {
-  CSSAnimationEventType,
   CSSEventHandler,
   CSSEventSubscriber,
   CSSEventType,

--- a/packages/react-native-reanimated/src/css/native/events/index.ts
+++ b/packages/react-native-reanimated/src/css/native/events/index.ts
@@ -7,9 +7,11 @@ export {
   TRANSITION_CALLBACK_PROP_BY_EVENT_TYPE,
 } from './mask';
 export type {
+  CSSAnimationEventType,
   CSSEventHandler,
   CSSEventSubscriber,
   CSSEventType,
+  CSSTransitionEventType,
   NativeCSSEvent,
 } from './types';
 export { CSS_EVENT_MASK } from './types';

--- a/packages/react-native-reanimated/src/css/native/events/mask.ts
+++ b/packages/react-native-reanimated/src/css/native/events/mask.ts
@@ -1,6 +1,9 @@
 'use strict';
-import type { CSSAnimationCallbackProp } from '../../types';
-import type { CSSAnimationEventType } from './types';
+import type {
+  CSSAnimationCallbackProp,
+  CSSTransitionCallbackProp,
+} from '../../types';
+import type { CSSAnimationEventType, CSSTransitionEventType } from './types';
 import { CSS_EVENT_MASK } from './types';
 
 export const ANIMATION_CALLBACK_PROP_BY_EVENT_TYPE = {
@@ -10,26 +13,47 @@ export const ANIMATION_CALLBACK_PROP_BY_EVENT_TYPE = {
   animationCancel: 'onAnimationCancel',
 } as const satisfies Record<CSSAnimationEventType, CSSAnimationCallbackProp>;
 
-type PropByEventType = typeof ANIMATION_CALLBACK_PROP_BY_EVENT_TYPE;
+export const TRANSITION_CALLBACK_PROP_BY_EVENT_TYPE = {
+  transitionRun: 'onTransitionRun',
+  transitionStart: 'onTransitionStart',
+  transitionEnd: 'onTransitionEnd',
+  transitionCancel: 'onTransitionCancel',
+} as const satisfies Record<CSSTransitionEventType, CSSTransitionCallbackProp>;
 
-/** Inverse of the table above, so the pairing is written down only once. */
-type EventTypeByProp = {
-  [T in keyof PropByEventType as PropByEventType[T]]: T;
+/** Inverse of a prop table, so each pairing is written down only once. */
+type EventTypeByProp<M extends Record<string, string>> = {
+  [T in keyof M as M[T] & string]: T;
 };
 
-const EVENT_TYPE_BY_PROP = Object.fromEntries(
-  Object.entries(ANIMATION_CALLBACK_PROP_BY_EVENT_TYPE).map(([type, prop]) => [
-    prop,
-    type,
-  ])
-) as EventTypeByProp;
+function invertPropTable<const M extends Record<string, string>>(map: M) {
+  return Object.fromEntries(
+    Object.entries(map).map(([type, prop]) => [prop, type])
+  ) as EventTypeByProp<M>;
+}
+
+const ANIMATION_EVENT_TYPE_BY_PROP = invertPropTable(
+  ANIMATION_CALLBACK_PROP_BY_EVENT_TYPE
+);
+const TRANSITION_EVENT_TYPE_BY_PROP = invertPropTable(
+  TRANSITION_CALLBACK_PROP_BY_EVENT_TYPE
+);
 
 export function getAnimationEventMaskFromProps(
   props: Iterable<CSSAnimationCallbackProp>
 ): number {
   let mask = 0;
   for (const prop of props) {
-    mask |= CSS_EVENT_MASK[EVENT_TYPE_BY_PROP[prop]];
+    mask |= CSS_EVENT_MASK[ANIMATION_EVENT_TYPE_BY_PROP[prop]];
+  }
+  return mask;
+}
+
+export function getTransitionEventMaskFromProps(
+  props: Iterable<CSSTransitionCallbackProp>
+): number {
+  let mask = 0;
+  for (const prop of props) {
+    mask |= CSS_EVENT_MASK[TRANSITION_EVENT_TYPE_BY_PROP[prop]];
   }
   return mask;
 }

--- a/packages/react-native-reanimated/src/css/native/events/types.ts
+++ b/packages/react-native-reanimated/src/css/native/events/types.ts
@@ -6,7 +6,7 @@ export type CSSAnimationEventType =
   | 'animationIteration'
   | 'animationCancel';
 
-type CSSTransitionEventType =
+export type CSSTransitionEventType =
   | 'transitionRun'
   | 'transitionStart'
   | 'transitionEnd'

--- a/packages/react-native-reanimated/src/css/native/managers/CSSCallbacksManager.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/CSSCallbacksManager.ts
@@ -1,42 +1,109 @@
 'use strict';
 import { CSSCallbackStore } from '../../models';
-import type { CSSAnimationCallbackProp, CSSAnimationEvent } from '../../types';
 import type {
-  CSSAnimationEventType,
+  CSSAnimationCallbackProp,
+  CSSAnimationCallbacks,
+  CSSAnimationEvent,
+  CSSTransitionCallbackProp,
+  CSSTransitionCallbacks,
+  CSSTransitionEvent,
+} from '../../types';
+import type {
   CSSEventSubscriber,
   CSSEventType,
   NativeCSSEvent,
 } from '../events';
 import {
-  ANIMATION_CALLBACK_PROP_BY_EVENT_TYPE as CALLBACK_PROP_BY_EVENT_TYPE,
+  ANIMATION_CALLBACK_PROP_BY_EVENT_TYPE,
   cssCallbacksRegistry,
   getAnimationEventMaskFromProps,
+  getTransitionEventMaskFromProps,
+  TRANSITION_CALLBACK_PROP_BY_EVENT_TYPE,
 } from '../events';
 
-const CALLBACK_PROPS: CSSAnimationCallbackProp[] = Object.values(
-  CALLBACK_PROP_BY_EVENT_TYPE
-);
-
-// Every CSS event for a view reaches this manager, so the table doubles as the
-// check for whether the kind is one it owns.
-const isAnimationEventType = (
-  type: CSSEventType
-): type is CSSAnimationEventType => type in CALLBACK_PROP_BY_EVENT_TYPE;
-
-export default class CSSCallbacksManager
-  extends CSSCallbackStore<CSSAnimationCallbackProp, CSSAnimationEvent>
-  implements CSSEventSubscriber
-{
-  private readonly viewTag: number;
+/** Callbacks of one CSS kind: routes its own events and keeps its own mask. */
+class CSSCallbackSlot<Prop extends string, Payload> extends CSSCallbackStore<
+  Prop,
+  Payload
+> {
   private eventMask = 0;
 
-  constructor(viewTag: number) {
-    super(CALLBACK_PROPS);
-    this.viewTag = viewTag;
+  constructor(
+    private readonly propByEventType: Partial<Record<CSSEventType, Prop>>,
+    private readonly maskFromProps: (props: Iterable<Prop>) => number,
+    private readonly buildPayload: (event: NativeCSSEvent) => Payload,
+    private readonly onMaskChange: () => void
+  ) {
+    super(Object.values(propByEventType));
   }
 
   getMask(): number {
     return this.eventMask;
+  }
+
+  handleOwnEvent(event: NativeCSSEvent): boolean {
+    const prop = this.propByEventType[event.type];
+    if (!prop) {
+      return false;
+    }
+    this.invoke(prop, this.buildPayload(event));
+    return true;
+  }
+
+  protected onPresenceChanged(present: ReadonlySet<Prop>): void {
+    this.eventMask = this.maskFromProps(present);
+    this.onMaskChange();
+  }
+}
+
+export default class CSSCallbacksManager implements CSSEventSubscriber {
+  private readonly viewTag: number;
+  private readonly animationCallbacks: CSSCallbackSlot<
+    CSSAnimationCallbackProp,
+    CSSAnimationEvent
+  >;
+  private readonly transitionCallbacks: CSSCallbackSlot<
+    CSSTransitionCallbackProp,
+    CSSTransitionEvent
+  >;
+
+  constructor(viewTag: number) {
+    this.viewTag = viewTag;
+    const updateRegistration = () => this.updateRegistration();
+
+    this.animationCallbacks = new CSSCallbackSlot(
+      ANIMATION_CALLBACK_PROP_BY_EVENT_TYPE,
+      getAnimationEventMaskFromProps,
+      ({ name, elapsedTime }) => ({ animationName: name, elapsedTime }),
+      updateRegistration
+    );
+    this.transitionCallbacks = new CSSCallbackSlot(
+      TRANSITION_CALLBACK_PROP_BY_EVENT_TYPE,
+      getTransitionEventMaskFromProps,
+      ({ name, elapsedTime }) => ({ propertyName: name, elapsedTime }),
+      updateRegistration
+    );
+  }
+
+  getAnimationEventMask(): number {
+    return this.animationCallbacks.getMask();
+  }
+
+  getTransitionEventMask(): number {
+    return this.transitionCallbacks.getMask();
+  }
+
+  syncAnimationCallbacks(callbacks: CSSAnimationCallbacks | null): void {
+    this.animationCallbacks.sync(callbacks ?? {});
+  }
+
+  syncTransitionCallbacks(callbacks: CSSTransitionCallbacks | null): void {
+    this.transitionCallbacks.sync(callbacks ?? {});
+  }
+
+  detach(): void {
+    this.animationCallbacks.detach();
+    this.transitionCallbacks.detach();
   }
 
   /**
@@ -50,28 +117,16 @@ export default class CSSCallbacksManager
   }
 
   handleCSSEvent(event: NativeCSSEvent): void {
-    // TODO: transition events arrive here too and are dropped, so transition
-    // callbacks never fire on native. They should reach the user once the
-    // native side emits them.
-    if (!isAnimationEventType(event.type)) {
-      return;
+    if (!this.animationCallbacks.handleOwnEvent(event)) {
+      this.transitionCallbacks.handleOwnEvent(event);
     }
-
-    this.invoke(CALLBACK_PROP_BY_EVENT_TYPE[event.type], {
-      animationName: event.name,
-      elapsedTime: event.elapsedTime,
-    });
   }
 
-  protected onPresenceChanged(
-    present: ReadonlySet<CSSAnimationCallbackProp>
-  ): void {
-    this.eventMask = getAnimationEventMaskFromProps(present);
-
+  private updateRegistration(): void {
     if (this.viewTag === -1) {
       return;
     }
-    if (present.size > 0) {
+    if (this.getAnimationEventMask() | this.getTransitionEventMask()) {
       cssCallbacksRegistry.register(this.viewTag, this);
     } else {
       cssCallbacksRegistry.unregister(this.viewTag, this);

--- a/packages/react-native-reanimated/src/css/native/managers/CSSCallbacksManager.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/CSSCallbacksManager.ts
@@ -11,7 +11,6 @@ import type {
 import type {
   CSSAnimationEventType,
   CSSEventSubscriber,
-  CSSEventType,
   CSSTransitionEventType,
   NativeCSSEvent,
 } from '../events';
@@ -23,15 +22,22 @@ import {
   TRANSITION_CALLBACK_PROP_BY_EVENT_TYPE,
 } from '../events';
 
-// Every CSS event for a view reaches both stores, so each table doubles as the
-// check for whether the event is the kind that store owns.
-const isAnimationEvent = (type: CSSEventType): type is CSSAnimationEventType =>
-  type in ANIMATION_CALLBACK_PROP_BY_EVENT_TYPE;
+// The registry routes by view tag, so a view with both kinds gets all of its
+// events here. Each table doubles as the check for which kind an event is.
+type NativeCSSAnimationEvent = NativeCSSEvent & { type: CSSAnimationEventType };
+type NativeCSSTransitionEvent = NativeCSSEvent & {
+  type: CSSTransitionEventType;
+};
+
+const isAnimationEvent = (
+  event: NativeCSSEvent
+): event is NativeCSSAnimationEvent =>
+  event.type in ANIMATION_CALLBACK_PROP_BY_EVENT_TYPE;
 
 const isTransitionEvent = (
-  type: CSSEventType
-): type is CSSTransitionEventType =>
-  type in TRANSITION_CALLBACK_PROP_BY_EVENT_TYPE;
+  event: NativeCSSEvent
+): event is NativeCSSTransitionEvent =>
+  event.type in TRANSITION_CALLBACK_PROP_BY_EVENT_TYPE;
 
 /** The view's animation callbacks, and the mask of the events they need. */
 class AnimationCallbacks extends CSSCallbackStore<
@@ -48,17 +54,11 @@ class AnimationCallbacks extends CSSCallbackStore<
     return this.eventMask;
   }
 
-  /** Returns false for an event of the other kind, which this must not touch. */
-  handleEvent(event: NativeCSSEvent): boolean {
-    if (!isAnimationEvent(event.type)) {
-      return false;
-    }
-
+  handleEvent(event: NativeCSSAnimationEvent): void {
     this.invoke(ANIMATION_CALLBACK_PROP_BY_EVENT_TYPE[event.type], {
       animationName: event.name,
       elapsedTime: event.elapsedTime,
     });
-    return true;
   }
 
   protected onPresenceChanged(
@@ -84,17 +84,11 @@ class TransitionCallbacks extends CSSCallbackStore<
     return this.eventMask;
   }
 
-  /** Returns false for an event of the other kind, which this must not touch. */
-  handleEvent(event: NativeCSSEvent): boolean {
-    if (!isTransitionEvent(event.type)) {
-      return false;
-    }
-
+  handleEvent(event: NativeCSSTransitionEvent): void {
     this.invoke(TRANSITION_CALLBACK_PROP_BY_EVENT_TYPE[event.type], {
       propertyName: event.name,
       elapsedTime: event.elapsedTime,
     });
-    return true;
   }
 
   protected onPresenceChanged(
@@ -150,7 +144,9 @@ export default class CSSCallbacksManager implements CSSEventSubscriber {
   }
 
   handleCSSEvent(event: NativeCSSEvent): void {
-    if (!this.animationCallbacks.handleEvent(event)) {
+    if (isAnimationEvent(event)) {
+      this.animationCallbacks.handleEvent(event);
+    } else if (isTransitionEvent(event)) {
       this.transitionCallbacks.handleEvent(event);
     }
   }

--- a/packages/react-native-reanimated/src/css/native/managers/CSSCallbacksManager.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/CSSCallbacksManager.ts
@@ -9,8 +9,10 @@ import type {
   CSSTransitionEvent,
 } from '../../types';
 import type {
+  CSSAnimationEventType,
   CSSEventSubscriber,
   CSSEventType,
+  CSSTransitionEventType,
   NativeCSSEvent,
 } from '../events';
 import {
@@ -21,68 +23,99 @@ import {
   TRANSITION_CALLBACK_PROP_BY_EVENT_TYPE,
 } from '../events';
 
-/** Callbacks of one CSS kind: routes its own events and keeps its own mask. */
-class CSSCallbackSlot<Prop extends string, Payload> extends CSSCallbackStore<
-  Prop,
-  Payload
+// Every CSS event for a view reaches both stores, so each table doubles as the
+// check for whether the event is the kind that store owns.
+const isAnimationEvent = (type: CSSEventType): type is CSSAnimationEventType =>
+  type in ANIMATION_CALLBACK_PROP_BY_EVENT_TYPE;
+
+const isTransitionEvent = (
+  type: CSSEventType
+): type is CSSTransitionEventType =>
+  type in TRANSITION_CALLBACK_PROP_BY_EVENT_TYPE;
+
+/** The view's animation callbacks, and the mask of the events they need. */
+class AnimationCallbacks extends CSSCallbackStore<
+  CSSAnimationCallbackProp,
+  CSSAnimationEvent
 > {
   private eventMask = 0;
 
-  constructor(
-    private readonly propByEventType: Partial<Record<CSSEventType, Prop>>,
-    private readonly maskFromProps: (props: Iterable<Prop>) => number,
-    private readonly buildPayload: (event: NativeCSSEvent) => Payload,
-    private readonly onMaskChange: () => void
-  ) {
-    super(Object.values(propByEventType));
+  constructor(private readonly onMaskChange: () => void) {
+    super(Object.values(ANIMATION_CALLBACK_PROP_BY_EVENT_TYPE));
   }
 
   getMask(): number {
     return this.eventMask;
   }
 
-  handleOwnEvent(event: NativeCSSEvent): boolean {
-    const prop = this.propByEventType[event.type];
-    if (!prop) {
+  /** Returns false for an event of the other kind, which this must not touch. */
+  handleEvent(event: NativeCSSEvent): boolean {
+    if (!isAnimationEvent(event.type)) {
       return false;
     }
-    this.invoke(prop, this.buildPayload(event));
+
+    this.invoke(ANIMATION_CALLBACK_PROP_BY_EVENT_TYPE[event.type], {
+      animationName: event.name,
+      elapsedTime: event.elapsedTime,
+    });
     return true;
   }
 
-  protected onPresenceChanged(present: ReadonlySet<Prop>): void {
-    this.eventMask = this.maskFromProps(present);
+  protected onPresenceChanged(
+    present: ReadonlySet<CSSAnimationCallbackProp>
+  ): void {
+    this.eventMask = getAnimationEventMaskFromProps(present);
+    this.onMaskChange();
+  }
+}
+
+/** The view's transition callbacks, and the mask of the events they need. */
+class TransitionCallbacks extends CSSCallbackStore<
+  CSSTransitionCallbackProp,
+  CSSTransitionEvent
+> {
+  private eventMask = 0;
+
+  constructor(private readonly onMaskChange: () => void) {
+    super(Object.values(TRANSITION_CALLBACK_PROP_BY_EVENT_TYPE));
+  }
+
+  getMask(): number {
+    return this.eventMask;
+  }
+
+  /** Returns false for an event of the other kind, which this must not touch. */
+  handleEvent(event: NativeCSSEvent): boolean {
+    if (!isTransitionEvent(event.type)) {
+      return false;
+    }
+
+    this.invoke(TRANSITION_CALLBACK_PROP_BY_EVENT_TYPE[event.type], {
+      propertyName: event.name,
+      elapsedTime: event.elapsedTime,
+    });
+    return true;
+  }
+
+  protected onPresenceChanged(
+    present: ReadonlySet<CSSTransitionCallbackProp>
+  ): void {
+    this.eventMask = getTransitionEventMaskFromProps(present);
     this.onMaskChange();
   }
 }
 
 export default class CSSCallbacksManager implements CSSEventSubscriber {
   private readonly viewTag: number;
-  private readonly animationCallbacks: CSSCallbackSlot<
-    CSSAnimationCallbackProp,
-    CSSAnimationEvent
-  >;
-  private readonly transitionCallbacks: CSSCallbackSlot<
-    CSSTransitionCallbackProp,
-    CSSTransitionEvent
-  >;
+  private readonly animationCallbacks: AnimationCallbacks;
+  private readonly transitionCallbacks: TransitionCallbacks;
 
   constructor(viewTag: number) {
     this.viewTag = viewTag;
     const updateRegistration = () => this.updateRegistration();
 
-    this.animationCallbacks = new CSSCallbackSlot(
-      ANIMATION_CALLBACK_PROP_BY_EVENT_TYPE,
-      getAnimationEventMaskFromProps,
-      ({ name, elapsedTime }) => ({ animationName: name, elapsedTime }),
-      updateRegistration
-    );
-    this.transitionCallbacks = new CSSCallbackSlot(
-      TRANSITION_CALLBACK_PROP_BY_EVENT_TYPE,
-      getTransitionEventMaskFromProps,
-      ({ name, elapsedTime }) => ({ propertyName: name, elapsedTime }),
-      updateRegistration
-    );
+    this.animationCallbacks = new AnimationCallbacks(updateRegistration);
+    this.transitionCallbacks = new TransitionCallbacks(updateRegistration);
   }
 
   getAnimationEventMask(): number {
@@ -117,8 +150,8 @@ export default class CSSCallbacksManager implements CSSEventSubscriber {
   }
 
   handleCSSEvent(event: NativeCSSEvent): void {
-    if (!this.animationCallbacks.handleOwnEvent(event)) {
-      this.transitionCallbacks.handleOwnEvent(event);
+    if (!this.animationCallbacks.handleEvent(event)) {
+      this.transitionCallbacks.handleEvent(event);
     }
   }
 
@@ -126,6 +159,7 @@ export default class CSSCallbacksManager implements CSSEventSubscriber {
     if (this.viewTag === -1) {
       return;
     }
+
     if (this.getAnimationEventMask() | this.getTransitionEventMask()) {
       cssCallbacksRegistry.register(this.viewTag, this);
     } else {

--- a/packages/react-native-reanimated/src/css/native/managers/CSSManager.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/CSSManager.ts
@@ -66,7 +66,7 @@ export default class CSSManager implements ICSSManager {
       transitionProperties,
       pseudoStylesBySelector,
       animationCallbacks,
-      ,
+      transitionCallbacks,
       filteredStyle,
     ] = filterCSSAndStyleProperties(style);
 

--- a/packages/react-native-reanimated/src/css/native/managers/CSSManager.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/CSSManager.ts
@@ -6,7 +6,11 @@ import {
 } from '../../../common';
 import type { ShadowNodeWrapper } from '../../../commonTypes';
 import type { ViewInfo } from '../../../createAnimatedComponent/commonTypes';
-import type { CSSAnimationCallbacks, CSSStyle } from '../../types';
+import type {
+  CSSAnimationCallbacks,
+  CSSStyle,
+  CSSTransitionCallbacks,
+} from '../../types';
 import type { ICSSManager } from '../../types/interfaces';
 import { filterCSSAndStyleProperties } from '../../utils';
 import { setViewStyle } from '../proxy';
@@ -68,7 +72,10 @@ export default class CSSManager implements ICSSManager {
 
     // Synced before either manager runs so a cancel emitted while detaching
     // still reaches the user.
-    const eventMask = this.syncCallbacks(animationCallbacks);
+    const { animationEventMask, transitionEventMask } = this.syncCallbacks(
+      animationCallbacks,
+      transitionCallbacks
+    );
 
     const hasAnimation = animationProperties !== null;
     const hasTransition = transitionProperties !== null;
@@ -82,7 +89,8 @@ export default class CSSManager implements ICSSManager {
 
     const transitionDetached = this.cssTransitionsManager.update(
       transitionProperties,
-      normalizedStyle ?? {}
+      normalizedStyle ?? {},
+      transitionEventMask
     );
 
     // Record the committed style as the base so animations and (on Android) a
@@ -94,7 +102,7 @@ export default class CSSManager implements ICSSManager {
       setViewStyle(this.viewTag, normalizedStyle);
     }
 
-    this.cssAnimationsManager.update(animationProperties, eventMask);
+    this.cssAnimationsManager.update(animationProperties, animationEventMask);
     this.cssPseudoStylesManager.update(
       pseudoStylesBySelector,
       transitionProperties
@@ -110,15 +118,22 @@ export default class CSSManager implements ICSSManager {
     this.cssPseudoStylesManager.unmountCleanup();
   }
 
-  private syncCallbacks(callbacks: CSSAnimationCallbacks | null): number {
+  private syncCallbacks(
+    animationCallbacks: CSSAnimationCallbacks | null,
+    transitionCallbacks: CSSTransitionCallbacks | null
+  ): { animationEventMask: number; transitionEventMask: number } {
     if (!this.cssCallbacksManager) {
-      if (!callbacks) {
-        return 0;
+      if (!animationCallbacks && !transitionCallbacks) {
+        return { animationEventMask: 0, transitionEventMask: 0 };
       }
       this.cssCallbacksManager = new CSSCallbacksManager(this.viewTag);
     }
 
-    this.cssCallbacksManager.sync(callbacks ?? {});
-    return this.cssCallbacksManager.getMask();
+    this.cssCallbacksManager.syncAnimationCallbacks(animationCallbacks);
+    this.cssCallbacksManager.syncTransitionCallbacks(transitionCallbacks);
+    return {
+      animationEventMask: this.cssCallbacksManager.getAnimationEventMask(),
+      transitionEventMask: this.cssCallbacksManager.getTransitionEventMask(),
+    };
   }
 }

--- a/packages/react-native-reanimated/src/css/native/managers/CSSTransitionsManager.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/CSSTransitionsManager.ts
@@ -24,6 +24,7 @@ export default class CSSTransitionsManager implements ICSSTransitionsManager {
   private propsWithTransitions = new Set<string>();
   // Indicates whether a CSS transition is currently attached to the view
   private hasTransition = false;
+  private appliedEventMask = 0;
 
   constructor(shadowNodeWrapper: ShadowNodeWrapper, viewTag: number) {
     this.viewTag = viewTag;
@@ -36,7 +37,8 @@ export default class CSSTransitionsManager implements ICSSTransitionsManager {
    */
   update(
     transitionProperties: CSSTransitionProperties | null,
-    nextProps: UnknownRecord = {}
+    nextProps: UnknownRecord = {},
+    eventMask = 0
   ): boolean {
     const transitionConfig =
       transitionProperties &&
@@ -64,10 +66,13 @@ export default class CSSTransitionsManager implements ICSSTransitionsManager {
     );
 
     if (Object.keys(config).length) {
-      // TODO: the mask is always empty because transition callbacks do not
-      // reach this manager yet; they should subscribe the view here.
-      runCSSTransition(this.shadowNodeWrapper, config, 0);
+      this.appliedEventMask = eventMask;
+      runCSSTransition(this.shadowNodeWrapper, config, eventMask);
       this.hasTransition = true;
+    } else if (this.hasTransition && eventMask !== this.appliedEventMask) {
+      // Only the mask changed, but the native side still has to learn about it.
+      this.appliedEventMask = eventMask;
+      runCSSTransition(this.shadowNodeWrapper, {}, eventMask);
     }
 
     return false;
@@ -81,6 +86,7 @@ export default class CSSTransitionsManager implements ICSSTransitionsManager {
     unregisterCSSTransition(this.viewTag);
     this.propsWithTransitions.clear();
     this.hasTransition = false;
+    this.appliedEventMask = 0;
   }
 
   private processTransitionConfig(

--- a/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSCallbacksManager.test.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSCallbacksManager.test.ts
@@ -25,11 +25,6 @@ describe('CSSCallbacksManager', () => {
   });
 
   describe('masks', () => {
-    test('start empty', () => {
-      expect(manager.getAnimationEventMask()).toBe(0);
-      expect(manager.getTransitionEventMask()).toBe(0);
-    });
-
     test('each kind reflects its own callbacks', () => {
       manager.syncAnimationCallbacks({ onAnimationEnd: jest.fn() });
       manager.syncTransitionCallbacks({ onTransitionStart: jest.fn() });
@@ -176,15 +171,6 @@ describe('CSSCallbacksManager', () => {
       cssCallbacksRegistry.dispatch([event('animationEnd')]);
       expect(onAnimationEnd).toHaveBeenCalledTimes(1);
     });
-
-    test('ignores events addressed to another view', () => {
-      const onAnimationEnd = jest.fn();
-      manager.syncAnimationCallbacks({ onAnimationEnd });
-
-      cssCallbacksRegistry.dispatch([event('animationEnd', { tag: 2 })]);
-
-      expect(onAnimationEnd).not.toHaveBeenCalled();
-    });
   });
 
   describe('registration', () => {
@@ -211,19 +197,6 @@ describe('CSSCallbacksManager', () => {
       cssCallbacksRegistry.dispatch([event('transitionEnd')]);
 
       expect(onTransitionEnd).toHaveBeenCalledTimes(1);
-    });
-
-    test('unregisters when the last callback of both kinds is removed', () => {
-      const unregisterSpy = jest.spyOn(cssCallbacksRegistry, 'unregister');
-
-      manager.syncAnimationCallbacks({ onAnimationStart: jest.fn() });
-      manager.syncTransitionCallbacks({ onTransitionEnd: jest.fn() });
-      manager.syncAnimationCallbacks({});
-      manager.syncTransitionCallbacks({});
-
-      expect(unregisterSpy).toHaveBeenCalledWith(VIEW_TAG, manager);
-
-      unregisterSpy.mockRestore();
     });
 
     test('does not register a view that has no tag yet', () => {

--- a/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSCallbacksManager.test.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSCallbacksManager.test.ts
@@ -24,26 +24,46 @@ describe('CSSCallbacksManager', () => {
     manager = new CSSCallbacksManager(VIEW_TAG);
   });
 
-  describe('mask', () => {
-    test('is recomputed from the latest callbacks, not accumulated', () => {
-      manager.sync({ onAnimationEnd: jest.fn(), onAnimationStart: jest.fn() });
-      manager.sync({ onAnimationEnd: jest.fn() });
-
-      expect(manager.getMask()).toBe(CSS_EVENT_MASK.animationEnd);
+  describe('masks', () => {
+    test('start empty', () => {
+      expect(manager.getAnimationEventMask()).toBe(0);
+      expect(manager.getTransitionEventMask()).toBe(0);
     });
 
-    test('is empty again after detach', () => {
-      manager.sync({ onAnimationEnd: jest.fn() });
+    test('each kind reflects its own callbacks', () => {
+      manager.syncAnimationCallbacks({ onAnimationEnd: jest.fn() });
+      manager.syncTransitionCallbacks({ onTransitionStart: jest.fn() });
+
+      expect(manager.getAnimationEventMask()).toBe(CSS_EVENT_MASK.animationEnd);
+      expect(manager.getTransitionEventMask()).toBe(
+        CSS_EVENT_MASK.transitionStart
+      );
+    });
+
+    test('drops the bit of a removed callback', () => {
+      manager.syncAnimationCallbacks({
+        onAnimationEnd: jest.fn(),
+        onAnimationStart: jest.fn(),
+      });
+      manager.syncAnimationCallbacks({ onAnimationEnd: jest.fn() });
+
+      expect(manager.getAnimationEventMask()).toBe(CSS_EVENT_MASK.animationEnd);
+    });
+
+    test('are empty again after detach', () => {
+      manager.syncAnimationCallbacks({ onAnimationEnd: jest.fn() });
+      manager.syncTransitionCallbacks({ onTransitionEnd: jest.fn() });
       manager.detach();
 
-      expect(manager.getMask()).toBe(0);
+      expect(manager.getAnimationEventMask()).toBe(0);
+      expect(manager.getTransitionEventMask()).toBe(0);
     });
   });
 
   describe('event delivery', () => {
     test('maps the native payload to the public animation event', () => {
       const onAnimationEnd = jest.fn();
-      manager.sync({ onAnimationEnd });
+      manager.syncAnimationCallbacks({ onAnimationEnd });
 
       cssCallbacksRegistry.dispatch([
         event('animationEnd', { name: 'pulse', elapsedTime: 1.5 }),
@@ -55,6 +75,20 @@ describe('CSSCallbacksManager', () => {
       });
     });
 
+    test('maps the native payload to the public transition event', () => {
+      const onTransitionEnd = jest.fn();
+      manager.syncTransitionCallbacks({ onTransitionEnd });
+
+      cssCallbacksRegistry.dispatch([
+        event('transitionEnd', { name: 'opacity', elapsedTime: 0.3 }),
+      ]);
+
+      expect(onTransitionEnd).toHaveBeenCalledWith({
+        propertyName: 'opacity',
+        elapsedTime: 0.3,
+      });
+    });
+
     test('routes every animation event type to its own callback', () => {
       const callbacks = {
         onAnimationStart: jest.fn(),
@@ -62,7 +96,7 @@ describe('CSSCallbacksManager', () => {
         onAnimationIteration: jest.fn(),
         onAnimationCancel: jest.fn(),
       };
-      manager.sync(callbacks);
+      manager.syncAnimationCallbacks(callbacks);
 
       cssCallbacksRegistry.dispatch([
         event('animationStart'),
@@ -77,9 +111,31 @@ describe('CSSCallbacksManager', () => {
       expect(callbacks.onAnimationCancel).toHaveBeenCalledTimes(1);
     });
 
-    test('ignores transition events', () => {
+    test('routes every transition event type to its own callback', () => {
+      const callbacks = {
+        onTransitionRun: jest.fn(),
+        onTransitionStart: jest.fn(),
+        onTransitionEnd: jest.fn(),
+        onTransitionCancel: jest.fn(),
+      };
+      manager.syncTransitionCallbacks(callbacks);
+
+      cssCallbacksRegistry.dispatch([
+        event('transitionRun'),
+        event('transitionStart'),
+        event('transitionEnd'),
+        event('transitionCancel'),
+      ]);
+
+      expect(callbacks.onTransitionRun).toHaveBeenCalledTimes(1);
+      expect(callbacks.onTransitionStart).toHaveBeenCalledTimes(1);
+      expect(callbacks.onTransitionEnd).toHaveBeenCalledTimes(1);
+      expect(callbacks.onTransitionCancel).toHaveBeenCalledTimes(1);
+    });
+
+    test('a transition event does not reach animation callbacks', () => {
       const onAnimationEnd = jest.fn();
-      manager.sync({ onAnimationEnd });
+      manager.syncAnimationCallbacks({ onAnimationEnd });
 
       cssCallbacksRegistry.dispatch([event('transitionEnd')]);
 
@@ -89,8 +145,8 @@ describe('CSSCallbacksManager', () => {
     test('invokes the callback from the latest sync', () => {
       const first = jest.fn();
       const second = jest.fn();
-      manager.sync({ onAnimationEnd: first });
-      manager.sync({ onAnimationEnd: second });
+      manager.syncAnimationCallbacks({ onAnimationEnd: first });
+      manager.syncAnimationCallbacks({ onAnimationEnd: second });
 
       cssCallbacksRegistry.dispatch([event('animationEnd')]);
 
@@ -100,8 +156,8 @@ describe('CSSCallbacksManager', () => {
 
     test('stops delivering once the callback is removed', () => {
       const onAnimationEnd = jest.fn();
-      manager.sync({ onAnimationEnd });
-      manager.sync({});
+      manager.syncAnimationCallbacks({ onAnimationEnd });
+      manager.syncAnimationCallbacks({});
 
       cssCallbacksRegistry.dispatch([event('animationEnd')]);
 
@@ -110,15 +166,24 @@ describe('CSSCallbacksManager', () => {
 
     test('stops delivering after detach and resumes after a new sync', () => {
       const onAnimationEnd = jest.fn();
-      manager.sync({ onAnimationEnd });
+      manager.syncAnimationCallbacks({ onAnimationEnd });
       manager.detach();
 
       cssCallbacksRegistry.dispatch([event('animationEnd')]);
       expect(onAnimationEnd).not.toHaveBeenCalled();
 
-      manager.sync({ onAnimationEnd });
+      manager.syncAnimationCallbacks({ onAnimationEnd });
       cssCallbacksRegistry.dispatch([event('animationEnd')]);
       expect(onAnimationEnd).toHaveBeenCalledTimes(1);
+    });
+
+    test('ignores events addressed to another view', () => {
+      const onAnimationEnd = jest.fn();
+      manager.syncAnimationCallbacks({ onAnimationEnd });
+
+      cssCallbacksRegistry.dispatch([event('animationEnd', { tag: 2 })]);
+
+      expect(onAnimationEnd).not.toHaveBeenCalled();
     });
   });
 
@@ -126,12 +191,39 @@ describe('CSSCallbacksManager', () => {
     test('adding a second callback does not duplicate delivery', () => {
       const onAnimationStart = jest.fn();
 
-      manager.sync({ onAnimationStart });
-      manager.sync({ onAnimationStart, onAnimationEnd: jest.fn() });
+      manager.syncAnimationCallbacks({ onAnimationStart });
+      manager.syncAnimationCallbacks({
+        onAnimationStart,
+        onAnimationEnd: jest.fn(),
+      });
 
       cssCallbacksRegistry.dispatch([event('animationStart')]);
 
       expect(onAnimationStart).toHaveBeenCalledTimes(1);
+    });
+
+    test('stays registered while either kind still has callbacks', () => {
+      const onTransitionEnd = jest.fn();
+      manager.syncAnimationCallbacks({ onAnimationEnd: jest.fn() });
+      manager.syncTransitionCallbacks({ onTransitionEnd });
+
+      manager.syncAnimationCallbacks({});
+      cssCallbacksRegistry.dispatch([event('transitionEnd')]);
+
+      expect(onTransitionEnd).toHaveBeenCalledTimes(1);
+    });
+
+    test('unregisters when the last callback of both kinds is removed', () => {
+      const unregisterSpy = jest.spyOn(cssCallbacksRegistry, 'unregister');
+
+      manager.syncAnimationCallbacks({ onAnimationStart: jest.fn() });
+      manager.syncTransitionCallbacks({ onTransitionEnd: jest.fn() });
+      manager.syncAnimationCallbacks({});
+      manager.syncTransitionCallbacks({});
+
+      expect(unregisterSpy).toHaveBeenCalledWith(VIEW_TAG, manager);
+
+      unregisterSpy.mockRestore();
     });
 
     test('does not register a view that has no tag yet', () => {
@@ -139,10 +231,10 @@ describe('CSSCallbacksManager', () => {
       const tagless = new CSSCallbacksManager(-1);
 
       const onAnimationEnd = jest.fn();
-      tagless.sync({ onAnimationEnd });
+      tagless.syncAnimationCallbacks({ onAnimationEnd });
 
       expect(registerSpy).not.toHaveBeenCalled();
-      expect(tagless.getMask()).toBe(CSS_EVENT_MASK.animationEnd);
+      expect(tagless.getAnimationEventMask()).toBe(CSS_EVENT_MASK.animationEnd);
 
       cssCallbacksRegistry.dispatch([event('animationEnd', { tag: -1 })]);
       expect(onAnimationEnd).not.toHaveBeenCalled();
@@ -155,8 +247,8 @@ describe('CSSCallbacksManager', () => {
       const inner = jest.fn();
       const otherManager = new CSSCallbacksManager(VIEW_TAG);
 
-      manager.sync({ onAnimationEnd: outer });
-      otherManager.sync({ onAnimationEnd: inner });
+      manager.syncAnimationCallbacks({ onAnimationEnd: outer });
+      otherManager.syncAnimationCallbacks({ onAnimationEnd: inner });
       manager.detach();
 
       cssCallbacksRegistry.dispatch([event('animationEnd')]);

--- a/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSManager.test.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSManager.test.ts
@@ -151,5 +151,30 @@ describe('CSSManager', () => {
 
       expect(onAnimationCancel).toHaveBeenCalledTimes(1);
     });
+
+    test('delivers a transition event to the provided callback', () => {
+      const onTransitionEnd = jest.fn();
+      manager.update({
+        opacity: 0,
+        transitionProperty: 'opacity',
+        transitionDuration: '300ms',
+        onTransitionEnd,
+      });
+
+      cssCallbacksRegistry.dispatch([
+        {
+          tag: viewTag,
+          type: 'transitionEnd',
+          name: 'opacity',
+          elapsedTime: 0.3,
+        },
+      ]);
+
+      expect(onTransitionEnd).toHaveBeenCalledWith({
+        propertyName: 'opacity',
+        elapsedTime: 0.3,
+      });
+    });
+
   });
 });

--- a/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSManager.test.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSManager.test.ts
@@ -175,6 +175,5 @@ describe('CSSManager', () => {
         elapsedTime: 0.3,
       });
     });
-
   });
 });

--- a/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSTransitionsManager.test.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSTransitionsManager.test.ts
@@ -272,6 +272,45 @@ describe('CSSTransitionsManager', () => {
         );
       });
 
+      describe('event mask', () => {
+        test('sends the requested mask alongside the transition', () => {
+          manager.update(DEFAULT_TRANSITION_CONFIG, { opacity: 0 }, 0b1110000);
+          manager.update(DEFAULT_TRANSITION_CONFIG, { opacity: 1 }, 0b1110000);
+
+          expect(runCSSTransition).toHaveBeenLastCalledWith(
+            shadowNodeWrapper,
+            { opacity: { ...DEFAULT_SETTINGS, value: [0, 1] } },
+            0b1110000
+          );
+        });
+
+        test('sends the new mask when only the mask changes', () => {
+          manager.update(DEFAULT_TRANSITION_CONFIG, { opacity: 0 }, 0b0010000);
+          manager.update(DEFAULT_TRANSITION_CONFIG, { opacity: 1 }, 0b0010000);
+          manager.update(DEFAULT_TRANSITION_CONFIG, { opacity: 1 }, 0b1000000);
+
+          expect(runCSSTransition).toHaveBeenLastCalledWith(
+            shadowNodeWrapper,
+            {},
+            0b1000000
+          );
+        });
+
+        test('does not call the native side again for an unchanged mask', () => {
+          manager.update(DEFAULT_TRANSITION_CONFIG, { opacity: 0 }, 0b0010000);
+          manager.update(DEFAULT_TRANSITION_CONFIG, { opacity: 1 }, 0b0010000);
+          manager.update(DEFAULT_TRANSITION_CONFIG, { opacity: 1 }, 0b0010000);
+
+          expect(runCSSTransition).toHaveBeenCalledTimes(1);
+        });
+
+        test('does not send a mask-only update before any transition ran', () => {
+          manager.update(DEFAULT_TRANSITION_CONFIG, { opacity: 0 }, 0b0010000);
+
+          expect(runCSSTransition).not.toHaveBeenCalled();
+        });
+      });
+
       describe('detach via null config', () => {
         test('unregisters and reports the detach after a transition has run', () => {
           manager.update(DEFAULT_TRANSITION_CONFIG, { opacity: 0 });


### PR DESCRIPTION
Makes `onTransitionRun`, `onTransitionStart`, `onTransitionEnd` and `onTransitionCancel` fire on iOS and Android. They already work on web, and the shared types promised them everywhere, but native dropped them.

The per-view callbacks manager now holds one callback store per CSS kind. Each store names its own prop table, keeps its own mask, builds its own payload shape and narrows the event type with its own predicate, so an event is routed by exactly one lookup and neither kind can read the other table. Only the masks cross the JSI boundary, never the user functions, and the transition mask is diffed so an unchanged set of callbacks costs no native call.

Callbacks are passed inside `style`, alongside the other CSS config props.

Stacked on #10119.