### PR TITLE
fix(Reanimated): Allow narrow SharedValues in optional props

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/InlineStylesAndPropsExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/InlineStylesAndPropsExample.tsx
@@ -1,5 +1,4 @@
 import { useCallback } from 'react';
-import type { ColorValue } from 'react-native';
 import {
   Button,
   StyleSheet,
@@ -8,7 +7,6 @@ import {
   TextInput,
   View,
 } from 'react-native';
-import type { SharedValue } from 'react-native-reanimated';
 import Animated, {
   useAnimatedProps,
   useAnimatedStyle,
@@ -67,19 +65,14 @@ export default function InlineStylesAndPropsExample() {
 
       <Text>Circle + inline prop</Text>
       <Svg width={60} height={60}>
-        <AnimatedCircle
-          cx={30}
-          cy={30}
-          r={25}
-          fill={colorSv as SharedValue<ColorValue | undefined>}
-        />
+        <AnimatedCircle cx={30} cy={30} r={25} fill={colorSv} />
       </Svg>
 
       <Text>Switch + useAnimatedProps</Text>
       <AnimatedSwitch animatedProps={switchAnimatedProps} />
 
       <Text>Switch + inline prop</Text>
-      <AnimatedSwitch value={value as SharedValue<boolean | undefined>} />
+      <AnimatedSwitch value={value} />
 
       <Text>TextInput + useAnimatedProps</Text>
       <AnimatedTextInput

--- a/apps/common-app/src/apps/reanimated/examples/SettledPropsLeakExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/SettledPropsLeakExample.tsx
@@ -31,9 +31,7 @@ export default function SettledPropsLeakExample() {
     sv.value = withTiming(1);
   }, [sv]);
 
-  const text = useDerivedValue<string | undefined>(
-    () => `${Math.round(sv.value * 100)}`
-  );
+  const text = useDerivedValue(() => `${Math.round(sv.value * 100)}`);
 
   const backgroundColor = useDerivedValue(() =>
     interpolateColor(sv.value, [0, 1], ['red', 'lime'])

--- a/packages/react-native-reanimated/__typetests__/AnimatedPropsTest.tst.ts
+++ b/packages/react-native-reanimated/__typetests__/AnimatedPropsTest.tst.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'tstyche';
+
+import type { AnimatedProps } from '..';
+import { useDerivedValue, useSharedValue } from '..';
+
+describe('AnimatedProps', () => {
+  test('accepts narrower shared values for optional props', () => {
+    type OptionalStringProp = AnimatedProps<{ value?: string }>['value'];
+
+    expect(useSharedValue('')).type.toBeAssignableTo<OptionalStringProp>();
+    expect(
+      useDerivedValue(() => '')
+    ).type.toBeAssignableTo<OptionalStringProp>();
+    expect(
+      useDerivedValue<string>(() => '')
+    ).type.toBeAssignableTo<OptionalStringProp>();
+    expect(useSharedValue(0)).type.not.toBeAssignableTo<OptionalStringProp>();
+  });
+});

--- a/packages/react-native-reanimated/src/commonTypes.ts
+++ b/packages/react-native-reanimated/src/commonTypes.ts
@@ -213,7 +213,7 @@ export interface SharedValue<Value = unknown> {
  * Instead of refactoring the code with small chances of success, we just
  * disable contravariance for `SharedValue` in this problematic case.
  */
-type SharedValueDisableContravariance<Value = unknown> = Omit<
+export type SharedValueDisableContravariance<Value = unknown> = Omit<
   SharedValue<Value>,
   'set' | 'modify'
 >;

--- a/packages/react-native-reanimated/src/helperTypes.ts
+++ b/packages/react-native-reanimated/src/helperTypes.ts
@@ -13,7 +13,7 @@ import type {
   AnimatedStyle,
   EntryExitAnimationFunction,
   LayoutAnimationFunction,
-  SharedValue,
+  SharedValueDisableContravariance,
 } from './commonTypes';
 import type { NestedArray } from './createAnimatedComponent/commonTypes';
 import type { CSSStyle } from './css';
@@ -55,7 +55,7 @@ type ComponentPropsWithoutStyle<Props extends object> = Omit<
 type RestProps<Props extends object> = {
   [K in keyof ComponentPropsWithoutStyle<Props>]:
     | Props[K]
-    | SharedValue<Props[K]>;
+    | SharedValueDisableContravariance<Props[K]>;
 };
 
 type LayoutProps = {


### PR DESCRIPTION
> [!NOTE]
> This pull request was authored by AI on behalf of @pawicao.

## Summary

Fixes #10155.

- Use a `SharedValue` type without `set` and `modify` methods for animated component props.
- Allow a narrow shared value when an optional prop also accepts `undefined`.
- Add TSTyche tests for inferred and explicit `DerivedValue<string>` types.

## Test plan

Use an inferred type and an explicit type with an optional string prop:

```tsx
const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);

function Example() {
  const inferredText = useDerivedValue(() => 'text');
  const explicitText = useDerivedValue<string>(() => 'text');

  return (
    <>
      <AnimatedTextInput defaultValue={inferredText} />
      <AnimatedTextInput defaultValue={explicitText} />
    </>
  );
}
```

Run:

```sh
yarn workspace react-native-reanimated type:check:tests
```

The type check accepts both string values. The test also confirms that `SharedValue<number>` stays invalid for an optional string prop.
