### PR TITLE
fix(Reanimated): fix shared values passed as inline top-level props

### DIFF
--- a/packages/react-native-reanimated/src/createAnimatedComponent/InlinePropManager.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/InlinePropManager.ts
@@ -13,6 +13,8 @@ import type {
 } from './commonTypes';
 import { flattenArray } from './utils';
 
+type InlinePropsMap = Record<string, unknown>;
+
 function isInlineStyleTransform(transform: unknown): boolean {
   if (!Array.isArray(transform)) {
     return false;
@@ -22,8 +24,8 @@ function isInlineStyleTransform(transform: unknown): boolean {
 }
 
 function inlinePropsHasChanged(
-  styles1: StyleProps,
-  styles2: StyleProps
+  styles1: InlinePropsMap,
+  styles2: InlinePropsMap
 ): boolean {
   if (Object.keys(styles1).length !== Object.keys(styles2).length) {
     return true;
@@ -132,7 +134,8 @@ export function getInlineStyle(
 export class InlinePropManager implements IInlinePropManager {
   _inlinePropsViewDescriptors: ViewDescriptorsSet | null = null;
   _inlinePropsMapperId: number | null = null;
-  _inlineProps: StyleProps = {};
+  _inlineStyleProps: InlinePropsMap = {};
+  _inlineTopLevelProps: InlinePropsMap = {};
 
   public attachInlineProps(
     animatedComponent: AnimatedComponentTypeInternal,
@@ -140,11 +143,9 @@ export class InlinePropManager implements IInlinePropManager {
   ) {
     const { inlineStyleProps, inlineTopLevelProps } =
       extractSharedValuesMapFromProps(animatedComponent.props);
-    const newInlineProps: Record<string, unknown> = {
-      ...inlineStyleProps,
-      ...inlineTopLevelProps,
-    };
-    const hasChanged = inlinePropsHasChanged(newInlineProps, this._inlineProps);
+    const hasChanged =
+      inlinePropsHasChanged(inlineStyleProps, this._inlineStyleProps) ||
+      inlinePropsHasChanged(inlineTopLevelProps, this._inlineTopLevelProps);
 
     if (hasChanged) {
       if (!this._inlinePropsViewDescriptors) {
@@ -163,6 +164,7 @@ export class InlinePropManager implements IInlinePropManager {
       const hasInlineStyleProps = Object.keys(inlineStyleProps).length > 0;
       const hasInlineTopLevelProps =
         Object.keys(inlineTopLevelProps).length > 0;
+      const hasInlineProps = hasInlineStyleProps || hasInlineTopLevelProps;
       const updaterFunction = () => {
         'worklet';
         if (hasInlineStyleProps) {
@@ -183,16 +185,18 @@ export class InlinePropManager implements IInlinePropManager {
           );
         }
       };
-      this._inlineProps = newInlineProps;
+      this._inlineStyleProps = inlineStyleProps;
+      this._inlineTopLevelProps = inlineTopLevelProps;
+
       if (this._inlinePropsMapperId) {
         stopMapper(this._inlinePropsMapperId);
       }
       this._inlinePropsMapperId = null;
-      if (Object.keys(newInlineProps).length) {
-        this._inlinePropsMapperId = startMapper(
-          updaterFunction,
-          Object.values(newInlineProps)
-        );
+      if (hasInlineProps) {
+        this._inlinePropsMapperId = startMapper(updaterFunction, [
+          inlineStyleProps,
+          inlineTopLevelProps,
+        ]);
       }
     }
   }
@@ -203,6 +207,7 @@ export class InlinePropManager implements IInlinePropManager {
       this._inlinePropsMapperId = null;
     }
     this._inlinePropsViewDescriptors = null;
-    this._inlineProps = {};
+    this._inlineStyleProps = {};
+    this._inlineTopLevelProps = {};
   }
 }

--- a/packages/react-native-reanimated/src/createAnimatedComponent/InlinePropManager.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/InlinePropManager.ts
@@ -1,4 +1,5 @@
 'use strict';
+import type { UnknownRecord } from '../common';
 import type { StyleProps } from '../commonTypes';
 import { isSharedValue } from '../isSharedValue';
 import { startMapper, stopMapper } from '../mappers';
@@ -13,8 +14,6 @@ import type {
 } from './commonTypes';
 import { flattenArray } from './utils';
 
-type InlinePropsMap = Record<string, unknown>;
-
 function isInlineStyleTransform(transform: unknown): boolean {
   if (!Array.isArray(transform)) {
     return false;
@@ -24,15 +23,15 @@ function isInlineStyleTransform(transform: unknown): boolean {
 }
 
 function inlinePropsHasChanged(
-  styles1: InlinePropsMap,
-  styles2: InlinePropsMap
+  props1: UnknownRecord,
+  props2: UnknownRecord
 ): boolean {
-  if (Object.keys(styles1).length !== Object.keys(styles2).length) {
+  if (Object.keys(props1).length !== Object.keys(props2).length) {
     return true;
   }
 
-  for (const key of Object.keys(styles1)) {
-    if (styles1[key] !== styles2[key]) {
+  for (const key of Object.keys(props1)) {
+    if (props1[key] !== props2[key]) {
       return true;
     }
   }
@@ -134,8 +133,8 @@ export function getInlineStyle(
 export class InlinePropManager implements IInlinePropManager {
   _inlinePropsViewDescriptors: ViewDescriptorsSet | null = null;
   _inlinePropsMapperId: number | null = null;
-  _inlineStyleProps: InlinePropsMap = {};
-  _inlineTopLevelProps: InlinePropsMap = {};
+  _inlineStyleProps: UnknownRecord = {};
+  _inlineTopLevelProps: UnknownRecord = {};
 
   public attachInlineProps(
     animatedComponent: AnimatedComponentTypeInternal,

--- a/packages/react-native-reanimated/src/createAnimatedComponent/InlinePropManager.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/InlinePropManager.ts
@@ -60,8 +60,12 @@ function extractSharedValuesMapFromProps(
   props: AnimatedComponentProps<
     Record<string, unknown> /* Initial component props */
   >
-): Record<string, unknown> {
-  const inlineProps: Record<string, unknown> = {};
+): {
+  inlineStyleProps: Record<string, unknown>;
+  inlineTopLevelProps: Record<string, unknown>;
+} {
+  const inlineStyleProps: Record<string, unknown> = {};
+  const inlineTopLevelProps: Record<string, unknown> = {};
 
   for (const key in props) {
     const value = props[key];
@@ -76,21 +80,21 @@ function extractSharedValuesMapFromProps(
         }
         for (const [styleKey, styleValue] of Object.entries(style)) {
           if (isSharedValue(styleValue)) {
-            inlineProps[styleKey] = styleValue;
+            inlineStyleProps[styleKey] = styleValue;
           } else if (
             styleKey === 'transform' &&
             isInlineStyleTransform(styleValue)
           ) {
-            inlineProps[styleKey] = styleValue;
+            inlineStyleProps[styleKey] = styleValue;
           }
         }
       });
     } else if (isSharedValue(value)) {
-      inlineProps[key] = value;
+      inlineTopLevelProps[key] = value;
     }
   }
 
-  return inlineProps;
+  return { inlineStyleProps, inlineTopLevelProps };
 }
 
 export function hasInlineStyles(style: StyleProps): boolean {
@@ -134,8 +138,12 @@ export class InlinePropManager implements IInlinePropManager {
     animatedComponent: AnimatedComponentTypeInternal,
     viewInfo: ViewInfo
   ) {
-    const newInlineProps: Record<string, unknown> =
+    const { inlineStyleProps, inlineTopLevelProps } =
       extractSharedValuesMapFromProps(animatedComponent.props);
+    const newInlineProps: Record<string, unknown> = {
+      ...inlineStyleProps,
+      ...inlineTopLevelProps,
+    };
     const hasChanged = inlinePropsHasChanged(newInlineProps, this._inlineProps);
 
     if (hasChanged) {
@@ -152,10 +160,28 @@ export class InlinePropManager implements IInlinePropManager {
       const shareableViewDescriptors =
         this._inlinePropsViewDescriptors.shareableViewDescriptors;
 
+      const hasInlineStyleProps = Object.keys(inlineStyleProps).length > 0;
+      const hasInlineTopLevelProps =
+        Object.keys(inlineTopLevelProps).length > 0;
       const updaterFunction = () => {
         'worklet';
-        const update = getInlinePropsUpdate(newInlineProps);
-        updateProps(shareableViewDescriptors, update);
+        if (hasInlineStyleProps) {
+          updateProps(
+            shareableViewDescriptors,
+            getInlinePropsUpdate(inlineStyleProps) as StyleProps
+          );
+        }
+        if (hasInlineTopLevelProps) {
+          // Shared values passed directly as top-level props are animated
+          // props, not styles — process them like `useAnimatedProps` updates
+          // (in particular, don't run them through the style props builder,
+          // which drops non-style keys).
+          updateProps(
+            shareableViewDescriptors,
+            getInlinePropsUpdate(inlineTopLevelProps) as StyleProps,
+            true
+          );
+        }
       };
       this._inlineProps = newInlineProps;
       if (this._inlinePropsMapperId) {


### PR DESCRIPTION
> [!NOTE]
> This pull request was authored by AI on behalf of @tomekzaw and @pawicao 

## Summary

Fixes #10147.

Shared values passed directly as top-level props, such as `<AnimatedSwitch value={value} />`, were incorrectly processed as styles. As a result, component-specific props such as `value`, `fill`, and `text` were dropped by the style props builder and never reached the native view.

This change separates inline styles from inline top-level props:

- Inline styles continue through the style update path.
- Inline top-level props use the animated props update path, matching `useAnimatedProps`.

## Test plan

Run the Fabric example app and open **Reanimated → Inline styles and props**.

Press **Toggle** and verify that both switches change state together.

Also verified:

- Inline styles, SVG props, Switch props, and TextInput props through a complete toggle cycle on the iOS Fabric example.
- No JavaScript runtime errors.
- Focused inline-style and animated-props Jest suites pass.
- Native and web TypeScript checks pass.
- ESLint and formatting checks pass.