### PR TITLE
chore(repo): removed legacy rngh api usage

### DIFF
--- a/apps/common-app/src/apps/css/components/inputs/Button.tsx
+++ b/apps/common-app/src/apps/css/components/inputs/Button.tsx
@@ -2,7 +2,7 @@ import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
 import type { StyleProp, ViewStyle } from 'react-native';
 import { StyleSheet, TouchableOpacity } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { GestureDetector, useTapGesture } from 'react-native-gesture-handler';
 import Animated, {
   FadeInRight,
   FadeOutLeft,
@@ -80,9 +80,11 @@ export default function Button({
 }: ButtonProps) {
   const { buttonStyle, fontVariant, iconSize } = BUTTON_VARIANTS[size];
 
+  const tapGesture = useTapGesture({ onDeactivate: onPress, runOnJS: true });
+
   return (
     <LayoutAnimationConfig skipEntering skipExiting>
-      <GestureDetector gesture={Gesture.Tap().onEnd(onPress).runOnJS(true)}>
+      <GestureDetector gesture={tapGesture}>
         <AnimatedTouchableOpacity
           activeOpacity={activeOpacity}
           disabled={disabled}

--- a/apps/common-app/src/apps/css/components/layout/TabView.tsx
+++ b/apps/common-app/src/apps/css/components/layout/TabView.tsx
@@ -11,7 +11,7 @@ import {
   useState,
 } from 'react';
 import { Dimensions, StyleSheet, View } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { GestureDetector, usePanGesture } from 'react-native-gesture-handler';
 import type { SharedValue } from 'react-native-reanimated';
 import Animated, {
   cancelAnimation,
@@ -126,50 +126,46 @@ const TabView: TabViewComponent = ({ children }: TabViewProps) => {
 
   const numberOfTabs = tabNames.length;
 
-  const swipeGesture = useMemo(
-    () =>
-      Gesture.Pan()
-        .enabled(numberOfTabs > 1)
-        .activeOffsetX([-SWIPE_ACTIVATION_DISTANCE, SWIPE_ACTIVATION_DISTANCE])
-        .failOffsetY([-SWIPE_FAIL_DISTANCE, SWIPE_FAIL_DISTANCE])
-        .onStart(() => {
-          cancelAnimation(tabProgress);
-          dragStartProgress.value = tabProgress.value;
-        })
-        .onUpdate((event) => {
-          const lastIndex = numberOfTabs - 1;
-          const raw =
-            dragStartProgress.value - event.translationX / WINDOW_WIDTH;
-          // Rubber-band past the first / last tab.
-          if (raw < 0) {
-            tabProgress.value = raw * EDGE_RESISTANCE;
-          } else if (raw > lastIndex) {
-            tabProgress.value = lastIndex + (raw - lastIndex) * EDGE_RESISTANCE;
-          } else {
-            tabProgress.value = raw;
-          }
-        })
-        .onEnd((event) => {
-          const current = selectedTabIndex.value;
-          const goNext =
-            (-event.translationX > SWIPE_DISTANCE_THRESHOLD ||
-              -event.velocityX > SWIPE_VELOCITY_THRESHOLD) &&
-            current < numberOfTabs - 1;
-          const goPrev =
-            (event.translationX > SWIPE_DISTANCE_THRESHOLD ||
-              event.velocityX > SWIPE_VELOCITY_THRESHOLD) &&
-            current > 0;
+  const swipeGesture = usePanGesture({
+    activeOffsetX: [-SWIPE_ACTIVATION_DISTANCE, SWIPE_ACTIVATION_DISTANCE],
+    enabled: numberOfTabs > 1,
+    failOffsetY: [-SWIPE_FAIL_DISTANCE, SWIPE_FAIL_DISTANCE],
+    onActivate: () => {
+      cancelAnimation(tabProgress);
+      dragStartProgress.value = tabProgress.value;
+    },
+    onDeactivate: (event) => {
+      const current = selectedTabIndex.value;
+      const goNext =
+        (-event.translationX > SWIPE_DISTANCE_THRESHOLD ||
+          -event.velocityX > SWIPE_VELOCITY_THRESHOLD) &&
+        current < numberOfTabs - 1;
+      const goPrev =
+        (event.translationX > SWIPE_DISTANCE_THRESHOLD ||
+          event.velocityX > SWIPE_VELOCITY_THRESHOLD) &&
+        current > 0;
 
-          const target = goNext ? current + 1 : goPrev ? current - 1 : current;
+      const target = goNext ? current + 1 : goPrev ? current - 1 : current;
 
-          if (target !== current) {
-            selectedTabIndex.value = target;
-            scheduleOnRN(setSelectedTabName, tabNames[target]);
-          }
-          tabProgress.value = withTiming(target);
-        }),
-    [numberOfTabs, tabNames, tabProgress, dragStartProgress, selectedTabIndex]
-  );
+      if (target !== current) {
+        selectedTabIndex.value = target;
+        scheduleOnRN(setSelectedTabName, tabNames[target]);
+      }
+      tabProgress.value = withTiming(target);
+    },
+    onUpdate: (event) => {
+      const lastIndex = numberOfTabs - 1;
+      const raw = dragStartProgress.value - event.translationX / WINDOW_WIDTH;
+      // Rubber-band past the first / last tab.
+      if (raw < 0) {
+        tabProgress.value = raw * EDGE_RESISTANCE;
+      } else if (raw > lastIndex) {
+        tabProgress.value = lastIndex + (raw - lastIndex) * EDGE_RESISTANCE;
+      } else {
+        tabProgress.value = raw;
+      }
+    },
+  });
 
   useEffect(() => {
     if (IS_WEB) {

--- a/apps/common-app/src/apps/css/components/misc/ActionSheetDropdown.tsx
+++ b/apps/common-app/src/apps/css/components/misc/ActionSheetDropdown.tsx
@@ -9,7 +9,7 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { GestureDetector, usePanGesture } from 'react-native-gesture-handler';
 import type { SharedValue } from 'react-native-reanimated';
 import Animated, {
   FadeIn,
@@ -125,6 +125,11 @@ export default function ActionSheetDropdown({
     setState({ isOpen: false, toggleMeasurements: null });
   };
 
+  const blockScrollGesture = usePanGesture({
+    onActivate: closeDropdown,
+    runOnJS: true,
+  });
+
   return (
     <>
       <Pressable hitSlop={hitSlop} onPress={openDropdown}>
@@ -139,8 +144,7 @@ export default function ActionSheetDropdown({
         {isOpen && toggleMeasurements && (
           // This gesture detector blocks scrolling when the dropdown is open
           // (this is needed for Android)
-          <GestureDetector
-            gesture={Gesture.Pan().onStart(closeDropdown).runOnJS(true)}>
+          <GestureDetector gesture={blockScrollGesture}>
             <View style={StyleSheet.absoluteFill}>
               <Backdrop handleClose={closeDropdown} />
               <DropdownContent

--- a/apps/common-app/src/apps/css/examples/transitions/screens/realWorldExamples/CircularPopupMenu.tsx
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/realWorldExamples/CircularPopupMenu.tsx
@@ -10,7 +10,7 @@ import {
 import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
 import { useState } from 'react';
 import { StyleSheet, TouchableOpacity, View } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { GestureDetector, useTapGesture } from 'react-native-gesture-handler';
 import type { CSSTransitionProperties } from 'react-native-reanimated';
 import Animated, { cubicBezier } from 'react-native-reanimated';
 
@@ -40,15 +40,17 @@ const MENU_ITEMS = [
 function CircularMenu() {
   const [open, setOpen] = useState(false);
 
+  const tapGesture = useTapGesture({
+    onDeactivate: () => setOpen(!open),
+    runOnJS: true,
+  });
+
   return (
     <Screen style={flex.center}>
       {MENU_ITEMS.map((item, index) => (
         <MenuItem icon={item.icon} index={index} key={index} open={open} />
       ))}
-      <GestureDetector
-        gesture={Gesture.Tap()
-          .onEnd(() => setOpen(!open))
-          .runOnJS(true)}>
+      <GestureDetector gesture={tapGesture}>
         <Animated.View
           style={[
             styles.menuButtonWrapper,

--- a/apps/common-app/src/apps/css/examples/transitions/screens/realWorldExamples/FlexGallery.tsx
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/realWorldExamples/FlexGallery.tsx
@@ -1,5 +1,6 @@
 import { faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
+import type { PropsWithChildren } from 'react';
 import { useMemo, useState } from 'react';
 import type { ImageSourcePropType } from 'react-native';
 import {
@@ -9,7 +10,7 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { GestureDetector, useTapGesture } from 'react-native-gesture-handler';
 import Animated, { cubicBezier } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Defs, LinearGradient, Rect, Stop, Svg } from 'react-native-svg';
@@ -68,23 +69,27 @@ export default function FlexGallery() {
           { paddingBottom: BOTTOM_BAR_HEIGHT + inset + spacing.sm },
         ]}>
         {CARDS.map(({ description, image, title }, idx) => (
-          <GestureDetector
-            key={idx}
-            gesture={Gesture.Tap()
-              .onEnd(() => setExpandedIdx(idx))
-              .runOnJS(true)}>
+          <TappableCard key={idx} onTap={() => setExpandedIdx(idx)}>
             <GalleryCard
               description={description}
               expanded={idx === expandedIdx}
               image={image}
-              key={idx}
               title={title}
             />
-          </GestureDetector>
+          </TappableCard>
         ))}
       </View>
     </Screen>
   );
+}
+
+function TappableCard({
+  children,
+  onTap,
+}: PropsWithChildren<{ onTap: () => void }>) {
+  const gesture = useTapGesture({ onDeactivate: onTap, runOnJS: true });
+
+  return <GestureDetector gesture={gesture}>{children}</GestureDetector>;
 }
 
 type GalleryCardProps = {

--- a/apps/common-app/src/apps/css/navigation/search/ExpandableHeaderScreen.tsx
+++ b/apps/common-app/src/apps/css/navigation/search/ExpandableHeaderScreen.tsx
@@ -1,7 +1,12 @@
 import { isValidElement, useEffect, useMemo } from 'react';
 import type { ScrollViewProps, StyleProp, ViewStyle } from 'react-native';
 import { StyleSheet, View } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import {
+  GestureDetector,
+  useNativeGesture,
+  usePanGesture,
+  useSimultaneousGestures,
+} from 'react-native-gesture-handler';
 import type { AnimatedRef, WithSpringConfig } from 'react-native-reanimated';
 import Animated, {
   Extrapolation,
@@ -144,55 +149,44 @@ export default function ExpandableHeaderScreen({
     },
   });
 
-  const gesture = useMemo(
-    () =>
-      Gesture.Simultaneous(
-        Gesture.Native(),
-        Gesture.Pan()
-          .onBegin(() => {
-            dragStartTranslateY.value = null;
-          })
-          .onChange((e) => {
-            dragStartTranslateY.value ??= translateY.value;
-            if (e.translationY > 0 && scrollOffsetY.value === 0) {
-              translateY.value =
-                (dragStartTranslateY.value ?? 0) +
-                Math.pow(e.translationY, 0.9);
-            } else if (
-              !isScrolling.value &&
-              e.translationY < 0 &&
-              translateY.value > 0 &&
-              scrollOffsetY.value === 0
-            ) {
-              translateY.value = Math.max(
-                0,
-                dragStartTranslateY.value + e.translationY
-              );
-            }
-          })
-          .onEnd(() => {
-            if (scrollOffsetY.value < 0 || isScrolling.value) {
-              return;
-            }
+  const nativeGesture = useNativeGesture();
 
-            if (headerShowProgress.value === 1) {
-              translateY.value = withSpring(headerHeight.value, SPRING);
-            } else {
-              translateY.value = withSpring(0, SPRING);
-            }
-          })
-          .enabled(expandEnabled)
-      ),
-    [
-      dragStartTranslateY,
-      expandEnabled,
-      headerHeight,
-      headerShowProgress,
-      isScrolling,
-      scrollOffsetY,
-      translateY,
-    ]
-  );
+  const panGesture = usePanGesture({
+    enabled: expandEnabled,
+    onBegin: () => {
+      dragStartTranslateY.value = null;
+    },
+    onDeactivate: () => {
+      if (scrollOffsetY.value < 0 || isScrolling.value) {
+        return;
+      }
+
+      if (headerShowProgress.value === 1) {
+        translateY.value = withSpring(headerHeight.value, SPRING);
+      } else {
+        translateY.value = withSpring(0, SPRING);
+      }
+    },
+    onUpdate: (e) => {
+      dragStartTranslateY.value ??= translateY.value;
+      if (e.translationY > 0 && scrollOffsetY.value === 0) {
+        translateY.value =
+          (dragStartTranslateY.value ?? 0) + Math.pow(e.translationY, 0.9);
+      } else if (
+        !isScrolling.value &&
+        e.translationY < 0 &&
+        translateY.value > 0 &&
+        scrollOffsetY.value === 0
+      ) {
+        translateY.value = Math.max(
+          0,
+          dragStartTranslateY.value + e.translationY
+        );
+      }
+    },
+  });
+
+  const gesture = useSimultaneousGestures(nativeGesture, panGesture);
 
   const animatedHeaderContainerStyle = useAnimatedStyle(() => ({
     height: Math.max(0, -totalOffsetY.value),

--- a/apps/common-app/src/apps/reanimated/examples/BouncingBoxExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/BouncingBoxExample.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
 import {
-  Gesture,
   GestureDetector,
   GestureHandlerRootView,
+  usePanGesture,
+  useRotationGesture,
+  useSimultaneousGestures,
 } from 'react-native-gesture-handler';
 import Animated, {
   interpolate,
@@ -16,32 +18,34 @@ export default function BouncingBoxExample() {
   const offset = useSharedValue(0);
   const angle = useSharedValue(0);
 
-  const pan = Gesture.Pan()
-    .minDistance(0)
-    .onChange((event) => {
+  const pan = usePanGesture({
+    minDistance: 0,
+    onFinalize: () => {
+      offset.value = withSpring(0, { damping: 20 });
+    },
+    onUpdate: (event) => {
       'worklet';
       offset.value = interpolate(
         event.translationX,
         [-100, -50, 0, 50, 100],
         [-30, -10, 0, 10, 30]
       );
-    })
-    .onFinalize(() => {
-      offset.value = withSpring(0, { damping: 20 });
-    });
+    },
+  });
 
-  const rotation = Gesture.Rotation()
-    .onChange((event) => {
+  const rotation = useRotationGesture({
+    onFinalize: () => {
+      angle.value = withSpring(0, { damping: 20 });
+    },
+    onUpdate: (event) => {
       'worklet';
       angle.value = interpolate(
         event.rotation,
         [-1.2, -1, -0.5, 0, 0.5, 1, 1.2],
         [-0.52, -0.5, -0.3, 0, 0.3, 0.5, 0.52]
       );
-    })
-    .onFinalize(() => {
-      angle.value = withSpring(0, { damping: 20 });
-    });
+    },
+  });
 
   const animatedStyles = useAnimatedStyle(() => {
     return {
@@ -52,7 +56,7 @@ export default function BouncingBoxExample() {
     };
   });
 
-  const gesture = Gesture.Simultaneous(pan, rotation);
+  const gesture = useSimultaneousGestures(pan, rotation);
 
   return (
     <GestureHandlerRootView style={styles.container}>

--- a/apps/common-app/src/apps/reanimated/examples/ChatHeadsExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/ChatHeadsExample.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Dimensions, StyleSheet, View } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { GestureDetector, usePanGesture } from 'react-native-gesture-handler';
 import Animated, {
   clamp,
   SharedValue,
@@ -18,12 +18,8 @@ function ChatHeads({
   const transX = useSharedValue(0);
   const transY = useSharedValue(0);
 
-  const gesture = Gesture.Pan()
-    .onChange((event) => {
-      transX.value += event.changeX;
-      transY.value += event.changeY;
-    })
-    .onEnd((event) => {
+  const gesture = usePanGesture({
+    onDeactivate: (event) => {
       const width = windowWidth - 100 - 40; // minus margins & width
       const height = windowHeight - 100 - 40 - 128; // minus margins & height & header height
       const toss = 0.2;
@@ -55,7 +51,12 @@ function ChatHeads({
 
       transX.value = withSpring(snapX, { velocity: event.velocityX });
       transY.value = withSpring(snapY, { velocity: event.velocityY });
-    });
+    },
+    onUpdate: (event) => {
+      transX.value += event.changeX;
+      transY.value += event.changeY;
+    },
+  });
 
   const stylez = useAnimatedStyle(() => {
     return {

--- a/apps/common-app/src/apps/reanimated/examples/ChessExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/ChessExample.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
 import {
-  Gesture,
   GestureDetector,
   GestureHandlerRootView,
+  usePanGesture,
 } from 'react-native-gesture-handler';
 import Animated, {
   clamp,
@@ -55,18 +55,12 @@ function Chessman({ row, col, color, symbol }: ChessmanProps) {
 
   const isActive = useSharedValue(false);
 
-  const gesture = Gesture.Pan()
-    .minDistance(0)
-    .onBegin(() => {
+  const gesture = usePanGesture({
+    minDistance: 0,
+    onBegin: () => {
       isActive.value = true;
-    })
-    .onChange((e) => {
-      offset.value = {
-        x: offset.value.x + e.changeX,
-        y: offset.value.y + e.changeY,
-      };
-    })
-    .onFinalize(() => {
+    },
+    onFinalize: () => {
       isActive.value = false;
       offset.value = withSpring(
         {
@@ -75,7 +69,14 @@ function Chessman({ row, col, color, symbol }: ChessmanProps) {
         },
         { duration: 300 }
       );
-    });
+    },
+    onUpdate: (e) => {
+      offset.value = {
+        x: offset.value.x + e.changeX,
+        y: offset.value.y + e.changeY,
+      };
+    },
+  });
 
   const animatedTextStyle = useAnimatedStyle(() => {
     return {

--- a/apps/common-app/src/apps/reanimated/examples/CircularSliderExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/CircularSliderExample.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import type { ColorValue } from 'react-native';
 import { StyleSheet, TextInput, View } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { GestureDetector, usePanGesture } from 'react-native-gesture-handler';
 import Animated, {
   interpolate,
   useAnimatedProps,
@@ -114,16 +114,17 @@ function CircularSlider(props: CircularSliderProps) {
     return { text, defaultValue: text };
   });
 
-  const gesture = Gesture.Pan()
-    .minDistance(0)
-    .onUpdate(({ x, y }) => {
-      currentAngle.value = cartesianToPolar({ x, y }, center);
-    })
-    .onFinalize(() => {
+  const gesture = usePanGesture({
+    minDistance: 0,
+    onFinalize: () => {
       if (onValueChange) {
         scheduleOnRN(onValueChange, currentValue.value);
       }
-    });
+    },
+    onUpdate: ({ x, y }) => {
+      currentAngle.value = cartesianToPolar({ x, y }, center);
+    },
+  });
 
   return (
     <>

--- a/apps/common-app/src/apps/reanimated/examples/DragAndSnapExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/DragAndSnapExample.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { GestureDetector, usePanGesture } from 'react-native-gesture-handler';
 import Animated, {
   Extrapolation,
   interpolate,
@@ -13,15 +13,16 @@ export default function DragAndSnapExample() {
   const translationX = useSharedValue(0);
   const translationY = useSharedValue(0);
 
-  const gesture = Gesture.Pan()
-    .onChange((event) => {
-      translationX.value += event.changeX;
-      translationY.value += event.changeY;
-    })
-    .onEnd(() => {
+  const gesture = usePanGesture({
+    onDeactivate: () => {
       translationX.value = withSpring(0);
       translationY.value = withSpring(0);
-    });
+    },
+    onUpdate: (event) => {
+      translationX.value += event.changeX;
+      translationY.value += event.changeY;
+    },
+  });
 
   const stylez = useAnimatedStyle(() => {
     const H = Math.round(

--- a/apps/common-app/src/apps/reanimated/examples/ExtrapolationExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/ExtrapolationExample.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { StyleSheet } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { GestureDetector, usePanGesture } from 'react-native-gesture-handler';
 import Animated, {
   Extrapolation,
   interpolate,
@@ -12,13 +12,14 @@ import Animated, {
 export default function ExtrapolationExample() {
   const translateY = useSharedValue(0);
 
-  const gesture = Gesture.Pan()
-    .onChange((event) => {
-      translateY.value += event.changeY;
-    })
-    .onEnd(() => {
+  const gesture = usePanGesture({
+    onDeactivate: () => {
       translateY.value = withTiming(0);
-    });
+    },
+    onUpdate: (event) => {
+      translateY.value += event.changeY;
+    },
+  });
 
   const button1Style = useAnimatedStyle(() => {
     const translateX = Math.round(

--- a/apps/common-app/src/apps/reanimated/examples/Game2048Example.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/Game2048Example.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import type { ColorValue } from 'react-native';
 import { Alert, StyleSheet, Text, View } from 'react-native';
 import {
-  Gesture,
   GestureDetector,
   GestureHandlerRootView,
+  usePanGesture,
 } from 'react-native-gesture-handler';
 import Animated, { LinearTransition, ZoomIn } from 'react-native-reanimated';
 
@@ -230,9 +230,8 @@ export default function Game2048Example() {
     setGameOver(false);
   }, []);
 
-  const fling = Gesture.Pan()
-    .runOnJS(true)
-    .onEnd((e) => {
+  const fling = usePanGesture({
+    onDeactivate: (e) => {
       if (gameOver) {
         return;
       }
@@ -247,7 +246,9 @@ export default function Game2048Example() {
           ]);
         }, 500);
       }
-    });
+    },
+    runOnJS: true,
+  });
 
   return (
     <GestureHandlerRootView style={styles.container}>

--- a/apps/common-app/src/apps/reanimated/examples/GestureHandlerExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/GestureHandlerExample.tsx
@@ -1,15 +1,14 @@
 import React from 'react';
 import { StyleSheet } from 'react-native';
 import type {
-  LegacyGestureStateManager,
   GestureTouchEvent,
-  GestureUpdateEvent,
-  PanGestureChangeEventPayload,
+  PanGestureActiveEvent,
 } from 'react-native-gesture-handler';
 import {
-  Gesture,
   GestureDetector,
   GestureHandlerRootView,
+  GestureStateManager,
+  usePanGesture,
 } from 'react-native-gesture-handler';
 import Animated, {
   useAnimatedStyle,
@@ -32,28 +31,27 @@ function Ball() {
     };
   });
 
-  const gesture = Gesture.Pan()
-    .manualActivation(true)
-    .onBegin(() => {
+  const gesture = usePanGesture({
+    manualActivation: true,
+    onBegin: () => {
       'worklet';
       isPressed.value = true;
-    })
-    .onChange((e: GestureUpdateEvent<PanGestureChangeEventPayload>) => {
+    },
+    onFinalize: () => {
+      'worklet';
+      isPressed.value = false;
+    },
+    onTouchesMove: (e: GestureTouchEvent) => {
+      GestureStateManager.activate(e.handlerTag);
+    },
+    onUpdate: (e: PanGestureActiveEvent) => {
       'worklet';
       offset.value = {
         x: e.changeX + offset.value.x,
         y: e.changeY + offset.value.y,
       };
-    })
-    .onFinalize(() => {
-      'worklet';
-      isPressed.value = false;
-    })
-    .onTouchesMove(
-      (_e: GestureTouchEvent, state: LegacyGestureStateManager) => {
-        state.activate();
-      }
-    );
+    },
+  });
 
   return (
     <GestureDetector gesture={gesture}>

--- a/apps/common-app/src/apps/reanimated/examples/IPodExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/IPodExample.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Dimensions, StyleSheet, Text, View } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { GestureDetector, usePanGesture } from 'react-native-gesture-handler';
 import type { SharedValue } from 'react-native-reanimated';
 import Animated, {
   Extrapolation,
@@ -74,12 +74,15 @@ export default function IPodExample() {
   const start = useSharedValue({ x: 0, y: 0 });
   const last = useSharedValue({ x: 0, y: 0 });
 
-  const gesture = Gesture.Pan()
-    .onBegin((e) => {
+  const gesture = usePanGesture({
+    onBegin: (e) => {
       start.value = { x: e.x, y: e.y };
       last.value = { x: e.x, y: e.y };
-    })
-    .onUpdate((e) => {
+    },
+    onDeactivate: () => {
+      scrollToNearestItem(position.value);
+    },
+    onUpdate: (e) => {
       const currentPos = { x: e.x, y: e.y };
       const lastPos = last.value;
       last.value = currentPos;
@@ -114,10 +117,8 @@ export default function IPodExample() {
         Extrapolation.CLAMP
       );
       scrollTo(animatedRef, position.value, 0, false);
-    })
-    .onEnd(() => {
-      scrollToNearestItem(position.value);
-    });
+    },
+  });
 
   return (
     <View style={styles.ipod}>

--- a/apps/common-app/src/apps/reanimated/examples/LightBoxExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/LightBoxExample.tsx
@@ -13,7 +13,7 @@ import {
 } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 import type { SharedValue } from 'react-native-reanimated';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { GestureDetector, usePanGesture } from 'react-native-gesture-handler';
 import Animated, {
   Easing,
   Extrapolation,
@@ -141,26 +141,8 @@ function ImageTransition({ activeImage, onClose }: ImageTransitionProps) {
   const translateX = useSharedValue(0);
   const translateY = useSharedValue(0);
 
-  const gesture = Gesture.Pan()
-    .onChange((event) => {
-      translateX.value = event.translationX;
-      translateY.value = event.translationY;
-
-      scale.value = interpolate(
-        translateY.value,
-        [-200, 0, 200],
-        [0.65, 1, 0.65],
-        Extrapolation.CLAMP
-      );
-
-      backdropOpacity.value = interpolate(
-        translateY.value,
-        [-100, 0, 100],
-        [0, 1, 0],
-        Extrapolation.CLAMP
-      );
-    })
-    .onEnd(() => {
+  const gesture = usePanGesture({
+    onDeactivate: () => {
       if (Math.abs(translateY.value) > 40) {
         targetX.value = translateX.value - targetX.value * -1;
         targetY.value = translateY.value - targetY.value * -1;
@@ -181,7 +163,26 @@ function ImageTransition({ activeImage, onClose }: ImageTransitionProps) {
       }
 
       scale.value = withTiming(1, timingConfig);
-    });
+    },
+    onUpdate: (event) => {
+      translateX.value = event.translationX;
+      translateY.value = event.translationY;
+
+      scale.value = interpolate(
+        translateY.value,
+        [-200, 0, 200],
+        [0.65, 1, 0.65],
+        Extrapolation.CLAMP
+      );
+
+      backdropOpacity.value = interpolate(
+        translateY.value,
+        [-100, 0, 100],
+        [0, 1, 0],
+        Extrapolation.CLAMP
+      );
+    },
+  });
 
   const imageStyles = useAnimatedStyle(() => {
     const interpolateProgress = (range: [number, number]) =>

--- a/apps/common-app/src/apps/reanimated/examples/LiquidSwipe/LiquidSwipe.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/LiquidSwipe/LiquidSwipe.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Dimensions, StyleSheet } from 'react-native';
 import {
-  Gesture,
   GestureDetector,
   GestureHandlerRootView,
+  usePanGesture,
 } from 'react-native-gesture-handler';
 import Animated, {
   cancelAnimation,
@@ -39,14 +39,22 @@ export default function LiquidSwipe() {
 
   const maxDist = width - initialSideWidth;
 
-  const gesture = Gesture.Pan()
-    .onStart((event) => {
+  const gesture = usePanGesture({
+    onActivate: (event) => {
       // stop animating progress, this will also place "isBack" value in the
       // final state (we update isBack in progress animation callback)
       cancelAnimation(progress);
       startY.value = isBack.value ? event.y : centerY.value;
-    })
-    .onChange((event) => {
+    },
+    onDeactivate: () => {
+      const threshold = isBack.value ? 0.5 : 0.2;
+      const goBack = progress.value > threshold;
+      centerY.value = withSpring(initialWaveCenter);
+      progress.value = withSpring(goBack ? 1 : 0, {}, () => {
+        isBack.value = goBack;
+      });
+    },
+    onUpdate: (event) => {
       centerY.value = startY.value + event.translationY;
       if (isBack.value) {
         progress.value = interpolate(
@@ -63,15 +71,8 @@ export default function LiquidSwipe() {
           Extrapolation.CLAMP
         );
       }
-    })
-    .onEnd(() => {
-      const threshold = isBack.value ? 0.5 : 0.2;
-      const goBack = progress.value > threshold;
-      centerY.value = withSpring(initialWaveCenter);
-      progress.value = withSpring(goBack ? 1 : 0, {}, () => {
-        isBack.value = goBack;
-      });
-    });
+    },
+  });
 
   return (
     <GestureHandlerRootView style={styles.container}>

--- a/apps/common-app/src/apps/reanimated/examples/OldMeasureExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/OldMeasureExample.tsx
@@ -3,7 +3,7 @@ import '../types';
 import type { ReactElement, ReactNode } from 'react';
 import React, { useRef } from 'react';
 import { Platform, SafeAreaView, StyleSheet, Text, View } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { GestureDetector, useTapGesture } from 'react-native-gesture-handler';
 import type { AnimatedRef, SharedValue } from 'react-native-reanimated';
 import Animated, {
   Easing,
@@ -198,7 +198,7 @@ function SectionHeader({
     };
   }
 
-  const gesture = Gesture.Tap().onBegin(onActiveImpl);
+  const gesture = useTapGesture({ onBegin: onActiveImpl });
 
   return (
     <View style={styles.sectionHeader}>

--- a/apps/common-app/src/apps/reanimated/examples/PendulumExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/PendulumExample.tsx
@@ -7,14 +7,12 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-import type {
-  LegacyGestureStateManager,
-  GestureTouchEvent,
-} from 'react-native-gesture-handler';
+import type { GestureTouchEvent } from 'react-native-gesture-handler';
 import {
-  Gesture,
   GestureDetector,
   GestureHandlerRootView,
+  GestureStateManager,
+  usePanGesture,
 } from 'react-native-gesture-handler';
 import Animated, {
   useAnimatedStyle,
@@ -85,24 +83,23 @@ export default function SpringExample() {
     };
   });
 
-  const gesture = Gesture.Pan()
-    .manualActivation(true)
-    .onChange((e) => {
+  const gesture = usePanGesture({
+    manualActivation: true,
+    onFinalize: () => {
+      pendulumSwing.value = withSpring(0, config);
+    },
+    onTouchesMove: (e: GestureTouchEvent) => {
+      GestureStateManager.activate(e.handlerTag);
+    },
+    onUpdate: (e) => {
       offset.value = {
         x: e.x,
         y: e.y,
       };
       pendulumSwing.value =
         (Math.atan2(-offset.value.x + 140 / 2, offset.value.y) * 180) / Math.PI;
-    })
-    .onFinalize(() => {
-      pendulumSwing.value = withSpring(0, config);
-    })
-    .onTouchesMove(
-      (_e: GestureTouchEvent, state: LegacyGestureStateManager) => {
-        state.activate();
-      }
-    );
+    },
+  });
 
   const fields: Array<FieldDefinition> = [
     { fieldName: 'Mass', value: mass, setValue: setMass },

--- a/apps/common-app/src/apps/reanimated/examples/PinExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/PinExample.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Platform, SafeAreaView, StyleSheet, Text, View } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { GestureDetector, usePanGesture } from 'react-native-gesture-handler';
 import { SharedValue } from 'react-native-reanimated';
 import Animated, {
   scrollTo,
@@ -95,19 +95,20 @@ function ProgressBar({ progress }: { progress: SharedValue<number> }) {
   const startX = useSharedValue(0);
   const max = useSharedValue(0);
 
-  const gesture = Gesture.Pan()
-    .onStart(() => {
+  const gesture = usePanGesture({
+    onActivate: () => {
       startX.value = x.value;
-    })
-    .onUpdate((e) => {
+    },
+    onDeactivate: () => {
+      progress.value = x.value / max.value;
+    },
+    onUpdate: (e) => {
       let newVal = startX.value + e.translationX;
       newVal = Math.min(max.value, newVal);
       newVal = Math.max(0, newVal);
       x.value = newVal;
-    })
-    .onEnd(() => {
-      progress.value = x.value / max.value;
-    });
+    },
+  });
 
   const stylez = useAnimatedStyle(() => {
     return {

--- a/apps/common-app/src/apps/reanimated/examples/ReducedMotionExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/ReducedMotionExample.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
 import { Button, StyleSheet, Text, View } from 'react-native';
 import {
-  Gesture,
   GestureDetector,
   GestureHandlerRootView,
+  usePanGesture,
 } from 'react-native-gesture-handler';
 import Animated, {
   ReducedMotionConfig,
@@ -215,16 +215,17 @@ function Example(props: { animation: () => number; text: string }) {
 function DecayExample() {
   const offset = useSharedValue(0);
 
-  const pan = Gesture.Pan()
-    .onChange((event) => {
-      offset.value += event.changeX;
-    })
-    .onFinalize((event) => {
+  const pan = usePanGesture({
+    onDeactivate: (event) => {
       offset.value = withDecay({
         velocity: event.velocityX,
         clamp: [initialValue, toValue],
       });
-    });
+    },
+    onUpdate: (event) => {
+      offset.value += event.changeX;
+    },
+  });
 
   const animatedStyles = useAnimatedStyle(() => ({
     transform: [{ translateX: offset.value }],

--- a/apps/common-app/src/apps/reanimated/examples/ScreenStackHeaderConfigBackgroundColorExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/ScreenStackHeaderConfigBackgroundColorExample.tsx
@@ -1,13 +1,10 @@
 import React, { useCallback } from 'react';
 import { Button, StyleSheet, Text, View } from 'react-native';
-import type {
-  GestureUpdateEvent,
-  PanGestureChangeEventPayload,
-} from 'react-native-gesture-handler';
+import type { PanGestureActiveEvent } from 'react-native-gesture-handler';
 import {
-  Gesture,
   GestureDetector,
   GestureHandlerRootView,
+  usePanGesture,
 } from 'react-native-gesture-handler';
 import Animated, {
   useAnimatedProps,
@@ -28,23 +25,24 @@ export default function ScreenStackHeaderConfigBackgroundColorExample() {
   const isPressed = useSharedValue(false);
   const offset = useSharedValue({ x: 0, y: 0 });
 
-  const gesture = Gesture.Pan()
-    .minDistance(0)
-    .onBegin(() => {
+  const gesture = usePanGesture({
+    minDistance: 0,
+    onBegin: () => {
       'worklet';
       isPressed.value = true;
-    })
-    .onChange((e: GestureUpdateEvent<PanGestureChangeEventPayload>) => {
+    },
+    onFinalize: () => {
+      'worklet';
+      isPressed.value = false;
+    },
+    onUpdate: (e: PanGestureActiveEvent) => {
       'worklet';
       offset.value = {
         x: e.changeX + offset.value.x,
         y: e.changeY + offset.value.y,
       };
-    })
-    .onFinalize(() => {
-      'worklet';
-      isPressed.value = false;
-    });
+    },
+  });
 
   const animatedStyles = useAnimatedStyle(() => {
     return {

--- a/apps/common-app/src/apps/reanimated/examples/ScrollableViewExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/ScrollableViewExample.tsx
@@ -2,7 +2,7 @@ import { useHeaderHeight } from '@react-navigation/elements';
 import type React from 'react';
 import type { LayoutChangeEvent } from 'react-native';
 import { Dimensions, Platform, StyleSheet, View } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { GestureDetector, usePanGesture } from 'react-native-gesture-handler';
 import Animated, {
   Easing,
   useAnimatedStyle,
@@ -61,25 +61,13 @@ function ScrollableView({
 
   const startY = useSharedValue(0);
 
-  const gesture = Gesture.Pan()
-    .onBegin(() => {
+  const gesture = usePanGesture({
+    onBegin: () => {
       const currentTranslateY = translateY.value;
       startY.value = currentTranslateY;
       translateY.value = currentTranslateY; // for stop animation (assigning to a shared value stops running animation)
-    })
-    .onUpdate((event) => {
-      const nextTranslate = startY.value + event.translationY;
-
-      if (nextTranslate < loverBound.value) {
-        translateY.value =
-          loverBound.value + friction(nextTranslate - loverBound.value);
-      } else if (nextTranslate > 0) {
-        translateY.value = friction(nextTranslate);
-      } else {
-        translateY.value = nextTranslate;
-      }
-    })
-    .onEnd((event) => {
+    },
+    onDeactivate: (event) => {
       if (translateY.value < loverBound.value || translateY.value > 0) {
         const toValue = translateY.value > 0 ? 0 : loverBound.value;
 
@@ -93,7 +81,20 @@ function ScrollableView({
           velocity: event.velocityY,
         });
       }
-    });
+    },
+    onUpdate: (event) => {
+      const nextTranslate = startY.value + event.translationY;
+
+      if (nextTranslate < loverBound.value) {
+        translateY.value =
+          loverBound.value + friction(nextTranslate - loverBound.value);
+      } else if (nextTranslate > 0) {
+        translateY.value = friction(nextTranslate);
+      } else {
+        translateY.value = nextTranslate;
+      }
+    },
+  });
 
   const animatedStyles = useAnimatedStyle(() => {
     return {

--- a/apps/common-app/src/apps/reanimated/examples/SetNativePropsExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/SetNativePropsExample.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Button, StyleSheet, TextInput } from 'react-native';
 import {
-  Gesture,
   GestureDetector,
   GestureHandlerRootView,
+  useTapGesture,
 } from 'react-native-gesture-handler';
 import Animated, {
   setNativeProps,
@@ -31,13 +31,15 @@ export default function SetNativePropsExample() {
     setText(''); // calling setText affects the JS state but doesn't update the native view
   };
 
-  const tap = Gesture.Tap().onEnd(() => {
-    'worklet';
-    setNativeProps(animatedRef, {
-      text: '',
-      backgroundColor: `hsl(${Math.random() * 360}, 100%, 50%)`,
-    });
-    scheduleOnRN(send);
+  const tap = useTapGesture({
+    onDeactivate: () => {
+      'worklet';
+      setNativeProps(animatedRef, {
+        text: '',
+        backgroundColor: `hsl(${Math.random() * 360}, 100%, 50%)`,
+      });
+      scheduleOnRN(send);
+    },
   });
 
   return (

--- a/apps/common-app/src/apps/reanimated/examples/SharedElementTransitions/Modals.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/SharedElementTransitions/Modals.tsx
@@ -2,7 +2,7 @@ import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import * as React from 'react';
 import { Pressable, StyleSheet } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { GestureDetector, usePanGesture } from 'react-native-gesture-handler';
 import Animated, {
   runOnJS,
   useAnimatedStyle,
@@ -114,22 +114,23 @@ function Screen2Content({
     y: useSharedValue(0),
   };
 
-  const gestureHandler = Gesture.Pan()
-    .onStart((event) => {
+  const gestureHandler = usePanGesture({
+    onActivate: (event) => {
       // ctx.startX = translation.x.value;
       // ctx.startY = translation.y.value;
-    })
-    .onUpdate((event) => {
-      translation.x.value = event.translationX;
-      translation.y.value = event.translationY;
-    })
-    .onEnd((_) => {
+    },
+    onDeactivate: (_) => {
       if (Math.abs(translation.x.value) + Math.abs(translation.y.value) > 150) {
         runOnJS(goNext)();
       }
       translation.x.value = withSpring(0);
       translation.y.value = withSpring(0);
-    });
+    },
+    onUpdate: (event) => {
+      translation.x.value = event.translationX;
+      translation.y.value = event.translationY;
+    },
+  });
 
   const animatedStyle = useAnimatedStyle(() => {
     return {

--- a/apps/common-app/src/apps/reanimated/examples/SharedElementTransitions/Profiles.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/SharedElementTransitions/Profiles.tsx
@@ -13,7 +13,7 @@ import {
   Text,
   View,
 } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { GestureDetector, usePanGesture } from 'react-native-gesture-handler';
 import Animated, {
   FadeIn,
   SharedTransition,
@@ -375,8 +375,12 @@ function DetailsScreenContent({
     navigation.goBack();
   };
 
-  const pan = Gesture.Pan()
-    .onChange((event) => {
+  const pan = usePanGesture({
+    onFinalize: () => {
+      translation.x.value = withSpring(0, springOptions);
+      translation.y.value = withSpring(0, springOptions);
+    },
+    onUpdate: (event) => {
       translation.x.value += event.changeX;
       translation.y.value += event.changeY;
 
@@ -391,11 +395,8 @@ function DetailsScreenContent({
           scheduleOnRN(goBack);
         }
       }
-    })
-    .onFinalize(() => {
-      translation.x.value = withSpring(0, springOptions);
-      translation.y.value = withSpring(0, springOptions);
-    });
+    },
+  });
 
   const animatedStyle = useAnimatedStyle(() => {
     return {

--- a/apps/common-app/src/apps/reanimated/examples/StrictDOMExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/StrictDOMExample.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { GestureDetector, usePanGesture } from 'react-native-gesture-handler';
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
@@ -48,15 +48,16 @@ export default function StrictDOMExample() {
     };
   }) as css.StyleXStyles;
 
-  const panGesture = Gesture.Pan()
-    .onUpdate((e) => {
-      x.value = e.translationX;
-      y.value = e.translationY;
-    })
-    .onEnd(() => {
+  const panGesture = usePanGesture({
+    onDeactivate: () => {
       x.value = withSpring(0);
       y.value = withSpring(0);
-    });
+    },
+    onUpdate: (e) => {
+      x.value = e.translationX;
+      y.value = e.translationY;
+    },
+  });
 
   useEffect(() => {
     opacity.value = withRepeat(withTiming(0.3, { duration: 800 }), -1, true);

--- a/apps/common-app/src/apps/reanimated/examples/SwipeableListExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/SwipeableListExample.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import {
   Alert,
   Dimensions,
@@ -9,8 +9,8 @@ import {
 } from 'react-native';
 import {
   FlatList,
-  Gesture,
   GestureDetector,
+  usePanGesture,
 } from 'react-native-gesture-handler';
 import Animated, {
   Easing,
@@ -106,32 +106,26 @@ function ListItem({ item, onRemove }: ListItemProps) {
   const startX = useSharedValue(0);
   const translateX = useSharedValue(0);
 
-  const panGesture = useMemo(
-    () =>
-      Gesture.Pan()
-        .activeOffsetX([-10, 10])
-        .onStart(() => {
-          startX.value = translateX.value;
-        })
-        .onUpdate((evt) => {
-          const nextTranslate = startX.value + evt.translationX;
-          translateX.value = Math.min(
-            0,
-            Math.max(nextTranslate, MAX_TRANSLATE)
-          );
-        })
-        .onEnd((evt) => {
-          if (evt.velocityX < -20) {
-            translateX.value = withSpring(
-              MAX_TRANSLATE,
-              springConfig(evt.velocityX)
-            );
-          } else {
-            translateX.value = withSpring(0, springConfig(evt.velocityX));
-          }
-        }),
-    [startX, translateX]
-  );
+  const panGesture = usePanGesture({
+    activeOffsetX: [-10, 10],
+    onActivate: () => {
+      startX.value = translateX.value;
+    },
+    onDeactivate: (evt) => {
+      if (evt.velocityX < -20) {
+        translateX.value = withSpring(
+          MAX_TRANSLATE,
+          springConfig(evt.velocityX)
+        );
+      } else {
+        translateX.value = withSpring(0, springConfig(evt.velocityX));
+      }
+    },
+    onUpdate: (evt) => {
+      const nextTranslate = startX.value + evt.translationX;
+      translateX.value = Math.min(0, Math.max(nextTranslate, MAX_TRANSLATE));
+    },
+  });
 
   const styles = useAnimatedStyle(() => {
     if (isRemoving.value) {

--- a/apps/common-app/src/apps/reanimated/examples/WithoutBabelPluginExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/WithoutBabelPluginExample.tsx
@@ -1,6 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import {
+  GestureDetector,
+  GestureStateManager,
+  usePanGesture,
+} from 'react-native-gesture-handler';
 import Animated, {
   isWorkletFunction,
   useAnimatedStyle,
@@ -39,26 +43,28 @@ function WithBabel() {
     };
   });
 
-  const gesture = Gesture.Pan()
-    .manualActivation(true)
-    .onBegin(() => {
+  const gesture = usePanGesture({
+    manualActivation: true,
+    onBegin: () => {
       'worklet';
       isPressed.value = true;
-    })
-    .onChange((e) => {
+    },
+    onFinalize: () => {
+      'worklet';
+      isPressed.value = false;
+    },
+    onTouchesMove: (e) => {
+      'worklet';
+      GestureStateManager.activate(e.handlerTag);
+    },
+    onUpdate: (e) => {
       'worklet';
       offset.value = {
         x: e.changeX + offset.value.x,
         y: e.changeY + offset.value.y,
       };
-    })
-    .onFinalize(() => {
-      'worklet';
-      isPressed.value = false;
-    })
-    .onTouchesMove((_, state) => {
-      state.activate();
-    });
+    },
+  });
 
   return (
     <GestureDetector gesture={gesture}>
@@ -98,26 +104,28 @@ export function WithoutBabel() {
     };
   }, [isPressed, offset, stateObject, stateBoolean, stateNumber]);
 
-  const gesture = Gesture.Pan()
-    .manualActivation(true)
-    .onBegin(() => {
+  const gesture = usePanGesture({
+    manualActivation: true,
+    onBegin: () => {
       'worklet';
       isPressed.value = true;
-    })
-    .onChange((e) => {
+    },
+    onFinalize: () => {
+      'worklet';
+      isPressed.value = false;
+    },
+    onTouchesMove: (e) => {
+      'worklet';
+      GestureStateManager.activate(e.handlerTag);
+    },
+    onUpdate: (e) => {
       'worklet';
       offset.value = {
         x: e.changeX + offset.value.x,
         y: e.changeY + offset.value.y,
       };
-    })
-    .onFinalize(() => {
-      'worklet';
-      isPressed.value = false;
-    })
-    .onTouchesMove((_, state) => {
-      state.activate();
-    });
+    },
+  });
 
   return (
     <GestureDetector gesture={gesture}>


### PR DESCRIPTION
## Summary

This is in preparation for enabling strictmode in fabric example, we need the new api to be able to ditch LegacyGestureDetector in favor of GestureDetector, which benefits from recent changes in RNGH in relation to strictmode.

Related: https://github.com/software-mansion/react-native-gesture-handler/pull/4369

## Test plan

Went through rngh examples in fabric example