### PR TITLE
fix: getNodeHandle on ref children of layoutanimationconfig

### DIFF
--- a/packages/react-native-reanimated/__tests__/LayoutAnimationConfig.strictMode.test.tsx
+++ b/packages/react-native-reanimated/__tests__/LayoutAnimationConfig.strictMode.test.tsx
@@ -62,4 +62,20 @@ describe('LayoutAnimationConfig findNodeHandle deprecation', () => {
     );
     expect(warning).toContain('findNodeHandle');
   });
+
+  test('does not report an invalid ref on a fragment child', () => {
+    const { unmount } = renderInStrictMode(
+      <>
+        <ForwardsHostInstance />
+      </>
+    );
+
+    unmount();
+
+    expect(
+      consoleError.mock.calls.filter((call) =>
+        String(call[0]).includes('React.Fragment')
+      )
+    ).toHaveLength(0);
+  });
 });

--- a/packages/react-native-reanimated/__tests__/LayoutAnimationConfig.test.tsx
+++ b/packages/react-native-reanimated/__tests__/LayoutAnimationConfig.test.tsx
@@ -99,6 +99,19 @@ describe('LayoutAnimationConfig view tag resolution', () => {
     expect(setShouldAnimateExitingForTag).toHaveBeenCalledWith(43, false);
   });
 
+  test('falls back to findNodeHandle for a fragment child', () => {
+    const { unmount } = renderWrapped(
+      <>
+        <ForwardsHostInstance />
+      </>
+    );
+
+    unmount();
+
+    expect(findNodeHandle).toHaveBeenCalled();
+    expect(setShouldAnimateExitingForTag).toHaveBeenCalledWith(1234, false);
+  });
+
   test('preserves a ref the child already had', () => {
     const childRef = jest.fn();
 

--- a/packages/react-native-reanimated/src/component/LayoutAnimationConfig.tsx
+++ b/packages/react-native-reanimated/src/component/LayoutAnimationConfig.tsx
@@ -5,6 +5,7 @@ import {
   cloneElement,
   Component,
   createContext,
+  Fragment,
   isValidElement,
   useEffect,
   useRef,
@@ -97,7 +98,10 @@ export class LayoutAnimationConfig extends Component<LayoutAnimationConfigProps>
     }
 
     const child = Children.only(children);
-    if (!isValidElement<{ ref?: Ref<InstanceWithViewTag> }>(child)) {
+    if (
+      !isValidElement<{ ref?: Ref<InstanceWithViewTag> }>(child) ||
+      child.type === Fragment
+    ) {
       return children;
     }
 


### PR DESCRIPTION
https://github.com/software-mansion/react-native-reanimated/pull/10160 introduced a subtle edge-case bug:
If a child of the LayoutAnimationConfig is a React.Fragment, it will pass a isValidElement() check, and the code will pass a ref to it, which is invalid as React.Fragment can't receive a ref.

This PR changes the behavior, so if the child is a React.Fragment, we fallback to findNodeHandle instead.

This PR also introduces a test for this fallback.