### PR TITLE
chore(rnre): ref forwarding for layoutanimationconfig

### DIFF
--- a/apps/common-app/src/apps/css/components/cards/ExpandableCard.tsx
+++ b/apps/common-app/src/apps/css/components/cards/ExpandableCard.tsx
@@ -1,6 +1,6 @@
 import { faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
-import type { PropsWithChildren } from 'react';
+import type { ComponentRef, PropsWithChildren, Ref } from 'react';
 import type { StyleProp, ViewStyle } from 'react-native';
 import { Pressable, StyleSheet } from 'react-native';
 import Animated, {
@@ -19,6 +19,7 @@ export type ExpandableCardProps = PropsWithChildren<{
   showExpandOverlay?: boolean;
   overlayHeight?: number;
   style?: StyleProp<ViewStyle>;
+  ref?: Ref<ComponentRef<typeof Animated.View>>;
 }>;
 
 export default function ExpandableCard({
@@ -26,6 +27,7 @@ export default function ExpandableCard({
   expanded,
   onChange,
   overlayHeight = sizes.lg,
+  ref,
   showExpandOverlay,
   style,
 }: ExpandableCardProps) {
@@ -36,6 +38,7 @@ export default function ExpandableCard({
   return (
     <Animated.View
       layout={LinearTransition}
+      ref={ref}
       style={[
         styles.container,
         { paddingBottom: showExpandOverlay ? spacing.lg : spacing.sm },

--- a/packages/react-native-reanimated/src/component/LayoutAnimationConfig.tsx
+++ b/packages/react-native-reanimated/src/component/LayoutAnimationConfig.tsx
@@ -1,6 +1,14 @@
 'use strict';
-import type { ReactNode } from 'react';
-import { Children, Component, createContext, useEffect, useRef } from 'react';
+import type { ReactNode, Ref, RefCallback } from 'react';
+import {
+  Children,
+  cloneElement,
+  Component,
+  createContext,
+  isValidElement,
+  useEffect,
+  useRef,
+} from 'react';
 
 import { setShouldAnimateExitingForTag } from '../core';
 import { findNodeHandle } from '../platformFunctions/findNodeHandle';
@@ -30,6 +38,67 @@ function SkipEntering(props: { shouldSkip: boolean; children: ReactNode }) {
   );
 }
 
+type TaggedInstance = {
+  getComponentViewTag?: () => number;
+  __nativeTag?: number;
+  getNativeScrollRef?: () => TaggedInstance | null;
+  getScrollableNode?: () => TaggedInstance | number | null;
+};
+
+function getTagFromChildInstance(
+  instance: TaggedInstance | null
+): number | null {
+  if (!instance) {
+    return null;
+  }
+
+  if (typeof instance.getComponentViewTag === 'function') {
+    const tag = instance.getComponentViewTag();
+    if (tag !== -1) {
+      return tag;
+    }
+  }
+
+  if (typeof instance.__nativeTag === 'number') {
+    return instance.__nativeTag;
+  }
+
+  const nativeScrollRef = instance.getNativeScrollRef?.();
+  if (typeof nativeScrollRef?.__nativeTag === 'number') {
+    return nativeScrollRef.__nativeTag;
+  }
+
+  const scrollableNode = instance.getScrollableNode?.();
+  if (typeof scrollableNode === 'number') {
+    return scrollableNode;
+  }
+  if (typeof scrollableNode?.__nativeTag === 'number') {
+    return scrollableNode.__nativeTag;
+  }
+
+  return null;
+}
+
+function mergeRefs<T>(...refs: (Ref<T> | undefined)[]): RefCallback<T> {
+  return (instance: T | null) => {
+    const cleanups = refs.map((ref) => {
+      if (typeof ref === 'function') {
+        const cleanup = ref(instance);
+        return typeof cleanup === 'function' ? cleanup : () => ref(null);
+      }
+      if (ref) {
+        ref.current = instance;
+        return () => {
+          ref.current = null;
+        };
+      }
+      return undefined;
+    });
+
+    return () => cleanups.forEach((cleanup) => cleanup?.());
+  };
+}
+
 // skipExiting (unlike skipEntering) cannot be done by conditionally
 // configuring the animation in `createAnimatedComponent`, since at this stage
 // we don't know if the wrapper is going to be unmounted or not.
@@ -47,17 +116,58 @@ function SkipEntering(props: { shouldSkip: boolean; children: ReactNode }) {
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/layout-animation-config/
  */
 export class LayoutAnimationConfig extends Component<LayoutAnimationConfigProps> {
+  _childInstance: TaggedInstance | null = null;
+  _mergedRef?: RefCallback<TaggedInstance>;
+  _mergedRefSource?: Ref<TaggedInstance>;
+
+  _setChildInstance = (instance: TaggedInstance | null) => {
+    this._childInstance = instance;
+  };
+
+  _getMergedRef(childRef: Ref<TaggedInstance> | undefined) {
+    if (!this._mergedRef || this._mergedRefSource !== childRef) {
+      this._mergedRefSource = childRef;
+      this._mergedRef = mergeRefs(childRef, this._setChildInstance);
+    }
+    return this._mergedRef;
+  }
+
+  getComponentViewTag() {
+    return getTagFromChildInstance(this._childInstance) ?? -1;
+  }
+
   getMaybeWrappedChildren() {
     return Children.count(this.props.children) > 1 && this.props.skipExiting
       ? Children.map(this.props.children, (child) => (
           <LayoutAnimationConfig skipExiting>{child}</LayoutAnimationConfig>
         ))
-      : this.props.children;
+      : this.getMaybeRefTrackedChild();
+  }
+
+  getMaybeRefTrackedChild() {
+    const { children } = this.props;
+
+    if (
+      this.props.skipExiting === undefined ||
+      Children.count(children) !== 1
+    ) {
+      return children;
+    }
+
+    const child = Children.only(children);
+    if (!isValidElement<{ ref?: Ref<TaggedInstance> }>(child)) {
+      return children;
+    }
+
+    return cloneElement(child, {
+      ref: this._getMergedRef(child.props.ref),
+    });
   }
 
   setShouldAnimateExiting() {
     if (Children.count(this.props.children) === 1) {
-      const tag = findNodeHandle(this);
+      const tag =
+        getTagFromChildInstance(this._childInstance) ?? findNodeHandle(this);
       if (tag) {
         setShouldAnimateExitingForTag(tag, !this.props.skipExiting);
       }

--- a/packages/react-native-reanimated/src/component/LayoutAnimationConfig.tsx
+++ b/packages/react-native-reanimated/src/component/LayoutAnimationConfig.tsx
@@ -11,7 +11,10 @@ import {
 } from 'react';
 
 import { setShouldAnimateExitingForTag } from '../core';
+import type { InstanceWithViewTag } from '../createAnimatedComponent/getViewInfo';
+import { getViewTagFromInstance } from '../createAnimatedComponent/getViewInfo';
 import { findNodeHandle } from '../platformFunctions/findNodeHandle';
+import { mergeRefs } from '../reactUtils';
 
 export const SkipEnteringContext =
   createContext<React.RefObject<boolean> | null>(null);
@@ -38,67 +41,6 @@ function SkipEntering(props: { shouldSkip: boolean; children: ReactNode }) {
   );
 }
 
-type TaggedInstance = {
-  getComponentViewTag?: () => number;
-  __nativeTag?: number;
-  getNativeScrollRef?: () => TaggedInstance | null;
-  getScrollableNode?: () => TaggedInstance | number | null;
-};
-
-function getTagFromChildInstance(
-  instance: TaggedInstance | null
-): number | null {
-  if (!instance) {
-    return null;
-  }
-
-  if (typeof instance.getComponentViewTag === 'function') {
-    const tag = instance.getComponentViewTag();
-    if (tag !== -1) {
-      return tag;
-    }
-  }
-
-  if (typeof instance.__nativeTag === 'number') {
-    return instance.__nativeTag;
-  }
-
-  const nativeScrollRef = instance.getNativeScrollRef?.();
-  if (typeof nativeScrollRef?.__nativeTag === 'number') {
-    return nativeScrollRef.__nativeTag;
-  }
-
-  const scrollableNode = instance.getScrollableNode?.();
-  if (typeof scrollableNode === 'number') {
-    return scrollableNode;
-  }
-  if (typeof scrollableNode?.__nativeTag === 'number') {
-    return scrollableNode.__nativeTag;
-  }
-
-  return null;
-}
-
-function mergeRefs<T>(...refs: (Ref<T> | undefined)[]): RefCallback<T> {
-  return (instance: T | null) => {
-    const cleanups = refs.map((ref) => {
-      if (typeof ref === 'function') {
-        const cleanup = ref(instance);
-        return typeof cleanup === 'function' ? cleanup : () => ref(null);
-      }
-      if (ref) {
-        ref.current = instance;
-        return () => {
-          ref.current = null;
-        };
-      }
-      return undefined;
-    });
-
-    return () => cleanups.forEach((cleanup) => cleanup?.());
-  };
-}
-
 // skipExiting (unlike skipEntering) cannot be done by conditionally
 // configuring the animation in `createAnimatedComponent`, since at this stage
 // we don't know if the wrapper is going to be unmounted or not.
@@ -116,15 +58,15 @@ function mergeRefs<T>(...refs: (Ref<T> | undefined)[]): RefCallback<T> {
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/layout-animation-config/
  */
 export class LayoutAnimationConfig extends Component<LayoutAnimationConfigProps> {
-  _childInstance: TaggedInstance | null = null;
-  _mergedRef?: RefCallback<TaggedInstance>;
-  _mergedRefSource?: Ref<TaggedInstance>;
+  _childInstance: InstanceWithViewTag | null = null;
+  _mergedRef?: RefCallback<InstanceWithViewTag>;
+  _mergedRefSource?: Ref<InstanceWithViewTag>;
 
-  _setChildInstance = (instance: TaggedInstance | null) => {
+  _setChildInstance = (instance: InstanceWithViewTag | null) => {
     this._childInstance = instance;
   };
 
-  _getMergedRef(childRef: Ref<TaggedInstance> | undefined) {
+  _getMergedRef(childRef: Ref<InstanceWithViewTag> | undefined) {
     if (!this._mergedRef || this._mergedRefSource !== childRef) {
       this._mergedRefSource = childRef;
       this._mergedRef = mergeRefs(childRef, this._setChildInstance);
@@ -133,7 +75,7 @@ export class LayoutAnimationConfig extends Component<LayoutAnimationConfigProps>
   }
 
   getComponentViewTag() {
-    return getTagFromChildInstance(this._childInstance) ?? -1;
+    return getViewTagFromInstance(this._childInstance) ?? -1;
   }
 
   getMaybeWrappedChildren() {
@@ -155,7 +97,7 @@ export class LayoutAnimationConfig extends Component<LayoutAnimationConfigProps>
     }
 
     const child = Children.only(children);
-    if (!isValidElement<{ ref?: Ref<TaggedInstance> }>(child)) {
+    if (!isValidElement<{ ref?: Ref<InstanceWithViewTag> }>(child)) {
       return children;
     }
 
@@ -167,7 +109,7 @@ export class LayoutAnimationConfig extends Component<LayoutAnimationConfigProps>
   setShouldAnimateExiting() {
     if (Children.count(this.props.children) === 1) {
       const tag =
-        getTagFromChildInstance(this._childInstance) ?? findNodeHandle(this);
+        getViewTagFromInstance(this._childInstance) ?? findNodeHandle(this);
       if (tag) {
         setShouldAnimateExitingForTag(tag, !this.props.skipExiting);
       }

--- a/packages/react-native-reanimated/src/createAnimatedComponent/getViewInfo.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/getViewInfo.ts
@@ -1,6 +1,9 @@
 'use strict';
 
+import type { Maybe } from '../common';
+import type { InternalHostInstance } from '../commonTypes';
 import type { HostInstance } from '../platform-specific/types';
+import type { IAnimatedComponentInternalBase } from './commonTypes';
 
 // Component naming convention:
 //
@@ -27,4 +30,40 @@ export function getViewInfo(element: HostInstance): {
       element?.__internalInstanceHandle?.elementType) as string,
     viewTag: element?.__nativeTag,
   };
+}
+
+export type InstanceWithViewTag = Partial<IAnimatedComponentInternalBase> &
+  InternalHostInstance;
+
+export function getViewTagFromInstance(
+  instance: Maybe<InstanceWithViewTag>
+): number | null {
+  if (!instance) {
+    return null;
+  }
+
+  if (typeof instance.getComponentViewTag === 'function') {
+    const viewTag = instance.getComponentViewTag();
+    if (viewTag !== -1) {
+      return viewTag;
+    }
+  }
+
+  const viewTag = getViewInfo(instance).viewTag;
+  if (viewTag !== undefined) {
+    return viewTag;
+  }
+
+  const nativeScrollRef = instance.getNativeScrollRef?.();
+  if (nativeScrollRef) {
+    return getViewInfo(nativeScrollRef).viewTag ?? null;
+  }
+
+  const scrollableNode = instance.getScrollableNode?.() as Maybe<
+    HostInstance | number
+  >;
+  if (typeof scrollableNode === 'number') {
+    return scrollableNode;
+  }
+  return scrollableNode ? (getViewInfo(scrollableNode).viewTag ?? null) : null;
 }

--- a/packages/react-native-reanimated/src/css/component/AnimatedComponent.native.tsx
+++ b/packages/react-native-reanimated/src/css/component/AnimatedComponent.native.tsx
@@ -15,6 +15,7 @@ import { getViewInfo } from '../../createAnimatedComponent/getViewInfo';
 import { getShadowNodeWrapperFromRef } from '../../fabricUtils';
 import type { DefaultStyle } from '../../hook/commonTypes';
 import { findHostInstance } from '../../platform-specific/findHostInstance';
+import { assignRef } from '../../reactUtils';
 import { markNodeAsRemovable, unmarkNodeAsRemovable } from '../native';
 import { CSSManager } from '../platform';
 import type { CSSStyle } from '../types';
@@ -89,18 +90,8 @@ export default class AnimatedComponent<
   }
 
   _setComponentRef = (ref: Component | HTMLElement) => {
-    const forwardedRef = this.props.forwardedRef as
-      | ((ref: Component | HTMLElement) => void)
-      | { current: Component | HTMLElement | null }
-      | undefined;
     // Forward to user ref prop (if one has been specified)
-    if (typeof forwardedRef === 'function') {
-      // Handle function-based refs. String-based refs are handled as functions.
-      forwardedRef(ref);
-    } else if (typeof forwardedRef === 'object' && forwardedRef) {
-      // Handle createRef-based refs
-      forwardedRef.current = ref;
-    }
+    assignRef(this.props.forwardedRef as Ref<Component | HTMLElement>, ref);
 
     if (!ref) {
       // component has been unmounted

--- a/packages/react-native-reanimated/src/css/component/AnimatedComponent.native.tsx
+++ b/packages/react-native-reanimated/src/css/component/AnimatedComponent.native.tsx
@@ -45,6 +45,7 @@ export default class AnimatedComponent<
   _componentRef: AnimatedComponentRef | HTMLElement | null = null;
   _componentDOMRef: HTMLElement | null = null;
   _willUnmount: boolean = false;
+  _forwardedRefCleanup?: () => void;
 
   constructor(ChildComponent: AnyComponent, props: P) {
     super(props);
@@ -91,12 +92,22 @@ export default class AnimatedComponent<
 
   _setComponentRef = (ref: Component | HTMLElement) => {
     // Forward to user ref prop (if one has been specified)
-    assignRef(this.props.forwardedRef as Ref<Component | HTMLElement>, ref);
+    const forwardedRef = this.props.forwardedRef as Ref<
+      Component | HTMLElement
+    >;
 
     if (!ref) {
       // component has been unmounted
+      if (this._forwardedRefCleanup) {
+        this._forwardedRefCleanup();
+        this._forwardedRefCleanup = undefined;
+      } else {
+        assignRef(forwardedRef, null);
+      }
       return;
     }
+
+    this._forwardedRefCleanup = assignRef(forwardedRef, ref);
     if (ref !== this._componentRef) {
       this._componentRef = this._resolveComponentRef(ref);
       // if ref is changed, reset viewInfo

--- a/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
@@ -13,6 +13,7 @@ import type {
   ViewInfo,
 } from '../../createAnimatedComponent/commonTypes';
 import type { DefaultStyle } from '../../hook/commonTypes';
+import { assignRef } from '../../reactUtils';
 import { CSSManager } from '../platform';
 import type { CSSStyle } from '../types';
 import { filterNonCSSStyleProps } from './utils';
@@ -78,18 +79,8 @@ export default class AnimatedComponent<
   }
 
   _setComponentRef = (ref: Component | HTMLElement) => {
-    const forwardedRef = this.props.forwardedRef as
-      | ((ref: Component | HTMLElement) => void)
-      | { current: Component | HTMLElement | null }
-      | undefined;
     // Forward to user ref prop (if one has been specified)
-    if (typeof forwardedRef === 'function') {
-      // Handle function-based refs. String-based refs are handled as functions.
-      forwardedRef(ref);
-    } else if (typeof forwardedRef === 'object' && forwardedRef) {
-      // Handle createRef-based refs
-      forwardedRef.current = ref;
-    }
+    assignRef(this.props.forwardedRef as Ref<Component | HTMLElement>, ref);
 
     if (!ref) {
       // component has been unmounted

--- a/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
@@ -42,6 +42,7 @@ export default class AnimatedComponent<
   _componentRef: AnimatedComponentRef | HTMLElement | null = null;
   _componentDOMRef: HTMLElement | null = null;
   _willUnmount: boolean = false;
+  _forwardedRefCleanup?: () => void;
 
   constructor(ChildComponent: AnyComponent, props: P) {
     super(props);
@@ -80,12 +81,22 @@ export default class AnimatedComponent<
 
   _setComponentRef = (ref: Component | HTMLElement) => {
     // Forward to user ref prop (if one has been specified)
-    assignRef(this.props.forwardedRef as Ref<Component | HTMLElement>, ref);
+    const forwardedRef = this.props.forwardedRef as Ref<
+      Component | HTMLElement
+    >;
 
     if (!ref) {
       // component has been unmounted
+      if (this._forwardedRefCleanup) {
+        this._forwardedRefCleanup();
+        this._forwardedRefCleanup = undefined;
+      } else {
+        assignRef(forwardedRef, null);
+      }
       return;
     }
+
+    this._forwardedRefCleanup = assignRef(forwardedRef, ref);
     if (ref !== this._componentRef) {
       this._componentRef = this._resolveComponentRef(ref);
       // if ref is changed, reset viewInfo

--- a/packages/react-native-reanimated/src/reactUtils.ts
+++ b/packages/react-native-reanimated/src/reactUtils.ts
@@ -1,5 +1,32 @@
 'use strict';
+import type { Ref, RefCallback } from 'react';
 import React from 'react';
+
+import type { Maybe } from './common';
+
+export function assignRef<T>(
+  ref: Maybe<Ref<T>>,
+  instance: T | null
+): (() => void) | undefined {
+  if (typeof ref === 'function') {
+    const cleanup: unknown = ref(instance);
+    return typeof cleanup === 'function' ? (cleanup as () => void) : undefined;
+  }
+  if (ref) {
+    ref.current = instance;
+  }
+  return undefined;
+}
+
+export function mergeRefs<T>(...refs: Maybe<Ref<T>>[]): RefCallback<T> {
+  return (instance: T | null) => {
+    const cleanups = refs.map(
+      (ref) => assignRef(ref, instance) ?? (() => assignRef(ref, null))
+    );
+
+    return () => cleanups.forEach((cleanup) => cleanup());
+  };
+}
 
 function getCurrentReactOwner() {
   return (


### PR DESCRIPTION
React 19 deprecated findNodeHandle when it is passed a component instance (what we consider a slow path; it recursively walks the tree until it finds the host instance)
The idiomatic way to prevent that from happening is to hold a ref all the way to the host instance

LayoutAnimationConfig needs the node handle on unmount
Before it would call findNodeHandle on `this` -> slow path, error in Strict Mode
Now, it holds a ref to its child, and gets the handle from it, allowing components that forward refs properly or are a host instance to resolve without the deprecated slow path. For components that do not support ref forwarding, we use the old behavior as a fallback.

The fallback/old behavior triggers the following warning (error in strictmode): `Warning: findNodeHandle is deprecated in StrictMode. findNodeHandle was passed an instance of <LayoutAnimationConfig/> which is inside StrictMode. Instead, add a ref directly to the element you want to reference. Learn more about using refs safely here: <link>`

The error message guides the user to use refs; the pattern of forwarding a ref to the hostinstance is recommended by react, so adoption of our fix should be natural.

If there are many children, they get mapped to a layoutanimationconfig with one child each, and the wrapping one no ops.

This change was verified on our examples from common-app and on the bluesky app.

Relevant snippets:
```ts
<LayoutAnimationConfig skipEntering skipExiting>
  <Animated.View exiting={FadeOut} style={{width: 100, height: 100, backgroundColor: 'tomato'}} />
</LayoutAnimationConfig>
```
Before: `findNodeHandle(this)`
Now: resolves via `getComponentViewTag()`

```ts
<LayoutAnimationConfig skipExiting>
  <View collapsable={false} style={{width: 100, height: 100}} />
</LayoutAnimationConfig>
```
Before: `findNodeHandle(this)`
Now: resolves via `__nativeTag`

```ts
<LayoutAnimationConfig skipExiting>
  <Animated.View exiting={FadeOut} style={{width: 60, height: 60}} />
  <Animated.View exiting={FadeOut} style={{width: 60, height: 60}} />
</LayoutAnimationConfig>
```
Each child gets its own LayoutAnimationConfig, which resolves via `getComponentViewTag()`. No `findNodeHandle`