### PR TITLE
chore: tests for LayoutAnimationConfig findNodeHandle fix

### DIFF
--- a/packages/react-native-reanimated/__tests__/LayoutAnimationConfig.strictMode.test.tsx
+++ b/packages/react-native-reanimated/__tests__/LayoutAnimationConfig.strictMode.test.tsx
@@ -1,0 +1,65 @@
+import { render } from '@testing-library/react-native';
+import type { ReactNode, Ref } from 'react';
+import { StrictMode, useImperativeHandle } from 'react';
+import { View } from 'react-native';
+
+import { LayoutAnimationConfig } from '../src';
+
+function ForwardsHostInstance({ ref }: { ref?: Ref<unknown> }) {
+  useImperativeHandle(ref, () => ({ __nativeTag: 42 }), []);
+  return <View />;
+}
+
+function DropsRef() {
+  return <View />;
+}
+
+let consoleError: jest.SpyInstance;
+
+const strictModeWarnings = () =>
+  consoleError.mock.calls.filter(
+    (call) =>
+      String(call[0]).includes('is deprecated in StrictMode') &&
+      String(call).includes('findNodeHandle') &&
+      call.includes('LayoutAnimationConfig')
+  );
+
+const renderInStrictMode = (children: ReactNode) =>
+  render(
+    <StrictMode>
+      <LayoutAnimationConfig skipExiting>{children}</LayoutAnimationConfig>
+    </StrictMode>
+  );
+
+describe('LayoutAnimationConfig findNodeHandle deprecation', () => {
+  beforeEach(() => {
+    consoleError = jest.spyOn(console, 'error').mockImplementation(() => {
+      // noop
+    });
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+  });
+
+  test('does not warn when the child forwards its ref', () => {
+    const { unmount } = renderInStrictMode(<ForwardsHostInstance />);
+
+    unmount();
+
+    expect(strictModeWarnings()).toHaveLength(0);
+  });
+
+  test('warns when the child drops its ref', () => {
+    const { unmount } = renderInStrictMode(<DropsRef />);
+
+    unmount();
+
+    const [warning] = strictModeWarnings();
+    expect(warning).toBeDefined();
+    expect(String(warning[0])).toContain(
+      'add a ref directly to the element you want to reference'
+    );
+    expect(warning).toContain('findNodeHandle');
+  });
+});

--- a/packages/react-native-reanimated/__tests__/LayoutAnimationConfig.test.tsx
+++ b/packages/react-native-reanimated/__tests__/LayoutAnimationConfig.test.tsx
@@ -9,15 +9,32 @@ jest.mock('../src/platformFunctions/findNodeHandle', () => ({
   findNodeHandle: jest.fn(() => 1234),
 }));
 
+jest.mock('../src/core', () => ({
+  ...jest.requireActual('../src/core'),
+  setShouldAnimateExitingForTag: jest.fn(),
+}));
+
 const { findNodeHandle }: { findNodeHandle: jest.Mock } = jest.requireMock(
   '../src/platformFunctions/findNodeHandle'
 );
 
+const {
+  setShouldAnimateExitingForTag,
+}: {
+  setShouldAnimateExitingForTag: jest.Mock;
+} = jest.requireMock('../src/core');
+
 // React Native components render as class wrappers under the jest preset, so
 // their refs never resolve to a host instance. These stand in for a child that
 // forwards its ref all the way down to one.
-function ForwardsHostInstance({ ref }: { ref?: Ref<unknown> }) {
-  useImperativeHandle(ref, () => ({ __nativeTag: 42 }), []);
+function ForwardsHostInstance({
+  ref,
+  tag = 42,
+}: {
+  ref?: Ref<unknown>;
+  tag?: number;
+}) {
+  useImperativeHandle(ref, () => ({ __nativeTag: tag }), [tag]);
   return <View />;
 }
 
@@ -36,6 +53,7 @@ const renderWrapped = (children: ReactNode) =>
 describe('LayoutAnimationConfig view tag resolution', () => {
   beforeEach(() => {
     findNodeHandle.mockClear();
+    setShouldAnimateExitingForTag.mockClear();
   });
 
   test('falls back to findNodeHandle when the child drops its ref', () => {
@@ -44,6 +62,7 @@ describe('LayoutAnimationConfig view tag resolution', () => {
     unmount();
 
     expect(findNodeHandle).toHaveBeenCalled();
+    expect(setShouldAnimateExitingForTag).toHaveBeenCalledWith(1234, false);
   });
 
   test('resolves a forwarded host instance without findNodeHandle', () => {
@@ -52,6 +71,7 @@ describe('LayoutAnimationConfig view tag resolution', () => {
     unmount();
 
     expect(findNodeHandle).not.toHaveBeenCalled();
+    expect(setShouldAnimateExitingForTag).toHaveBeenCalledWith(42, false);
   });
 
   test('resolves an animated component child without findNodeHandle', () => {
@@ -60,19 +80,23 @@ describe('LayoutAnimationConfig view tag resolution', () => {
     unmount();
 
     expect(findNodeHandle).not.toHaveBeenCalled();
+    expect(setShouldAnimateExitingForTag).toHaveBeenCalledWith(7, false);
   });
 
   test('resolves each of multiple children without findNodeHandle', () => {
     const { unmount } = render(
       <LayoutAnimationConfig skipExiting>
-        <ForwardsHostInstance />
-        <ForwardsHostInstance />
+        <ForwardsHostInstance tag={42} />
+        <ForwardsHostInstance tag={43} />
       </LayoutAnimationConfig>
     );
 
     unmount();
 
     expect(findNodeHandle).not.toHaveBeenCalled();
+    expect(setShouldAnimateExitingForTag).toHaveBeenCalledTimes(2);
+    expect(setShouldAnimateExitingForTag).toHaveBeenCalledWith(42, false);
+    expect(setShouldAnimateExitingForTag).toHaveBeenCalledWith(43, false);
   });
 
   test('preserves a ref the child already had', () => {
@@ -85,5 +109,6 @@ describe('LayoutAnimationConfig view tag resolution', () => {
     unmount();
 
     expect(findNodeHandle).not.toHaveBeenCalled();
+    expect(setShouldAnimateExitingForTag).toHaveBeenCalledWith(42, false);
   });
 });

--- a/packages/react-native-reanimated/__tests__/LayoutAnimationConfig.test.tsx
+++ b/packages/react-native-reanimated/__tests__/LayoutAnimationConfig.test.tsx
@@ -1,0 +1,89 @@
+import { render } from '@testing-library/react-native';
+import type { ReactNode, Ref } from 'react';
+import { useImperativeHandle } from 'react';
+import { View } from 'react-native';
+
+import { LayoutAnimationConfig } from '../src';
+
+jest.mock('../src/platformFunctions/findNodeHandle', () => ({
+  findNodeHandle: jest.fn(() => 1234),
+}));
+
+const { findNodeHandle }: { findNodeHandle: jest.Mock } = jest.requireMock(
+  '../src/platformFunctions/findNodeHandle'
+);
+
+// React Native components render as class wrappers under the jest preset, so
+// their refs never resolve to a host instance. These stand in for a child that
+// forwards its ref all the way down to one.
+function ForwardsHostInstance({ ref }: { ref?: Ref<unknown> }) {
+  useImperativeHandle(ref, () => ({ __nativeTag: 42 }), []);
+  return <View />;
+}
+
+function ForwardsAnimatedComponent({ ref }: { ref?: Ref<unknown> }) {
+  useImperativeHandle(ref, () => ({ getComponentViewTag: () => 7 }), []);
+  return <View />;
+}
+
+function DropsRef({ children }: { children?: ReactNode }) {
+  return <View>{children}</View>;
+}
+
+const renderWrapped = (children: ReactNode) =>
+  render(<LayoutAnimationConfig skipExiting>{children}</LayoutAnimationConfig>);
+
+describe('LayoutAnimationConfig view tag resolution', () => {
+  beforeEach(() => {
+    findNodeHandle.mockClear();
+  });
+
+  test('falls back to findNodeHandle when the child drops its ref', () => {
+    const { unmount } = renderWrapped(<DropsRef />);
+
+    unmount();
+
+    expect(findNodeHandle).toHaveBeenCalled();
+  });
+
+  test('resolves a forwarded host instance without findNodeHandle', () => {
+    const { unmount } = renderWrapped(<ForwardsHostInstance />);
+
+    unmount();
+
+    expect(findNodeHandle).not.toHaveBeenCalled();
+  });
+
+  test('resolves an animated component child without findNodeHandle', () => {
+    const { unmount } = renderWrapped(<ForwardsAnimatedComponent />);
+
+    unmount();
+
+    expect(findNodeHandle).not.toHaveBeenCalled();
+  });
+
+  test('resolves each of multiple children without findNodeHandle', () => {
+    const { unmount } = render(
+      <LayoutAnimationConfig skipExiting>
+        <ForwardsHostInstance />
+        <ForwardsHostInstance />
+      </LayoutAnimationConfig>
+    );
+
+    unmount();
+
+    expect(findNodeHandle).not.toHaveBeenCalled();
+  });
+
+  test('preserves a ref the child already had', () => {
+    const childRef = jest.fn();
+
+    const { unmount } = renderWrapped(<ForwardsHostInstance ref={childRef} />);
+
+    expect(childRef).toHaveBeenCalledWith({ __nativeTag: 42 });
+
+    unmount();
+
+    expect(findNodeHandle).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
This PR introduces tests for the fix in https://github.com/software-mansion/react-native-reanimated/pull/10160

Please refer to that PR for context