### PR TITLE
docs(Worklets): note that Bundle Mode forces inlineRequires in Expo

### DIFF
--- a/docs/docs-worklets/docs/bundleMode/setup.mdx
+++ b/docs/docs-worklets/docs/bundleMode/setup.mdx
@@ -77,6 +77,10 @@ To use `react-native-worklets`'s Bundle Mode feature, you need to make the follo
   </TabItem>
 </Tabs>
 
+:::note
+In Expo projects, this Metro configuration forces the `inlineRequires` option to be enabled, which may cause some libraries to fail or change their behavior. For a discussion on this option, see [expo/expo#27279](https://github.com/expo/expo/issues/27279).
+:::
+
 ## Enable seamless Metro bundling
 
 _This step is optional but highly recommended._

--- a/docs/docs-worklets/docs/bundleMode/setup.mdx
+++ b/docs/docs-worklets/docs/bundleMode/setup.mdx
@@ -78,7 +78,9 @@ To use `react-native-worklets`'s Bundle Mode feature, you need to make the follo
 </Tabs>
 
 :::note
-In Expo projects, this Metro configuration forces the `inlineRequires` option to be enabled, which may cause some libraries to fail or change their behavior. For a discussion on this option, see [expo/expo#27279](https://github.com/expo/expo/issues/27279).
+In Expo projects, this Metro configuration forces the `inlineRequires` option to be enabled, which may cause some libraries to fail or change their behavior. 
+
+`inlineRequires: true` defers module evaluation: modules whose imports are only referenced inside functions are evaluated at the first use of their imports instead of at the top of the importing module. Libraries that rely on import-time side effects for initialization may fail or change behavior. For a discussion on this option, see [expo/expo#27279](https://github.com/expo/expo/issues/27279).
 :::
 
 ## Enable seamless Metro bundling


### PR DESCRIPTION
## Summary

`getBundleModeMetroConfig` forces `inlineRequires: true` in Metro's transform options. This is required for the Worklets initialization pipeline, but it can affect how third-party libraries are loaded: inline requires defer the evaluation of modules whose imports are only referenced inside functions, which may cause libraries that rely on module-level side effects for initialization (e.g. schema validators with circular imports) to fail at module load.

This PR adds a note in the Bundle Mode setup docs warning Expo users about this side effect, with a link to the discussion on this option in expo/expo#27279.