### PR TITLE
perf: Intern easings and route properties by id across the transition JNI

### DIFF
--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
@@ -150,8 +150,8 @@ bool CSSPlatformTransitions::applyTransition(
           *to,
           reversing.duration,
           reversing.startTimestamp,
-              *easingId,
-              persistent)) {
+          *easingId,
+          persistent)) {
     return false;
   }
 

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
@@ -31,10 +31,52 @@ PlatformEasing toPlatformEasing(const css::EasingConfig &easingConfig) {
   return {PlatformEasing::Type::Linear, {}, {}};
 }
 
+/// Must match cssPropertyWriterFor on the Kotlin side.
+std::optional<int> platformPropertyId(const std::string &propertyName) {
+  if (propertyName == "opacity") {
+    return 0;
+  }
+  return std::nullopt;
+}
+
+constexpr size_t kMaxInternedEasings = 256;
+
 } // namespace
 
-CSSPlatformTransitions::CSSPlatformTransitions(AnimateFunction animate, RemoveFunction remove)
-    : animate_(std::move(animate)), remove_(std::move(remove)) {}
+std::size_t CSSPlatformTransitions::EasingKeyHash::operator()(const EasingKey &key) const {
+  std::size_t seed = std::hash<int>{}(key.type);
+  const auto combine = [&seed](const float value) {
+    seed ^= std::hash<float>{}(value) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+  };
+  for (const float value : key.pointsX) {
+    combine(value);
+  }
+  for (const float value : key.pointsY) {
+    combine(value);
+  }
+  return seed;
+}
+
+CSSPlatformTransitions::CSSPlatformTransitions(
+    AnimateFunction animate,
+    RemoveFunction remove,
+    DefineEasingFunction defineEasing)
+    : animate_(std::move(animate)), remove_(std::move(remove)), defineEasing_(std::move(defineEasing)) {}
+
+std::optional<int> CSSPlatformTransitions::easingIdFor(const PlatformEasing &easing) {
+  EasingKey key{static_cast<std::uint8_t>(easing.type), easing.pointsX, easing.pointsY};
+  const auto it = easingIds_.find(key);
+  if (it != easingIds_.end()) {
+    return it->second;
+  }
+  if (easingIds_.size() >= kMaxInternedEasings) {
+    return std::nullopt;
+  }
+  const int easingId = static_cast<int>(easingIds_.size());
+  defineEasing_(easingId, static_cast<int>(easing.type), easing.pointsX, easing.pointsY);
+  easingIds_.emplace(std::move(key), easingId);
+  return easingId;
+}
 
 const CSSPlatformTransitions::ActiveTransition *CSSPlatformTransitions::activeTransitionFor(
     const Tag viewTag,
@@ -59,6 +101,11 @@ bool CSSPlatformTransitions::applyTransition(
   const auto *from = std::get_if<double>(&fromValue);
   const auto *to = std::get_if<double>(&toValue);
   if (from == nullptr || to == nullptr) {
+    return false;
+  }
+
+  const auto propertyId = platformPropertyId(propertyName);
+  if (!propertyId) {
     return false;
   }
 
@@ -92,15 +139,20 @@ bool CSSPlatformTransitions::applyTransition(
     adjustedStart = active->adjustedEnd;
   }
 
+  const auto easingId = easingIdFor(toPlatformEasing(resolvedSettings.easingConfig));
+  if (!easingId) {
+    return false;
+  }
+
   if (!animate_(
           static_cast<int>(viewTag),
-          propertyName,
+          *propertyId,
           *from,
           *to,
           reversing.duration,
           reversing.startTimestamp,
-          toPlatformEasing(resolvedSettings.easingConfig),
-          persistent)) {
+              *easingId,
+              persistent)) {
     return false;
   }
 
@@ -116,7 +168,10 @@ void CSSPlatformTransitions::removeTransition(const Tag viewTag, const std::stri
       active_.erase(propertiesIt);
     }
   }
-  remove_(static_cast<int>(viewTag), propertyName);
+  // A property without an id was never routed, so there is nothing to remove.
+  if (const auto propertyId = platformPropertyId(propertyName)) {
+    remove_(static_cast<int>(viewTag), *propertyId);
+  }
 }
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
@@ -43,20 +43,6 @@ constexpr size_t kMaxInternedEasings = 256;
 
 } // namespace
 
-std::size_t CSSPlatformTransitions::EasingKeyHash::operator()(const EasingKey &key) const {
-  std::size_t seed = std::hash<int>{}(key.type);
-  const auto combine = [&seed](const float value) {
-    seed ^= std::hash<float>{}(value) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-  };
-  for (const float value : key.pointsX) {
-    combine(value);
-  }
-  for (const float value : key.pointsY) {
-    combine(value);
-  }
-  return seed;
-}
-
 CSSPlatformTransitions::CSSPlatformTransitions(
     AnimateFunction animate,
     RemoveFunction remove,
@@ -64,17 +50,18 @@ CSSPlatformTransitions::CSSPlatformTransitions(
     : animate_(std::move(animate)), remove_(std::move(remove)), defineEasing_(std::move(defineEasing)) {}
 
 std::optional<int> CSSPlatformTransitions::easingIdFor(const PlatformEasing &easing) {
-  EasingKey key{static_cast<std::uint8_t>(easing.type), easing.pointsX, easing.pointsY};
-  const auto it = easingIds_.find(key);
-  if (it != easingIds_.end()) {
-    return it->second;
+  // A handful of curves in practice, so a scan beats hashing the point lists.
+  for (size_t i = 0; i < internedEasings_.size(); i++) {
+    if (internedEasings_[i] == easing) {
+      return static_cast<int>(i);
+    }
   }
-  if (easingIds_.size() >= kMaxInternedEasings) {
+  if (internedEasings_.size() >= kMaxInternedEasings) {
     return std::nullopt;
   }
-  const int easingId = static_cast<int>(easingIds_.size());
+  const int easingId = static_cast<int>(internedEasings_.size());
   defineEasing_(easingId, static_cast<int>(easing.type), easing.pointsX, easing.pointsY);
-  easingIds_.emplace(std::move(key), easingId);
+  internedEasings_.push_back(easing);
   return easingId;
 }
 

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
@@ -49,19 +49,31 @@ CSSPlatformTransitions::CSSPlatformTransitions(
     DefineEasingFunction defineEasing)
     : animate_(std::move(animate)), remove_(std::move(remove)), defineEasing_(std::move(defineEasing)) {}
 
-std::optional<int> CSSPlatformTransitions::easingIdFor(const PlatformEasing &easing) {
-  // A handful of curves in practice, so a scan beats hashing the point lists.
-  for (size_t i = 0; i < internedEasings_.size(); i++) {
-    if (internedEasings_[i] == easing) {
-      return static_cast<int>(i);
-    }
+std::size_t PlatformEasingHash::operator()(const PlatformEasing &easing) const {
+  std::size_t seed = std::hash<std::uint8_t>{}(static_cast<std::uint8_t>(easing.type));
+  const auto combine = [&seed](const float value) {
+    seed ^= std::hash<float>{}(value) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+  };
+  for (const float value : easing.pointsX) {
+    combine(value);
   }
-  if (internedEasings_.size() >= kMaxInternedEasings) {
+  for (const float value : easing.pointsY) {
+    combine(value);
+  }
+  return seed;
+}
+
+std::optional<int> CSSPlatformTransitions::easingIdFor(const PlatformEasing &easing) {
+  const auto it = easingIds_.find(easing);
+  if (it != easingIds_.end()) {
+    return it->second;
+  }
+  if (easingIds_.size() >= kMaxInternedEasings) {
     return std::nullopt;
   }
-  const int easingId = static_cast<int>(internedEasings_.size());
+  const int easingId = static_cast<int>(easingIds_.size());
   defineEasing_(easingId, static_cast<int>(easing.type), easing.pointsX, easing.pointsY);
-  internedEasings_.push_back(easing);
+  easingIds_.emplace(easing, easingId);
   return easingId;
 }
 

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
@@ -25,6 +25,8 @@ struct PlatformEasing {
   Type type;
   std::vector<float> pointsX;
   std::vector<float> pointsY;
+
+  bool operator==(const PlatformEasing &other) const = default;
 };
 
 class CSSPlatformTransitions {
@@ -72,27 +74,16 @@ class CSSPlatformTransitions {
     css::CSSTransitionPropertySettings settings;
   };
 
-  struct EasingKey {
-    std::uint8_t type;
-    std::vector<float> pointsX;
-    std::vector<float> pointsY;
-
-    bool operator==(const EasingKey &other) const = default;
-  };
-
-  struct EasingKeyHash {
-    std::size_t operator()(const EasingKey &key) const;
-  };
-
   const ActiveTransition *activeTransitionFor(Tag viewTag, const std::string &propertyName) const;
 
-  /// Interns the curve, registering it on first sight. Returns nullopt once the
-  /// table is full (an app computing easing points at runtime could otherwise grow
-  /// it forever); such transitions fall back to the loop, which plays any easing.
+  /// Interns the curve, registering it on first sight; the id is its index. Returns
+  /// nullopt once the table is full (an app computing easing points at runtime could
+  /// otherwise grow it forever); such transitions fall back to the loop, which plays
+  /// any easing.
   std::optional<int> easingIdFor(const PlatformEasing &easing);
 
   std::unordered_map<Tag, std::unordered_map<std::string, ActiveTransition>> active_;
-  std::unordered_map<EasingKey, int, EasingKeyHash> easingIds_;
+  std::vector<PlatformEasing> internedEasings_;
   AnimateFunction animate_;
   RemoveFunction remove_;
   DefineEasingFunction defineEasing_;

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
@@ -29,12 +29,14 @@ struct PlatformEasing {
   bool operator==(const PlatformEasing &other) const = default;
 };
 
+struct PlatformEasingHash {
+  std::size_t operator()(const PlatformEasing &easing) const;
+};
+
 class CSSPlatformTransitions {
  public:
-  /// False means the view can't carry the animation and the property falls back to
-  /// the loop. All-primitive (easing and property pre-registered by id), so the hot
-  /// per-transition JNI hop allocates nothing. A `persistent` value must outlive the
-  /// animation itself.
+  /// False means the property falls back to the loop. Ids and scalars only, so the
+  /// per-transition JNI hop allocates nothing.
   using AnimateFunction = std::function<bool(
       int viewTag,
       int propertyId,
@@ -46,7 +48,7 @@ class CSSPlatformTransitions {
       bool persistent)>;
   using RemoveFunction = std::function<void(int viewTag, int propertyId)>;
 
-  /// Registers an easing curve once; later transitions reference it by id.
+  /// Registers a curve on the platform under an id.
   using DefineEasingFunction =
       std::function<void(int easingId, int type, const std::vector<float> &pointsX, const std::vector<float> &pointsY)>;
 
@@ -76,14 +78,13 @@ class CSSPlatformTransitions {
 
   const ActiveTransition *activeTransitionFor(Tag viewTag, const std::string &propertyName) const;
 
-  /// Interns the curve, registering it on first sight; the id is its index. Returns
-  /// nullopt once the table is full (an app computing easing points at runtime could
-  /// otherwise grow it forever); such transitions fall back to the loop, which plays
-  /// any easing.
+  /// Interns the curve, registering it on first sight. Returns nullopt once the table is
+  /// full, which an app computing easing points at runtime could otherwise grow forever;
+  /// those transitions fall back to the loop, which plays any easing.
   std::optional<int> easingIdFor(const PlatformEasing &easing);
 
   std::unordered_map<Tag, std::unordered_map<std::string, ActiveTransition>> active_;
-  std::vector<PlatformEasing> internedEasings_;
+  std::unordered_map<PlatformEasing, int, PlatformEasingHash> easingIds_;
   AnimateFunction animate_;
   RemoveFunction remove_;
   DefineEasingFunction defineEasing_;

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
@@ -29,21 +29,26 @@ struct PlatformEasing {
 
 class CSSPlatformTransitions {
  public:
-  /// Returns false when the view can't carry the animation, in which case the
-  /// property falls back to the loop. A `persistent` transition has no committed
-  /// style behind it, so its value must outlive the animation itself.
+  /// False means the view can't carry the animation and the property falls back to
+  /// the loop. All-primitive (easing and property pre-registered by id), so the hot
+  /// per-transition JNI hop allocates nothing. A `persistent` value must outlive the
+  /// animation itself.
   using AnimateFunction = std::function<bool(
       int viewTag,
-      const std::string &propertyName,
+      int propertyId,
       double fromValue,
       double toValue,
       double durationMs,
       double startTimestampMs,
-      const PlatformEasing &easing,
+      int easingId,
       bool persistent)>;
-  using RemoveFunction = std::function<void(int viewTag, const std::string &propertyName)>;
+  using RemoveFunction = std::function<void(int viewTag, int propertyId)>;
 
-  CSSPlatformTransitions(AnimateFunction animate, RemoveFunction remove);
+  /// Registers an easing curve once; later transitions reference it by id.
+  using DefineEasingFunction =
+      std::function<void(int easingId, int type, const std::vector<float> &pointsX, const std::vector<float> &pointsY)>;
+
+  CSSPlatformTransitions(AnimateFunction animate, RemoveFunction remove, DefineEasingFunction defineEasing);
 
   /// A null `settings` marks the pseudo-selector toggle path, which carries none of
   /// its own and reuses whatever the last config apply stored. A settings-only config
@@ -67,11 +72,30 @@ class CSSPlatformTransitions {
     css::CSSTransitionPropertySettings settings;
   };
 
+  struct EasingKey {
+    std::uint8_t type;
+    std::vector<float> pointsX;
+    std::vector<float> pointsY;
+
+    bool operator==(const EasingKey &other) const = default;
+  };
+
+  struct EasingKeyHash {
+    std::size_t operator()(const EasingKey &key) const;
+  };
+
   const ActiveTransition *activeTransitionFor(Tag viewTag, const std::string &propertyName) const;
 
+  /// Interns the curve, registering it on first sight. Returns nullopt once the
+  /// table is full (an app computing easing points at runtime could otherwise grow
+  /// it forever); such transitions fall back to the loop, which plays any easing.
+  std::optional<int> easingIdFor(const PlatformEasing &easing);
+
   std::unordered_map<Tag, std::unordered_map<std::string, ActiveTransition>> active_;
+  std::unordered_map<EasingKey, int, EasingKeyHash> easingIds_;
   AnimateFunction animate_;
   RemoveFunction remove_;
+  DefineEasingFunction defineEasing_;
 };
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
@@ -251,45 +251,45 @@ void NativeProxy::attachPseudoSelector(Tag tag, PseudoSelector selector, std::fu
 
 bool NativeProxy::cssAnimateTransition(
     const int viewTag,
-    const std::string &propertyName,
+    const int propertyId,
     const double fromValue,
     const double toValue,
     const double durationMs,
     const double startTimestampMs,
-    const PlatformEasing &easing,
+    const int easingId,
     const bool persistent) {
-  static const auto method = getJniMethod<jboolean(
-      int,
-      jni::alias_ref<jni::JString>,
-      double,
-      double,
-      double,
-      double,
-      int,
-      jni::alias_ref<jni::JArrayFloat>,
-      jni::alias_ref<jni::JArrayFloat>,
-      jboolean)>("cssAnimateTransition");
-  auto jPointsX = jni::JArrayFloat::newArray(easing.pointsX.size());
-  jPointsX->setRegion(0, easing.pointsX.size(), easing.pointsX.data());
-  auto jPointsY = jni::JArrayFloat::newArray(easing.pointsY.size());
-  jPointsY->setRegion(0, easing.pointsY.size(), easing.pointsY.data());
+  static const auto method =
+      getJniMethod<jboolean(int, int, double, double, double, double, int, jboolean)>("cssAnimateTransition");
   return method(
              javaPart_.get(),
              viewTag,
-             jni::make_jstring(propertyName),
+             propertyId,
              fromValue,
              toValue,
              durationMs,
              startTimestampMs,
-             static_cast<int>(easing.type),
-             jPointsX,
-             jPointsY,
+             easingId,
              static_cast<jboolean>(persistent)) != JNI_FALSE;
 }
 
-void NativeProxy::cssRemoveTransition(const int viewTag, const std::string &propertyName) {
-  static const auto method = getJniMethod<void(int, jni::alias_ref<jni::JString>)>("cssRemoveTransition");
-  method(javaPart_.get(), viewTag, jni::make_jstring(propertyName));
+void NativeProxy::cssRemoveTransition(const int viewTag, const int propertyId) {
+  static const auto method = getJniMethod<void(int, int)>("cssRemoveTransition");
+  method(javaPart_.get(), viewTag, propertyId);
+}
+
+void NativeProxy::cssDefineEasing(
+    const int easingId,
+    const int type,
+    const std::vector<float> &pointsX,
+    const std::vector<float> &pointsY) {
+  static const auto method =
+      getJniMethod<void(int, int, jni::alias_ref<jni::JArrayFloat>, jni::alias_ref<jni::JArrayFloat>)>(
+          "cssDefineEasing");
+  auto jPointsX = jni::JArrayFloat::newArray(pointsX.size());
+  jPointsX->setRegion(0, pointsX.size(), pointsX.data());
+  auto jPointsY = jni::JArrayFloat::newArray(pointsY.size());
+  jPointsY->setRegion(0, pointsY.size(), pointsY.data());
+  method(javaPart_.get(), easingId, type, jPointsX, jPointsY);
 }
 
 void NativeProxy::detachPseudoSelector(Tag tag, PseudoSelector selector) {
@@ -378,7 +378,9 @@ PlatformDepMethodsHolder NativeProxy::getPlatformDependentMethods() {
   // the constructor's member-initializer list, where a member would still be raw
   // memory.
   auto cssPlatformTransitions = std::make_shared<CSSPlatformTransitions>(
-      bindThis(&NativeProxy::cssAnimateTransition), bindThis(&NativeProxy::cssRemoveTransition));
+      bindThis(&NativeProxy::cssAnimateTransition),
+      bindThis(&NativeProxy::cssRemoveTransition),
+      bindThis(&NativeProxy::cssDefineEasing));
 
   auto cssCanRouteProperty = css::CSSCanRoutePropertyFunction(&css::canRouteCSSProperty);
 

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
@@ -76,14 +76,15 @@ class NativeProxy : public jni::HybridClass<NativeProxy>, std::enable_shared_fro
   void detachPseudoSelector(Tag tag, PseudoSelector selector);
   bool cssAnimateTransition(
       int viewTag,
-      const std::string &propertyName,
+      int propertyId,
       double fromValue,
       double toValue,
       double durationMs,
       double startTimestampMs,
-      const PlatformEasing &easing,
+      int easingId,
       bool persistent);
-  void cssRemoveTransition(int viewTag, const std::string &propertyName);
+  void cssRemoveTransition(int viewTag, int propertyId);
+  void cssDefineEasing(int easingId, int type, const std::vector<float> &pointsX, const std::vector<float> &pointsY);
 
   /***
    * Wraps a method of `NativeProxy` in a function object capturing `this`

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
@@ -256,6 +256,7 @@ open class NativeProxy {
         intBuffer: IntArray,
         doubleBuffer: DoubleArray,
     ) {
+        cssPlatformTransitionsManager.onPropsWrittenSynchronously()
         SynchronousPropsBufferParser.parse(intBuffer, doubleBuffer) { viewTag, props ->
             if (BuildConfig.IS_REACT_NATIVE_86_OR_NEWER) {
                 try {

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
@@ -271,37 +271,43 @@ open class NativeProxy {
     }
 
     @DoNotStrip
+    fun cssDefineEasing(
+        easingId: Int,
+        easingType: Int,
+        easingPointsX: FloatArray,
+        easingPointsY: FloatArray,
+    ) {
+        cssPlatformTransitionsManager.defineEasing(easingId, easingType, easingPointsX, easingPointsY)
+    }
+
+    @DoNotStrip
     fun cssAnimateTransition(
         viewTag: Int,
-        propertyName: String,
+        propertyId: Int,
         fromValue: Double,
         toValue: Double,
         durationMs: Double,
         startTimestampMs: Double,
-        easingType: Int,
-        easingPointsX: FloatArray,
-        easingPointsY: FloatArray,
+        easingId: Int,
         persistent: Boolean,
     ): Boolean =
         cssPlatformTransitionsManager.animateTransition(
             viewTag,
-            propertyName,
+            propertyId,
             fromValue,
             toValue,
             durationMs,
             startTimestampMs,
-            easingType,
-            easingPointsX,
-            easingPointsY,
+            easingId,
             persistent,
         )
 
     @DoNotStrip
     fun cssRemoveTransition(
         viewTag: Int,
-        propertyName: String,
+        propertyId: Int,
     ) {
-        cssPlatformTransitionsManager.removeTransition(viewTag, propertyName)
+        cssPlatformTransitionsManager.removeTransition(viewTag, propertyId)
     }
 
     @DoNotStrip

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
@@ -57,11 +57,17 @@ internal class CSSPlatformTransitionsManager(
     private var invalidated = false
 
     private var nextStartToken = 0L
-    private val interpolators = HashMap<InterpolatorKey, TimeInterpolator>()
+
+    /**
+     * Indexed by the easing id the C++ interner assigned; a define always precedes the
+     * first animate call using its id. Copy-on-append keeps reads lock-free.
+     */
+    @Volatile
+    private var easings = arrayOfNulls<TimeInterpolator>(0)
 
     private data class Key(
         val viewTag: Int,
-        val propertyName: String,
+        val propertyId: Int,
     )
 
     private class RunningTransition(
@@ -90,41 +96,33 @@ internal class CSSPlatformTransitionsManager(
         }
     }
 
-    private data class InterpolatorKey(
-        val type: Int,
-        val pointsX: List<Float>,
-        val pointsY: List<Float>,
-    )
-
     /** Whether the property is accepted; it can still fail later if the View never mounts. */
     fun animateTransition(
         viewTag: Int,
-        propertyName: String,
+        propertyId: Int,
         fromValue: Double,
         toValue: Double,
         durationMs: Double,
         startTimestampMs: Double,
-        easingType: Int,
-        easingPointsX: FloatArray,
-        easingPointsY: FloatArray,
+        easingId: Int,
         persistent: Boolean,
     ): Boolean {
         if (invalidated) return false
-        val writer = cssPropertyWriterFor(propertyName) ?: return false
+        val writer = cssPropertyWriterFor(propertyId) ?: return false
+        val interpolator = easings.getOrNull(easingId) ?: return false
         val context = reactContext.get() ?: return false
         val scale = DurationScale.effectiveScale(context)
         if (scale <= 0f) return false
 
         UiThreadUtil.runOnUiThread {
             if (invalidated) return@runOnUiThread
-            val key = Key(viewTag, propertyName)
+            val key = Key(viewTag, propertyId)
             // A fresh token invalidates any retry still queued for this key.
             val token = ++nextStartToken
             startTokens[key] = token
 
             beginWhenMounted(key, token, startTimestampMs + durationMs) {
                 viewForTag(viewTag)?.also { view ->
-                    val interpolator = interpolatorFor(easingType, easingPointsX, easingPointsY)
                     start(view, key, writer, fromValue, toValue, durationMs, startTimestampMs, interpolator, scale, persistent)
                 } != null
             }
@@ -151,10 +149,10 @@ internal class CSSPlatformTransitionsManager(
 
     fun removeTransition(
         viewTag: Int,
-        propertyName: String,
+        propertyId: Int,
     ) {
         UiThreadUtil.runOnUiThread {
-            val key = Key(viewTag, propertyName)
+            val key = Key(viewTag, propertyId)
             startTokens.remove(key)
             animators.remove(key)?.animator?.cancel()
         }
@@ -251,15 +249,18 @@ internal class CSSPlatformTransitionsManager(
         return animators.isNotEmpty()
     }
 
-    /** PathInterpolator flattens its curve on construction, so cache it. Type is in the key
-     * because families share point lists. */
-    private fun interpolatorFor(
-        type: Int,
-        pointsX: FloatArray,
-        pointsY: FloatArray,
-    ): TimeInterpolator {
-        val key = InterpolatorKey(type, pointsX.toList(), pointsY.toList())
-        return interpolators.getOrPut(key) { CSSEasing.interpolator(type, pointsX, pointsY) }
+    /** PathInterpolator flattens its curve natively on construction, so build once per id. */
+    fun defineEasing(
+        easingId: Int,
+        easingType: Int,
+        easingPointsX: FloatArray,
+        easingPointsY: FloatArray,
+    ) {
+        val interpolator = CSSEasing.interpolator(easingType, easingPointsX, easingPointsY)
+        val current = easings
+        val grown = if (easingId < current.size) current.copyOf() else current.copyOf(easingId + 1)
+        grown[easingId] = interpolator
+        easings = grown
     }
 
     private fun viewForTag(viewTag: Int): View? =

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
@@ -24,10 +24,10 @@ internal class CSSPlatformTransitionsManager(
     private val animators = HashMap<Key, RunningTransition>()
 
     /**
-     * React can overwrite an animated value only on frames where a mount ran, so the
+     * React can overwrite an animated value only on frames where it wrote props, so the
      * pre-draw repair is skipped on all others. Everything here runs on the UI thread.
      */
-    private var mountedSinceLastDraw = true
+    private var reactWroteSinceLastDraw = true
 
     @OptIn(UnstableReactNativeAPI::class)
     private val mountListener =
@@ -37,7 +37,7 @@ internal class CSSPlatformTransitionsManager(
             override fun willMountItems(uiManager: UIManager) = Unit
 
             override fun didMountItems(uiManager: UIManager) {
-                mountedSinceLastDraw = true
+                reactWroteSinceLastDraw = true
             }
 
             override fun didDispatchMountItems(uiManager: UIManager) = Unit
@@ -233,10 +233,15 @@ internal class CSSPlatformTransitionsManager(
         reconciler.track(view)
     }
 
+    /** Synchronous prop writes run their mount item inline, so no listener reports them. */
+    fun onPropsWrittenSynchronously() {
+        reactWroteSinceLastDraw = true
+    }
+
     /** Re-asserts each animator's own value wherever a commit overwrote it. */
     private fun repairClobberedValues(): Boolean {
-        if (!mountedSinceLastDraw) return animators.isNotEmpty()
-        mountedSinceLastDraw = false
+        if (!reactWroteSinceLastDraw) return animators.isNotEmpty()
+        reactWroteSinceLastDraw = false
         animators.values.forEach { running ->
             // target is held weakly, so read the View through it rather than keeping one.
             val view = running.animator.target as? View ?: return@forEach

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
@@ -8,7 +8,10 @@ import android.util.FloatProperty
 import android.view.Choreographer
 import android.view.View
 import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.UIManager
+import com.facebook.react.bridge.UIManagerListener
 import com.facebook.react.bridge.UiThreadUtil
+import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.fabric.FabricUIManager
 import com.facebook.react.uimanager.IllegalViewOperationException
 import java.lang.ref.WeakReference
@@ -19,6 +22,34 @@ internal class CSSPlatformTransitionsManager(
     private val animationTimestamp: () -> Long,
 ) {
     private val animators = HashMap<Key, RunningTransition>()
+
+    /**
+     * React can overwrite an animated value only on frames where a mount ran, so the
+     * pre-draw repair is skipped on all others. Everything here runs on the UI thread.
+     */
+    private var mountedSinceLastDraw = true
+
+    @OptIn(UnstableReactNativeAPI::class)
+    private val mountListener =
+        object : UIManagerListener {
+            override fun willDispatchViewUpdates(uiManager: UIManager) = Unit
+
+            override fun willMountItems(uiManager: UIManager) = Unit
+
+            override fun didMountItems(uiManager: UIManager) {
+                mountedSinceLastDraw = true
+            }
+
+            override fun didDispatchMountItems(uiManager: UIManager) = Unit
+
+            override fun didScheduleMountItems(uiManager: UIManager) = Unit
+        }
+
+    init {
+        @OptIn(UnstableReactNativeAPI::class)
+        fabricUIManager.addUIManagerEventListener(mountListener)
+    }
+
     private val reconciler = CSSPlatformTransitionReconciler(::repairClobberedValues)
     private val startTokens = HashMap<Key, Long>()
 
@@ -106,6 +137,8 @@ internal class CSSPlatformTransitionsManager(
         // Set before posting: a start already queued would otherwise register a new
         // animator and listener behind the cleanup.
         invalidated = true
+        @OptIn(UnstableReactNativeAPI::class)
+        fabricUIManager.removeUIManagerEventListener(mountListener)
         UiThreadUtil.runOnUiThread {
             startTokens.clear()
             // Snapshot first: cancel() runs onAnimationEnd, which reads the map.
@@ -202,6 +235,8 @@ internal class CSSPlatformTransitionsManager(
 
     /** Re-asserts each animator's own value wherever a commit overwrote it. */
     private fun repairClobberedValues(): Boolean {
+        if (!mountedSinceLastDraw) return animators.isNotEmpty()
+        mountedSinceLastDraw = false
         animators.values.forEach { running ->
             // target is held weakly, so read the View through it rather than keeping one.
             val view = running.animator.target as? View ?: return@forEach

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPropertyWriter.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPropertyWriter.kt
@@ -3,10 +3,15 @@ package com.swmansion.reanimated.css
 import android.util.FloatProperty
 import android.view.View
 
-/** The View property React Native itself writes, so a commit can overwrite a running animation. */
-internal fun cssPropertyWriterFor(propertyName: String): FloatProperty<View>? =
-    when (propertyName) {
-        "opacity" -> AlphaProperty
+/**
+ * The View property React Native itself writes, so a commit can overwrite a running
+ * animation, which the pre-draw reconciliation repairs.
+ *
+ * Ids must match `platformPropertyId` in CSSPlatformTransitions.cpp.
+ */
+internal fun cssPropertyWriterFor(propertyId: Int): FloatProperty<View>? =
+    when (propertyId) {
+        0 -> AlphaProperty
         else -> null
     }
 


### PR DESCRIPTION
Each easing is defined once under an integer id and properties are routed by id as well, so starting a transition passes only scalars across JNI. Previously every start re-crossed the boundary with the property name string and the easing curve points.
