### PR TITLE
perf: Drive platform transitions from a single frame pump

### DIFF
--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionReconciler.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionReconciler.kt
@@ -2,23 +2,50 @@ package com.swmansion.reanimated.css
 
 import android.view.View
 import android.view.ViewTreeObserver
+import java.util.Collections
+import java.util.WeakHashMap
 
 /**
  * A platform transition animates the property React Native itself writes, so a commit can
- * overwrite it mid-flight. Re-asserting just before the frame is drawn covers every writer -
- * a Fabric mount, the synchronous props path, the animation backend - without knowing which
- * one ran, since they all run earlier in the same frame.
- *
- * [repair] returns whether anything is still animating.
+ * overwrite it mid-flight; re-asserting just before draw covers every writer, since they
+ * all run earlier in the same frame. [repair] returns whether anything is still animating.
  */
 internal class CSSPlatformTransitionReconciler(
     private val repair: () -> Boolean,
 ) {
-    /** Keyed by window: getViewTreeObserver is per window, not per view. */
-    private val tracked = HashSet<ViewTreeObserver>()
+    /**
+     * Keyed by window (getViewTreeObserver is per window). Weakly held: a destroyed
+     * window's observer stays isAlive forever and never draws, so a strong set would
+     * pin one observer per torn-down window.
+     */
+    private val tracked: MutableSet<ViewTreeObserver> =
+        Collections.newSetFromMap(WeakHashMap())
+
+    /** Views awaiting attach, so repeated starts do not stack one listener each. */
+    private val pendingAttach: MutableSet<View> =
+        Collections.newSetFromMap(WeakHashMap())
 
     fun track(view: View) {
-        // A window torn down mid-animation never draws again, so its listener never retires.
+        if (!view.isAttachedToWindow) {
+            // A detached view's floating observer dies on attach, leaving its listener
+            // unremovable; register only once the view is genuinely attached.
+            if (!pendingAttach.add(view)) return
+            view.addOnAttachStateChangeListener(
+                object : View.OnAttachStateChangeListener {
+                    override fun onViewAttachedToWindow(attached: View) {
+                        attached.removeOnAttachStateChangeListener(this)
+                        pendingAttach.remove(attached)
+                        track(attached)
+                    }
+
+                    override fun onViewDetachedFromWindow(detached: View) {
+                        detached.removeOnAttachStateChangeListener(this)
+                        pendingAttach.remove(detached)
+                    }
+                },
+            )
+            return
+        }
         tracked.removeAll { !it.isAlive }
 
         val observer = view.viewTreeObserver
@@ -29,9 +56,7 @@ internal class CSSPlatformTransitionReconciler(
                 override fun onPreDraw(): Boolean {
                     if (repair()) return true
 
-                    // Retiring here rather than when the registry empties: cancelling an
-                    // animator runs its end callback part way through installing the
-                    // replacement, when the registry is briefly empty.
+                    // Nothing left to defend: retire until the next track().
                     if (observer.isAlive) observer.removeOnPreDrawListener(this)
                     tracked.remove(observer)
                     return true

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
@@ -1,16 +1,15 @@
 package com.swmansion.reanimated.css
 
-import android.animation.Animator
-import android.animation.AnimatorListenerAdapter
-import android.animation.ObjectAnimator
 import android.animation.TimeInterpolator
+import android.os.Handler
+import android.os.Looper
+import android.os.Message
 import android.util.FloatProperty
 import android.view.Choreographer
 import android.view.View
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.UIManager
 import com.facebook.react.bridge.UIManagerListener
-import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.fabric.FabricUIManager
 import com.facebook.react.uimanager.IllegalViewOperationException
@@ -21,7 +20,7 @@ internal class CSSPlatformTransitionsManager(
     private val reactContext: WeakReference<ReactApplicationContext>,
     private val animationTimestamp: () -> Long,
 ) {
-    private val animators = HashMap<Key, RunningTransition>()
+    private val transitions = HashMap<Key, RunningTransition>()
 
     /**
      * React can overwrite an animated value only on frames where a mount ran, so the
@@ -61,180 +60,107 @@ internal class CSSPlatformTransitionsManager(
     @Volatile
     private var easings = arrayOfNulls<TimeInterpolator>(0)
 
+    private var pumping = false
+
+    private val commandLock = Any()
+    private var pendingCommands = ArrayList<Command>()
+    private var spareCommands = ArrayList<Command>()
+    private var flushScheduled = false
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    /**
+     * Single per-frame driver for every running transition. Values come from the absolute
+     * start timestamp, so delay (t < 0) and late starts need no extra state.
+     */
+    private val framePump =
+        object : Choreographer.FrameCallback {
+            override fun doFrame(frameTimeNanos: Long) {
+                val now = animationTimestamp().toDouble()
+                var active = false
+                val iterator = transitions.entries.iterator()
+                while (iterator.hasNext()) {
+                    val running = iterator.next().value
+                    val view = running.viewRef.get()
+                    if (view == null) {
+                        iterator.remove()
+                        continue
+                    }
+                    if (running.finished) continue
+                    val elapsedMs = now - running.startTimeMs
+                    if (elapsedMs < 0) {
+                        // Delay phase: hold the raw start value; step easings are already nonzero at t = 0.
+                        running.current = running.startValue
+                        running.writer.setValue(view, running.startValue)
+                        active = true
+                        continue
+                    }
+                    val progress = (elapsedMs / running.durationMs).toFloat().coerceAtMost(1f)
+                    val value =
+                        running.startValue +
+                            (running.toValue - running.startValue) * running.interpolator.getInterpolation(progress)
+                    running.current = value
+                    // setAlpha early-outs on unchanged values, so unconditional writes cost nothing.
+                    running.writer.setValue(view, value)
+                    if (elapsedMs < running.durationMs) {
+                        active = true
+                        continue
+                    }
+                    if (running.persistent) {
+                        // Keeps its entry so the pre-draw repair defends the final value.
+                        running.finished = true
+                    } else {
+                        iterator.remove()
+                    }
+                }
+                if (active) {
+                    Choreographer.getInstance().postFrameCallback(this)
+                } else {
+                    pumping = false
+                }
+            }
+        }
+
     private data class Key(
         val viewTag: Int,
         val propertyId: Int,
     )
 
     private class RunningTransition(
-        val animator: ObjectAnimator,
+        view: View,
         val writer: FloatProperty<View>,
         val startValue: Float,
+        val toValue: Float,
+        val startTimeMs: Double,
+        val durationMs: Double,
+        val interpolator: TimeInterpolator,
+        val persistent: Boolean,
     ) {
-        /** Final value of a finished persistent transition, which outlives its animator. */
-        var heldValue: Float? = null
+        val viewRef = WeakReference(view)
 
-        /**
-         * ObjectAnimator leaves its animated value uninitialised until its first frame, which
-         * a start delay defers, so until then the property must show the start value.
-         */
-        fun currentValue(): Float = heldValue ?: if (animator.isRunning) animator.animatedValue as Float else startValue
+        /** Last value this manager wrote; the repair pass re-asserts it after commits. */
+        var current: Float = startValue
+
+        /** A finished persistent transition stays registered so its value keeps being defended. */
+        var finished: Boolean = false
     }
 
-    /** Holds the start value for the leading [delayFraction], then plays [inner] over the rest. */
-    private class HoldThenEase(
-        private val delayFraction: Float,
-        private val inner: TimeInterpolator,
-    ) : TimeInterpolator {
-        override fun getInterpolation(input: Float): Float =
-            if (input <= delayFraction) 0f else inner.getInterpolation((input - delayFraction) / (1f - delayFraction))
-    }
+    private sealed class Command {
+        abstract val key: Key
 
-    /**
-     * Returns whether the property is accepted for native playback, decided before the
-     * hop to the UI thread. Playback itself can still fail there if the View never
-     * mounts, and there is no path back to demote the property afterwards - the same
-     * contract the Apple backend has.
-     */
-    fun animateTransition(
-        viewTag: Int,
-        propertyId: Int,
-        fromValue: Double,
-        toValue: Double,
-        durationMs: Double,
-        startTimestampMs: Double,
-        easingId: Int,
-        persistent: Boolean,
-    ): Boolean {
-        val writer = cssPropertyWriterFor(propertyId) ?: return false
-        val interpolator = easings.getOrNull(easingId) ?: return false
-        val context = reactContext.get() ?: return false
-        val scale = DurationScale.effectiveScale(context)
-        // Scale 0 means animations are off, and ValueAnimator would finish instantly.
-        if (scale <= 0f) return false
+        class Start(
+            override val key: Key,
+            val writer: FloatProperty<View>,
+            val fromValue: Double,
+            val toValue: Double,
+            val durationMs: Double,
+            val startTimestampMs: Double,
+            val interpolator: TimeInterpolator,
+            val persistent: Boolean,
+        ) : Command()
 
-        UiThreadUtil.runOnUiThread {
-            val key = Key(viewTag, propertyId)
-            // Claiming a fresh token invalidates any retry still queued for this key,
-            // so a superseded request cannot start on a later frame.
-            val token = ++nextStartToken
-            startTokens[key] = token
-
-            beginWhenMounted(key, token, startTimestampMs + durationMs) {
-                viewForTag(viewTag)?.also { view ->
-                    start(view, key, writer, fromValue, toValue, durationMs, startTimestampMs, interpolator, scale, persistent)
-                } != null
-            }
-        }
-        return true
-    }
-
-    fun removeTransition(
-        viewTag: Int,
-        propertyId: Int,
-    ) {
-        UiThreadUtil.runOnUiThread {
-            val key = Key(viewTag, propertyId)
-            // Also drops any queued retry for this key.
-            startTokens.remove(key)
-            animators.remove(key)?.animator?.cancel()
-        }
-    }
-
-    /**
-     * A tag can be registered before its View exists, with the mount still in flight.
-     * The start timestamp is absolute, so a late start seeks rather than drifting, and
-     * retrying needs no arbitrary timeout: once the transition would have ended there
-     * is nothing left to play.
-     */
-    private fun beginWhenMounted(
-        key: Key,
-        token: Long,
-        endTimestampMs: Double,
-        begin: () -> Boolean,
-    ) {
-        if (startTokens[key] != token) return
-        if (begin() || animationTimestamp() >= endTimestampMs) {
-            startTokens.remove(key)
-            return
-        }
-        Choreographer.getInstance().postFrameCallback { beginWhenMounted(key, token, endTimestampMs, begin) }
-    }
-
-    private fun start(
-        view: View,
-        key: Key,
-        writer: FloatProperty<View>,
-        fromValue: Double,
-        toValue: Double,
-        durationMs: Double,
-        startTimestampMs: Double,
-        interpolator: TimeInterpolator,
-        scale: Float,
-        persistent: Boolean,
-    ) {
-        // On interruption resume from what is on screen: fromValue is the committed
-        // style value, so starting there would snap the view back to where the
-        // cancelled transition began.
-        val interrupted = animators.remove(key)
-        val startValue = if (interrupted != null) writer.get(view) else fromValue.toFloat()
-        interrupted?.animator?.cancel()
-
-        // React Native has already committed the target, and ObjectAnimator writes nothing
-        // until its first frame - which transition-delay defers. Without this the view
-        // would show the target for the whole delay and then jump back.
-        writer.setValue(view, startValue)
-
-        val animator = ObjectAnimator.ofFloat(view, writer, startValue, toValue.toFloat())
-        animator.addListener(
-            object : AnimatorListenerAdapter() {
-                override fun onAnimationEnd(animation: Animator) {
-                    // A replacement may already own the key.
-                    val running = animators[key] ?: return
-                    if (running.animator !== animation) return
-                    // A persistent value has no committed style behind it, so dropping the entry
-                    // would let the next commit revert the view.
-                    if (persistent) {
-                        running.heldValue = animator.animatedValue as Float
-                    } else {
-                        animators.remove(key)
-                    }
-                }
-            },
-        )
-        // ObjectAnimator has no absolute start time, so resolve one against the clock
-        // here rather than in C++: the hop to this thread and the wait for the next
-        // frame would otherwise shift the whole timeline late.
-        val elapsedMs = animationTimestamp().toDouble() - startTimestampMs
-        val delayMs = if (elapsedMs < 0) -elapsedMs else 0.0
-        // Play through the delay rather than using startDelay. A delayed ObjectAnimator
-        // writes nothing while it waits, so any commit landing in that window stays on
-        // screen; holding the start value inside the curve makes the animator rewrite the
-        // property every frame instead. This is what kCAFillModeBackwards gives us on Apple.
-        animator.duration = ((delayMs + durationMs) / scale).toLong().coerceAtLeast(1L)
-        animator.interpolator =
-            if (delayMs > 0) HoldThenEase((delayMs / (delayMs + durationMs)).toFloat(), interpolator) else interpolator
-        if (elapsedMs > 0 && durationMs > 0) {
-            // Seek before starting: ValueAnimator.start() gates on `mSeekFraction >= 0` when
-            // deciding whether to begin immediately, so a later seek races the first frame.
-            animator.setCurrentFraction((elapsedMs / durationMs).toFloat().coerceIn(0f, 1f))
-        }
-        animator.start()
-        animators[key] = RunningTransition(animator, writer, startValue)
-        reconciler.track(view)
-    }
-
-    /** Re-asserts each animator's own value wherever a commit overwrote it. */
-    private fun repairClobberedValues(): Boolean {
-        if (!mountedSinceLastDraw) return animators.isNotEmpty()
-        mountedSinceLastDraw = false
-        animators.values.forEach { running ->
-            // target is held weakly, so read the View through it rather than keeping one.
-            val view = running.animator.target as? View ?: return@forEach
-            val current = running.currentValue()
-            if (running.writer.get(view) != current) running.writer.setValue(view, current)
-        }
-        return animators.isNotEmpty()
+        class Remove(
+            override val key: Key,
+        ) : Command()
     }
 
     /** PathInterpolator flattens its curve natively on construction, so build once per id. */
@@ -249,6 +175,210 @@ internal class CSSPlatformTransitionsManager(
         val grown = if (easingId < current.size) current.copyOf() else current.copyOf(easingId + 1)
         grown[easingId] = interpolator
         easings = grown
+    }
+
+    /**
+     * Accepts or refuses the property for native playback; false sends it to the loop.
+     * There is no later demotion path - the same contract the Apple backend has.
+     */
+    fun animateTransition(
+        viewTag: Int,
+        propertyId: Int,
+        fromValue: Double,
+        toValue: Double,
+        durationMs: Double,
+        startTimestampMs: Double,
+        easingId: Int,
+        persistent: Boolean,
+    ): Boolean {
+        val writer = cssPropertyWriterFor(propertyId) ?: return false
+        val interpolator = easings.getOrNull(easingId) ?: return false
+        val context = reactContext.get() ?: return false
+        // With animations disabled the loop settles the final style without animating;
+        // platform transitions otherwise ignore the animator duration scale.
+        if (!DurationScale.animationsEnabled(context)) return false
+
+        enqueue(
+            Command.Start(
+                Key(viewTag, propertyId),
+                writer,
+                fromValue,
+                toValue,
+                durationMs,
+                startTimestampMs,
+                interpolator,
+                persistent,
+            ),
+        )
+        return true
+    }
+
+    fun removeTransition(
+        viewTag: Int,
+        propertyId: Int,
+    ) {
+        enqueue(Command.Remove(Key(viewTag, propertyId)))
+    }
+
+    /**
+     * One asynchronous main-looper message per burst, not one per transition: per-command
+     * messages flood the looper under churn, and a synchronous message can be deferred by
+     * a traversal's sync barrier until the committed end value was already drawn.
+     */
+    private fun enqueue(command: Command) {
+        val schedule: Boolean
+        synchronized(commandLock) {
+            pendingCommands.add(command)
+            schedule = !flushScheduled
+            if (schedule) flushScheduled = true
+        }
+        if (schedule) {
+            val message = Message.obtain(mainHandler) { flushCommands() }
+            message.isAsynchronous = true
+            mainHandler.sendMessage(message)
+        }
+    }
+
+    private fun hasPendingCommand(key: Key): Boolean =
+        synchronized(commandLock) {
+            pendingCommands.any { it.key == key }
+        }
+
+    private fun flushCommands() {
+        val batch: ArrayList<Command>
+        synchronized(commandLock) {
+            batch = pendingCommands
+            pendingCommands = spareCommands
+            flushScheduled = false
+        }
+        for (command in batch) {
+            when (command) {
+                is Command.Start -> beginTransition(command)
+                is Command.Remove -> dropTransition(command)
+            }
+        }
+        batch.clear()
+        spareCommands = batch
+    }
+
+    private fun beginTransition(command: Command.Start) {
+        val key = command.key
+        // A fresh token invalidates any retry still queued for this key.
+        val token = ++nextStartToken
+        startTokens[key] = token
+        beginWhenMounted(key, token, command.startTimestampMs + command.durationMs, command.persistent) {
+            viewForTag(key.viewTag)?.also { view ->
+                start(
+                    view,
+                    key,
+                    command.writer,
+                    command.fromValue,
+                    command.toValue,
+                    command.durationMs,
+                    command.startTimestampMs,
+                    command.interpolator,
+                    command.persistent,
+                )
+            } != null
+        }
+    }
+
+    private fun dropTransition(command: Command.Remove) {
+        val key = command.key
+        // Also drops any queued retry for this key.
+        startTokens.remove(key)
+        val dropped = transitions.remove(key) ?: return
+        // A persistent value has no committed style to settle to; leave it as drawn.
+        if (dropped.persistent) return
+        val view = dropped.viewRef.get() ?: return
+        // Settle on the committed target so the view does not stick mid-flight, but only
+        // if nothing newer was written: a racing mount may have applied a fresh value.
+        if (dropped.writer.get(view) == dropped.current) {
+            dropped.writer.setValue(view, dropped.toValue)
+        }
+    }
+
+    /**
+     * A tag can be registered before its View mounts; retry per frame until it does.
+     * The absolute start timestamp makes a late start seek instead of drift, and an
+     * already-ended timeline stops retrying without any arbitrary timeout.
+     */
+    private fun beginWhenMounted(
+        key: Key,
+        token: Long,
+        endTimestampMs: Double,
+        persistent: Boolean,
+        begin: () -> Boolean,
+    ) {
+        if (startTokens[key] != token) return
+        if (hasPendingCommand(key)) {
+            // A queued command may invalidate this token; let the flush run first.
+            Choreographer.getInstance().postFrameCallback { beginWhenMounted(key, token, endTimestampMs, persistent, begin) }
+            return
+        }
+        // A persistent value outlives its timeline, so its start never expires.
+        if (begin() || (!persistent && animationTimestamp() >= endTimestampMs)) {
+            startTokens.remove(key)
+            return
+        }
+        Choreographer.getInstance().postFrameCallback { beginWhenMounted(key, token, endTimestampMs, persistent, begin) }
+    }
+
+    private fun start(
+        view: View,
+        key: Key,
+        writer: FloatProperty<View>,
+        fromValue: Double,
+        toValue: Double,
+        durationMs: Double,
+        startTimestampMs: Double,
+        interpolator: TimeInterpolator,
+        persistent: Boolean,
+    ) {
+        // Resume interruptions from the last written value; fromValue would snap back.
+        val startValue = transitions.remove(key)?.current ?: fromValue.toFloat()
+
+        // The target is already committed; show the start value until the first pump frame.
+        writer.setValue(view, startValue)
+
+        transitions[key] =
+            RunningTransition(
+                view,
+                writer,
+                startValue,
+                toValue.toFloat(),
+                startTimestampMs,
+                durationMs.coerceAtLeast(1.0),
+                interpolator,
+                persistent,
+            )
+        reconciler.track(view)
+        ensurePumping()
+    }
+
+    private fun ensurePumping() {
+        if (!pumping) {
+            pumping = true
+            Choreographer.getInstance().postFrameCallback(framePump)
+        }
+    }
+
+    /** Re-asserts each transition's own value wherever a commit overwrote it. */
+    private fun repairClobberedValues(): Boolean {
+        if (!mountedSinceLastDraw) return transitions.isNotEmpty()
+        mountedSinceLastDraw = false
+        val iterator = transitions.values.iterator()
+        while (iterator.hasNext()) {
+            val running = iterator.next()
+            val view = running.viewRef.get()
+            if (view == null) {
+                iterator.remove()
+                continue
+            }
+            // setAlpha early-outs when unchanged, so re-asserting is free.
+            running.writer.setValue(view, running.current)
+        }
+        return transitions.isNotEmpty()
     }
 
     private fun viewForTag(viewTag: Int): View? =

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/DurationScale.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/DurationScale.kt
@@ -5,26 +5,16 @@ import android.content.Context
 import android.os.Build
 import android.provider.Settings
 
-/**
- * `ValueAnimator` multiplies every duration and start delay by a process-global scale,
- * but a CSS transition has to last exactly as long as the author wrote, so callers
- * pre-divide by this. `overrideDurationScale` would opt a single animator out, but it
- * is `@hide` with no greylist entry, and the only other setter is process-global.
- */
+/** Animations can be disabled system-wide (duration scale 0, battery saver). */
 internal object DurationScale {
-    fun effectiveScale(context: Context): Float {
-        // Battery saver disables animations without touching Settings.Global, and
-        // areAnimatorsEnabled() (literally `scale != 0`) is the only signal for it.
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && !ValueAnimator.areAnimatorsEnabled()) {
-            return 0f
-        }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            return ValueAnimator.getDurationScale()
+    fun animationsEnabled(context: Context): Boolean {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            return ValueAnimator.areAnimatorsEnabled()
         }
         return Settings.Global.getFloat(
             context.contentResolver,
             Settings.Global.ANIMATOR_DURATION_SCALE,
             1f,
-        )
+        ) > 0f
     }
 }


### PR DESCRIPTION
Replaces the per-property ObjectAnimator player with one Choreographer frame callback that walks the active transitions and writes values directly. Cost scales with the number of running animations rather than the number of animator objects, and delays and late starts resolve from the absolute start timestamp so they need no extra state.

Supersedes #10126 in the restacked series.