### PR TITLE
chore: remove the CSS callback warnings

### DIFF
--- a/packages/react-native-reanimated/src/css/native/managers/CSSManager.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/CSSManager.ts
@@ -72,11 +72,7 @@ export default class CSSManager implements ICSSManager {
     const hasAnimation = animationProperties !== null;
     const hasTransition = transitionProperties !== null;
 
-    const [animationCallbacks, transitionCallbacks] = splitCSSCallbacks(
-      props,
-      hasAnimation,
-      hasTransition
-    );
+    const [animationCallbacks, transitionCallbacks] = splitCSSCallbacks(props);
 
     // Synced before either manager runs so a cancel emitted while detaching
     // still reaches the user.

--- a/packages/react-native-reanimated/src/css/utils/__tests__/props.test.ts
+++ b/packages/react-native-reanimated/src/css/utils/__tests__/props.test.ts
@@ -531,62 +531,16 @@ describe(filterCSSAndStyleProperties, () => {
       const onCSSTransitionEnd = jest.fn();
       const onCSSTransitionRun = jest.fn();
 
-      const [animationCallbacks, transitionCallbacks] = splitCSSCallbacks(
-        { onCSSTransitionRun, onCSSTransitionEnd },
-        false,
-        true
-      );
+      const [animationCallbacks, transitionCallbacks] = splitCSSCallbacks({
+        onCSSTransitionRun,
+        onCSSTransitionEnd,
+      });
 
       expect(transitionCallbacks).toEqual({
         onCSSTransitionRun,
         onCSSTransitionEnd,
       });
       expect(animationCallbacks).toBeNull();
-    });
-  });
-
-  describe('transition callbacks validation', () => {
-    const globalWithDev = globalThis as unknown as { __DEV__: boolean };
-
-    beforeEach(() => {
-      (console.warn as jest.Mock).mockClear();
-    });
-
-    describe('in development (__DEV__)', () => {
-      beforeEach(() => {
-        globalWithDev.__DEV__ = true;
-      });
-
-      test('warns when transition callbacks are used without any transition props', () => {
-        splitCSSCallbacks({ onCSSTransitionEnd: jest.fn() }, false, false);
-        expect(console.warn).toHaveBeenCalledWith(
-          expect.stringContaining('onCSSTransitionEnd')
-        );
-      });
-
-      test('does not warn when a transition is configured alongside callbacks', () => {
-        splitCSSCallbacks({ onCSSTransitionEnd: jest.fn() }, false, true);
-        expect(console.warn).not.toHaveBeenCalled();
-      });
-
-      test('does not warn when only the transition shorthand is provided', () => {
-        filterCSSAndStyleProperties({
-          transition: 'opacity 2s',
-          onCSSTransitionEnd: jest.fn(),
-        } as CSSStyle);
-        expect(console.warn).not.toHaveBeenCalled();
-      });
-    });
-
-    describe('in production (!__DEV__)', () => {
-      beforeEach(() => {
-        globalWithDev.__DEV__ = false;
-      });
-
-      test('skips validation entirely - never warns, even without transition props', () => {
-        splitCSSCallbacks({ onCSSTransitionEnd: jest.fn() }, false, false);
-        expect(console.warn).not.toHaveBeenCalled();
-      });
     });
   });
 
@@ -611,72 +565,16 @@ describe(filterCSSAndStyleProperties, () => {
       const onCSSAnimationStart = jest.fn();
       const onCSSAnimationEnd = jest.fn();
 
-      const [animationCallbacks, transitionCallbacks] = splitCSSCallbacks(
-        { onCSSAnimationStart, onCSSAnimationEnd },
-        true,
-        false
-      );
+      const [animationCallbacks, transitionCallbacks] = splitCSSCallbacks({
+        onCSSAnimationStart,
+        onCSSAnimationEnd,
+      });
 
       expect(animationCallbacks).toEqual({
         onCSSAnimationStart,
         onCSSAnimationEnd,
       });
       expect(transitionCallbacks).toBeNull();
-    });
-  });
-
-  describe('animation callbacks validation', () => {
-    const globalWithDev = globalThis as unknown as { __DEV__: boolean };
-
-    beforeEach(() => {
-      (console.warn as jest.Mock).mockClear();
-    });
-
-    describe('in development (__DEV__)', () => {
-      beforeEach(() => {
-        globalWithDev.__DEV__ = true;
-      });
-
-      test('warns when animation callbacks are used without any animation props', () => {
-        splitCSSCallbacks({ onCSSAnimationEnd: jest.fn() }, false, false);
-        expect(console.warn).toHaveBeenCalledWith(
-          expect.stringContaining('onCSSAnimationEnd')
-        );
-      });
-
-      test('does not warn when an animation is configured alongside callbacks', () => {
-        splitCSSCallbacks({ onCSSAnimationEnd: jest.fn() }, true, false);
-        expect(console.warn).not.toHaveBeenCalled();
-      });
-
-      test('does not warn when animationName is a plain keyframes object', () => {
-        filterCSSAndStyleProperties({
-          animationName: { from: { opacity: 0 }, to: { opacity: 1 } },
-          animationDuration: 100,
-          onCSSAnimationEnd: jest.fn(),
-        } as CSSStyle);
-        expect(console.warn).not.toHaveBeenCalled();
-      });
-
-      test('warns when callbacks are used but animationName has no valid keyframes', () => {
-        // An empty keyframes object means no animation actually runs, so the
-        // callbacks can never fire and the warning must still be emitted.
-        splitCSSCallbacks({ onCSSAnimationEnd: jest.fn() }, false, false);
-        expect(console.warn).toHaveBeenCalledWith(
-          expect.stringContaining('onCSSAnimationEnd')
-        );
-      });
-    });
-
-    describe('in production (!__DEV__)', () => {
-      beforeEach(() => {
-        globalWithDev.__DEV__ = false;
-      });
-
-      test('skips validation entirely - never warns, even without animation props', () => {
-        splitCSSCallbacks({ onCSSAnimationEnd: jest.fn() }, false, false);
-        expect(console.warn).not.toHaveBeenCalled();
-      });
     });
   });
 });

--- a/packages/react-native-reanimated/src/css/utils/props.ts
+++ b/packages/react-native-reanimated/src/css/utils/props.ts
@@ -155,35 +155,9 @@ function validateCSSTransitionProps(props: Partial<CSSTransitionProperties>) {
   }
 }
 
-function validateCSSCallbacks(
-  kind: 'animation' | 'transition',
-  exampleProp: string,
-  callbacks: CSSAnimationCallbacks | CSSTransitionCallbacks,
-  hasConfig: boolean
-) {
-  // These callbacks are driven by an actual CSS animation/transition; without
-  // the matching properties configured there is nothing that could fire them.
-  const callbackNames = Object.keys(callbacks);
-  if (callbackNames.length === 0 || hasConfig) {
-    return;
-  }
-
-  const isPlural = callbackNames.length > 1;
-  logger.warn(
-    `CSS ${kind} ${isPlural ? 'callbacks' : 'callback'} (${callbackNames.join(', ')}) ` +
-      `${isPlural ? 'were' : 'was'} provided without any CSS ${kind} properties ` +
-      `(e.g. ${exampleProp}), so ${isPlural ? 'they' : 'it'} will never be called.`
-  );
-}
-
-/**
- * Splits the callback props into their animation and transition halves, warning
- * in dev about a kind that is subscribed to but never configured.
- */
+/** Splits the callback props into their animation and transition halves. */
 export function splitCSSCallbacks(
-  props: Readonly<UnknownRecord>,
-  hasAnimationConfig: boolean,
-  hasTransitionConfig: boolean
+  props: Readonly<UnknownRecord>
 ): [CSSAnimationCallbacks | null, CSSTransitionCallbacks | null] {
   const animationCallbacks: CSSAnimationCallbacks = {};
   const transitionCallbacks: CSSTransitionCallbacks = {};
@@ -204,21 +178,6 @@ export function splitCSSCallbacks(
       transitionCallbacks[prop] = value as CSSTransitionCallback;
       hasTransitionCallbacks = true;
     }
-  }
-
-  if (__DEV__) {
-    validateCSSCallbacks(
-      'animation',
-      'animationName',
-      animationCallbacks,
-      hasAnimationConfig
-    );
-    validateCSSCallbacks(
-      'transition',
-      'transitionDuration',
-      transitionCallbacks,
-      hasTransitionConfig
-    );
   }
 
   return [

--- a/packages/react-native-reanimated/src/css/web/managers/CSSManager.ts
+++ b/packages/react-native-reanimated/src/css/web/managers/CSSManager.ts
@@ -33,11 +33,7 @@ export default class CSSManager implements ICSSManager {
     const [animationProperties, transitionProperties, pseudoStylesBySelector] =
       filterCSSAndStyleProperties(style);
 
-    const [animationCallbacks, transitionCallbacks] = splitCSSCallbacks(
-      props,
-      animationProperties !== null,
-      transitionProperties !== null
-    );
+    const [animationCallbacks, transitionCallbacks] = splitCSSCallbacks(props);
 
     this.animationsManager.update(animationProperties, animationCallbacks);
     this.transitionsManager.update(transitionProperties, transitionCallbacks);


### PR DESCRIPTION
The dev warning fired whenever a CSS lifecycle callback was attached to a view with no matching animation or transition configured. That covers the reasonable pattern of wiring the handlers up first and attaching the animation later, so it warned on correct code, once per render, for as long as the config was absent.

It has no case left that is worth reporting. A misspelled prop name is not recognised as a CSS callback at all, so it never reached the warning in the first place, and nothing distinguishes "no animation yet" from "no animation ever".

Removes `validateCSSCallbacks` along with the config flags `splitCSSCallbacks` only needed in order to call it.