### PR TITLE
chore(repo): remove unnecessary deps array in examples

### DIFF
--- a/apps/common-app/src/apps/css/navigation/BottomTabBar.tsx
+++ b/apps/common-app/src/apps/css/navigation/BottomTabBar.tsx
@@ -55,7 +55,7 @@ export default function BottomTabBar({
       left: withTiming(offset),
       width: withTiming(width),
     };
-  }, []);
+  });
 
   const gradient = useMemo(
     () => (

--- a/apps/common-app/src/apps/reanimated/examples/AnimatedTextWidthExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/AnimatedTextWidthExample.tsx
@@ -23,7 +23,7 @@ export default function AnimatedTextWidthExample() {
 
   const animatedStyle = useAnimatedStyle(() => {
     return { width: (1.4 + Math.sin(sv.value)) * 150 };
-  }, [sv]);
+  });
 
   return (
     <View style={styles.container}>

--- a/apps/common-app/src/apps/reanimated/examples/AnimatedTextWidthExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/AnimatedTextWidthExample.tsx
@@ -19,7 +19,7 @@ export default function AnimatedTextWidthExample() {
     return () => {
       sv.value = 0;
     };
-  });
+  }, [sv]);
 
   const animatedStyle = useAnimatedStyle(() => {
     return { width: (1.4 + Math.sin(sv.value)) * 150 };

--- a/apps/common-app/src/apps/reanimated/examples/ArticleProgressExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/ArticleProgressExample.tsx
@@ -44,7 +44,7 @@ export default function ArticleProgressExample() {
     const width = clampedProgress * maxWidth;
 
     return { width };
-  }, []);
+  });
 
   return (
     <SafeAreaView>

--- a/apps/common-app/src/apps/reanimated/examples/BokehExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/BokehExample.tsx
@@ -49,13 +49,10 @@ function Circle({
     hue.value = withRepeat(withTiming(endHue, config), -1, true);
   }, [duration, startX, startY, startHue, endX, endY, endHue, hue, left, top]);
 
-  const animatedStyle = useAnimatedStyle(
-    () => ({
-      backgroundColor: `hsl(${hue.value},100%,50%)`,
-      transform: [{ translateX: left.value }, { translateY: top.value }],
-    }),
-    []
-  );
+  const animatedStyle = useAnimatedStyle(() => ({
+    backgroundColor: `hsl(${hue.value},100%,50%)`,
+    transform: [{ translateX: left.value }, { translateY: top.value }],
+  }));
 
   return (
     <Animated.View

--- a/apps/common-app/src/apps/reanimated/examples/BubblesExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/BubblesExample.tsx
@@ -35,7 +35,7 @@ function Bubble({ row, col }: BubbleProps) {
       height: width.value,
       borderRadius: width.value / 2,
     };
-  }, []);
+  });
 
   return <Animated.View style={[{ backgroundColor }, animatedStyle]} />;
 }

--- a/apps/common-app/src/apps/reanimated/examples/ChessboardExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/ChessboardExample.tsx
@@ -48,7 +48,7 @@ export default function ChessboardExample() {
       width: 10 + sv.value * 20,
       height: 10 + sv.value * 20,
     };
-  }, []);
+  });
 
   return (
     <View style={styles.workaround} collapsable={false}>

--- a/apps/common-app/src/apps/reanimated/examples/ColorInterpolationExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/ColorInterpolationExample.tsx
@@ -67,7 +67,7 @@ function ColorInterpolation({
     return {
       backgroundColor: interpolateFunction(color1, color2, progress.value),
     };
-  }, [color1, color2]);
+  });
 
   return (
     <View>

--- a/apps/common-app/src/apps/reanimated/examples/DetachAnimatedStylesExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/DetachAnimatedStylesExample.tsx
@@ -35,7 +35,7 @@ export default function DetachAnimatedStylesExample() {
 
   useDerivedValue(() => {
     console.log(sv.value);
-  }, []);
+  });
 
   const handleToggleSharedValue = useCallback(() => {
     ref.current = 1 - ref.current;

--- a/apps/common-app/src/apps/reanimated/examples/InvertedFlatListExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/InvertedFlatListExample.tsx
@@ -28,22 +28,19 @@ function List({ horizontal }: { horizontal?: boolean }) {
   const scrollPosition = useSharedValue(0);
   const isScrolling = useSharedValue(false);
 
-  const scrollHandler = useAnimatedScrollHandler(
-    {
-      onScroll: (event) => {
-        scrollPosition.value = horizontal
-          ? event.contentOffset.x
-          : event.contentOffset.y;
-      },
-      onBeginDrag: () => {
-        isScrolling.value = true;
-      },
-      onEndDrag: () => {
-        isScrolling.value = false;
-      },
+  const scrollHandler = useAnimatedScrollHandler({
+    onScroll: (event) => {
+      scrollPosition.value = horizontal
+        ? event.contentOffset.x
+        : event.contentOffset.y;
     },
-    [horizontal]
-  );
+    onBeginDrag: () => {
+      isScrolling.value = true;
+    },
+    onEndDrag: () => {
+      isScrolling.value = false;
+    },
+  });
 
   const inset = (scrollViewSize - cardInterval) / 2;
   const containerPadding = horizontal

--- a/apps/common-app/src/apps/reanimated/examples/LayoutAnimations/ReactionsCounterExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/LayoutAnimations/ReactionsCounterExample.tsx
@@ -57,7 +57,7 @@ function ReactionsCounter({
         duration: COLOR_ANIMATION_DURATION,
       }),
     };
-  }, [you]);
+  });
 
   const entering = (values: EntryAnimationsValues) => {
     'worklet';

--- a/apps/common-app/src/apps/reanimated/examples/MeasureExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/MeasureExample.tsx
@@ -37,7 +37,7 @@ export default function MeasureExample() {
     return {
       width: 80 + 230 * sv.value,
     };
-  }, []);
+  });
 
   return (
     <>

--- a/apps/common-app/src/apps/reanimated/examples/RefExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RefExample.tsx
@@ -37,7 +37,7 @@ export default function RefExample() {
 
   const style = useAnimatedStyle(() => {
     return { left: 200 * x.value, top: 200 * y.value };
-  }, []);
+  });
 
   const handleToggleSharedValue = () => {
     x.value = withTiming(Math.random(), { duration: 500 });

--- a/apps/common-app/src/apps/reanimated/examples/ScreenStackExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/ScreenStackExample.tsx
@@ -53,7 +53,7 @@ function SecondScreen() {
 
   const animatedStyle = useAnimatedStyle(() => {
     return { width: (1 + Math.sin(sv.value)) * 150 };
-  }, [sv]);
+  });
 
   return (
     <View style={styles.container}>

--- a/apps/common-app/src/apps/reanimated/examples/ScreenStackHeaderConfigBackgroundColorExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/ScreenStackHeaderConfigBackgroundColorExample.tsx
@@ -62,7 +62,7 @@ export default function ScreenStackHeaderConfigBackgroundColorExample() {
       backgroundColor: color,
       title: color,
     };
-  }, [offset]);
+  });
 
   const [counter, setCounter] = React.useState(0);
 

--- a/apps/common-app/src/apps/reanimated/examples/SynchronousPropsExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/SynchronousPropsExample.tsx
@@ -25,37 +25,47 @@ export default function SynchronousPropsExample() {
     sv.value = withRepeat(withTiming(1, { duration: 500 }), -1, true);
   }, [sv]);
 
-  const tenSv = useDerivedValue(() => sv.value * 10, [sv]);
+  const tenSv = useDerivedValue(() => sv.value * 10);
 
-  const fiftySv = useDerivedValue(() => sv.value * 50, [sv]);
+  const fiftySv = useDerivedValue(() => sv.value * 50);
 
-  const percentSv = useDerivedValue(() => `${sv.value * 100}%`, [sv]);
+  const percentSv = useDerivedValue(() => `${sv.value * 100}%`);
 
-  const degSv = useDerivedValue(() => `${sv.value * 45}deg`, [sv]);
+  const degSv = useDerivedValue(() => `${sv.value * 45}deg`);
 
-  const radSv = useDerivedValue(() => `${(sv.value * Math.PI) / 4}rad`, [sv]);
+  const radSv = useDerivedValue(() => `${(sv.value * Math.PI) / 4}rad`);
 
-  const zIndexSv = useDerivedValue(() => Math.round(sv.value * 10), [sv]);
+  const zIndexSv = useDerivedValue(() => Math.round(sv.value * 10));
 
-  const colorSv = useDerivedValue(
-    () => interpolateColor(sv.value, [0, 1], ['red', 'blue']),
-    [sv]
+  const colorSv = useDerivedValue(() =>
+    interpolateColor(sv.value, [0, 1], ['red', 'blue'])
   );
 
-  const shadowOffsetSv = useDerivedValue(
-    () => ({ width: tenSv.value, height: tenSv.value }),
-    [sv]
-  );
+  const shadowOffsetSv = useDerivedValue(() => ({
+    width: tenSv.value,
+    height: tenSv.value,
+  }));
 
-  const perspectiveSv = useDerivedValue(
-    () => Math.pow(2, sv.value * 3 + 4.5),
-    [sv]
-  );
+  const perspectiveSv = useDerivedValue(() => Math.pow(2, sv.value * 3 + 4.5));
 
-  const matrixSv = useDerivedValue(
-    () => [sv.value * 2, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 10, 1],
-    [sv]
-  );
+  const matrixSv = useDerivedValue(() => [
+    sv.value * 2,
+    1,
+    0,
+    0,
+    1,
+    0,
+    0,
+    0,
+    0,
+    0,
+    1,
+    0,
+    0,
+    0,
+    10,
+    1,
+  ]);
 
   const placeholderTextColorAnimatedProps = useAnimatedProps(() => ({
     placeholderTextColor: colorSv.value,

--- a/apps/common-app/src/apps/reanimated/examples/SynchronousPropsExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/SynchronousPropsExample.tsx
@@ -49,7 +49,22 @@ export default function SynchronousPropsExample() {
   const perspectiveSv = useDerivedValue(() => Math.pow(2, sv.value * 3 + 4.5));
 
   const matrixSv = useDerivedValue(() => [
-    sv.value * 2, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 10, 1
+    sv.value * 2,
+    1,
+    0,
+    0,
+    1,
+    0,
+    0,
+    0,
+    0,
+    0,
+    1,
+    0,
+    0,
+    0,
+    10,
+    1,
   ]);
 
   const placeholderTextColorAnimatedProps = useAnimatedProps(() => ({

--- a/apps/common-app/src/apps/reanimated/examples/SynchronousPropsExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/SynchronousPropsExample.tsx
@@ -49,22 +49,7 @@ export default function SynchronousPropsExample() {
   const perspectiveSv = useDerivedValue(() => Math.pow(2, sv.value * 3 + 4.5));
 
   const matrixSv = useDerivedValue(() => [
-    sv.value * 2,
-    1,
-    0,
-    0,
-    1,
-    0,
-    0,
-    0,
-    0,
-    0,
-    1,
-    0,
-    0,
-    0,
-    10,
-    1,
+    sv.value * 2, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 10, 1
   ]);
 
   const placeholderTextColorAnimatedProps = useAnimatedProps(() => ({

--- a/apps/common-app/src/apps/reanimated/examples/ThirdPartyComponentsExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/ThirdPartyComponentsExample.tsx
@@ -19,7 +19,7 @@ function TextInputDemo({ sv }: { sv: SharedValue<number> }) {
       text: `${Math.round(sv.value * 100)}`,
       defaultValue: `${Math.round(sv.value * 100)}`,
     };
-  }, []);
+  });
 
   return (
     <View style={styles.demo}>
@@ -45,7 +45,7 @@ function SvgCircleDemo({ sv }: { sv: SharedValue<number> }) {
       fill: interpolateColor(sv.value, [0, 1], ['red', 'lime'], 'HSV'),
       stroke: interpolateColor(sv.value, [0, 1], ['black', 'white'], 'HSV'),
     };
-  }, []);
+  });
 
   return (
     <View style={styles.demo}>
@@ -70,7 +70,7 @@ function SvgRectDemo({ sv }: { sv: SharedValue<number> }) {
       fill: interpolateColor(sv.value, [0, 1], ['red', 'lime'], 'HSV'),
       stroke: interpolateColor(sv.value, [0, 1], ['black', 'white'], 'HSV'),
     };
-  }, []);
+  });
 
   return (
     <View style={styles.demo}>
@@ -90,7 +90,7 @@ function SvgPathDemo({ sv }: { sv: SharedValue<number> }) {
       d: `M 0 0 C 50 ${sv.value * 200}, 150 ${sv.value * 200}, 200 0`,
       stroke: interpolateColor(sv.value, [0, 1], ['red', 'lime'], 'HSV'),
     };
-  }, []);
+  });
 
   return (
     <View style={styles.demo}>
@@ -122,7 +122,7 @@ function SvgPolygonsDemo({ sv }: { sv: SharedValue<number> }) {
       points: `50 ${topY}, ${leftX} 125, ${rightX} 125`, // this is a JS prop
       stroke: interpolateColor(sv.value, [0, 1], ['black', 'white'], 'HSV'),
     };
-  }, []);
+  });
 
   return (
     <View style={styles.demo}>

--- a/apps/common-app/src/apps/reanimated/examples/WidthExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/WidthExample.tsx
@@ -28,7 +28,7 @@ export default function WidthExample() {
     return {
       width: 80 + 230 * sv.value,
     };
-  }, []);
+  });
 
   return (
     <>


### PR DESCRIPTION
This touches only the examples, not reanimated itself
Deps should not be used with babel plugin on (which is the case here)
It causes unnecessary console.warn spam which makes it harder to scan for actual issues

I removed it, it results in less clutter in our console in dev mode