### PR TITLE
chore(rnre): findNodeHandle cleanups

### DIFF
--- a/packages/react-native-reanimated/__tests__/fabricUtils.test.ts
+++ b/packages/react-native-reanimated/__tests__/fabricUtils.test.ts
@@ -1,0 +1,86 @@
+import type { InternalHostInstance } from '../src/commonTypes';
+import type * as FabricUtils from '../src/fabricUtils.native';
+
+const REACT_FABRIC_PUBLIC_INSTANCE_PATH =
+  'react-native/Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance';
+
+const FABRIC_UTILS_PATH = '../src/fabricUtils.native';
+
+function makeHostInstance(node: unknown) {
+  return { __internalInstanceHandle: { stateNode: { node } } };
+}
+
+function requireFabricUtils(): typeof FabricUtils {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  return require(FABRIC_UTILS_PATH);
+}
+
+describe('getShadowNodeWrapperFromRef', () => {
+  describe('when React Native exposes getNodeFromPublicInstance', () => {
+    let getNodeFromPublicInstance: jest.Mock;
+    let getShadowNodeWrapperFromRef: typeof FabricUtils.getShadowNodeWrapperFromRef;
+
+    beforeEach(() => {
+      jest.resetModules();
+      getNodeFromPublicInstance = jest.fn();
+      jest.doMock(REACT_FABRIC_PUBLIC_INSTANCE_PATH, () => ({
+        getNodeFromPublicInstance,
+      }));
+      getShadowNodeWrapperFromRef =
+        requireFabricUtils().getShadowNodeWrapperFromRef;
+    });
+
+    test('prefers the explicitly passed host instance', () => {
+      const node = { shadowNode: true };
+      const hostInstance = makeHostInstance(node);
+      getNodeFromPublicInstance.mockReturnValue(node);
+
+      expect(
+        getShadowNodeWrapperFromRef({} as InternalHostInstance, hostInstance)
+      ).toBe(node);
+      expect(getNodeFromPublicInstance).toHaveBeenCalledWith(hostInstance);
+    });
+
+    test('resolves scrollable refs through getNativeScrollRef', () => {
+      const node = { shadowNode: true };
+      const hostInstance = makeHostInstance(node);
+      getNodeFromPublicInstance.mockReturnValue(node);
+
+      const ref = {
+        getNativeScrollRef: () => hostInstance,
+      } as unknown as InternalHostInstance;
+
+      expect(getShadowNodeWrapperFromRef(ref)).toBe(node);
+      expect(getNodeFromPublicInstance).toHaveBeenCalledWith(hostInstance);
+    });
+
+    test('throws when no shadow node can be resolved', () => {
+      getNodeFromPublicInstance.mockReturnValue(null);
+
+      expect(() =>
+        getShadowNodeWrapperFromRef(
+          {} as InternalHostInstance,
+          makeHostInstance(null)
+        )
+      ).toThrow('[Reanimated] Failed to find shadow node for a ref.');
+    });
+
+    test('throws when the ref is neither a host instance nor a React component', () => {
+      expect(() =>
+        getShadowNodeWrapperFromRef({} as InternalHostInstance)
+      ).toThrow('[Reanimated] Failed to find host instance for a ref.');
+    });
+  });
+
+  describe('when React Native does not expose getNodeFromPublicInstance', () => {
+    test('falls back to reading the internal instance handle', () => {
+      jest.resetModules();
+      jest.doMock(REACT_FABRIC_PUBLIC_INSTANCE_PATH, () => ({}));
+
+      const node = { shadowNode: true };
+      const ref = makeHostInstance(node) as unknown as InternalHostInstance;
+
+      expect(requireFabricUtils().getShadowNodeWrapperFromRef(ref)).toBe(node);
+    });
+  });
+});

--- a/packages/react-native-reanimated/__tests__/fabricUtils.test.ts
+++ b/packages/react-native-reanimated/__tests__/fabricUtils.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import type { InternalHostInstance } from '../src/commonTypes';
 import type * as FabricUtils from '../src/fabricUtils.native';
 
@@ -5,6 +6,14 @@ const REACT_FABRIC_PUBLIC_INSTANCE_PATH =
   'react-native/Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance';
 
 const FABRIC_UTILS_PATH = '../src/fabricUtils.native';
+
+jest.mock('react-native/Libraries/Renderer/shims/ReactFabric', () => ({
+  findHostInstance_DEPRECATED: jest.fn(),
+}));
+
+function requireReactFabric(): { findHostInstance_DEPRECATED: jest.Mock } {
+  return jest.requireMock('react-native/Libraries/Renderer/shims/ReactFabric');
+}
 
 function makeHostInstance(node: unknown) {
   return { __internalInstanceHandle: { stateNode: { node } } };
@@ -48,6 +57,23 @@ describe('getShadowNodeWrapperFromRef', () => {
 
       const ref = {
         getNativeScrollRef: () => hostInstance,
+      } as unknown as InternalHostInstance;
+
+      expect(getShadowNodeWrapperFromRef(ref)).toBe(node);
+      expect(getNodeFromPublicInstance).toHaveBeenCalledWith(hostInstance);
+    });
+
+    test('falls back to _reactInternals when getNativeScrollRef returns null', () => {
+      const node = { shadowNode: true };
+      const hostInstance = makeHostInstance(node);
+      getNodeFromPublicInstance.mockReturnValue(node);
+      requireReactFabric().findHostInstance_DEPRECATED.mockReturnValue(
+        hostInstance
+      );
+
+      const ref = {
+        getNativeScrollRef: () => null,
+        _reactInternals: {},
       } as unknown as InternalHostInstance;
 
       expect(getShadowNodeWrapperFromRef(ref)).toBe(node);

--- a/packages/react-native-reanimated/__tests__/fabricUtils.test.ts
+++ b/packages/react-native-reanimated/__tests__/fabricUtils.test.ts
@@ -98,6 +98,32 @@ describe('getShadowNodeWrapperFromRef', () => {
     });
   });
 
+  describe('when resolving against the installed React Native', () => {
+    test('uses the React Native implementation rather than the fallback', () => {
+      jest.resetModules();
+      jest.dontMock(REACT_FABRIC_PUBLIC_INSTANCE_PATH);
+
+      const ReactFabricPublicInstance: {
+        getNodeFromPublicInstance: (publicInstance: unknown) => unknown;
+        // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+      } = require(REACT_FABRIC_PUBLIC_INSTANCE_PATH);
+
+      const node = { shadowNode: true };
+      const spy = jest
+        .spyOn(ReactFabricPublicInstance, 'getNodeFromPublicInstance')
+        .mockReturnValue(node);
+
+      const ref = makeHostInstance({
+        unreachableThroughReactNative: true,
+      }) as unknown as InternalHostInstance;
+
+      expect(requireFabricUtils().getShadowNodeWrapperFromRef(ref)).toBe(node);
+      expect(spy).toHaveBeenCalledWith(ref);
+
+      spy.mockRestore();
+    });
+  });
+
   describe('when React Native does not expose getNodeFromPublicInstance', () => {
     test('falls back to reading the internal instance handle', () => {
       jest.resetModules();

--- a/packages/react-native-reanimated/__tests__/findHostInstance.test.ts
+++ b/packages/react-native-reanimated/__tests__/findHostInstance.test.ts
@@ -44,4 +44,53 @@ describe('findHostInstance', () => {
     expect(findHostInstance(animatedComponent)).toBe(hostInstance);
     expect(ReactFabric.findHostInstance_DEPRECATED).not.toHaveBeenCalled();
   });
+
+  test('resolves scrollable components through getNativeScrollRef', () => {
+    const hostInstance = {
+      __internalInstanceHandle: {},
+      __nativeTag: 42,
+      __viewConfig: { uiViewClassName: 'RCTScrollView' },
+    };
+    const animatedComponent = {
+      _componentRef: { getNativeScrollRef: () => hostInstance },
+      _hasAnimatedRef: false,
+    } as unknown as IAnimatedComponentInternalBase;
+
+    expect(findHostInstance(animatedComponent)).toBe(hostInstance);
+    expect(ReactFabric.findHostInstance_DEPRECATED).not.toHaveBeenCalled();
+  });
+
+  test('resolves scrollable components through getScrollableNode', () => {
+    const hostInstance = {
+      __internalInstanceHandle: {},
+      __nativeTag: 42,
+      __viewConfig: { uiViewClassName: 'RCTScrollView' },
+    };
+    const animatedComponent = {
+      _componentRef: { getScrollableNode: () => hostInstance },
+      _hasAnimatedRef: false,
+    } as unknown as IAnimatedComponentInternalBase;
+
+    expect(findHostInstance(animatedComponent)).toBe(hostInstance);
+    expect(ReactFabric.findHostInstance_DEPRECATED).not.toHaveBeenCalled();
+  });
+
+  test('falls back when getScrollableNode returns a view tag', () => {
+    const hostInstance = { host: true };
+    const componentRef = {
+      getNativeScrollRef: () => null,
+      getScrollableNode: () => 42,
+    };
+    const animatedComponent = {
+      _componentRef: componentRef,
+      _hasAnimatedRef: false,
+    } as unknown as IAnimatedComponentInternalBase;
+
+    ReactFabric.findHostInstance_DEPRECATED.mockReturnValue(hostInstance);
+
+    expect(findHostInstance(animatedComponent)).toBe(hostInstance);
+    expect(ReactFabric.findHostInstance_DEPRECATED).toHaveBeenCalledWith(
+      componentRef
+    );
+  });
 });

--- a/packages/react-native-reanimated/src/createAnimatedComponent/NativeEventsManager.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/NativeEventsManager.ts
@@ -1,4 +1,5 @@
 'use strict';
+import { findHostInstance } from '../platform-specific/findHostInstance';
 import { findNodeHandle } from '../platformFunctions/findNodeHandle';
 import { WorkletEventHandler } from '../WorkletEventHandler';
 import type {
@@ -97,7 +98,7 @@ export class NativeEventsManager implements INativeEventsManager {
     if (this.#componentOptions?.setNativeProps) {
       // This case ensures backward compatibility with components that
       // have their own setNativeProps method passed as an option.
-      return findNodeHandle(this.#managedComponent) ?? -1;
+      return this.#managedComponent.getComponentViewTag();
     }
     if (!componentUpdate) {
       // On the first render of a component, we may already receive a resolved view tag.
@@ -107,10 +108,17 @@ export class NativeEventsManager implements INativeEventsManager {
       return componentAnimatedRef.__nativeTag ?? -1;
     }
     /*
-      When a component is updated, a child could potentially change and have a different 
+      When a component is updated, a child could potentially change and have a different
       view tag. This can occur with a GestureDetector component.
     */
-    return findNodeHandle(componentAnimatedRef) ?? -1;
+    if (!componentAnimatedRef) {
+      return -1;
+    }
+    return (
+      findHostInstance(this.#managedComponent)?.__nativeTag ??
+      findNodeHandle(componentAnimatedRef) ??
+      -1
+    );
   }
 }
 

--- a/packages/react-native-reanimated/src/createAnimatedComponent/commonTypes.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/commonTypes.ts
@@ -131,8 +131,8 @@ export interface IAnimatedComponentInternalBase {
   _viewInfo?: ViewInfo;
 
   /**
-   * Used for Layout Animations and Animated Styles. It is not related to event
-   * handling.
+   * Resolves the tag of the host view backing this component. Used for Layout
+   * Animations, Animated Styles and event registration.
    */
   getComponentViewTag: () => number;
 }

--- a/packages/react-native-reanimated/src/fabricUtils.native.ts
+++ b/packages/react-native-reanimated/src/fabricUtils.native.ts
@@ -43,8 +43,9 @@ function resolvePublicInstance(
   if (ref?.__internalInstanceHandle) {
     return ref as HostInstance;
   }
-  if (ref.getNativeScrollRef) {
-    return ref.getNativeScrollRef() as HostInstance;
+  const nativeScrollRef = ref.getNativeScrollRef?.();
+  if (nativeScrollRef) {
+    return nativeScrollRef as HostInstance;
   }
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   if ((ref as any)._reactInternals) {

--- a/packages/react-native-reanimated/src/fabricUtils.native.ts
+++ b/packages/react-native-reanimated/src/fabricUtils.native.ts
@@ -4,25 +4,67 @@ import type { InternalHostInstance, ShadowNodeWrapper } from './commonTypes';
 import { findHostInstance } from './platform-specific/findHostInstance';
 import type { HostInstance } from './platform-specific/types';
 
+type GetNodeFromPublicInstance = (
+  publicInstance: HostInstance
+) => ShadowNodeWrapper | null | undefined;
+
+let getNodeFromPublicInstance: GetNodeFromPublicInstance | undefined;
+
+function resolveGetNodeFromPublicInstance(): GetNodeFromPublicInstance {
+  try {
+    const ReactFabricPublicInstance =
+      // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+      require('react-native/Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance');
+    return (
+      ReactFabricPublicInstance?.getNodeFromPublicInstance ??
+      ReactFabricPublicInstance?.default?.getNodeFromPublicInstance ??
+      getNodeFromPublicInstanceFallback
+    );
+  } catch (_e) {
+    return getNodeFromPublicInstanceFallback;
+  }
+}
+
+function getNodeFromPublicInstanceFallback(publicInstance: HostInstance) {
+  return (
+    publicInstance?.__internalInstanceHandle?.stateNode as
+      | { node?: ShadowNodeWrapper }
+      | undefined
+  )?.node;
+}
+
+function resolvePublicInstance(
+  ref: InternalHostInstance,
+  hostInstance?: HostInstance
+): HostInstance {
+  if (hostInstance?.__internalInstanceHandle) {
+    return hostInstance;
+  }
+  if (ref?.__internalInstanceHandle) {
+    return ref as HostInstance;
+  }
+  if (ref.getNativeScrollRef) {
+    return ref.getNativeScrollRef() as HostInstance;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  if ((ref as any)._reactInternals) {
+    return findHostInstance(ref);
+  }
+  throw new Error(`[Reanimated] Failed to find host instance for a ref.`);
+}
+
 export function getShadowNodeWrapperFromRef(
   ref: InternalHostInstance,
   hostInstance?: HostInstance
 ): ShadowNodeWrapper {
-  let resolvedInstance =
-    hostInstance?.__internalInstanceHandle ?? ref?.__internalInstanceHandle;
+  getNodeFromPublicInstance ??= resolveGetNodeFromPublicInstance();
 
-  if (!resolvedInstance) {
-    if (ref.getNativeScrollRef) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      resolvedInstance = (ref.getNativeScrollRef() as any)
-        .__internalInstanceHandle;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } else if ((ref as any)._reactInternals) {
-      resolvedInstance = findHostInstance(ref).__internalInstanceHandle;
-    } else {
-      throw new Error(`[Reanimated] Failed to find host instance for a ref.`);
-    }
+  const publicInstance = resolvePublicInstance(ref, hostInstance);
+  const shadowNodeWrapper = getNodeFromPublicInstance(publicInstance);
+
+  if (!shadowNodeWrapper) {
+    throw new Error(`[Reanimated] Failed to find shadow node for a ref.`);
   }
 
-  return (resolvedInstance!.stateNode as { node: ShadowNodeWrapper }).node;
+  return shadowNodeWrapper;
 }

--- a/packages/react-native-reanimated/src/fabricUtils.native.ts
+++ b/packages/react-native-reanimated/src/fabricUtils.native.ts
@@ -8,7 +8,13 @@ type GetNodeFromPublicInstance = (
   publicInstance: HostInstance
 ) => ShadowNodeWrapper | null | undefined;
 
-let getNodeFromPublicInstance: GetNodeFromPublicInstance | undefined;
+function getNodeFromPublicInstanceFallback(publicInstance: HostInstance) {
+  return (
+    publicInstance?.__internalInstanceHandle?.stateNode as
+      | { node?: ShadowNodeWrapper }
+      | undefined
+  )?.node;
+}
 
 function resolveGetNodeFromPublicInstance(): GetNodeFromPublicInstance {
   try {
@@ -25,13 +31,7 @@ function resolveGetNodeFromPublicInstance(): GetNodeFromPublicInstance {
   }
 }
 
-function getNodeFromPublicInstanceFallback(publicInstance: HostInstance) {
-  return (
-    publicInstance?.__internalInstanceHandle?.stateNode as
-      | { node?: ShadowNodeWrapper }
-      | undefined
-  )?.node;
-}
+const getNodeFromPublicInstance = resolveGetNodeFromPublicInstance();
 
 function resolvePublicInstance(
   ref: InternalHostInstance,
@@ -58,8 +58,6 @@ export function getShadowNodeWrapperFromRef(
   ref: InternalHostInstance,
   hostInstance?: HostInstance
 ): ShadowNodeWrapper {
-  getNodeFromPublicInstance ??= resolveGetNodeFromPublicInstance();
-
   const publicInstance = resolvePublicInstance(ref, hostInstance);
   const shadowNodeWrapper = getNodeFromPublicInstance(publicInstance);
 

--- a/packages/react-native-reanimated/src/platform-specific/findHostInstance.native.ts
+++ b/packages/react-native-reanimated/src/platform-specific/findHostInstance.native.ts
@@ -5,7 +5,9 @@ import type { InternalHostInstance } from '../commonTypes';
 import type { IAnimatedComponentInternalBase } from '../createAnimatedComponent/commonTypes';
 import type { HostInstance } from './types';
 
-function findHostInstanceFastPath(maybeNativeRef: HostInstance | undefined) {
+function findHostInstanceFastPath(
+  maybeNativeRef: HostInstance | null | undefined
+) {
   if (!maybeNativeRef) {
     return undefined;
   }
@@ -35,14 +37,15 @@ function findHostInstanceFromScrollableRef(
     return undefined;
   }
 
-  const nativeScrollRef = maybeScrollableRef.getNativeScrollRef?.();
-  const hostInstance = findHostInstanceFastPath(nativeScrollRef ?? undefined);
+  const hostInstance = findHostInstanceFastPath(
+    maybeScrollableRef.getNativeScrollRef?.()
+  );
   if (hostInstance !== undefined) {
     return hostInstance;
   }
 
   const scrollableNode = maybeScrollableRef.getScrollableNode?.();
-  if (typeof scrollableNode !== 'object' || scrollableNode === null) {
+  if (typeof scrollableNode === 'number') {
     return undefined;
   }
   return findHostInstanceFastPath(scrollableNode);

--- a/packages/react-native-reanimated/src/platform-specific/findHostInstance.native.ts
+++ b/packages/react-native-reanimated/src/platform-specific/findHostInstance.native.ts
@@ -5,9 +5,7 @@ import type { InternalHostInstance } from '../commonTypes';
 import type { IAnimatedComponentInternalBase } from '../createAnimatedComponent/commonTypes';
 import type { HostInstance } from './types';
 
-function findHostInstanceFastPath(
-  maybeNativeRef: HostInstance | null | undefined
-) {
+function findHostInstanceFastPath(maybeNativeRef: HostInstance | undefined) {
   if (!maybeNativeRef) {
     return undefined;
   }
@@ -37,15 +35,16 @@ function findHostInstanceFromScrollableRef(
     return undefined;
   }
 
-  const hostInstance = findHostInstanceFastPath(
-    maybeScrollableRef.getNativeScrollRef?.()
-  );
-  if (hostInstance !== undefined) {
-    return hostInstance;
+  const nativeScrollRef = maybeScrollableRef.getNativeScrollRef?.();
+  if (nativeScrollRef) {
+    const hostInstance = findHostInstanceFastPath(nativeScrollRef);
+    if (hostInstance !== undefined) {
+      return hostInstance;
+    }
   }
 
   const scrollableNode = maybeScrollableRef.getScrollableNode?.();
-  if (typeof scrollableNode === 'number') {
+  if (!scrollableNode || typeof scrollableNode === 'number') {
     return undefined;
   }
   return findHostInstanceFastPath(scrollableNode);

--- a/packages/react-native-reanimated/src/platform-specific/findHostInstance.native.ts
+++ b/packages/react-native-reanimated/src/platform-specific/findHostInstance.native.ts
@@ -23,6 +23,31 @@ function findHostInstanceFastPath(maybeNativeRef: HostInstance | undefined) {
   return undefined;
 }
 
+type ScrollableRef = {
+  getNativeScrollRef?: () => HostInstance | null;
+  getScrollableNode?: () => HostInstance | number | null;
+};
+
+function findHostInstanceFromScrollableRef(
+  maybeScrollableRef: ScrollableRef | undefined
+) {
+  if (!maybeScrollableRef) {
+    return undefined;
+  }
+
+  const nativeScrollRef = maybeScrollableRef.getNativeScrollRef?.();
+  const hostInstance = findHostInstanceFastPath(nativeScrollRef ?? undefined);
+  if (hostInstance !== undefined) {
+    return hostInstance;
+  }
+
+  const scrollableNode = maybeScrollableRef.getScrollableNode?.();
+  if (typeof scrollableNode !== 'object' || scrollableNode === null) {
+    return undefined;
+  }
+  return findHostInstanceFastPath(scrollableNode);
+}
+
 function resolveFindHostInstance_DEPRECATED() {
   if (findHostInstance_DEPRECATED !== undefined) {
     return;
@@ -46,12 +71,20 @@ let findHostInstance_DEPRECATED: (ref: unknown) => HostInstance;
 export function findHostInstance(
   ref: IAnimatedComponentInternalBase | InternalHostInstance
 ): HostInstance {
+  const componentRef = (ref as IAnimatedComponentInternalBase)
+    ._componentRef as HostInstance;
+
   // Fast path for native refs
-  const hostInstance = findHostInstanceFastPath(
-    (ref as IAnimatedComponentInternalBase)._componentRef as HostInstance
-  );
+  const hostInstance = findHostInstanceFastPath(componentRef);
   if (hostInstance !== undefined) {
     return hostInstance;
+  }
+
+  const scrollableHostInstance = findHostInstanceFromScrollableRef(
+    componentRef as ScrollableRef | undefined
+  );
+  if (scrollableHostInstance !== undefined) {
+    return scrollableHostInstance;
   }
 
   resolveFindHostInstance_DEPRECATED();
@@ -61,7 +94,5 @@ export function findHostInstance(
     forward their ref to the host view that should be animated. Components that expose an animatable
     ref via `getAnimatableRef` already have it resolved into `_componentRef`.
   */
-  return findHostInstance_DEPRECATED(
-    (ref as IAnimatedComponentInternalBase)._componentRef ?? ref
-  );
+  return findHostInstance_DEPRECATED(componentRef ?? ref);
 }


### PR DESCRIPTION
This PR is related to enabling strict mode in fabric example

The main issue was findNodeHandle being called on a class component, which then goes through the slow child search path

This PR does 3 things:
1) Add some fast path fallbacks for common use cases (getScrollableNode, getNativeScrollRef)
2) Use the getNodeFromPublicInstance function instead of digging up the shadowNodeWrapper manually
3) take the event view tag from `_componentRef` instead of `findNodeHandle` on the class component (findNodeHandle only as fallback)