### PR TITLE
fix(reanimated): restart inline props mapper after remount

### DIFF
--- a/packages/react-native-reanimated/src/createAnimatedComponent/InlinePropManager.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/InlinePropManager.ts
@@ -174,6 +174,8 @@ export class InlinePropManager implements IInlinePropManager {
   public detachInlineProps() {
     if (this._inlinePropsMapperId) {
       stopMapper(this._inlinePropsMapperId);
+      this._inlinePropsMapperId = null;
     }
+    this._inlineProps = {};
   }
 }

--- a/packages/react-native-reanimated/src/createAnimatedComponent/InlinePropManager.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/InlinePropManager.ts
@@ -176,6 +176,7 @@ export class InlinePropManager implements IInlinePropManager {
       stopMapper(this._inlinePropsMapperId);
       this._inlinePropsMapperId = null;
     }
+    this._inlinePropsViewDescriptors = null;
     this._inlineProps = {};
   }
 }


### PR DESCRIPTION
  > [!NOTE]
  > This pr description is AI generated

`attachInlineProps` starts a mapper only when the inline props changed, but
`detachInlineProps` left `_inlineProps` and `_inlinePropsMapperId` populated. A
component remounted with the same inline shared values therefore fails the change
check, never gets a new mapper, and silently stops updating — the view freezes at
its last value while the animation keeps running.

Clears both on detach so the next attach restarts the mapper.

Reproducible with any remount that keeps props equal; React StrictMode
(mount → unmount → mount) hits it every time.
