### PR TITLE
refactor(Worklets): move microtasks call to C++

### DIFF
--- a/apps/common-app/runtime-tests/worklets/tests/runtimes/microtaskDrains.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/runtimes/microtaskDrains.test.tsx
@@ -1,13 +1,11 @@
 import {
   createSynchronizable,
-  getRuntimeKind,
   runOnRuntimeAsync,
   runOnRuntimeAsyncWithId,
   runOnRuntimeSync,
   runOnRuntimeSyncWithId,
   runOnUIAsync,
   runOnUISync,
-  RuntimeKind,
   scheduleOnRN,
   scheduleOnRuntime,
   scheduleOnRuntimeWithId,
@@ -27,15 +25,10 @@ import {
 
 const DONE_NOTIFICATION = 'DONE';
 
-const NOTHING_RAN = 0;
-const ANIMATION_FRAME_RAN = 1;
-const MICROTASK_RAN = 2;
-
 describe('microtask draining', () => {
   const workletRuntime = getWorkletRuntimeFromPool('test');
 
   const microtaskDrainCount = createSynchronizable(0);
-  const firstCallbackThatRan = createSynchronizable(NOTHING_RAN);
 
   const notifyDone = () => {
     notify(DONE_NOTIFICATION);
@@ -52,18 +45,17 @@ describe('microtask draining', () => {
   }
 
   function startCountingMicrotaskDrains(runtimeId: number) {
-    restoreCallMicrotasks(runtimeId);
-
     runOnRuntimeSyncWithId(runtimeId, () => {
       'worklet';
       const previousCallMicrotasks = globalThis.__callMicrotasks;
       globalThis.originalCallMicrotasks = previousCallMicrotasks;
       globalThis.__callMicrotasks = () => {
-        microtaskDrainCount.setBlocking((count) => count + 1);
+        if (!new Error().stack!.includes('executeQueue')) {
+          microtaskDrainCount.setBlocking((count) => count + 1);
+        }
         previousCallMicrotasks();
       };
     });
-
     microtaskDrainCount.setBlocking(0);
   }
 
@@ -74,42 +66,13 @@ describe('microtask draining', () => {
     });
   }
 
-  /**
-   * Queues a microtask that reports back once it runs. On the UI Runtime it
-   * also queues an animation frame callback - `executeQueue` runs those before
-   * draining, so if the callback records itself first, the frame loop drained
-   * the microtask rather than the call under test. Only the first callback to
-   * run records itself, which keeps the check free of races.
-   */
   const probeDrainingCall = () => {
     'worklet';
-    let animationFrameHandle: number | undefined;
-    if (getRuntimeKind() === RuntimeKind.UI) {
-      animationFrameHandle = requestAnimationFrame(() => {
-        firstCallbackThatRan.setBlocking((first) =>
-          first === NOTHING_RAN ? ANIMATION_FRAME_RAN : first
-        );
-      });
-    }
     queueMicrotask(() => {
-      // Cancelling here keeps the callback from outliving this case and
-      // recording itself against the next one. If the frame loop got there
-      // first it has already recorded itself and this is a no-op.
-      if (animationFrameHandle !== undefined) {
-        cancelAnimationFrame(animationFrameHandle);
-      }
-      firstCallbackThatRan.setBlocking((first) =>
-        first === NOTHING_RAN ? MICROTASK_RAN : first
-      );
       scheduleOnRN(notifyDone);
     });
   };
 
-  /**
-   * Leaves a microtask pending without reporting back, so the runtime has
-   * microtask work to drain even when the call under test is not expected to
-   * drain it.
-   */
   const probeNonDrainingCall = () => {
     'worklet';
     queueMicrotask(() => {});
@@ -201,7 +164,6 @@ describe('microtask draining', () => {
   cases.forEach(({ name, runtimeId, expectedDrains, invoke }) => {
     describe(name, () => {
       beforeEach(() => {
-        firstCallbackThatRan.setBlocking(NOTHING_RAN);
         startCountingMicrotaskDrains(runtimeId);
       });
 
@@ -217,10 +179,6 @@ describe('microtask draining', () => {
         }
 
         const microtaskDrains = microtaskDrainCount.getBlocking();
-        const didAnimationFrameRunFirst =
-          firstCallbackThatRan.getBlocking() === ANIMATION_FRAME_RAN;
-
-        expect(didAnimationFrameRunFirst).toBe(false);
         expect(microtaskDrains).toBe(expectedDrains);
       });
     });

--- a/packages/react-native-worklets/Common/cpp/worklets/RunLoop/EventLoop.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/RunLoop/EventLoop.cpp
@@ -1,4 +1,5 @@
 #include <worklets/RunLoop/EventLoop.h>
+#include <worklets/Tools/WorkletsJSIUtils.h>
 
 #include <memory>
 #include <string>
@@ -11,8 +12,13 @@ namespace worklets {
 EventLoop::EventLoop(
     const std::string &name,
     const std::shared_ptr<jsi::Runtime> &runtime,
-    const std::shared_ptr<AsyncQueue> &queue)
-    : runtime_(runtime), queue_(queue), timeoutsQueueState_(std::make_shared<TimeoutsQueueState>()), name_(name) {}
+    const std::shared_ptr<AsyncQueue> &queue,
+    const std::shared_ptr<std::recursive_mutex> &runtimeMutex)
+    : runtime_(runtime),
+      queue_(queue),
+      runtimeMutex_(runtimeMutex),
+      timeoutsQueueState_(std::make_shared<TimeoutsQueueState>()),
+      name_(name) {}
 
 EventLoop::~EventLoop() {
   {
@@ -76,11 +82,14 @@ void EventLoop::run() {
 }
 
 void EventLoop::pushTask(std::function<void(jsi::Runtime &rt)> &&job) {
-  queue_->push([weakRuntime = std::weak_ptr<jsi::Runtime>{runtime_}, job = std::move(job)] {
-    if (auto runtime = weakRuntime.lock()) {
-      job(*runtime);
-    }
-  });
+  queue_->push(
+      [weakRuntime = std::weak_ptr<jsi::Runtime>{runtime_}, runtimeMutex = runtimeMutex_, job = std::move(job)] {
+        if (auto runtime = weakRuntime.lock()) {
+          std::unique_lock lock(*runtimeMutex);
+          job(*runtime);
+          jsi_utils::drainMicrotasks(*runtime);
+        }
+      });
 }
 
 void EventLoop::pushTimeout(std::function<void(jsi::Runtime &rt)> &&job, int64_t delay) {

--- a/packages/react-native-worklets/Common/cpp/worklets/RunLoop/EventLoop.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/RunLoop/EventLoop.h
@@ -6,7 +6,7 @@
 #include <atomic>
 #include <condition_variable>
 #include <memory>
-#include <queue>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -34,7 +34,8 @@ class EventLoop : public std::enable_shared_from_this<EventLoop> {
   EventLoop(
       const std::string &name,
       const std::shared_ptr<jsi::Runtime> &runtime,
-      const std::shared_ptr<AsyncQueue> &queue);
+      const std::shared_ptr<AsyncQueue> &queue,
+      const std::shared_ptr<std::recursive_mutex> &runtimeMutex);
   ~EventLoop();
   void run();
   void pushTask(std::function<void(jsi::Runtime &rt)> &&job);
@@ -43,6 +44,7 @@ class EventLoop : public std::enable_shared_from_this<EventLoop> {
  private:
   const std::shared_ptr<jsi::Runtime> runtime_;
   const std::shared_ptr<AsyncQueue> queue_;
+  const std::shared_ptr<std::recursive_mutex> runtimeMutex_;
   const std::shared_ptr<TimeoutsQueueState> timeoutsQueueState_;
   const std::string name_;
 

--- a/packages/react-native-worklets/Common/cpp/worklets/Tools/WorkletsJSIUtils.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/Tools/WorkletsJSIUtils.h
@@ -11,6 +11,19 @@ using namespace facebook;
 
 namespace worklets::jsi_utils {
 
+/**
+ * Drains both Worklets and Hermes microtasks.
+ */
+inline void drainMicrotasks(jsi::Runtime &rt) {
+  auto callMicrotasks = rt.global().getProperty(rt, "__callMicrotasks");
+  if (callMicrotasks.isObject()) {
+    auto callMicrotasksObject = callMicrotasks.getObject(rt);
+    if (callMicrotasksObject.isFunction(rt)) {
+      callMicrotasksObject.getFunction(rt).call(rt);
+    }
+  }
+}
+
 // `get` functions take a pointer to `jsi::Value` and
 // call an appropriate method to cast to the native type
 template <typename T>

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/RuntimeManager.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/RuntimeManager.cpp
@@ -70,7 +70,7 @@ std::shared_ptr<WorkletRuntime> RuntimeManager::createWorkletRuntime(
 #endif // NDEBUG
 
   if (initializer) {
-    workletRuntime->runSync(initializer);
+    workletRuntime->runSyncAndDrainMicrotasks(initializer);
   }
 
   registerRuntime(runtimeId, workletRuntime);

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.cpp
@@ -66,6 +66,7 @@ WorkletRuntime::WorkletRuntime(
     : runtimeId_(runtimeId),
       enableLocking_(enableLocking),
       runtimeMutex_(std::make_shared<std::recursive_mutex>()),
+      microtaskQueueEnabled_(enableEventLoop || runtimeKind == RuntimeData::RuntimeKind::UI),
       runtime_(makeRuntime(runtimeMutex_, enableLocking_)),
       runtimeKind_(runtimeKind),
       name_(name),
@@ -77,7 +78,7 @@ WorkletRuntime::WorkletRuntime(
   jsi::Runtime &rt = *runtime_;
   WorkletRuntimeCollector::install(rt);
   if (enableEventLoop) {
-    eventLoop_ = std::make_shared<EventLoop>(name_, runtime_, queue_);
+    eventLoop_ = std::make_shared<EventLoop>(name_, runtime_, queue_, runtimeMutex_);
     eventLoop_->run();
   }
 }
@@ -147,13 +148,14 @@ void WorkletRuntime::legacyModeInit(const std::shared_ptr<UnpackerLoader> &unpac
 
 void WorkletRuntime::schedule(jsi::Function &&function) const {
   scheduleImpl([function = std::make_shared<jsi::Function>(std::move(function))](const WorkletRuntime &workletRuntime) {
-    workletRuntime.runSyncImpl(*function);
+    workletRuntime.runSyncImpl<MicrotaskCheckpoint::Run>(*function);
   });
 }
 
 void WorkletRuntime::schedule(std::shared_ptr<SerializableWorklet> worklet) const {
-  scheduleImpl(
-      [worklet = std::move(worklet)](const WorkletRuntime &workletRuntime) { workletRuntime.runSyncImpl(worklet); });
+  scheduleImpl([worklet = std::move(worklet)](const WorkletRuntime &workletRuntime) {
+    workletRuntime.runSyncImpl<MicrotaskCheckpoint::Run>(worklet);
+  });
 }
 
 void WorkletRuntime::schedule(std::vector<std::shared_ptr<SerializableWorklet>> worklets) const {
@@ -173,7 +175,7 @@ void WorkletRuntime::scheduleWithStack(
     std::optional<std::string> scheduleStack) const {
   scheduleImpl([worklet = std::move(worklet),
                 scheduleStack = std::move(scheduleStack)](const WorkletRuntime &workletRuntime) {
-    workletRuntime.runSyncImpl<MicrotaskCheckpoint::Skip, jsi::Value, ScheduleStack::Requested>(worklet, scheduleStack);
+    workletRuntime.runSyncImpl<MicrotaskCheckpoint::Run, jsi::Value, ScheduleStack::Requested>(worklet, scheduleStack);
   });
 }
 
@@ -195,7 +197,9 @@ void WorkletRuntime::scheduleWithStack(
 #endif // NDEBUG
 
 void WorkletRuntime::schedule(std::function<void(jsi::Runtime &)> job) const {
-  scheduleImpl([job = std::move(job)](const WorkletRuntime &workletRuntime) { workletRuntime.runSyncImpl(job); });
+  scheduleImpl([job = std::move(job)](const WorkletRuntime &workletRuntime) {
+    workletRuntime.runSyncImpl<MicrotaskCheckpoint::Run>(job);
+  });
 }
 
 void WorkletRuntime::scheduleImpl(ScheduledJob job) const {

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.h
@@ -10,6 +10,7 @@
 #include <worklets/Tools/JSLogger.h>
 #include <worklets/Tools/JSScheduler.h>
 #include <worklets/Tools/ScriptBuffer.h>
+#include <worklets/Tools/WorkletsJSIUtils.h>
 #include <worklets/WorkletRuntime/RuntimeBindings.h>
 #include <worklets/WorkletRuntime/RuntimeData.h>
 
@@ -49,7 +50,7 @@ class WorkletRuntime : public jsi::HostObject, public std::enable_shared_from_th
   /**
    * Schedules a std::function to run asynchronously.
    *
-   * Does not run a microtask checkpoint.
+   * Runs a single microtask checkpoint on completion.
    */
   void schedule(std::function<void(jsi::Runtime &)> job) const;
 
@@ -59,14 +60,14 @@ class WorkletRuntime : public jsi::HostObject, public std::enable_shared_from_th
    * The jsi::Function has to originate from this runtime, otherwise it will
    crash.
    *
-   * Does not run a microtask checkpoint.
+   * Runs a single microtask checkpoint on completion.
    */
   void schedule(jsi::Function &&function) const;
 
   /**
    * Schedules a serialized worklet to run asynchronously.
    *
-   * Does not run a microtask checkpoint.
+   * Runs a single microtask checkpoint on completion.
    */
   void schedule(std::shared_ptr<SerializableWorklet> worklet) const;
 
@@ -81,7 +82,7 @@ class WorkletRuntime : public jsi::HostObject, public std::enable_shared_from_th
    * Schedules a serialized worklet to run asynchronously on the worklet runtime,
    * remembering the call site that scheduled it for error reporting.
    *
-   * Does not run a microtask checkpoint.
+   * Runs a single microtask checkpoint on completion.
    */
   void scheduleWithStack(std::shared_ptr<SerializableWorklet> worklet, std::optional<std::string> scheduleStack) const;
 
@@ -203,8 +204,6 @@ class WorkletRuntime : public jsi::HostObject, public std::enable_shared_from_th
    * call site that scheduled it for error reporting.
    *
    * TResult must be either jsi::Value or std::shared_ptr<Serializable>.
-   *
-   * The runtime lock is held until the microtask checkpoint completes.
    */
   template <SyncCallResult TResult, RuntimeCallable TCallable, typename... TArgs>
   auto runSyncWithStackAndDrainMicrotasks(
@@ -307,13 +306,13 @@ class WorkletRuntime : public jsi::HostObject, public std::enable_shared_from_th
       SyncCallResult TResult = jsi::Value,
       ScheduleStack TScheduleStack = ScheduleStack::NotRequested,
       typename TCallable,
-      typename... TTArgs>
+      typename... TArgs>
     requires RuntimeJob<TCallable> || RuntimeCallable<TCallable>
-  auto runSyncImpl(TCallable &&callable, TTArgs &&...args) const -> decltype(auto) {
+  auto runSyncImpl(TCallable &&callable, TArgs &&...args) const -> decltype(auto) {
     jsi::Runtime &rt = getJSIRuntime();
     if constexpr (std::is_same_v<std::remove_cvref_t<TCallable>, std::shared_ptr<SerializableWorklet>>) {
       auto function = callable->toJSValue(rt).getObject(rt).getFunction(rt);
-      return runSyncImpl<TCheckpoint, TResult, TScheduleStack>(function, std::forward<TTArgs>(args)...);
+      return runSyncImpl<TCheckpoint, TResult, TScheduleStack>(function, std::forward<TArgs>(args)...);
     } else {
       auto stackPolicyInvocation = [&]<typename TScheduleStackContext, typename... TCallArgs>(
                                        TScheduleStackContext &&scheduleStackContext,
@@ -322,7 +321,11 @@ class WorkletRuntime : public jsi::HostObject, public std::enable_shared_from_th
           if constexpr (RuntimeJob<TCallable>) {
             return std::forward<TCallable>(callable)(rt);
           } else {
-            auto result = this->invoke(rt, callable, scheduleStackContext, std::forward<TCallArgs>(callArgs)...);
+            auto result = this->invoke(
+                rt,
+                callable,
+                std::forward<TScheduleStackContext>(scheduleStackContext),
+                std::forward<TCallArgs>(callArgs)...);
             if constexpr (std::is_same_v<TResult, std::shared_ptr<Serializable>>) {
               return extractSerializableOrThrow(rt, result);
             } else {
@@ -331,10 +334,11 @@ class WorkletRuntime : public jsi::HostObject, public std::enable_shared_from_th
           }
         };
 
-        return invokeWithMicrotaskCheckpointPolicyImpl<TCheckpoint>(microtaskPolicyInvocation);
+        return invokeWithMicrotaskCheckpointPolicyImpl<TCheckpoint>(std::move(microtaskPolicyInvocation));
       };
 
-      return invokeWithStackPolicyImpl<TScheduleStack, TCallable>(stackPolicyInvocation, std::forward<TTArgs>(args)...);
+      return invokeWithStackPolicyImpl<TScheduleStack, TCallable>(
+          std::move(stackPolicyInvocation), std::forward<TArgs>(args)...);
     }
   }
 
@@ -353,7 +357,8 @@ class WorkletRuntime : public jsi::HostObject, public std::enable_shared_from_th
             std::is_same_v<std::remove_cvref_t<TScheduleStackArg>, std::optional<std::string>>,
             "[Worklets] The first argument must be an optional scheduling stack.");
         return std::forward<TInvoker>(invoke)(
-            RequestedScheduleStack{scheduleStack}, std::forward<TCallArgs>(callArgs)...);
+            RequestedScheduleStack{std::forward<TScheduleStackArg>(scheduleStack)},
+            std::forward<TCallArgs>(callArgs)...);
       }(std::forward<TArgs>(args)...);
     } else
 #endif // NDEBUG
@@ -367,18 +372,20 @@ class WorkletRuntime : public jsi::HostObject, public std::enable_shared_from_th
    */
   template <MicrotaskCheckpoint TCheckpoint, typename TInvoker>
   auto invokeWithMicrotaskCheckpointPolicyImpl(TInvoker &&invoke) const -> std::invoke_result_t<TInvoker> {
-    if constexpr (TCheckpoint == MicrotaskCheckpoint::Skip) {
-      return std::forward<TInvoker>(invoke)();
-    } else {
-      using Result = std::invoke_result_t<TInvoker>;
-      if constexpr (std::is_void_v<Result>) {
-        std::forward<TInvoker>(invoke)();
-        drainMicrotasksImpl();
+    using Result = std::invoke_result_t<TInvoker>;
+    const auto checkpoint = [&]() {
+      if constexpr (TCheckpoint == MicrotaskCheckpoint::Skip) {
       } else {
-        auto result = std::forward<TInvoker>(invoke)();
         drainMicrotasksImpl();
-        return result;
       }
+    };
+    if constexpr (std::is_void_v<Result>) {
+      std::forward<TInvoker>(invoke)();
+      checkpoint();
+    } else {
+      Result result = std::forward<TInvoker>(invoke)();
+      checkpoint();
+      return std::forward<Result>(result);
     }
   }
 
@@ -386,18 +393,8 @@ class WorkletRuntime : public jsi::HostObject, public std::enable_shared_from_th
    * Assumes the caller acquired the runtime lock.
    */
   void drainMicrotasksImpl() const {
-    jsi::Runtime &rt = getJSIRuntime();
-    if (!eventLoop_ && runtimeKind_ != RuntimeData::RuntimeKind::UI) {
-      // UI Runtime doesn't have a C++-kind Event Loop, but one polyfilled in JS.
-      return;
-    }
-
-    auto callMicrotasks = rt.global().getProperty(rt, "__callMicrotasks");
-    if (callMicrotasks.isObject()) {
-      auto callMicrotasksObject = callMicrotasks.getObject(rt);
-      if (callMicrotasksObject.isFunction(rt)) {
-        callMicrotasksObject.getFunction(rt).call(rt);
-      }
+    if (microtaskQueueEnabled_) {
+      jsi_utils::drainMicrotasks(getJSIRuntime());
     }
   }
 
@@ -445,6 +442,7 @@ class WorkletRuntime : public jsi::HostObject, public std::enable_shared_from_th
   const RuntimeData::RuntimeId runtimeId_;
   const bool enableLocking_;
   const std::shared_ptr<std::recursive_mutex> runtimeMutex_;
+  const bool microtaskQueueEnabled_;
   const std::shared_ptr<jsi::Runtime> runtime_;
   std::shared_ptr<JSScheduler> jsScheduler_;
   const RuntimeData::RuntimeKind runtimeKind_;

--- a/packages/react-native-worklets/src/runLoop/uiRuntime/requestAnimationFrame.ts
+++ b/packages/react-native-worklets/src/runLoop/uiRuntime/requestAnimationFrame.ts
@@ -2,7 +2,6 @@
 
 export function setupRequestAnimationFrame() {
   'worklet';
-  const callMicrotasks = globalThis.__callMicrotasks;
 
   let queuedCallbacks: ((timestamp: number) => void)[] = [];
   let queuedCallbacksBegin = 0;
@@ -28,7 +27,7 @@ export function setupRequestAnimationFrame() {
 
     flushedCallbacksBegin = flushedCallbacksEnd;
 
-    callMicrotasks();
+    globalThis.__callMicrotasks();
 
     const finalizers = queuedFinalizers;
     queuedFinalizers = [];

--- a/packages/react-native-worklets/src/runLoop/workletRuntime/taskQueue.ts
+++ b/packages/react-native-worklets/src/runLoop/workletRuntime/taskQueue.ts
@@ -19,7 +19,6 @@ export function setupTaskQueue() {
     const task = queue.timeoutCallbacks.get(handlerId);
     task?.();
     queue.timeoutCallbacks.delete(handlerId);
-    globalThis.__callMicrotasks();
   };
 
   globalThis.__callMicrotasks = function callMicrotasks() {

--- a/packages/react-native-worklets/src/runtimes.native.ts
+++ b/packages/react-native-worklets/src/runtimes.native.ts
@@ -182,7 +182,6 @@ export function scheduleOnRuntime<Args extends unknown[], ReturnValue>(
     createSerializable(() => {
       'worklet';
       worklet(...args);
-      globalThis.__callMicrotasks?.();
     }),
     SHOULD_CAPTURE_SCHEDULE_STACK ? new Error().stack : undefined
   );
@@ -206,7 +205,6 @@ if (!isBundleModeEnabled()) {
       globalThis.__serializer(() => {
         'worklet';
         worklet(...args);
-        globalThis.__callMicrotasks?.();
       })
     );
   }
@@ -260,7 +258,6 @@ export function scheduleOnRuntimeWithId<Args extends unknown[], ReturnValue>(
     createSerializable(() => {
       'worklet';
       worklet(...args);
-      globalThis.__callMicrotasks?.();
     }),
     SHOULD_CAPTURE_SCHEDULE_STACK ? new Error().stack : undefined
   );
@@ -284,7 +281,6 @@ if (!isBundleModeEnabled()) {
       globalThis.__serializer(() => {
         'worklet';
         worklet(...args);
-        globalThis.__callMicrotasks?.();
       })
     );
   }
@@ -480,7 +476,6 @@ export function runOnRuntimeAsync<Args extends unknown[], ReturnValue>(
             serializedError
           );
         }
-        globalThis.__callMicrotasks?.();
       }),
       scheduleStack
     );
@@ -555,7 +550,6 @@ export function runOnRuntimeAsyncWithId<Args extends unknown[], ReturnValue>(
             serializedError
           );
         }
-        globalThis.__callMicrotasks?.();
       }),
       scheduleStack
     );


### PR DESCRIPTION
## Summary

- #10085 
adds support for WeakRef but it requires calling microtasks in C++. I'm doing it in this PR for greater atomicity.

## Test plan

Simplified runtime tests pass.
