### PR TITLE
chore: add Slow animations example

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/SlowAnimationsExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/SlowAnimationsExample.tsx
@@ -143,7 +143,7 @@ export default function SlowAnimationsExample() {
           title="Fling"
           onPress={() => {
             decayOffset.value = 0;
-            decayOffset.value = withDecay({ velocity: 600, clamp: [0, 250] });
+            decayOffset.value = withDecay({ velocity: 500, clamp: [0, 250] });
           }}
         />
       </View>

--- a/apps/common-app/src/apps/reanimated/examples/SlowAnimationsExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/SlowAnimationsExample.tsx
@@ -15,11 +15,13 @@ import Animated, {
   FadeOut,
   LinearTransition,
   useAnimatedStyle,
+  useFrameCallback,
   useSharedValue,
   withRepeat,
   withSpring,
   withTiming,
 } from 'react-native-reanimated';
+import { scheduleOnRN } from 'react-native-worklets';
 
 const INSTRUCTIONS = Platform.select({
   ios: 'select Debug > Slow Animations in the iOS Simulator menu bar',
@@ -42,6 +44,31 @@ const TRANSITION = {
   transitionTimingFunction: 'linear',
 } satisfies CSSTransitionProperties;
 
+// The frame clock (requestAnimationFrame timestamps) is slowed down by slow
+// animations while the wall clock (Date.now) is not, so a frame-to-wall time
+// ratio well below 1 means slow animations are enabled.
+function useDetectSlowAnimations() {
+  const [slowEnabled, setSlowEnabled] = useState<boolean | null>(null);
+  const detected = useSharedValue<boolean | null>(null);
+  const prevRealTime = useSharedValue(0);
+
+  useFrameCallback((frameInfo) => {
+    const realDelta = Date.now() - prevRealTime.value;
+    prevRealTime.value = Date.now();
+    const frameDelta = frameInfo.timeSincePreviousFrame;
+    if (frameDelta === null || realDelta > 1000) {
+      return; // first frame or the app was suspended
+    }
+    const slow = frameDelta / realDelta < 0.5;
+    if (slow !== detected.value) {
+      detected.value = slow;
+      scheduleOnRN(setSlowEnabled, slow);
+    }
+  });
+
+  return slowEnabled;
+}
+
 export default function SlowAnimationsExample() {
   const offset = useSharedValue(0);
   const springOffset = useSharedValue(0);
@@ -49,6 +76,7 @@ export default function SlowAnimationsExample() {
   const [transitionOn, setTransitionOn] = useState(false);
   const [ids, setIds] = useState([0, 1, 2]);
   const nextId = useRef(3);
+  const slowEnabled = useDetectSlowAnimations();
 
   useEffect(() => {
     offset.value = 0;
@@ -77,6 +105,17 @@ export default function SlowAnimationsExample() {
         While the animations below are running, {INSTRUCTIONS} to toggle slow
         animations. The animations should run slower (when enabled) or faster
         (when disabled).
+      </Text>
+      <Text style={styles.text}>
+        Slow animations are now{' '}
+        {slowEnabled === null ? (
+          <Text style={styles.bold}>undetected yet</Text>
+        ) : slowEnabled ? (
+          <Text style={[styles.bold, styles.enabled]}>🐢 enabled</Text>
+        ) : (
+          <Text style={[styles.bold, styles.disabled]}>❌ disabled</Text>
+        )}
+        {'\n'}(detected by comparing frame and wall clocks).
       </Text>
       <Text style={styles.heading}>Timing animation</Text>
       <Text style={styles.text}>The box moves back and forth in a loop.</Text>
@@ -157,6 +196,15 @@ const styles = StyleSheet.create({
   },
   text: {
     marginBottom: 12,
+  },
+  bold: {
+    fontWeight: 'bold',
+  },
+  enabled: {
+    color: 'forestgreen',
+  },
+  disabled: {
+    color: 'crimson',
   },
   box: {
     width: 60,

--- a/apps/common-app/src/apps/reanimated/examples/SlowAnimationsExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/SlowAnimationsExample.tsx
@@ -82,9 +82,7 @@ export default function SlowAnimationsExample() {
       <Text style={styles.text}>The box moves back and forth in a loop.</Text>
       <Animated.View style={[styles.box, animatedStyle]} />
       <Text style={styles.heading}>Spring animation</Text>
-      <Text style={styles.text}>
-        The box springs between two positions.
-      </Text>
+      <Text style={styles.text}>The box springs between two positions.</Text>
       <View style={styles.buttons}>
         <Button title="Toggle" onPress={() => setSpringOn((on) => !on)} />
       </View>
@@ -120,8 +118,8 @@ export default function SlowAnimationsExample() {
       />
       <Text style={styles.heading}>Layout animations</Text>
       <Text style={styles.text}>
-        Add and remove boxes – entering and exiting animations as well as
-        layout transitions of the other boxes are also affected.
+        Add and remove boxes – entering and exiting animations as well as layout
+        transitions of the other boxes are also affected.
       </Text>
       <View style={styles.buttons}>
         <Button

--- a/apps/common-app/src/apps/reanimated/examples/SlowAnimationsExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/SlowAnimationsExample.tsx
@@ -24,9 +24,9 @@ const INSTRUCTIONS = Platform.select({
     "select 'Toggle slow animations (Reanimated)' in the Dev Menu (press d in the Metro console)",
 });
 
-const ENTERING = FadeIn.duration(800);
-const EXITING = FadeOut.duration(800);
-const LAYOUT = LinearTransition.duration(800);
+const ENTERING = FadeIn.duration(200);
+const EXITING = FadeOut.duration(200);
+const LAYOUT = LinearTransition.duration(200);
 
 export default function SlowAnimationsExample() {
   const offset = useSharedValue(0);

--- a/apps/common-app/src/apps/reanimated/examples/SlowAnimationsExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/SlowAnimationsExample.tsx
@@ -83,14 +83,14 @@ export default function SlowAnimationsExample() {
   useEffect(() => {
     offset.value = 0;
     offset.value = withRepeat(
-      withTiming(300, { duration: 1500, easing: Easing.linear }),
+      withTiming(250, { duration: 1500, easing: Easing.linear }),
       -1,
       true
     );
   }, [offset]);
 
   useEffect(() => {
-    springOffset.value = withSpring(springOn ? 300 : 0);
+    springOffset.value = withSpring(springOn ? 250 : 0);
   }, [springOn, springOffset]);
 
   const animatedStyle = useAnimatedStyle(() => ({
@@ -143,7 +143,7 @@ export default function SlowAnimationsExample() {
           title="Fling"
           onPress={() => {
             decayOffset.value = 0;
-            decayOffset.value = withDecay({ velocity: 600, clamp: [0, 300] });
+            decayOffset.value = withDecay({ velocity: 600, clamp: [0, 250] });
           }}
         />
       </View>
@@ -174,7 +174,7 @@ export default function SlowAnimationsExample() {
         style={[
           styles.box,
           TRANSITION,
-          { transform: [{ translateX: transitionOn ? 300 : 0 }] },
+          { transform: [{ translateX: transitionOn ? 250 : 0 }] },
         ]}
       />
       <Text style={styles.heading}>Layout animations</Text>

--- a/apps/common-app/src/apps/reanimated/examples/SlowAnimationsExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/SlowAnimationsExample.tsx
@@ -1,0 +1,121 @@
+import React, { useEffect, useRef, useState } from 'react';
+import {
+  Button,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import Animated, {
+  Easing,
+  FadeIn,
+  FadeOut,
+  LinearTransition,
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withTiming,
+} from 'react-native-reanimated';
+
+const INSTRUCTIONS = Platform.select({
+  ios: 'select Debug > Slow Animations in the iOS Simulator menu bar',
+  default:
+    "select 'Toggle slow animations (Reanimated)' in the Dev Menu (press d in the Metro console)",
+});
+
+const ENTERING = FadeIn.duration(800);
+const EXITING = FadeOut.duration(800);
+const LAYOUT = LinearTransition.duration(800);
+
+export default function SlowAnimationsExample() {
+  const offset = useSharedValue(0);
+  const [ids, setIds] = useState([0, 1, 2]);
+  const nextId = useRef(3);
+
+  useEffect(() => {
+    offset.value = 0;
+    offset.value = withRepeat(
+      withTiming(300, { duration: 1500, easing: Easing.linear }),
+      -1,
+      true
+    );
+  }, [offset]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: offset.value }],
+  }));
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <Text style={styles.text}>
+        While the animations below are running, {INSTRUCTIONS} to toggle slow
+        animations. The animations should run slower (when enabled) or faster
+        (when disabled).
+      </Text>
+      <Text style={styles.heading}>Timing animation</Text>
+      <Text style={styles.text}>The box moves back and forth in a loop.</Text>
+      <Animated.View style={[styles.box, animatedStyle]} />
+      <Text style={styles.heading}>Layout animations</Text>
+      <Text style={styles.text}>
+        Add and remove boxes – entering and exiting animations as well as
+        layout transitions of the other boxes are also affected.
+      </Text>
+      <View style={styles.buttons}>
+        <Button
+          title="Add"
+          onPress={() => setIds((prev) => [nextId.current++, ...prev])}
+        />
+        <Button
+          title="Remove"
+          onPress={() => setIds((prev) => prev.slice(1))}
+        />
+      </View>
+      <View style={styles.boxes}>
+        {ids.map((id) => (
+          <Animated.View
+            key={id}
+            entering={ENTERING}
+            exiting={EXITING}
+            layout={LAYOUT}
+            style={styles.smallBox}
+          />
+        ))}
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 20,
+  },
+  heading: {
+    fontWeight: 'bold',
+    marginTop: 24,
+    marginBottom: 8,
+  },
+  text: {
+    marginBottom: 12,
+  },
+  box: {
+    width: 60,
+    height: 60,
+    backgroundColor: 'navy',
+  },
+  buttons: {
+    flexDirection: 'row',
+    gap: 8,
+    marginBottom: 12,
+  },
+  boxes: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  smallBox: {
+    width: 40,
+    height: 40,
+    backgroundColor: 'navy',
+  },
+});

--- a/apps/common-app/src/apps/reanimated/examples/SlowAnimationsExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/SlowAnimationsExample.tsx
@@ -7,7 +7,9 @@ import {
   Text,
   View,
 } from 'react-native';
+import type { CSSTransitionProperties } from 'react-native-reanimated';
 import Animated, {
+  css,
   Easing,
   FadeIn,
   FadeOut,
@@ -15,6 +17,7 @@ import Animated, {
   useAnimatedStyle,
   useSharedValue,
   withRepeat,
+  withSpring,
   withTiming,
 } from 'react-native-reanimated';
 
@@ -28,8 +31,22 @@ const ENTERING = FadeIn.duration(200);
 const EXITING = FadeOut.duration(200);
 const LAYOUT = LinearTransition.duration(200);
 
+const SPIN = css.keyframes({
+  from: { transform: [{ rotate: '0deg' }] },
+  to: { transform: [{ rotate: '360deg' }] },
+});
+
+const TRANSITION = {
+  transitionProperty: 'transform',
+  transitionDuration: 1000,
+  transitionTimingFunction: 'linear',
+} satisfies CSSTransitionProperties;
+
 export default function SlowAnimationsExample() {
   const offset = useSharedValue(0);
+  const springOffset = useSharedValue(0);
+  const [springOn, setSpringOn] = useState(false);
+  const [transitionOn, setTransitionOn] = useState(false);
   const [ids, setIds] = useState([0, 1, 2]);
   const nextId = useRef(3);
 
@@ -42,8 +59,16 @@ export default function SlowAnimationsExample() {
     );
   }, [offset]);
 
+  useEffect(() => {
+    springOffset.value = withSpring(springOn ? 300 : 0);
+  }, [springOn, springOffset]);
+
   const animatedStyle = useAnimatedStyle(() => ({
     transform: [{ translateX: offset.value }],
+  }));
+
+  const springStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: springOffset.value }],
   }));
 
   return (
@@ -56,6 +81,43 @@ export default function SlowAnimationsExample() {
       <Text style={styles.heading}>Timing animation</Text>
       <Text style={styles.text}>The box moves back and forth in a loop.</Text>
       <Animated.View style={[styles.box, animatedStyle]} />
+      <Text style={styles.heading}>Spring animation</Text>
+      <Text style={styles.text}>
+        The box springs between two positions.
+      </Text>
+      <View style={styles.buttons}>
+        <Button title="Toggle" onPress={() => setSpringOn((on) => !on)} />
+      </View>
+      <Animated.View style={[styles.box, springStyle]} />
+      <Text style={styles.heading}>CSS animation</Text>
+      <Text style={styles.text}>
+        The box rotates in a loop using a CSS animation.
+      </Text>
+      <Animated.View
+        style={[
+          styles.box,
+          {
+            animationName: SPIN,
+            animationDuration: 3000,
+            animationIterationCount: 'infinite',
+            animationTimingFunction: 'linear',
+          },
+        ]}
+      />
+      <Text style={styles.heading}>CSS transition</Text>
+      <Text style={styles.text}>
+        The box slides between two positions using a CSS transition.
+      </Text>
+      <View style={styles.buttons}>
+        <Button title="Toggle" onPress={() => setTransitionOn((on) => !on)} />
+      </View>
+      <Animated.View
+        style={[
+          styles.box,
+          TRANSITION,
+          { transform: [{ translateX: transitionOn ? 300 : 0 }] },
+        ]}
+      />
       <Text style={styles.heading}>Layout animations</Text>
       <Text style={styles.text}>
         Add and remove boxes – entering and exiting animations as well as

--- a/apps/common-app/src/apps/reanimated/examples/SlowAnimationsExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/SlowAnimationsExample.tsx
@@ -117,7 +117,7 @@ export default function SlowAnimationsExample() {
       <Text style={styles.text}>
         Slow animations are now{' '}
         {slowEnabled === null ? (
-          <Text style={styles.bold}>undetected yet</Text>
+          <Text style={styles.bold}>not yet detected</Text>
         ) : slowEnabled ? (
           <Text style={[styles.bold, styles.enabled]}>🐢 enabled</Text>
         ) : (

--- a/apps/common-app/src/apps/reanimated/examples/SlowAnimationsExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/SlowAnimationsExample.tsx
@@ -41,7 +41,7 @@ const SPIN = css.keyframes({
 
 const TRANSITION = {
   transitionProperty: 'transform',
-  transitionDuration: 1500,
+  transitionDuration: 1000,
   transitionTimingFunction: 'linear',
 } satisfies CSSTransitionProperties;
 
@@ -83,7 +83,7 @@ export default function SlowAnimationsExample() {
   useEffect(() => {
     offset.value = 0;
     offset.value = withRepeat(
-      withTiming(250, { duration: 1500, easing: Easing.linear }),
+      withTiming(250, { duration: 1000, easing: Easing.linear }),
       -1,
       true
     );

--- a/apps/common-app/src/apps/reanimated/examples/SlowAnimationsExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/SlowAnimationsExample.tsx
@@ -17,6 +17,7 @@ import Animated, {
   useAnimatedStyle,
   useFrameCallback,
   useSharedValue,
+  withDecay,
   withRepeat,
   withSpring,
   withTiming,
@@ -72,6 +73,7 @@ function useDetectSlowAnimations() {
 export default function SlowAnimationsExample() {
   const offset = useSharedValue(0);
   const springOffset = useSharedValue(0);
+  const decayOffset = useSharedValue(0);
   const [springOn, setSpringOn] = useState(false);
   const [transitionOn, setTransitionOn] = useState(false);
   const [ids, setIds] = useState([0, 1, 2]);
@@ -97,6 +99,10 @@ export default function SlowAnimationsExample() {
 
   const springStyle = useAnimatedStyle(() => ({
     transform: [{ translateX: springOffset.value }],
+  }));
+
+  const decayStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: decayOffset.value }],
   }));
 
   return (
@@ -128,6 +134,20 @@ export default function SlowAnimationsExample() {
         <Button title="Toggle" onPress={() => setSpringOn((on) => !on)} />
       </View>
       <Animated.View style={[styles.box, springStyle]} />
+      <Text style={styles.heading}>Decay animation</Text>
+      <Text style={styles.text}>
+        The box is flung with an initial velocity and decays to a stop.
+      </Text>
+      <View style={styles.buttons}>
+        <Button
+          title="Fling"
+          onPress={() => {
+            decayOffset.value = 0;
+            decayOffset.value = withDecay({ velocity: 600, clamp: [0, 300] });
+          }}
+        />
+      </View>
+      <Animated.View style={[styles.box, decayStyle]} />
       <Text style={styles.heading}>CSS animation</Text>
       <Text style={styles.text}>
         The box rotates in a loop using a CSS animation.

--- a/apps/common-app/src/apps/reanimated/examples/SlowAnimationsExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/SlowAnimationsExample.tsx
@@ -100,7 +100,9 @@ export default function SlowAnimationsExample() {
   }));
 
   return (
-    <ScrollView contentContainerStyle={styles.container}>
+    <ScrollView
+      automaticallyAdjustsScrollIndicatorInsets={false}
+      contentContainerStyle={styles.container}>
       <Text style={styles.text}>
         While the animations below are running, {INSTRUCTIONS} to toggle slow
         animations. The animations should run slower (when enabled) or faster

--- a/apps/common-app/src/apps/reanimated/examples/SlowAnimationsExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/SlowAnimationsExample.tsx
@@ -41,7 +41,7 @@ const SPIN = css.keyframes({
 
 const TRANSITION = {
   transitionProperty: 'transform',
-  transitionDuration: 1000,
+  transitionDuration: 1500,
   transitionTimingFunction: 'linear',
 } satisfies CSSTransitionProperties;
 

--- a/apps/common-app/src/apps/reanimated/examples/index.ts
+++ b/apps/common-app/src/apps/reanimated/examples/index.ts
@@ -436,6 +436,8 @@ const ShadowNodesCloningExample: React.FC = () =>
   );
 const SharedStyleExample: React.FC = () =>
   React.createElement(require('./SharedStyleExample').default as React.FC);
+const SlowAnimationsExample: React.FC = () =>
+  React.createElement(require('./SlowAnimationsExample').default as React.FC);
 const SpringLayoutAnimation: React.FC = () =>
   React.createElement(
     require('./LayoutAnimations/SpringLayoutAnimation').default
@@ -556,6 +558,11 @@ export const EXAMPLES: Record<string, Example> = {
     icon: '🎞️',
     title: 'FPS',
     screen: FpsExample,
+  },
+  SlowAnimationsExample: {
+    icon: '🐢',
+    title: 'Slow animations',
+    screen: SlowAnimationsExample,
   },
   HermesSamplingProfilerExample: {
     icon: '📊',


### PR DESCRIPTION
> [!NOTE]
> This pull request was authored by AI on behalf of tomekzaw.

## Summary

Adds a **Slow animations** example (🐢) to the example app for testing the Slow animations developer tool documented in #10185. The screen demonstrates each animation engine that consumes the animation clock:

- a **timing animation** – a box moving back and forth in a loop (linear easing, so speed changes are easy to see),
- a **spring animation** – a box springing between two positions on toggle,
- a **CSS animation** – a box rotating in a loop via `animationName` keyframes,
- a **CSS transition** – a box sliding between two positions via `transitionProperty`,
- **layout animations** – Add/Remove buttons that trigger entering and exiting animations and layout transitions of the remaining boxes,

along with short in-app instructions on how to toggle slow animations on each platform (iOS Simulator Debug menu, Android Dev Menu).

The example intentionally makes no claims about behavior when *disabling* slow animations – with the current implementation, ongoing animations jump ahead when the toggle is turned off. #10187 fixes that, and once it lands the example text can mention that animations never jump.

## Test plan

Open the **Slow animations** example. While the animations are running (and while adding/removing boxes), toggle slow animations (iOS Simulator: **Debug** > **Slow Animations**; Android: **Toggle slow animations (Reanimated)** in the Dev Menu) and verify all sections slow down 10× and speed back up when disabled. `tsc --noEmit` passes for the example app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)