### PR TITLE
fix(Reanimated): Accept text prop in animated TextInput types

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/InlineStylesAndPropsExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/InlineStylesAndPropsExample.tsx
@@ -86,7 +86,6 @@ export default function InlineStylesAndPropsExample() {
         editable={false}
         style={styles.input}
         defaultValue="false"
-        // @ts-expect-error `text` is the native prop backing TextInput's value
         text={textSv}
       />
     </View>

--- a/packages/react-native-reanimated/__typetests__/AnimatedPropsTest.tsx
+++ b/packages/react-native-reanimated/__typetests__/AnimatedPropsTest.tsx
@@ -2,9 +2,13 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import React from 'react';
 import type { FlatListProps } from 'react-native';
-import { FlatList } from 'react-native';
+import { FlatList, TextInput } from 'react-native';
 
-import Animated, { useAnimatedProps } from '..';
+import Animated, {
+  useAnimatedProps,
+  useDerivedValue,
+  useSharedValue,
+} from '..';
 
 function AnimatedPropsTest() {
   function AnimatedPropsTestClass1() {
@@ -35,6 +39,31 @@ function AnimatedPropsTest() {
     return (
       // @ts-expect-error
       <AnimatedPath animatedProps={animatedProps} />
+    );
+  }
+
+  function AnimatedPropsTestTextInputText() {
+    const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);
+    const text = useSharedValue('text');
+    const derivedText = useDerivedValue(() => text.value);
+    const numericValue = useSharedValue(0);
+    const animatedProps = useAnimatedProps(() => ({
+      text: text.value,
+      defaultValue: text.value,
+    }));
+    return (
+      <>
+        {/* `text` is accepted inline as a shared value */}
+        <AnimatedTextInput text={text} />
+        {/* `text` is accepted inline as a derived value */}
+        <AnimatedTextInput text={derivedText} />
+        {/* raw values are accepted via `useAnimatedProps` */}
+        <AnimatedTextInput animatedProps={animatedProps} />
+        {/* @ts-expect-error A static string is not accepted - use `value` or `defaultValue` instead. */}
+        <AnimatedTextInput text="some string" />
+        {/* @ts-expect-error A shared value of a non-string type is not accepted. */}
+        <AnimatedTextInput text={numericValue} />
+      </>
     );
   }
 

--- a/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
@@ -57,20 +57,6 @@ type AnimatableComponent<C extends ComponentType<any>> = C & {
 };
 
 /**
- * `text` is the native prop backing `TextInput`'s value. It's not part of
- * `TextInputProps`, but Reanimated can update it directly, so the animated
- * `TextInput` accepts it as a shared value. Static strings are still disallowed
- * - use `value` or `defaultValue` for those. It's added only to the inline
- * props (not to the base component props) so that `useAnimatedProps`, which
- * supplies raw values, keeps accepting `{ text: string }`.
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnimatableComponentExtraProps<TInstance extends ComponentType<any>> =
-  TInstance extends typeof TextInput
-    ? { text?: SharedValueDisableContravariance<string> }
-    : object;
-
-/**
  * Lets you create an Animated version of any React Native component.
  *
  * @param Component - The component you want to make animatable.
@@ -86,18 +72,35 @@ export function createAnimatedComponent<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   TInstance extends AnimatableComponent<ComponentType<any>>,
 >(
-  // `FlatList` is excluded so that calls passing it fall through to the
-  // deprecated overload below (which nudges towards `Animated.FlatList`).
-  // This overload is declared first so that a bare reference to
-  // `createAnimatedComponent` (e.g. `Animated.createAnimatedComponent` passed
-  // as a value) resolves to a non-deprecated signature instead of being
-  // falsely flagged by `@typescript-eslint/no-deprecated`.
-  Component: TInstance extends typeof FlatList<infer _> ? never : TInstance,
+  // `FlatList` and `TextInput` are excluded so that calls passing them fall
+  // through to the dedicated overloads below. This overload is declared first
+  // so that a bare reference to `createAnimatedComponent` (e.g.
+  // `Animated.createAnimatedComponent` passed as a value) resolves to a
+  // non-deprecated signature instead of being falsely flagged by
+  // `@typescript-eslint/no-deprecated`.
+  Component: TInstance extends typeof FlatList<infer _>
+    ? never
+    : TInstance extends typeof TextInput
+      ? never
+      : TInstance,
+  options?: Options<InitialComponentProps>
+): AnimatedComponentType<Readonly<ComponentProps<TInstance>>, TInstance>;
+
+/**
+ * `text` is the native prop backing `TextInput`'s value. It's not part of
+ * `TextInputProps`, but Reanimated can update it directly, so the animated
+ * `TextInput` accepts it as a shared value. Static strings are still disallowed
+ * - use `value` or `defaultValue` for those. It's added only to the inline
+ * props (not to the base component props) so that `useAnimatedProps`, which
+ * supplies raw values, keeps accepting `{ text: string }`.
+ */
+export function createAnimatedComponent(
+  Component: typeof TextInput,
   options?: Options<InitialComponentProps>
 ): AnimatedComponentType<
-  Readonly<ComponentProps<TInstance>>,
-  TInstance,
-  AnimatableComponentExtraProps<TInstance>
+  Readonly<ComponentProps<typeof TextInput>>,
+  typeof TextInput,
+  { text?: SharedValueDisableContravariance<string> }
 >;
 
 /**

--- a/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
@@ -78,9 +78,9 @@ export function createAnimatedComponent<
   // `Animated.createAnimatedComponent` passed as a value) resolves to a
   // non-deprecated signature instead of being falsely flagged by
   // `@typescript-eslint/no-deprecated`.
-  Component: TInstance extends typeof FlatList<infer _>
+  Component: TInstance extends typeof FlatList<infer _> | typeof TextInput
     ? never
-    : Exclude<TInstance, typeof TextInput>,
+    : TInstance,
   options?: Options<InitialComponentProps>
 ): AnimatedComponentType<Readonly<ComponentProps<TInstance>>, TInstance>;
 

--- a/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
@@ -9,7 +9,10 @@ import type {
 } from 'react';
 import type { FlatList, FlatListProps, TextInput } from 'react-native';
 
-import type { InstanceOrElement } from '../commonTypes';
+import type {
+  InstanceOrElement,
+  SharedValueDisableContravariance,
+} from '../commonTypes';
 import type { AnimatedProps } from '../helperTypes';
 import type { AnimatedRef } from '../hook';
 import type { ExtractElementRef } from '../hook/commonTypes';
@@ -30,14 +33,20 @@ type AnimatedComponentRef<TInstance> =
 export type AnimatedComponentType<
   Props extends object = object,
   Instance = unknown,
+  // Extra props accepted only when passed inline on the animated component.
+  // They are not part of the base component props, so they don't affect the
+  // `animatedProps` typing.
+  ExtraProps extends object = object,
 > = {
   (
-    props: Omit<AnimatedProps<Props>, 'ref'> & {
-      ref?: AnimatedComponentRef<Instance>;
-    }
+    props: Omit<AnimatedProps<Props>, 'ref'> &
+      ExtraProps & {
+        ref?: AnimatedComponentRef<Instance>;
+      }
   ): ReactNode;
   (
     props: Omit<AnimatedProps<Props>, 'ref'> &
+      ExtraProps &
       RefAttributes<ExtractElementRef<Instance>>
   ): ReactNode;
 };
@@ -50,13 +59,16 @@ type AnimatableComponent<C extends ComponentType<any>> = C & {
 /**
  * `text` is the native prop backing `TextInput`'s value. It's not part of
  * `TextInputProps`, but Reanimated can update it directly, so the animated
- * `TextInput` accepts it.
+ * `TextInput` accepts it as a shared value. Static strings are still disallowed
+ * - use `value` or `defaultValue` for those. It's added only to the inline
+ * props (not to the base component props) so that `useAnimatedProps`, which
+ * supplies raw values, keeps accepting `{ text: string }`.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnimatableComponentProps<TInstance extends ComponentType<any>> =
+type AnimatableComponentExtraProps<TInstance extends ComponentType<any>> =
   TInstance extends typeof TextInput
-    ? ComponentProps<TInstance> & { text?: string }
-    : ComponentProps<TInstance>;
+    ? { text?: SharedValueDisableContravariance<string> }
+    : object;
 
 /**
  * Lets you create an Animated version of any React Native component.
@@ -83,8 +95,9 @@ export function createAnimatedComponent<
   Component: TInstance extends typeof FlatList<infer _> ? never : TInstance,
   options?: Options<InitialComponentProps>
 ): AnimatedComponentType<
-  Readonly<AnimatableComponentProps<TInstance>>,
-  TInstance
+  Readonly<ComponentProps<TInstance>>,
+  TInstance,
+  AnimatableComponentExtraProps<TInstance>
 >;
 
 /**

--- a/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
@@ -80,9 +80,7 @@ export function createAnimatedComponent<
   // `@typescript-eslint/no-deprecated`.
   Component: TInstance extends typeof FlatList<infer _>
     ? never
-    : TInstance extends typeof TextInput
-      ? never
-      : TInstance,
+    : Exclude<TInstance, typeof TextInput>,
   options?: Options<InitialComponentProps>
 ): AnimatedComponentType<Readonly<ComponentProps<TInstance>>, TInstance>;
 

--- a/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
@@ -7,7 +7,7 @@ import type {
   Ref,
   RefAttributes,
 } from 'react';
-import type { FlatList, FlatListProps } from 'react-native';
+import type { FlatList, FlatListProps, TextInput } from 'react-native';
 
 import type { InstanceOrElement } from '../commonTypes';
 import type { AnimatedProps } from '../helperTypes';
@@ -48,6 +48,17 @@ type AnimatableComponent<C extends ComponentType<any>> = C & {
 };
 
 /**
+ * `text` is the native prop backing `TextInput`'s value. It's not part of
+ * `TextInputProps`, but Reanimated can update it directly, so the animated
+ * `TextInput` accepts it.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnimatableComponentProps<TInstance extends ComponentType<any>> =
+  TInstance extends typeof TextInput
+    ? ComponentProps<TInstance> & { text?: string }
+    : ComponentProps<TInstance>;
+
+/**
  * Lets you create an Animated version of any React Native component.
  *
  * @param Component - The component you want to make animatable.
@@ -71,7 +82,10 @@ export function createAnimatedComponent<
   // falsely flagged by `@typescript-eslint/no-deprecated`.
   Component: TInstance extends typeof FlatList<infer _> ? never : TInstance,
   options?: Options<InitialComponentProps>
-): AnimatedComponentType<Readonly<ComponentProps<TInstance>>, TInstance>;
+): AnimatedComponentType<
+  Readonly<AnimatableComponentProps<TInstance>>,
+  TInstance
+>;
 
 /**
  * @deprecated Please use `Animated.FlatList` component instead of calling


### PR DESCRIPTION
> [!NOTE]
> This pull request was authored by AI on behalf of tomekzaw.

## Summary

`text` is the native prop backing `TextInput`'s value. Animating it with Reanimated works at runtime, but it's not part of `TextInputProps`, so users had to suppress a type error.

This PR types it in `createAnimatedComponent`: an animated `TextInput` now accepts `text` inline, but only as a shared value — static strings stay rejected (use `value`/`defaultValue` instead). The prop is injected through a new defaulted `ExtraProps` generic on `AnimatedComponentType` rather than the base component props, so `useAnimatedProps(() => ({ text }))` keeps accepting raw strings. Other components are unaffected.

Whether each case type-checks:

| Case | Before | After |
| --- | :---: | :---: |
| `text={stringSharedValue}` | ❌ | ✅ |
| `text={stringDerivedValue}` | ❌ | ✅ |
| `animatedProps` returning `{ text: string }` | ✅ | ✅ |
| `text="some string"` — use `value`/`defaultValue` instead | ❌ | ❌ |
| `text={numberSharedValue}` — wrong value type | ❌ | ❌ |

## Test plan

- All five cases above are pinned as type tests in `AnimatedPropsTest.tsx`.
- `yarn type:check` passes; `InlineStylesAndPropsExample` compiles without `@ts-expect-error`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)