### PR TITLE
fix: prevent animation jumps when disabling slow animations

### DIFF
--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
@@ -277,8 +277,7 @@ open class NativeProxy {
     }
 
     @DoNotStrip
-    fun getAnimationTimestamp(): Long =
-        (virtualBaseMs + (SystemClock.uptimeMillis() - realBaseMs) / currentDragFactor()).toLong()
+    fun getAnimationTimestamp(): Long = (virtualBaseMs + (SystemClock.uptimeMillis() - realBaseMs) / currentDragFactor()).toLong()
 
     @DoNotStrip
     fun registerEventHandler(handler: EventHandler) {

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
@@ -46,7 +46,8 @@ open class NativeProxy {
     private val gestureHandlerStateManager: GestureHandlerStateManager?
     private val keyboardAnimationManager: KeyboardAnimationManager
     private val pseudoSelectorManager: PseudoSelectorManager
-    private var firstUptime: Long = SystemClock.uptimeMillis()
+    private var virtualBaseMs = SystemClock.uptimeMillis().toDouble()
+    private var realBaseMs = virtualBaseMs
     private var slowAnimationsEnabled = false
     private val animationsDragFactor = 10
 
@@ -140,13 +141,17 @@ open class NativeProxy {
     }
 
     private fun toggleSlowAnimations() {
+        // The virtual clock is rebased on every toggle so getAnimationTimestamp()
+        // stays continuous and ongoing animations don't jump.
+        val nowMs = SystemClock.uptimeMillis().toDouble()
+        virtualBaseMs += (nowMs - realBaseMs) / currentDragFactor()
+        realBaseMs = nowMs
         slowAnimationsEnabled = !slowAnimationsEnabled
-        if (slowAnimationsEnabled) {
-            firstUptime = SystemClock.uptimeMillis()
-        }
         mNodesManager!!.enableSlowAnimations(slowAnimationsEnabled, animationsDragFactor)
         toggleSlowAnimationsOnUIRuntime()
     }
+
+    private fun currentDragFactor() = if (slowAnimationsEnabled) animationsDragFactor.toDouble() else 1.0
 
     private fun addDevMenuOption() {
         // In Expo, `ApplicationContext` is not an instance of `ReactApplication`
@@ -273,11 +278,7 @@ open class NativeProxy {
 
     @DoNotStrip
     fun getAnimationTimestamp(): Long =
-        if (slowAnimationsEnabled) {
-            firstUptime + (SystemClock.uptimeMillis() - firstUptime) / animationsDragFactor
-        } else {
-            SystemClock.uptimeMillis()
-        }
+        (virtualBaseMs + (SystemClock.uptimeMillis() - realBaseMs) / currentDragFactor()).toLong()
 
     @DoNotStrip
     fun registerEventHandler(handler: EventHandler) {

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NodesManager.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NodesManager.kt
@@ -27,9 +27,9 @@ class NodesManager(
         fun onAnimationFrame(timestampMs: Double)
     }
 
-    private var mFirstUptime: Long = SystemClock.uptimeMillis()
-    private var mSlowAnimationsEnabled = false
-    private var mAnimationsDragFactor = 0
+    private var mVirtualBaseMs = SystemClock.uptimeMillis().toDouble()
+    private var mRealBaseMs = mVirtualBaseMs
+    private var mAnimationsDragFactor = 1.0
 
     private val mEventEmitter: DeviceEventManagerModule.RCTDeviceEventEmitter =
         context.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
@@ -149,11 +149,8 @@ class NodesManager(
 
             mDrawPassDetector.initialize()
 
-            var currentFrameTimeMs = frameTimeNanos / 1000000.0
-            if (mSlowAnimationsEnabled) {
-                currentFrameTimeMs =
-                    mFirstUptime + (currentFrameTimeMs - mFirstUptime) / mAnimationsDragFactor
-            }
+            val currentFrameTimeMs =
+                mVirtualBaseMs + (frameTimeNanos / 1000000.0 - mRealBaseMs) / mAnimationsDragFactor
 
             if (currentFrameTimeMs > lastFrameTimeMs) {
                 // It is possible for ChoreographerCallback to be executed twice within the same frame
@@ -259,10 +256,11 @@ class NodesManager(
         slowAnimationsEnabled: Boolean,
         animationsDragFactor: Int,
     ) {
-        mSlowAnimationsEnabled = slowAnimationsEnabled
-        mAnimationsDragFactor = animationsDragFactor
-        if (slowAnimationsEnabled) {
-            mFirstUptime = SystemClock.uptimeMillis()
-        }
+        // The virtual clock is rebased on every toggle so it stays continuous
+        // and ongoing animations don't jump.
+        val nowMs = SystemClock.uptimeMillis().toDouble()
+        mVirtualBaseMs += (nowMs - mRealBaseMs) / mAnimationsDragFactor
+        mRealBaseMs = nowMs
+        mAnimationsDragFactor = if (slowAnimationsEnabled) animationsDragFactor.toDouble() else 1.0
     }
 }

--- a/packages/react-native-worklets/android/src/main/java/com/swmansion/worklets/runloop/AnimationFrameQueue.kt
+++ b/packages/react-native-worklets/android/src/main/java/com/swmansion/worklets/runloop/AnimationFrameQueue.kt
@@ -9,10 +9,10 @@ import java.util.concurrent.atomic.AtomicBoolean
 class AnimationFrameQueue(
     reactApplicationContext: ReactApplicationContext,
 ) {
-    private var mFirstUptime = SystemClock.uptimeMillis()
-    private var mSlowAnimationsEnabled = false
+    private var mVirtualBaseMs = SystemClock.uptimeMillis().toDouble()
+    private var mRealBaseMs = mVirtualBaseMs
     private var lastFrameTimeMs = 0.0
-    private var mAnimationsDragFactor = 1
+    private var mAnimationsDragFactor = 1.0
 
     // ReactChoreographer is
     // [thread safe](https://github.com/facebook/react-native/blob/main/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/core/ReactChoreographer.kt#L21).
@@ -55,11 +55,12 @@ class AnimationFrameQueue(
         slowAnimationsEnabled: Boolean,
         animationsDragFactor: Int,
     ) {
-        mSlowAnimationsEnabled = slowAnimationsEnabled
-        mAnimationsDragFactor = animationsDragFactor
-        if (slowAnimationsEnabled) {
-            mFirstUptime = SystemClock.uptimeMillis()
-        }
+        // The virtual clock is rebased on every toggle so it stays continuous
+        // and ongoing animations don't jump.
+        val nowMs = SystemClock.uptimeMillis().toDouble()
+        mVirtualBaseMs += (nowMs - mRealBaseMs) / mAnimationsDragFactor
+        mRealBaseMs = nowMs
+        mAnimationsDragFactor = if (slowAnimationsEnabled) animationsDragFactor.toDouble() else 1.0
     }
 
     private fun scheduleQueueExecution() {
@@ -102,11 +103,7 @@ class AnimationFrameQueue(
 
     private fun calculateTimestamp(frameTimeNanos: Long): Double {
         val nanosecondsInMilliseconds = 1000000.0
-        var currentFrameTimeMs = frameTimeNanos / nanosecondsInMilliseconds
-        if (mSlowAnimationsEnabled) {
-            currentFrameTimeMs =
-                mFirstUptime + (currentFrameTimeMs - mFirstUptime) / mAnimationsDragFactor
-        }
-        return currentFrameTimeMs
+        val currentFrameTimeMs = frameTimeNanos / nanosecondsInMilliseconds
+        return mVirtualBaseMs + (currentFrameTimeMs - mRealBaseMs) / mAnimationsDragFactor
     }
 }

--- a/packages/react-native-worklets/apple/worklets/apple/SlowAnimations.mm
+++ b/packages/react-native-worklets/apple/worklets/apple/SlowAnimations.mm
@@ -23,19 +23,20 @@ CGFloat getUIAnimationDragCoefficient(void)
 CFTimeInterval calculateTimestampWithSlowAnimations(CFTimeInterval currentTimestamp)
 {
 #if TARGET_IPHONE_SIMULATOR
-  static CFTimeInterval dragCoefChangedTimestamp = CACurrentMediaTime();
-  static CGFloat previousDragCoef = getUIAnimationDragCoefficient();
+  // The virtual clock is rebased on every drag coefficient change so it stays
+  // continuous and ongoing animations don't jump when toggling Slow Animations.
+  static CFTimeInterval realBaseTimestamp = CACurrentMediaTime();
+  static CFTimeInterval virtualBaseTimestamp = realBaseTimestamp;
+  static CGFloat dragCoef = getUIAnimationDragCoefficient();
 
-  const CGFloat dragCoef = getUIAnimationDragCoefficient();
-  if (previousDragCoef != dragCoef) {
-    previousDragCoef = dragCoef;
-    dragCoefChangedTimestamp = CACurrentMediaTime();
+  const CGFloat newDragCoef = getUIAnimationDragCoefficient();
+  if (newDragCoef != dragCoef) {
+    virtualBaseTimestamp += (currentTimestamp - realBaseTimestamp) / dragCoef;
+    realBaseTimestamp = currentTimestamp;
+    dragCoef = newDragCoef;
   }
 
-  const bool areSlowAnimationsEnabled = dragCoef != 1.f;
-  if (areSlowAnimationsEnabled) {
-    currentTimestamp = (dragCoefChangedTimestamp + (currentTimestamp - dragCoefChangedTimestamp) / dragCoef);
-  }
+  currentTimestamp = virtualBaseTimestamp + (currentTimestamp - realBaseTimestamp) / dragCoef;
 #endif // TARGET_IPHONE_SIMULATOR
   return currentTimestamp;
 }


### PR DESCRIPTION
> [!NOTE]
> This pull request was authored by AI on behalf of tomekzaw.

Stacked on #10186.

## Summary

Disabling slow animations currently makes ongoing animations jump ahead, usually straight to their final state: while slow mode is on, the animation clock lags behind real time, and switching back to the raw clock snaps it forward by the accumulated difference.

This PR makes the animation clock piecewise-continuous. On every toggle (or drag coefficient change on iOS), the virtual clock is rebased – the virtual base advances by the elapsed real time divided by the old factor, and the real base resets – so time keeps flowing without discontinuities and animations smoothly change pace in both directions. Same rebase logic in all clocks:

- iOS: `SlowAnimations.mm` (canonical after #10186)
- Android: `NodesManager.kt`, `NativeProxy.kt` (`getAnimationTimestamp`) and `AnimationFrameQueue.kt`

Trade-offs (dev-only tool):

- After a slow period the virtual clock permanently lags real time by Δ·9/10 (previously it resnapped to the raw clock on disable).
- Timers (`setTimeout`, `setInterval`) and other app logic still run at full speed, so timer-driven shared value updates or unmounts can still cause visible jumps relative to slowed-down animations.

The docs remark about the jump-on-disable behavior (#10185) will need a follow-up update once this lands.

## Test plan

Use the **Slow animations** example added in #10189 (or any long-running animation). Mid-animation, toggle slow animations on and off (iOS Simulator: **Debug** > **Slow Animations**; Android: **Toggle slow animations (Reanimated)** in the Dev Menu). Expected: all animations change pace smoothly in both directions and no longer jump to their final state on disable. Also verified with an assert-based model of the clock math (continuity at both transitions, correct slopes, monotonicity) and `clang++ -fsyntax-only` on the iOS file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)