### PR TITLE
Add inline styles and props example

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/InlineStylesAndPropsExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/InlineStylesAndPropsExample.tsx
@@ -1,5 +1,5 @@
-import { useCallback } from "react";
-import type { ColorValue } from "react-native";
+import { useCallback } from 'react';
+import type { ColorValue } from 'react-native';
 import {
   Button,
   StyleSheet,
@@ -7,15 +7,15 @@ import {
   Text,
   TextInput,
   View,
-} from "react-native";
-import type { SharedValue } from "react-native-reanimated";
+} from 'react-native';
+import type { SharedValue } from 'react-native-reanimated';
 import Animated, {
   useAnimatedProps,
   useAnimatedStyle,
   useDerivedValue,
   useSharedValue,
-} from "react-native-reanimated";
-import { Circle, Svg } from "react-native-svg";
+} from 'react-native-reanimated';
+import { Circle, Svg } from 'react-native-svg';
 
 const AnimatedSwitch = Animated.createAnimatedComponent(Switch);
 const AnimatedCircle = Animated.createAnimatedComponent(Circle);
@@ -28,7 +28,7 @@ export default function InlineStylesAndPropsExample() {
     value.set((current) => !current);
   }, [value]);
 
-  const colorSv = useDerivedValue(() => (value.value ? "lime" : "red"));
+  const colorSv = useDerivedValue(() => (value.value ? 'lime' : 'red'));
 
   const textSv = useDerivedValue(() => String(value.value ?? false));
 
@@ -103,8 +103,8 @@ export default function InlineStylesAndPropsExample() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    alignItems: "center",
-    justifyContent: "center",
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   box: {
     width: 60,
@@ -112,9 +112,9 @@ const styles = StyleSheet.create({
   },
   input: {
     borderWidth: 1,
-    borderColor: "gray",
+    borderColor: 'gray',
     width: 100,
     padding: 4,
-    textAlign: "center",
+    textAlign: 'center',
   },
 });

--- a/apps/common-app/src/apps/reanimated/examples/InlineStylesAndPropsExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/InlineStylesAndPropsExample.tsx
@@ -1,0 +1,120 @@
+import { useCallback } from "react";
+import type { ColorValue } from "react-native";
+import {
+  Button,
+  StyleSheet,
+  Switch,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import type { SharedValue } from "react-native-reanimated";
+import Animated, {
+  useAnimatedProps,
+  useAnimatedStyle,
+  useDerivedValue,
+  useSharedValue,
+} from "react-native-reanimated";
+import { Circle, Svg } from "react-native-svg";
+
+const AnimatedSwitch = Animated.createAnimatedComponent(Switch);
+const AnimatedCircle = Animated.createAnimatedComponent(Circle);
+const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);
+
+export default function InlineStylesAndPropsExample() {
+  const value = useSharedValue(false);
+
+  const handleToggle = useCallback(() => {
+    value.set((current) => !current);
+  }, [value]);
+
+  const colorSv = useDerivedValue(() => (value.value ? "lime" : "red"));
+
+  const textSv = useDerivedValue(() => String(value.value ?? false));
+
+  const viewAnimatedStyle = useAnimatedStyle(() => ({
+    backgroundColor: colorSv.value,
+  }));
+
+  const circleAnimatedProps = useAnimatedProps(() => ({ fill: colorSv.value }));
+
+  const switchAnimatedProps = useAnimatedProps(() => ({ value: value.value }));
+
+  const textInputAnimatedProps = useAnimatedProps(() => ({
+    text: textSv.value,
+    defaultValue: textSv.value,
+  }));
+
+  return (
+    <View style={styles.container}>
+      <Button title="Toggle" onPress={handleToggle} />
+
+      <Text>View + useAnimatedStyle</Text>
+      <Animated.View style={[styles.box, viewAnimatedStyle]} />
+
+      <Text>View + inline style</Text>
+      <Animated.View style={[styles.box, { backgroundColor: colorSv }]} />
+
+      <Text>Circle + useAnimatedProps</Text>
+      <Svg width={60} height={60}>
+        <AnimatedCircle
+          cx={30}
+          cy={30}
+          r={25}
+          animatedProps={circleAnimatedProps}
+        />
+      </Svg>
+
+      <Text>Circle + inline prop</Text>
+      <Svg width={60} height={60}>
+        <AnimatedCircle
+          cx={30}
+          cy={30}
+          r={25}
+          fill={colorSv as SharedValue<ColorValue | undefined>}
+        />
+      </Svg>
+
+      <Text>Switch + useAnimatedProps</Text>
+      <AnimatedSwitch animatedProps={switchAnimatedProps} />
+
+      <Text>Switch + inline prop</Text>
+      <AnimatedSwitch value={value as SharedValue<boolean | undefined>} />
+
+      <Text>TextInput + useAnimatedProps</Text>
+      <AnimatedTextInput
+        editable={false}
+        style={styles.input}
+        animatedProps={textInputAnimatedProps}
+      />
+
+      <Text>TextInput + inline prop</Text>
+      <AnimatedTextInput
+        editable={false}
+        style={styles.input}
+        defaultValue="false"
+        // @ts-expect-error `text` is the native prop backing TextInput's value
+        text={textSv}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  box: {
+    width: 60,
+    height: 60,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: "gray",
+    width: 100,
+    padding: 4,
+    textAlign: "center",
+  },
+});

--- a/apps/common-app/src/apps/reanimated/examples/index.ts
+++ b/apps/common-app/src/apps/reanimated/examples/index.ts
@@ -186,6 +186,10 @@ const EmojiWaterfallExample: React.FC = () =>
   React.createElement(require('./EmojiWaterfallExample').default as React.FC);
 const EmptyExample: React.FC = () =>
   React.createElement(require('./EmptyExample').default as React.FC);
+const InlineStylesAndPropsExample: React.FC = () =>
+  React.createElement(
+    require('./InlineStylesAndPropsExample').default as React.FC
+  );
 const SuspenseLayoutAnimationCrashExample: React.FC = () =>
   React.createElement(
     require('./SuspenseLayoutAnimationCrashExample').default as React.FC
@@ -535,6 +539,11 @@ export const EXAMPLES: Record<string, Example> = {
     icon: '👻',
     title: 'Empty',
     screen: EmptyExample,
+  },
+  InlineStylesAndPropsExample: {
+    icon: '🎛️',
+    title: 'Inline styles and props',
+    screen: InlineStylesAndPropsExample,
   },
   FpsExample: {
     icon: '🎞️',


### PR DESCRIPTION
## Summary

This PR adds inline styles and props example.

> [!NOTE]
> Some part of this example (namely inline props) doesn't work as intended – reported as issue https://github.com/software-mansion/react-native-reanimated/issues/10147.

<table>
<thead>
<tr>
<th>Android</th>
<th>iOS</th>
</tr>
</thead>
<tbody>
<tr>
<td><video src="https://github.com/user-attachments/assets/9af09752-afc2-440b-bcc8-5be9d852cafe" /></td>
<td><video src="https://github.com/user-attachments/assets/9b33b3e1-da38-42e9-ac73-5e3a5cd0189d" /></td>
</tr>
</tbody>
</table>

## Test plan

