### PR TITLE
fix(Reanimated): preserve layout animations final updates during batch sync

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/LayoutAnimations/FinalFrameAccuracy.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/LayoutAnimations/FinalFrameAccuracy.tsx
@@ -1,12 +1,20 @@
 import React, { useState } from 'react';
 import type { LayoutChangeEvent } from 'react-native';
-import { Pressable, StyleSheet, Text, View } from 'react-native';
-import type { EasingFunction } from 'react-native-reanimated';
-import Animated, { Easing, LinearTransition } from 'react-native-reanimated';
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import type {
+  EasingFunction,
+  EntryOrExitLayoutType,
+} from 'react-native-reanimated';
+import Animated, {
+  Easing,
+  FadeInLeft,
+  LinearTransition,
+} from 'react-native-reanimated';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-// Every row travels the same distance with the same trigger; only the easing
-// and the duration differ. Each square should come to rest exactly inside the
-// dashed outline at the far end.
+// The layout rows travel the full track. The opacity rows replay FadeInLeft,
+// which animates opacity and a 25 px translation. Each square should come to
+// rest exactly inside the dashed outline at its target.
 //
 // A layout animation's last keyframe is the one that puts the view exactly on
 // its target, and it is the keyframe most at risk of being dropped. What that
@@ -17,12 +25,16 @@ const FRAME_MS = 1000 / 60;
 
 const SQUARE_SIZE = 36;
 const TRACK_PADDING = 4;
+const OPACITY_TRAVEL = 25;
+const IN_CUBIC = Easing.in(Easing.cubic);
 
 type Row = {
   label: string;
   easing: EasingFunction;
   duration: number;
   color: string;
+  entering?: EntryOrExitLayoutType;
+  travel?: number;
 };
 
 const ROWS: Array<Row> = [
@@ -41,7 +53,7 @@ const ROWS: Array<Row> = [
   {
     color: '#FFD93D',
     duration: 300,
-    easing: Easing.in(Easing.cubic),
+    easing: IN_CUBIC,
     label: 'in(cubic)',
   },
   {
@@ -56,6 +68,22 @@ const ROWS: Array<Row> = [
     easing: Easing.exp,
     label: 'exp (half the duration)',
   },
+  {
+    color: '#9C6ADE',
+    duration: 150,
+    easing: IN_CUBIC,
+    entering: FadeInLeft.duration(150).easing(IN_CUBIC),
+    label: 'opacity + in(cubic)',
+    travel: OPACITY_TRAVEL,
+  },
+  {
+    color: '#D84A9B',
+    duration: 150,
+    easing: Easing.exp,
+    entering: FadeInLeft.duration(150).easing(Easing.exp),
+    label: 'opacity + exp',
+    travel: OPACITY_TRAVEL,
+  },
 ];
 
 // Share of the distance still left to travel one frame before the end.
@@ -66,19 +94,24 @@ function missingFraction({ duration, easing }: Row) {
 export default function FinalFrameAccuracyExample() {
   const [toggled, setToggled] = useState(false);
   const [travel, setTravel] = useState(0);
+  const insets = useSafeAreaInsets();
 
   const onTrackLayout = (event: LayoutChangeEvent) => {
     setTravel(event.nativeEvent.layout.width - 2 * TRACK_PADDING - SQUARE_SIZE);
   };
 
   return (
-    <View style={styles.root}>
+    <ScrollView
+      style={styles.root}
+      contentContainerStyle={{ paddingBottom: insets.bottom + 16 }}>
       <Text style={styles.title}>Where does the last keyframe land?</Text>
       <Text style={styles.hint}>
         Each square must end up inside the dashed outline. A dropped final
         keyframe leaves it `1 - easing(1 - frame/duration)` of the way short -
         negligible for ease-out, huge for ease-in, and worse the shorter the
-        duration. Figures assume 60 fps; on a 120 Hz display they halve.
+        duration. The opacity rows use entering animations that the old
+        opacity-based check allowed. Figures assume 60 fps; on a 120 Hz display
+        they halve.
       </Text>
 
       <Pressable
@@ -89,6 +122,7 @@ export default function FinalFrameAccuracyExample() {
 
       {ROWS.map((row) => {
         const missing = missingFraction(row);
+        const animatedTravel = row.travel ?? travel;
 
         return (
           <View key={row.label} style={styles.row}>
@@ -98,7 +132,9 @@ export default function FinalFrameAccuracyExample() {
               </Text>
               <Text style={styles.rowValue}>
                 {(missing * 100).toFixed(missing < 0.01 ? 2 : 1)}%
-                {travel > 0 ? ` · ${(missing * travel).toFixed(1)} px` : ''}
+                {animatedTravel > 0
+                  ? ` · ${(missing * animatedTravel).toFixed(1)} px`
+                  : ''}
               </Text>
             </View>
 
@@ -117,16 +153,20 @@ export default function FinalFrameAccuracyExample() {
                 style={[styles.ghost, styles.ghostRight]}
               />
               <Animated.View
+                key={row.entering ? String(toggled) : row.label}
+                entering={row.entering}
                 style={[styles.square, { backgroundColor: row.color }]}
-                layout={LinearTransition.easing(row.easing).duration(
-                  row.duration
-                )}
+                layout={
+                  row.entering
+                    ? undefined
+                    : LinearTransition.easing(row.easing).duration(row.duration)
+                }
               />
             </View>
           </View>
         );
       })}
-    </View>
+    </ScrollView>
   );
 }
 

--- a/apps/common-app/src/apps/reanimated/examples/LayoutAnimations/FinalFrameAccuracy.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/LayoutAnimations/FinalFrameAccuracy.tsx
@@ -1,0 +1,209 @@
+import React, { useState } from 'react';
+import type { LayoutChangeEvent } from 'react-native';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import type { EasingFunction } from 'react-native-reanimated';
+import Animated, { Easing, LinearTransition } from 'react-native-reanimated';
+
+// Every row travels the same distance with the same trigger; only the easing
+// and the duration differ. Each square should come to rest exactly inside the
+// dashed outline at the far end.
+//
+// A layout animation's last keyframe is the one that puts the view exactly on
+// its target, and it is the keyframe most at risk of being dropped. What that
+// costs is `1 - easing(1 - frame / duration)` of the distance - so it grows
+// with how steep the easing is at the very end, and with how few frames the
+// duration spans. Ease-out curves pay nothing, ease-in curves pay a lot.
+const FRAME_MS = 1000 / 60;
+
+const SQUARE_SIZE = 36;
+const TRACK_PADDING = 4;
+
+type Row = {
+  label: string;
+  easing: EasingFunction;
+  duration: number;
+  color: string;
+};
+
+const ROWS: Array<Row> = [
+  {
+    color: '#6BCB77',
+    duration: 600,
+    easing: Easing.out(Easing.exp),
+    label: 'out(exp)',
+  },
+  {
+    color: '#4D96FF',
+    duration: 600,
+    easing: Easing.linear,
+    label: 'linear',
+  },
+  {
+    color: '#FFD93D',
+    duration: 300,
+    easing: Easing.in(Easing.cubic),
+    label: 'in(cubic)',
+  },
+  {
+    color: '#FF9F45',
+    duration: 300,
+    easing: Easing.exp,
+    label: 'exp',
+  },
+  {
+    color: '#FF6B6B',
+    duration: 150,
+    easing: Easing.exp,
+    label: 'exp (half the duration)',
+  },
+];
+
+// Share of the distance still left to travel one frame before the end.
+function missingFraction({ duration, easing }: Row) {
+  return 1 - easing(1 - FRAME_MS / duration);
+}
+
+export default function FinalFrameAccuracyExample() {
+  const [toggled, setToggled] = useState(false);
+  const [travel, setTravel] = useState(0);
+
+  const onTrackLayout = (event: LayoutChangeEvent) => {
+    setTravel(event.nativeEvent.layout.width - 2 * TRACK_PADDING - SQUARE_SIZE);
+  };
+
+  return (
+    <View style={styles.root}>
+      <Text style={styles.title}>Where does the last keyframe land?</Text>
+      <Text style={styles.hint}>
+        Each square must end up inside the dashed outline. A dropped final
+        keyframe leaves it `1 - easing(1 - frame/duration)` of the way short -
+        negligible for ease-out, huge for ease-in, and worse the shorter the
+        duration. Figures assume 60 fps; on a 120 Hz display they halve.
+      </Text>
+
+      <Pressable
+        style={styles.button}
+        onPress={() => setToggled((value) => !value)}>
+        <Text style={styles.buttonText}>Toggle</Text>
+      </Pressable>
+
+      {ROWS.map((row) => {
+        const missing = missingFraction(row);
+
+        return (
+          <View key={row.label} style={styles.row}>
+            <View style={styles.rowHeader}>
+              <Text style={styles.rowLabel}>
+                {row.label} · {row.duration} ms
+              </Text>
+              <Text style={styles.rowValue}>
+                {(missing * 100).toFixed(missing < 0.01 ? 2 : 1)}%
+                {travel > 0 ? ` · ${(missing * travel).toFixed(1)} px` : ''}
+              </Text>
+            </View>
+
+            <View
+              style={[
+                styles.track,
+                { justifyContent: toggled ? 'flex-end' : 'flex-start' },
+              ]}
+              onLayout={onTrackLayout}>
+              <View
+                pointerEvents="none"
+                style={[styles.ghost, styles.ghostLeft]}
+              />
+              <View
+                pointerEvents="none"
+                style={[styles.ghost, styles.ghostRight]}
+              />
+              <Animated.View
+                style={[styles.square, { backgroundColor: row.color }]}
+                layout={LinearTransition.easing(row.easing).duration(
+                  row.duration
+                )}
+              />
+            </View>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    alignSelf: 'flex-start',
+    backgroundColor: '#001a72',
+    borderRadius: 10,
+    height: 44,
+    justifyContent: 'center',
+    marginBottom: 20,
+    paddingHorizontal: 24,
+  },
+  buttonText: {
+    color: '#fff',
+    fontSize: 15,
+    fontWeight: '700',
+  },
+  ghost: {
+    borderColor: '#b0b4c0',
+    borderRadius: 8,
+    borderStyle: 'dashed',
+    borderWidth: 1,
+    height: SQUARE_SIZE,
+    position: 'absolute',
+    top: TRACK_PADDING,
+    width: SQUARE_SIZE,
+  },
+  ghostLeft: {
+    left: TRACK_PADDING,
+  },
+  ghostRight: {
+    right: TRACK_PADDING,
+  },
+  hint: {
+    color: '#666',
+    fontSize: 12,
+    lineHeight: 17,
+    marginBottom: 12,
+  },
+  root: {
+    backgroundColor: '#fff',
+    flex: 1,
+    padding: 16,
+  },
+  row: {
+    marginBottom: 16,
+  },
+  rowHeader: {
+    alignItems: 'baseline',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 4,
+  },
+  rowLabel: {
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  rowValue: {
+    color: '#888',
+    fontSize: 12,
+    fontVariant: ['tabular-nums'],
+  },
+  square: {
+    borderRadius: 8,
+    height: SQUARE_SIZE,
+    width: SQUARE_SIZE,
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: '700',
+    marginBottom: 6,
+  },
+  track: {
+    backgroundColor: '#f1f2f6',
+    borderRadius: 10,
+    flexDirection: 'row',
+    padding: TRACK_PADDING,
+  },
+});

--- a/apps/common-app/src/apps/reanimated/examples/index.ts
+++ b/apps/common-app/src/apps/reanimated/examples/index.ts
@@ -206,6 +206,10 @@ const FetchExample: React.FC = () =>
   React.createElement(require('./FetchExample').default as React.FC);
 const FilterExample: React.FC = () =>
   React.createElement(require('./FilterExample').default as React.FC);
+const FinalFrameAccuracyExample: React.FC = () =>
+  React.createElement(
+    require('./LayoutAnimations/FinalFrameAccuracy').default as React.FC
+  );
 const FlatListExample: React.FC = () =>
   React.createElement(
     require('./SharedElementTransitions/FlatList').default as React.FC
@@ -1263,6 +1267,10 @@ export const EXAMPLES: Record<string, Example> = {
     icon: '🧹',
     title: '[LA] Nested exiting cleanup',
     screen: NestedExitingCleanupExample,
+  },
+  FinalFrameAccuracyExample: {
+    screen: FinalFrameAccuracyExample,
+    title: '[LA] Final frame accuracy',
   },
 
   // Shared Element Transitions

--- a/packages/react-native-reanimated/CHANGELOG.md
+++ b/packages/react-native-reanimated/CHANGELOG.md
@@ -14,5 +14,6 @@
 - Fix missing unmount of ancestors of animated components with exiting animations in experimental Layout Animations Proxy ([#10103](https://github.com/software-mansion/react-native-reanimated/pull/10103) by [@pawicao](https://github.com/pawicao))
 - Fix crash when a CSS animation or transition runs between two keyword values on a property that also accepts relative lengths, such as `width` going from `auto` to `auto`. ([#10281](https://github.com/software-mansion/react-native-reanimated/pull/10281) by [@MatiPl01](https://github.com/MatiPl01))
 - Fix Android flashes at the start of entering animations in experimental Layout Animations Proxy by temporarily setting opacity 0 at the start of an insert mutation ([#10198](https://github.com/software-mansion/react-native-reanimated/pull/10198) by [@pawicao](https://github.com/pawicao))
+- Fix preserving layout animations final updates during batch sync ([#10171](https://github.com/software-mansion/react-native-reanimated/pull/10171) by [@pawicao](https://github.com/pawicao))
 
 ### 💡 Others

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.h
@@ -22,6 +22,7 @@ struct LayoutAnimation {
   Tag parentTag;
   std::optional<double> opacity;
   bool isViewAlreadyMounted = false;
+  bool isExitingWhenSettled = false;
   int count = 1;
   LayoutAnimation &operator=(const LayoutAnimation &other) = default;
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
@@ -356,6 +356,7 @@ std::optional<SurfaceId> LayoutAnimationsProxy_Experimental::endLayoutAnimation(
   if (--layoutAnimation.count > 0) {
     return {};
   }
+  layoutAnimation.isExitingWhenSettled = shouldRemove;
   maybeSettledAnimationTags_.insert(tag);
   auto surfaceId = layoutAnimation.finalView.surfaceId;
 
@@ -478,10 +479,12 @@ void LayoutAnimationsProxy_Experimental::addOngoingAnimations(SurfaceId surfaceI
     const auto layoutAnimationIt = layoutAnimations_.find(tag);
 
     if (layoutAnimationIt == layoutAnimations_.end() ||
-        (layoutAnimationIt->second.isSettled() && !layoutAnimationIt->second.opacity.has_value())) {
+        (layoutAnimationIt->second.isSettled() && layoutAnimationIt->second.isExitingWhenSettled)) {
       continue;
     }
 
+    // A settled non-exiting animation still has its exact final update in
+    // updateMap. Apply it before the entry is cleaned up later in this transaction.
     auto &layoutAnimation = layoutAnimationIt->second;
     layoutAnimation.isViewAlreadyMounted = true;
     auto newView = layoutAnimation.finalView;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
@@ -483,8 +483,6 @@ void LayoutAnimationsProxy_Experimental::addOngoingAnimations(SurfaceId surfaceI
       continue;
     }
 
-    // A settled non-exiting animation still has its exact final update in
-    // updateMap. Apply it before the entry is cleaned up later in this transaction.
     auto &layoutAnimation = layoutAnimationIt->second;
     layoutAnimation.isViewAlreadyMounted = true;
     auto newView = layoutAnimation.finalView;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
@@ -642,6 +642,9 @@ void LayoutAnimationsProxy_Experimental::maybeCancelAnimation(const int tag) con
   }
   if (layoutAnimationIt->second.isSettled()) {
     // Already settled - cleanupAnimations will erase it together with its updateMap entry.
+    // Mark it as exiting so addOngoingAnimations doesn't flush a pending Update
+    // after the caller has queued this view for removal.
+    layoutAnimationIt->second.isExitingWhenSettled = true;
     return;
   }
   layoutAnimations_.erase(layoutAnimationIt);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
@@ -227,6 +227,7 @@ std::optional<SurfaceId> LayoutAnimationsProxy_Legacy::endLayoutAnimation(int ta
   if (--layoutAnimation.count > 0) {
     return {};
   }
+  layoutAnimation.isExitingWhenSettled = shouldRemove;
   maybeSettledAnimationTags_.insert(tag);
   auto surfaceId = layoutAnimation.finalView.surfaceId;
 
@@ -530,15 +531,12 @@ void LayoutAnimationsProxy_Legacy::addOngoingAnimations(SurfaceId surfaceId, Sha
     auto layoutAnimationIt = layoutAnimations_.find(tag);
 
     if (layoutAnimationIt == layoutAnimations_.end() ||
-        // A settled animation is normally cleaned up without applying further
-        // updates. The exception is a flaky entering animation whose opacity was
-        // never restored (the view wasn't mounted in time) - we still need to
-        // apply that pending opacity, otherwise the view stays invisible. Only
-        // entering animations carry an opacity value.
-        (layoutAnimationIt->second.isSettled() && !layoutAnimationIt->second.opacity.has_value())) {
+        (layoutAnimationIt->second.isSettled() && layoutAnimationIt->second.isExitingWhenSettled)) {
       continue;
     }
 
+    // A settled non-exiting animation still has its exact final update in
+    // updateMap. Apply it before the entry is cleaned up later in this transaction.
     auto &layoutAnimation = layoutAnimationIt->second;
     layoutAnimation.isViewAlreadyMounted = true;
     auto newView = layoutAnimation.finalView;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
@@ -535,8 +535,6 @@ void LayoutAnimationsProxy_Legacy::addOngoingAnimations(SurfaceId surfaceId, Sha
       continue;
     }
 
-    // A settled non-exiting animation still has its exact final update in
-    // updateMap. Apply it before the entry is cleaned up later in this transaction.
     auto &layoutAnimation = layoutAnimationIt->second;
     layoutAnimation.isViewAlreadyMounted = true;
     auto newView = layoutAnimation.finalView;


### PR DESCRIPTION
> [!NOTE]
> This pull request was authored by AI on behalf of @pawicao.

## Summary

Fixes ~~#10163 and~~ #10200.

A layout animation can become settled before native code applies its exact final update. Cleanup can then remove the pending update. The view stops one keyframe before its target. This error can cause list items to overlap.

This pull request:

- Records whether an animation was exiting when it became settled.
- Applies the pending final update before cleanup for a settled non-exiting animation.
- Does not apply the final update to an exiting view.
- Prevents the Experimental proxy from adding an `Update` after a caller adds a `Delete` for the same view.
- Adds the `[LA] Final frame accuracy` example.

**Before**

https://github.com/user-attachments/assets/53d90d81-9e51-4357-80e6-6ac85bd0fdc2

**After** (the initial lag here comes from github, locally this screen recording keep things smooth)


https://github.com/user-attachments/assets/d68d3cba-de14-4410-87fe-b298f4331c3b



## Test plan

1. Open the Fabric Example app on iOS.
2. Open the `[LA] Change theme` example.
3. Add items multiple times.
4. Verify that each item moves to its correct final position.
5. Verify that the items do not overlap.
6. Open the `[LA] Final frame accuracy` example.
7. Press **Toggle** multiple times.
8. Verify that each square stops inside the dashed outline.

The Common C++ formatting check also passes.