### PR TITLE
feat(CSS): support animating backgroundImage gradients

### DIFF
--- a/apps/common-app/src/apps/css/examples/animations/routes/properties/base.ts
+++ b/apps/common-app/src/apps/css/examples/animations/routes/properties/base.ts
@@ -152,6 +152,10 @@ const layoutAndPositioningRoutes = {
 } satisfies Routes;
 
 const appearanceRoutes = {
+  BackgroundImage: {
+    Component: baseAnimatedProperties.appearance.BackgroundImage,
+    name: 'Background Image',
+  },
   Borders: {
     name: 'Borders',
     routes: {

--- a/apps/common-app/src/apps/css/examples/animations/screens/animatedProperties/base/appearance/BackgroundImage.tsx
+++ b/apps/common-app/src/apps/css/examples/animations/screens/animatedProperties/base/appearance/BackgroundImage.tsx
@@ -1,0 +1,136 @@
+/* eslint-disable camelcase */
+import type { ViewStyle } from 'react-native';
+import { StyleSheet } from 'react-native';
+import type { CSSAnimationKeyframes } from 'react-native-reanimated';
+import Animated from 'react-native-reanimated';
+
+import { ExamplesScreen, VerticalExampleCard } from '@/apps/css/components';
+import { radius, sizes } from '@/theme';
+
+export default function BackgroundImage() {
+  return (
+    <ExamplesScreen<ViewStyle, { keyframes: CSSAnimationKeyframes<ViewStyle> }>
+      CardComponent={VerticalExampleCard}
+      buildAnimation={({ keyframes }) => ({
+        animationDirection: 'alternate',
+        animationDuration: '2s',
+        animationIterationCount: 'infinite',
+        animationName: keyframes,
+      })}
+      renderExample={({ animation }) => (
+        <Animated.View style={[styles.box, animation]} />
+      )}
+      tabs={[
+        {
+          name: 'Linear Gradient',
+          sections: [
+            {
+              examples: [
+                {
+                  description:
+                    'Gradients with the same number of color stops are interpolated smoothly - colors, stop positions and the gradient angle all animate.',
+                  keyframes: {
+                    from: {
+                      experimental_backgroundImage:
+                        'linear-gradient(0deg, red, blue)',
+                    },
+                    to: {
+                      experimental_backgroundImage:
+                        'linear-gradient(180deg, yellow, green)',
+                    },
+                  },
+                  title: 'CSS string syntax',
+                },
+                {
+                  description:
+                    'The same gradient animation can be written with the object syntax.',
+                  keyframes: {
+                    from: {
+                      experimental_backgroundImage: [
+                        {
+                          colorStops: [
+                            { color: 'red', positions: ['0%'] },
+                            { color: 'blue', positions: ['50%'] },
+                          ],
+                          direction: '45deg',
+                          type: 'linear-gradient',
+                        },
+                      ],
+                    },
+                    to: {
+                      experimental_backgroundImage: [
+                        {
+                          colorStops: [
+                            { color: 'blue', positions: ['50%'] },
+                            { color: 'red', positions: ['100%'] },
+                          ],
+                          direction: '45deg',
+                          type: 'linear-gradient',
+                        },
+                      ],
+                    },
+                  },
+                  title: 'Object syntax',
+                },
+              ],
+              title: 'Smooth interpolation',
+            },
+            {
+              examples: [
+                {
+                  description:
+                    'Gradients with a different number of color stops cannot be interpolated smoothly, so the value flips discretely in the middle of the animation.',
+                  keyframes: {
+                    from: {
+                      experimental_backgroundImage:
+                        'linear-gradient(red, blue)',
+                    },
+                    to: {
+                      experimental_backgroundImage:
+                        'linear-gradient(red, yellow, blue)',
+                    },
+                  },
+                  title: 'Different number of color stops',
+                },
+              ],
+              title: 'Discrete interpolation',
+            },
+          ],
+        },
+        {
+          name: 'Radial Gradient',
+          sections: [
+            {
+              examples: [
+                {
+                  description:
+                    'Radial gradient colors, sizes and positions are interpolated smoothly when both gradients have the same shape and compatible units.',
+                  keyframes: {
+                    from: {
+                      experimental_backgroundImage:
+                        'radial-gradient(circle 50% at 25% 25%, yellow, red)',
+                    },
+                    to: {
+                      experimental_backgroundImage:
+                        'radial-gradient(circle 100% at 75% 75%, blue, green)',
+                    },
+                  },
+                  title: 'Moving highlight',
+                },
+              ],
+              title: 'Smooth interpolation',
+            },
+          ],
+        },
+      ]}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  box: {
+    borderRadius: radius.md,
+    height: sizes.xl,
+    width: sizes.xl,
+  },
+});

--- a/apps/common-app/src/apps/css/examples/animations/screens/animatedProperties/base/appearance/BackgroundImage.tsx
+++ b/apps/common-app/src/apps/css/examples/animations/screens/animatedProperties/base/appearance/BackgroundImage.tsx
@@ -108,11 +108,11 @@ export default function BackgroundImage() {
                   keyframes: {
                     from: {
                       experimental_backgroundImage:
-                        'radial-gradient(circle 50% at 25% 25%, yellow, red)',
+                        'radial-gradient(circle 60px at 25% 25%, yellow, red)',
                     },
                     to: {
                       experimental_backgroundImage:
-                        'radial-gradient(circle 100% at 75% 75%, blue, green)',
+                        'radial-gradient(circle 120px at 75% 75%, blue, green)',
                     },
                   },
                   title: 'Moving highlight',

--- a/apps/common-app/src/apps/css/examples/animations/screens/animatedProperties/base/appearance/index.ts
+++ b/apps/common-app/src/apps/css/examples/animations/screens/animatedProperties/base/appearance/index.ts
@@ -1,3 +1,4 @@
+import BackgroundImage from './BackgroundImage';
 import borders from './borders';
 import colors from './colors';
 import Filter from './Filter';
@@ -7,6 +8,7 @@ import shadows from './shadows';
 import transforms from './transforms';
 
 export default {
+  BackgroundImage,
   borders,
   colors,
   Filter,

--- a/docs/docs-reanimated/docs/guides/supported-properties.mdx
+++ b/docs/docs-reanimated/docs/guides/supported-properties.mdx
@@ -81,6 +81,7 @@ For animating `react-native-svg` components, see [Animating SVG](/docs/guides/an
   | aspectRatio             | <Yes/>  | <Yes/> | <Yes/> |
   | boxSizing               | <No/>   | <No/>  | <Yes/> |
   | backgroundColor         | <Yes/>  | <Yes/> | <Yes/> |
+  | backgroundImage         | <Yes/>  | <Yes/> | <Yes/> |
   | color                   | <Yes/>  | <Yes/> | <Yes/> |
   | textDecorationColor     | <No/>   | <Yes/> | <Yes/> |
   | textShadowColor         | <Yes/>  | <Yes/> | <Yes/> |

--- a/docs/docs-reanimated/docs/guides/supported-properties.mdx
+++ b/docs/docs-reanimated/docs/guides/supported-properties.mdx
@@ -258,6 +258,10 @@ Similarly to the text shadow styles - all shadow styles (i.e. `shadowColor`, `sh
 
 We highly recommend to use [the `boxShadow` property](https://reactnative.dev/blog/2024/10/23/release-0.76-new-architecture#boxshadow) which doesn't have this limitation and also works on Android.
 
+### Animating background image gradients
+
+The `backgroundImage` style property (linear and radial gradients) is available under this name since React Native 0.87. On older React Native versions use the `experimental_backgroundImage` property instead - both names are supported and animate the same way. Gradients interpolate smoothly when both keyframes use the same gradient type, direction kind, number of color stops and compatible units; otherwise the value changes discretely in the middle of the animation.
+
 ### Animating image tint color
 
 To animate the `tintColor` property on iOS, you must ensure that `tintColor` is included in the style object when the `Image` component is first rendered (mounted). If `tintColor` is not set initially, this property won't be updated via CSS animations or transitions.

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/InterpolatorRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/InterpolatorRegistry.cpp
@@ -11,6 +11,7 @@
 #include <reanimated/CSS/common/values/CSSValue.h>
 
 #include <reanimated/CSS/common/transforms/TransformMatrix2D.h>
+#include <reanimated/CSS/common/values/complex/CSSBackgroundImage.h>
 #include <reanimated/CSS/common/values/complex/CSSBoxShadow.h>
 
 #include <reanimated/CSS/svg/values/CSSLengthArray.h>
@@ -206,6 +207,8 @@ const InterpolatorFactoriesRecord STYLE_INTERPOLATORS = {
     {"cursor", value<CSSKeyword>("auto")},
     {"boxShadow", array({value<CSSBoxShadow>(CSSBoxShadow())})},
     {"mixBlendMode", value<CSSKeyword>("normal")},
+    {"backgroundImage", array({value<CSSLinearGradient, CSSRadialGradient>(CSSLinearGradient())})},
+    {"experimental_backgroundImage", array({value<CSSLinearGradient, CSSRadialGradient>(CSSLinearGradient())})},
 
     // Text
     {"color", value<CSSColor>(BLACK)},

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSValueVariant.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSValueVariant.cpp
@@ -6,6 +6,7 @@
 #include <reanimated/CSS/common/values/CSSLength.h>
 #include <reanimated/CSS/common/values/CSSNumber.h>
 #include <reanimated/CSS/common/values/CSSValueVariant.h>
+#include <reanimated/CSS/common/values/complex/CSSBackgroundImage.h>
 #include <reanimated/CSS/common/values/complex/CSSBoxShadow.h>
 #include <reanimated/CSS/svg/values/CSSLengthArray.h>
 #include <reanimated/CSS/svg/values/SVGBrush.h>
@@ -163,6 +164,7 @@ template class CSSValueVariant<CSSBoolean>;
 template class CSSValueVariant<CSSColor>;
 template class CSSValueVariant<CSSDisplay>;
 template class CSSValueVariant<CSSBoxShadow>;
+template class CSSValueVariant<CSSLinearGradient, CSSRadialGradient>;
 template class CSSValueVariant<CSSDiscreteArray<CSSKeyword>>;
 
 template class CSSValueVariant<SVGPath>;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/complex/CSSBackgroundImage.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/complex/CSSBackgroundImage.cpp
@@ -1,0 +1,449 @@
+#include <reanimated/CSS/common/values/complex/CSSBackgroundImage.h>
+
+#include <jsi/JSIDynamic.h>
+
+#include <cstdlib>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace reanimated::css {
+
+namespace {
+
+constexpr const char *LINEAR_GRADIENT_TYPE = "linear-gradient";
+constexpr const char *RADIAL_GRADIENT_TYPE = "radial-gradient";
+
+// Radial gradient position sides in the order used for serialization
+const std::vector<std::string> POSITION_SIDES = {"top", "left", "bottom", "right"};
+
+bool hasGradientType(const folly::dynamic &value, const char *gradientType) {
+  if (!value.isObject()) {
+    return false;
+  }
+  const auto typeIt = value.find("type");
+  return typeIt != value.items().end() && typeIt->second.isString() && typeIt->second.getString() == gradientType;
+}
+
+bool hasGradientType(jsi::Runtime &rt, const jsi::Value &jsiValue, const char *gradientType) {
+  if (!jsiValue.isObject()) {
+    return false;
+  }
+  const auto &obj = jsiValue.asObject(rt);
+  const auto type = obj.getProperty(rt, "type");
+  return type.isString() && type.asString(rt).utf8(rt) == gradientType;
+}
+
+std::vector<GradientColorStop> colorStopsFromDynamic(const folly::dynamic &value) {
+  std::vector<GradientColorStop> result;
+
+  const auto stopsIt = value.find("colorStops");
+  if (stopsIt != value.items().end() && stopsIt->second.isArray()) {
+    result.reserve(stopsIt->second.size());
+    for (const auto &stop : stopsIt->second) {
+      result.push_back(GradientColorStop::fromDynamic(stop));
+    }
+  }
+
+  return result;
+}
+
+} // namespace
+
+// GradientLengthPercentage
+
+std::optional<GradientLengthPercentage> GradientLengthPercentage::tryFromDynamic(const folly::dynamic &dynValue) {
+  if (dynValue.isNumber()) {
+    return GradientLengthPercentage{dynValue.asDouble(), false};
+  }
+  if (dynValue.isString()) {
+    const auto &str = dynValue.getString();
+    if (!str.empty() && str.back() == '%') {
+      char *parseEnd = nullptr;
+      const double parsedValue = std::strtod(str.c_str(), &parseEnd);
+      if (parseEnd != str.c_str()) {
+        return GradientLengthPercentage{parsedValue, true};
+      }
+    }
+  }
+  return std::nullopt;
+}
+
+folly::dynamic GradientLengthPercentage::toDynamic() const {
+  if (isPercent) {
+    return std::to_string(value) + "%";
+  }
+  return value;
+}
+
+std::string GradientLengthPercentage::toString() const {
+  return isPercent ? (std::to_string(value) + "%") : std::to_string(value);
+}
+
+GradientLengthPercentage GradientLengthPercentage::interpolate(double progress, const GradientLengthPercentage &to)
+    const {
+  return {value + (to.value - value) * progress, isPercent};
+}
+
+bool GradientLengthPercentage::canInterpolateTo(const GradientLengthPercentage &to) const {
+  return isPercent == to.isPercent;
+}
+
+// GradientColorStop
+
+GradientColorStop GradientColorStop::fromDynamic(const folly::dynamic &dynValue) {
+  GradientColorStop result;
+
+  if (!dynValue.isObject()) {
+    return result;
+  }
+
+  const auto colorIt = dynValue.find("color");
+  if (colorIt != dynValue.items().end() && CSSColor::canConstruct(colorIt->second)) {
+    result.color = CSSColor(colorIt->second);
+  }
+
+  const auto positionIt = dynValue.find("position");
+  if (positionIt != dynValue.items().end()) {
+    result.position = GradientLengthPercentage::tryFromDynamic(positionIt->second);
+  }
+
+  return result;
+}
+
+folly::dynamic GradientColorStop::toDynamic() const {
+  folly::dynamic obj = folly::dynamic::object();
+  obj["color"] = color.has_value() ? color->toDynamic() : folly::dynamic();
+  obj["position"] = position.has_value() ? position->toDynamic() : folly::dynamic();
+  return obj;
+}
+
+std::string GradientColorStop::toString() const {
+  std::string result = color.has_value() ? color->toString() : "";
+  if (position.has_value()) {
+    result += (result.empty() ? "" : " ") + position->toString();
+  }
+  return result;
+}
+
+GradientColorStop GradientColorStop::interpolate(double progress, const GradientColorStop &to) const {
+  GradientColorStop result;
+  if (color.has_value() && to.color.has_value()) {
+    result.color = color->interpolate(progress, *to.color);
+  }
+  if (position.has_value() && to.position.has_value()) {
+    result.position = position->interpolate(progress, *to.position);
+  }
+  return result;
+}
+
+bool GradientColorStop::canInterpolateTo(const GradientColorStop &to) const {
+  if (color.has_value() != to.color.has_value()) {
+    return false;
+  }
+  if (position.has_value() != to.position.has_value()) {
+    return false;
+  }
+  return !position.has_value() || position->canInterpolateTo(*to.position);
+}
+
+bool GradientColorStop::operator==(const GradientColorStop &other) const {
+  return color == other.color && position == other.position;
+}
+
+bool areColorStopsCompatible(const std::vector<GradientColorStop> &from, const std::vector<GradientColorStop> &to) {
+  if (from.size() != to.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < from.size(); ++i) {
+    if (!from[i].canInterpolateTo(to[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+std::vector<GradientColorStop> interpolateColorStops(
+    double progress,
+    const std::vector<GradientColorStop> &from,
+    const std::vector<GradientColorStop> &to) {
+  std::vector<GradientColorStop> result;
+  result.reserve(from.size());
+  for (size_t i = 0; i < from.size(); ++i) {
+    result.push_back(from[i].interpolate(progress, to[i]));
+  }
+  return result;
+}
+
+// CSSLinearGradient
+
+CSSLinearGradient::CSSLinearGradient(double angle, std::vector<GradientColorStop> colorStops)
+    : angle(angle), colorStops(std::move(colorStops)) {}
+
+CSSLinearGradient::CSSLinearGradient(std::string keyword, std::vector<GradientColorStop> colorStops)
+    : isKeywordDirection(true), keyword(std::move(keyword)), colorStops(std::move(colorStops)) {}
+
+CSSLinearGradient::CSSLinearGradient(jsi::Runtime &rt, const jsi::Value &jsiValue)
+    : CSSLinearGradient(jsi::dynamicFromValue(rt, jsiValue)) {}
+
+CSSLinearGradient::CSSLinearGradient(const folly::dynamic &value) {
+  const auto directionIt = value.find("direction");
+  if (directionIt != value.items().end() && directionIt->second.isObject()) {
+    const auto &direction = directionIt->second;
+    const auto typeIt = direction.find("type");
+    const auto valueIt = direction.find("value");
+    if (typeIt != direction.items().end() && valueIt != direction.items().end()) {
+      if (typeIt->second == "keyword" && valueIt->second.isString()) {
+        isKeywordDirection = true;
+        keyword = valueIt->second.getString();
+      } else if (typeIt->second == "angle" && valueIt->second.isNumber()) {
+        angle = valueIt->second.asDouble();
+      }
+    }
+  }
+
+  colorStops = colorStopsFromDynamic(value);
+}
+
+bool CSSLinearGradient::canConstruct(jsi::Runtime &rt, const jsi::Value &jsiValue) {
+  return hasGradientType(rt, jsiValue, LINEAR_GRADIENT_TYPE);
+}
+
+bool CSSLinearGradient::canConstruct(const folly::dynamic &value) {
+  return hasGradientType(value, LINEAR_GRADIENT_TYPE);
+}
+
+folly::dynamic CSSLinearGradient::toDynamic() const {
+  folly::dynamic direction = folly::dynamic::object();
+  if (isKeywordDirection) {
+    direction["type"] = "keyword";
+    direction["value"] = keyword;
+  } else {
+    direction["type"] = "angle";
+    direction["value"] = angle;
+  }
+
+  folly::dynamic stops = folly::dynamic::array();
+  for (const auto &stop : colorStops) {
+    stops.push_back(stop.toDynamic());
+  }
+
+  folly::dynamic obj = folly::dynamic::object();
+  obj["type"] = LINEAR_GRADIENT_TYPE;
+  obj["direction"] = std::move(direction);
+  obj["colorStops"] = std::move(stops);
+  return obj;
+}
+
+std::string CSSLinearGradient::toString() const {
+  std::string result = "linear-gradient(";
+  result += isKeywordDirection ? keyword : (std::to_string(angle) + "deg");
+  for (const auto &stop : colorStops) {
+    result += ", " + stop.toString();
+  }
+  return result + ")";
+}
+
+CSSLinearGradient CSSLinearGradient::interpolate(double progress, const CSSLinearGradient &to) const {
+  auto stops = interpolateColorStops(progress, colorStops, to.colorStops);
+  if (isKeywordDirection) {
+    return CSSLinearGradient(keyword, std::move(stops));
+  }
+  return CSSLinearGradient(angle + (to.angle - angle) * progress, std::move(stops));
+}
+
+bool CSSLinearGradient::canInterpolateTo(const CSSLinearGradient &to) const {
+  if (isKeywordDirection != to.isKeywordDirection) {
+    return false;
+  }
+  if (isKeywordDirection && keyword != to.keyword) {
+    return false;
+  }
+  return areColorStopsCompatible(colorStops, to.colorStops);
+}
+
+bool CSSLinearGradient::operator==(const CSSLinearGradient &other) const {
+  return isKeywordDirection == other.isKeywordDirection && angle == other.angle && keyword == other.keyword &&
+      colorStops == other.colorStops;
+}
+
+#ifndef NDEBUG
+
+std::ostream &operator<<(std::ostream &os, const CSSLinearGradient &gradientValue) {
+  os << "CSSLinearGradient(" << gradientValue.toString() << ")";
+  return os;
+}
+
+#endif // NDEBUG
+
+// CSSRadialGradient
+
+CSSRadialGradient::CSSRadialGradient()
+    : position({{"top", GradientLengthPercentage{50, true}}, {"left", GradientLengthPercentage{50, true}}}) {}
+
+CSSRadialGradient::CSSRadialGradient(jsi::Runtime &rt, const jsi::Value &jsiValue)
+    : CSSRadialGradient(jsi::dynamicFromValue(rt, jsiValue)) {}
+
+CSSRadialGradient::CSSRadialGradient(const folly::dynamic &value) {
+  const auto shapeIt = value.find("shape");
+  if (shapeIt != value.items().end() && shapeIt->second.isString()) {
+    shape = shapeIt->second.getString();
+  }
+
+  const auto sizeIt = value.find("size");
+  if (sizeIt != value.items().end()) {
+    const auto &size = sizeIt->second;
+    if (size.isString()) {
+      sizeKeyword = size.getString();
+    } else if (size.isObject()) {
+      const auto xIt = size.find("x");
+      const auto yIt = size.find("y");
+      if (xIt != size.items().end() && yIt != size.items().end()) {
+        const auto x = GradientLengthPercentage::tryFromDynamic(xIt->second);
+        const auto y = GradientLengthPercentage::tryFromDynamic(yIt->second);
+        if (x.has_value() && y.has_value()) {
+          sizeKeyword = std::nullopt;
+          sizeX = x;
+          sizeY = y;
+        }
+      }
+    }
+  }
+
+  const auto positionIt = value.find("position");
+  if (positionIt != value.items().end() && positionIt->second.isObject()) {
+    for (const auto &side : POSITION_SIDES) {
+      const auto sideIt = positionIt->second.find(side);
+      if (sideIt != positionIt->second.items().end()) {
+        const auto sideValue = GradientLengthPercentage::tryFromDynamic(sideIt->second);
+        if (sideValue.has_value()) {
+          position.emplace_back(side, *sideValue);
+        }
+      }
+    }
+  }
+  if (position.empty()) {
+    position = {{"top", GradientLengthPercentage{50, true}}, {"left", GradientLengthPercentage{50, true}}};
+  }
+
+  colorStops = colorStopsFromDynamic(value);
+}
+
+bool CSSRadialGradient::canConstruct(jsi::Runtime &rt, const jsi::Value &jsiValue) {
+  return hasGradientType(rt, jsiValue, RADIAL_GRADIENT_TYPE);
+}
+
+bool CSSRadialGradient::canConstruct(const folly::dynamic &value) {
+  return hasGradientType(value, RADIAL_GRADIENT_TYPE);
+}
+
+folly::dynamic CSSRadialGradient::toDynamic() const {
+  folly::dynamic obj = folly::dynamic::object();
+  obj["type"] = RADIAL_GRADIENT_TYPE;
+  obj["shape"] = shape;
+
+  if (sizeKeyword.has_value()) {
+    obj["size"] = *sizeKeyword;
+  } else {
+    folly::dynamic size = folly::dynamic::object();
+    size["x"] = sizeX.has_value() ? sizeX->toDynamic() : folly::dynamic();
+    size["y"] = sizeY.has_value() ? sizeY->toDynamic() : folly::dynamic();
+    obj["size"] = std::move(size);
+  }
+
+  folly::dynamic positionObj = folly::dynamic::object();
+  for (const auto &[side, sideValue] : position) {
+    positionObj[side] = sideValue.toDynamic();
+  }
+  obj["position"] = std::move(positionObj);
+
+  folly::dynamic stops = folly::dynamic::array();
+  for (const auto &stop : colorStops) {
+    stops.push_back(stop.toDynamic());
+  }
+  obj["colorStops"] = std::move(stops);
+
+  return obj;
+}
+
+std::string CSSRadialGradient::toString() const {
+  std::string result = "radial-gradient(" + shape;
+  if (sizeKeyword.has_value()) {
+    result += " " + *sizeKeyword;
+  } else if (sizeX.has_value() && sizeY.has_value()) {
+    result += " " + sizeX->toString() + " " + sizeY->toString();
+  }
+  result += " at";
+  for (const auto &[side, sideValue] : position) {
+    result += " " + side + " " + sideValue.toString();
+  }
+  for (const auto &stop : colorStops) {
+    result += ", " + stop.toString();
+  }
+  return result + ")";
+}
+
+CSSRadialGradient CSSRadialGradient::interpolate(double progress, const CSSRadialGradient &to) const {
+  CSSRadialGradient result;
+  result.shape = shape;
+  result.sizeKeyword = sizeKeyword;
+  if (!sizeKeyword.has_value() && sizeX.has_value() && to.sizeX.has_value() && sizeY.has_value() &&
+      to.sizeY.has_value()) {
+    result.sizeX = sizeX->interpolate(progress, *to.sizeX);
+    result.sizeY = sizeY->interpolate(progress, *to.sizeY);
+  } else {
+    result.sizeX = sizeX;
+    result.sizeY = sizeY;
+  }
+
+  result.position.clear();
+  result.position.reserve(position.size());
+  for (size_t i = 0; i < position.size(); ++i) {
+    result.position.emplace_back(position[i].first, position[i].second.interpolate(progress, to.position[i].second));
+  }
+
+  result.colorStops = interpolateColorStops(progress, colorStops, to.colorStops);
+  return result;
+}
+
+bool CSSRadialGradient::canInterpolateTo(const CSSRadialGradient &to) const {
+  if (shape != to.shape) {
+    return false;
+  }
+  if (sizeKeyword.has_value() != to.sizeKeyword.has_value()) {
+    return false;
+  }
+  if (sizeKeyword.has_value() && *sizeKeyword != *to.sizeKeyword) {
+    return false;
+  }
+  if (!sizeKeyword.has_value() &&
+      (!sizeX.has_value() || !to.sizeX.has_value() || !sizeX->canInterpolateTo(*to.sizeX) || !sizeY.has_value() ||
+       !to.sizeY.has_value() || !sizeY->canInterpolateTo(*to.sizeY))) {
+    return false;
+  }
+  if (position.size() != to.position.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < position.size(); ++i) {
+    if (position[i].first != to.position[i].first || !position[i].second.canInterpolateTo(to.position[i].second)) {
+      return false;
+    }
+  }
+  return areColorStopsCompatible(colorStops, to.colorStops);
+}
+
+bool CSSRadialGradient::operator==(const CSSRadialGradient &other) const {
+  return shape == other.shape && sizeKeyword == other.sizeKeyword && sizeX == other.sizeX && sizeY == other.sizeY &&
+      position == other.position && colorStops == other.colorStops;
+}
+
+#ifndef NDEBUG
+
+std::ostream &operator<<(std::ostream &os, const CSSRadialGradient &gradientValue) {
+  os << "CSSRadialGradient(" << gradientValue.toString() << ")";
+  return os;
+}
+
+#endif // NDEBUG
+
+} // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/complex/CSSBackgroundImage.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/complex/CSSBackgroundImage.h
@@ -1,0 +1,116 @@
+#pragma once
+
+#include <reanimated/CSS/common/definitions.h>
+#include <reanimated/CSS/common/values/CSSColor.h>
+
+#include <folly/json.h>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace reanimated::css {
+
+// A single <length-percentage> value used in gradients (color stop positions,
+// radial gradient sizes and positions). Pixel values are serialized as
+// numbers, percentage values as strings (e.g. "50%") - the same format that
+// React Native's backgroundImage prop parsing expects.
+struct GradientLengthPercentage {
+  double value{0};
+  bool isPercent{false};
+
+  static std::optional<GradientLengthPercentage> tryFromDynamic(const folly::dynamic &dynValue);
+
+  folly::dynamic toDynamic() const;
+  std::string toString() const;
+  GradientLengthPercentage interpolate(double progress, const GradientLengthPercentage &to) const;
+  bool canInterpolateTo(const GradientLengthPercentage &to) const;
+
+  bool operator==(const GradientLengthPercentage &other) const = default;
+};
+
+// A single gradient color stop. The color is std::nullopt for transition
+// hints (e.g. the "20%" in "red, 20%, blue"), the position is std::nullopt
+// when it's not specified (React Native distributes such stops evenly).
+struct GradientColorStop {
+  std::optional<CSSColor> color;
+  std::optional<GradientLengthPercentage> position;
+
+  static GradientColorStop fromDynamic(const folly::dynamic &dynValue);
+
+  folly::dynamic toDynamic() const;
+  std::string toString() const;
+  GradientColorStop interpolate(double progress, const GradientColorStop &to) const;
+  bool canInterpolateTo(const GradientColorStop &to) const;
+
+  bool operator==(const GradientColorStop &other) const;
+};
+
+bool areColorStopsCompatible(const std::vector<GradientColorStop> &from, const std::vector<GradientColorStop> &to);
+
+std::vector<GradientColorStop> interpolateColorStops(
+    double progress,
+    const std::vector<GradientColorStop> &from,
+    const std::vector<GradientColorStop> &to);
+
+struct CSSLinearGradient : public CSSSimpleValue<CSSLinearGradient> {
+  // Direction is either an angle in degrees or a corner keyword
+  // (e.g. "to top right")
+  bool isKeywordDirection{false};
+  double angle{180};
+  std::string keyword;
+  std::vector<GradientColorStop> colorStops;
+
+  CSSLinearGradient() = default;
+  explicit CSSLinearGradient(double angle, std::vector<GradientColorStop> colorStops);
+  explicit CSSLinearGradient(std::string keyword, std::vector<GradientColorStop> colorStops);
+  explicit CSSLinearGradient(jsi::Runtime &rt, const jsi::Value &jsiValue);
+  explicit CSSLinearGradient(const folly::dynamic &value);
+
+  static bool canConstruct(jsi::Runtime &rt, const jsi::Value &jsiValue);
+  static bool canConstruct(const folly::dynamic &value);
+
+  folly::dynamic toDynamic() const override;
+  std::string toString() const override;
+  CSSLinearGradient interpolate(double progress, const CSSLinearGradient &to) const override;
+  bool canInterpolateTo(const CSSLinearGradient &to) const override;
+
+  bool operator==(const CSSLinearGradient &other) const;
+
+#ifndef NDEBUG
+  friend std::ostream &operator<<(std::ostream &os, const CSSLinearGradient &gradientValue);
+#endif // NDEBUG
+};
+
+struct CSSRadialGradient : public CSSSimpleValue<CSSRadialGradient> {
+  std::string shape{"ellipse"};
+  // Size is either an extent keyword (e.g. "farthest-corner") or a pair of
+  // lengths
+  std::optional<std::string> sizeKeyword{"farthest-corner"};
+  std::optional<GradientLengthPercentage> sizeX;
+  std::optional<GradientLengthPercentage> sizeY;
+  // Position is a list of (side, offset) pairs (e.g. {("top", 50%), ("left",
+  // 50%)})
+  std::vector<std::pair<std::string, GradientLengthPercentage>> position;
+  std::vector<GradientColorStop> colorStops;
+
+  CSSRadialGradient();
+  explicit CSSRadialGradient(jsi::Runtime &rt, const jsi::Value &jsiValue);
+  explicit CSSRadialGradient(const folly::dynamic &value);
+
+  static bool canConstruct(jsi::Runtime &rt, const jsi::Value &jsiValue);
+  static bool canConstruct(const folly::dynamic &value);
+
+  folly::dynamic toDynamic() const override;
+  std::string toString() const override;
+  CSSRadialGradient interpolate(double progress, const CSSRadialGradient &to) const override;
+  bool canInterpolateTo(const CSSRadialGradient &to) const override;
+
+  bool operator==(const CSSRadialGradient &other) const;
+
+#ifndef NDEBUG
+  friend std::ostream &operator<<(std::ostream &os, const CSSRadialGradient &gradientValue);
+#endif // NDEBUG
+};
+
+} // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/SimpleValueInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/SimpleValueInterpolator.cpp
@@ -10,6 +10,7 @@
 #include <reanimated/CSS/common/values/CSSKeyword.h>
 #include <reanimated/CSS/common/values/CSSLength.h>
 #include <reanimated/CSS/common/values/CSSNumber.h>
+#include <reanimated/CSS/common/values/complex/CSSBackgroundImage.h>
 #include <reanimated/CSS/common/values/complex/CSSBoxShadow.h>
 #include <reanimated/CSS/svg/values/CSSLengthArray.h>
 #include <reanimated/CSS/svg/values/SVGBrush.h>
@@ -63,6 +64,7 @@ template class SimpleValueInterpolator<CSSBoolean>;
 template class SimpleValueInterpolator<CSSDisplay>;
 template class SimpleValueInterpolator<CSSKeyword>;
 template class SimpleValueInterpolator<CSSBoxShadow>;
+template class SimpleValueInterpolator<CSSLinearGradient, CSSRadialGradient>;
 template class SimpleValueInterpolator<CSSDiscreteArray<CSSKeyword>>;
 
 template class SimpleValueInterpolator<SVGPath>;

--- a/packages/react-native-reanimated/src/common/style/config.ts
+++ b/packages/react-native-reanimated/src/common/style/config.ts
@@ -3,6 +3,7 @@
 import { IS_ANDROID } from '../constants';
 import {
   processAspectRatio,
+  processBackgroundImage,
   processBoxShadow,
   processColor,
   processFilter,
@@ -192,8 +193,8 @@ export const STYLE_PROPERTIES_CONFIG: PropsBuilderConfig<AllStyleProps> = {
   mixBlendMode: true,
 
   // @ts-ignore Available since RN 0.87
-  backgroundImage: false, // TODO
-  experimental_backgroundImage: false, // TODO
+  backgroundImage: { process: processBackgroundImage },
+  experimental_backgroundImage: { process: processBackgroundImage },
   // @ts-ignore This type doesn't exist on non-strict-api
   experimental_backgroundPosition: false, // TODO
   // @ts-ignore This type doesn't exist on non-strict-api

--- a/packages/react-native-reanimated/src/common/style/processors/__tests__/backgroundImage.test.ts
+++ b/packages/react-native-reanimated/src/common/style/processors/__tests__/backgroundImage.test.ts
@@ -1,0 +1,332 @@
+'use strict';
+import type { BackgroundImageValue } from '../backgroundImage';
+import { processBackgroundImage } from '../backgroundImage';
+import { processColor } from '../colors';
+
+const RED = processColor('red');
+const BLUE = processColor('blue');
+const GREEN = processColor('green');
+
+describe(processBackgroundImage, () => {
+  describe('when input is a string', () => {
+    test('returns an empty array for "none"', () => {
+      expect(processBackgroundImage('none')).toEqual([]);
+    });
+
+    test('parses a linear gradient with the default direction', () => {
+      expect(processBackgroundImage('linear-gradient(red, blue)')).toEqual([
+        {
+          type: 'linear-gradient',
+          direction: { type: 'angle', value: 180 },
+          colorStops: [
+            { color: RED, position: null },
+            { color: BLUE, position: null },
+          ],
+        },
+      ]);
+    });
+
+    test.each([
+      ['45deg', 45],
+      ['0.5turn', 180],
+      ['100grad', 90],
+      [`${Math.PI}rad`, 180],
+    ])('parses a linear gradient with the %s angle', (angle, expected) => {
+      expect(
+        processBackgroundImage(`linear-gradient(${angle}, red, blue)`)
+      ).toEqual([
+        expect.objectContaining({
+          direction: { type: 'angle', value: expect.closeTo(expected, 5) },
+        }),
+      ]);
+    });
+
+    test.each([
+      ['to top', { type: 'angle', value: 0 }],
+      ['to right', { type: 'angle', value: 90 }],
+      ['to bottom', { type: 'angle', value: 180 }],
+      ['to left', { type: 'angle', value: 270 }],
+      ['to top right', { type: 'keyword', value: 'to top right' }],
+      ['to left bottom', { type: 'keyword', value: 'to bottom left' }],
+    ])(
+      'parses a linear gradient with the "%s" direction',
+      (direction, expected) => {
+        expect(
+          processBackgroundImage(`linear-gradient(${direction}, red, blue)`)
+        ).toEqual([expect.objectContaining({ direction: expected })]);
+      }
+    );
+
+    test('parses color stop positions', () => {
+      expect(
+        processBackgroundImage(
+          'linear-gradient(red 0%, green 25% 50%, blue 100px)'
+        )
+      ).toEqual([
+        expect.objectContaining({
+          colorStops: [
+            { color: RED, position: '0%' },
+            { color: GREEN, position: '25%' },
+            { color: GREEN, position: '50%' },
+            { color: BLUE, position: 100 },
+          ],
+        }),
+      ]);
+    });
+
+    test('parses transition hints', () => {
+      expect(processBackgroundImage('linear-gradient(red, 20%, blue)')).toEqual(
+        [
+          expect.objectContaining({
+            colorStops: [
+              { color: RED, position: null },
+              { color: null, position: '20%' },
+              { color: BLUE, position: null },
+            ],
+          }),
+        ]
+      );
+    });
+
+    test('parses colors with function syntax', () => {
+      expect(
+        processBackgroundImage(
+          'linear-gradient(rgba(255, 0, 0, 0.5) 10%, rgb(0, 0, 255))'
+        )
+      ).toEqual([
+        expect.objectContaining({
+          colorStops: [
+            { color: processColor('rgba(255, 0, 0, 0.5)'), position: '10%' },
+            { color: processColor('rgb(0, 0, 255)'), position: null },
+          ],
+        }),
+      ]);
+    });
+
+    test('parses a radial gradient with default values', () => {
+      expect(processBackgroundImage('radial-gradient(red, blue)')).toEqual([
+        {
+          type: 'radial-gradient',
+          shape: 'ellipse',
+          size: 'farthest-corner',
+          position: { top: '50%', left: '50%' },
+          colorStops: [
+            { color: RED, position: null },
+            { color: BLUE, position: null },
+          ],
+        },
+      ]);
+    });
+
+    test('parses a radial gradient with a shape, size and position', () => {
+      expect(
+        processBackgroundImage(
+          'radial-gradient(circle closest-side at 25% 75%, red, blue)'
+        )
+      ).toEqual([
+        expect.objectContaining({
+          shape: 'circle',
+          size: 'closest-side',
+          position: { top: '75%', left: '25%' },
+        }),
+      ]);
+    });
+
+    test('parses a radial gradient with numeric sizes', () => {
+      expect(
+        processBackgroundImage('radial-gradient(100px 50%, red, blue)')
+      ).toEqual([
+        expect.objectContaining({
+          shape: 'ellipse',
+          size: { x: 100, y: '50%' },
+        }),
+      ]);
+    });
+
+    test('infers the circle shape from a single numeric size', () => {
+      expect(
+        processBackgroundImage('radial-gradient(100px, red, blue)')
+      ).toEqual([
+        expect.objectContaining({ shape: 'circle', size: { x: 100, y: 100 } }),
+      ]);
+    });
+
+    test('parses a radial gradient with an edge offset position', () => {
+      expect(
+        processBackgroundImage(
+          'radial-gradient(at right 20% bottom 10%, red, blue)'
+        )
+      ).toEqual([
+        expect.objectContaining({ position: { bottom: '10%', right: '20%' } }),
+      ]);
+    });
+
+    test('parses multiple gradients', () => {
+      expect(
+        processBackgroundImage(
+          'linear-gradient(red, blue), radial-gradient(circle, green, blue)'
+        )
+      ).toEqual([
+        expect.objectContaining({ type: 'linear-gradient' }),
+        expect.objectContaining({ type: 'radial-gradient', shape: 'circle' }),
+      ]);
+    });
+
+    test.each([
+      'gradient(red, blue)', // invalid gradient function
+      'linear-gradient(to nowhere, red, blue)', // invalid direction
+      'linear-gradient(red 10rem, blue)', // invalid position unit
+      'linear-gradient(20%, red, blue)', // hint without a preceding color
+      'radial-gradient(square, red, blue)', // invalid color
+      'radial-gradient(ellipse 100px, red, blue)', // single size with ellipse
+    ])('throws for invalid input "%s"', (input) => {
+      expect(() => processBackgroundImage(input)).toThrow();
+    });
+  });
+
+  describe('when input is an array of objects', () => {
+    test('processes a linear gradient with the default direction', () => {
+      expect(
+        processBackgroundImage([
+          {
+            type: 'linear-gradient',
+            colorStops: [{ color: 'red' }, { color: 'blue' }],
+          },
+        ])
+      ).toEqual([
+        {
+          type: 'linear-gradient',
+          direction: { type: 'angle', value: 180 },
+          colorStops: [
+            { color: RED, position: null },
+            { color: BLUE, position: null },
+          ],
+        },
+      ]);
+    });
+
+    test.each([
+      ['45deg', { type: 'angle', value: 45 }],
+      ['to left', { type: 'angle', value: 270 }],
+      ['To Bottom Right', { type: 'keyword', value: 'to bottom right' }],
+    ] as const)(
+      'processes a linear gradient with the "%s" direction',
+      (direction, expected) => {
+        expect(
+          processBackgroundImage([
+            {
+              type: 'linear-gradient',
+              direction,
+              colorStops: [{ color: 'red' }, { color: 'blue' }],
+            },
+          ])
+        ).toEqual([expect.objectContaining({ direction: expected })]);
+      }
+    );
+
+    test('expands multiple color stop positions', () => {
+      expect(
+        processBackgroundImage([
+          {
+            type: 'linear-gradient',
+            colorStops: [
+              { color: 'red', positions: ['0%', '20%'] },
+              { color: 'blue', positions: ['100%'] },
+            ],
+          },
+        ])
+      ).toEqual([
+        expect.objectContaining({
+          colorStops: [
+            { color: RED, position: '0%' },
+            { color: RED, position: '20%' },
+            { color: BLUE, position: '100%' },
+          ],
+        }),
+      ]);
+    });
+
+    test('processes transition hints', () => {
+      expect(
+        processBackgroundImage([
+          {
+            type: 'linear-gradient',
+            colorStops: [
+              { color: 'red' },
+              { color: null, positions: ['30%'] },
+              { color: 'blue' },
+            ],
+          },
+        ])
+      ).toEqual([
+        expect.objectContaining({
+          colorStops: [
+            { color: RED, position: null },
+            { color: null, position: '30%' },
+            { color: BLUE, position: null },
+          ],
+        }),
+      ]);
+    });
+
+    test('processes a radial gradient with default values', () => {
+      expect(
+        processBackgroundImage([
+          {
+            type: 'radial-gradient',
+            colorStops: [{ color: 'red' }, { color: 'blue' }],
+          },
+        ])
+      ).toEqual([
+        {
+          type: 'radial-gradient',
+          shape: 'ellipse',
+          size: 'farthest-corner',
+          position: { top: '50%', left: '50%' },
+          colorStops: [
+            { color: RED, position: null },
+            { color: BLUE, position: null },
+          ],
+        },
+      ]);
+    });
+
+    test('processes a radial gradient with custom values', () => {
+      expect(
+        processBackgroundImage([
+          {
+            type: 'radial-gradient',
+            shape: 'circle',
+            size: { x: '50%', y: 100 },
+            position: { bottom: '10%', right: 0 },
+            colorStops: [{ color: 'red' }, { color: 'blue' }],
+          },
+        ])
+      ).toEqual([
+        expect.objectContaining({
+          shape: 'circle',
+          size: { x: '50%', y: 100 },
+          position: { bottom: '10%', right: 0 },
+        }),
+      ]);
+    });
+
+    test.each([
+      [{ type: 'linear-gradient', direction: 'diagonal', colorStops: [] }],
+      [
+        {
+          type: 'linear-gradient',
+          colorStops: [{ color: 'red', positions: ['10rem'] }],
+        },
+      ],
+      [{ type: 'radial-gradient', shape: 'square', colorStops: [] }],
+      [{ type: 'radial-gradient', size: 'huge', colorStops: [] }],
+      [{ type: 'conic-gradient', colorStops: [] }],
+    ] as unknown as [BackgroundImageValue][])(
+      'throws for invalid input %j',
+      (input) => {
+        expect(() => processBackgroundImage([input])).toThrow();
+      }
+    );
+  });
+});

--- a/packages/react-native-reanimated/src/common/style/processors/__tests__/backgroundImage.test.ts
+++ b/packages/react-native-reanimated/src/common/style/processors/__tests__/backgroundImage.test.ts
@@ -154,13 +154,24 @@ describe(processBackgroundImage, () => {
     test('parses a radial gradient with an explicit size and position', () => {
       expect(
         processBackgroundImage(
-          'radial-gradient(circle 50% at 25% 25%, yellow, red)'
+          'radial-gradient(circle 100px at 25% 75%, yellow, red)'
         )
       ).toEqual([
         expect.objectContaining({
           shape: 'circle',
-          size: { x: '50%', y: '50%' },
-          position: { top: '25%', left: '25%' },
+          size: { x: 100, y: 100 },
+          position: { top: '75%', left: '25%' },
+        }),
+      ]);
+    });
+
+    test('allows percentage sizes for ellipses', () => {
+      expect(
+        processBackgroundImage('radial-gradient(50% 20%, red, blue)')
+      ).toEqual([
+        expect.objectContaining({
+          shape: 'ellipse',
+          size: { x: '50%', y: '20%' },
         }),
       ]);
     });
@@ -208,6 +219,8 @@ describe(processBackgroundImage, () => {
       'linear-gradient(20%, red, blue)', // hint without a preceding color
       'radial-gradient(square, red, blue)', // invalid color
       'radial-gradient(ellipse 100px, red, blue)', // single size with ellipse
+      'radial-gradient(circle 50%, red, blue)', // circle with percentage radius
+      'radial-gradient(50%, red, blue)', // inferred circle with percentage radius
     ])('throws for invalid input "%s"', (input) => {
       expect(() => processBackgroundImage(input)).toThrow();
     });

--- a/packages/react-native-reanimated/src/common/style/processors/__tests__/backgroundImage.test.ts
+++ b/packages/react-native-reanimated/src/common/style/processors/__tests__/backgroundImage.test.ts
@@ -151,6 +151,34 @@ describe(processBackgroundImage, () => {
       ]);
     });
 
+    test('parses a radial gradient with an explicit size and position', () => {
+      expect(
+        processBackgroundImage(
+          'radial-gradient(circle 50% at 25% 25%, yellow, red)'
+        )
+      ).toEqual([
+        expect.objectContaining({
+          shape: 'circle',
+          size: { x: '50%', y: '50%' },
+          position: { top: '25%', left: '25%' },
+        }),
+      ]);
+    });
+
+    test('parses a radial gradient with a two-value size and position', () => {
+      expect(
+        processBackgroundImage(
+          'radial-gradient(100px 50% at left bottom, red, blue)'
+        )
+      ).toEqual([
+        expect.objectContaining({
+          shape: 'ellipse',
+          size: { x: 100, y: '50%' },
+          position: { top: '100%', left: '0%' },
+        }),
+      ]);
+    });
+
     test('parses a radial gradient with an edge offset position', () => {
       expect(
         processBackgroundImage(
@@ -174,6 +202,7 @@ describe(processBackgroundImage, () => {
 
     test.each([
       'gradient(red, blue)', // invalid gradient function
+      'linear-gradient(red, blue) trailing garbage', // trailing characters
       'linear-gradient(to nowhere, red, blue)', // invalid direction
       'linear-gradient(red 10rem, blue)', // invalid position unit
       'linear-gradient(20%, red, blue)', // hint without a preceding color

--- a/packages/react-native-reanimated/src/common/style/processors/backgroundImage.ts
+++ b/packages/react-native-reanimated/src/common/style/processors/backgroundImage.ts
@@ -443,8 +443,10 @@ function parseRadialGradientCSSString(
         size = { x: sizeX, y: sizeY };
       } else {
         hasExplicitSingleSize = true;
-        // The consumed token isn't a second size value (e.g. it starts the
-        // 'at <position>' clause), so put it back for the loop to re-process
+        // The token after the size is not a second size value (e.g. 'at' or a
+        // shape keyword). Put it back so the loop can process it, otherwise
+        // the position would be silently dropped and its values re-parsed as
+        // a new size.
         firstPartTokens.unshift(token);
       }
     } else if (tokenTrimmed === 'at') {
@@ -631,6 +633,18 @@ function parseRadialGradientCSSString(
     if (hasExplicitSingleSize && hasExplicitShape && shape === 'ellipse') {
       // A single size can be used only with the circle shape
       throw invalidGradient();
+    }
+
+    if (
+      shape === 'circle' &&
+      typeof size === 'object' &&
+      (typeof size.x === 'string' || typeof size.y === 'string')
+    ) {
+      // A circle radius must be a <length>. Percentages are only valid for
+      // ellipses, so browsers reject the whole declaration.
+      throw new Error(
+        `[Reanimated] ${ERROR_MESSAGES.invalidGradientSize(size)}`
+      );
     }
   }
 

--- a/packages/react-native-reanimated/src/common/style/processors/backgroundImage.ts
+++ b/packages/react-native-reanimated/src/common/style/processors/backgroundImage.ts
@@ -443,6 +443,9 @@ function parseRadialGradientCSSString(
         size = { x: sizeX, y: sizeY };
       } else {
         hasExplicitSingleSize = true;
+        // The consumed token isn't a second size value (e.g. it starts the
+        // 'at <position>' clause), so put it back for the loop to re-process
+        firstPartTokens.unshift(token);
       }
     } else if (tokenTrimmed === 'at') {
       let top: string | number | undefined;
@@ -680,7 +683,7 @@ function parseBackgroundImageCSSString(
   for (const bgImageString of bgImageStrings) {
     const bgImage = bgImageString.toLowerCase();
     const match = GRADIENT_REGEX.exec(bgImage);
-    if (!match) {
+    if (!match || match[0].length !== bgImage.length) {
       throw new Error(
         `[Reanimated] ${ERROR_MESSAGES.invalidGradientString(bgImageString)}`
       );

--- a/packages/react-native-reanimated/src/common/style/processors/backgroundImage.ts
+++ b/packages/react-native-reanimated/src/common/style/processors/backgroundImage.ts
@@ -1,0 +1,817 @@
+'use strict';
+import type { ColorValue } from 'react-native';
+
+import type { ValueProcessor, ValueProcessorContext } from '../../types';
+import { processColor, type ProcessedColor } from './colors';
+
+// Types are defined locally instead of being imported from `react-native`
+// because the stable `backgroundImage` style prop (and its types) is
+// available only since react-native 0.87.
+type GradientColorStop = {
+  color: ColorValue | number | null;
+  positions?: ReadonlyArray<string>;
+};
+
+type LinearGradientValue = {
+  type: 'linear-gradient';
+  // Angle or direction enums
+  direction?: string;
+  colorStops: ReadonlyArray<GradientColorStop>;
+};
+
+type RadialGradientShape = 'circle' | 'ellipse';
+
+type RadialGradientSize =
+  | 'closest-corner'
+  | 'closest-side'
+  | 'farthest-corner'
+  | 'farthest-side'
+  | {
+      x: string | number;
+      y: string | number;
+    };
+
+type RadialGradientPosition = {
+  top?: number | string;
+  left?: number | string;
+  bottom?: number | string;
+  right?: number | string;
+};
+
+type RadialGradientValue = {
+  type: 'radial-gradient';
+  shape?: RadialGradientShape;
+  size?: RadialGradientSize;
+  position?: RadialGradientPosition;
+  colorStops: ReadonlyArray<GradientColorStop>;
+};
+
+export type BackgroundImageValue = LinearGradientValue | RadialGradientValue;
+
+// null color indicates that the transition hint syntax is used (e.g. red, 20%, blue)
+type ProcessedColorStopColor = ProcessedColor | null;
+// number - pixel value, string - percentage, null - position not specified
+type ProcessedColorStopPosition = number | string | null;
+
+type ProcessedGradientColorStop = {
+  color: ProcessedColorStopColor;
+  position: ProcessedColorStopPosition;
+};
+
+type ProcessedLinearGradientDirection =
+  | { type: 'angle'; value: number }
+  | { type: 'keyword'; value: string };
+
+type ProcessedLinearGradient = {
+  type: 'linear-gradient';
+  direction: ProcessedLinearGradientDirection;
+  colorStops: ProcessedGradientColorStop[];
+};
+
+type ProcessedRadialGradient = {
+  type: 'radial-gradient';
+  shape: RadialGradientShape;
+  size: RadialGradientSize;
+  position: RadialGradientPosition;
+  colorStops: ProcessedGradientColorStop[];
+};
+
+type ProcessedBackgroundImage = Array<
+  ProcessedLinearGradient | ProcessedRadialGradient
+>;
+
+const NEWLINE_REGEX = /\n/g;
+const GRADIENT_REGEX = /^(linear|radial)-gradient\(((?:\([^)]*\)|[^()])*)\)/;
+const COMMA_SPLIT_REGEX = /,(?![^(]*\))/;
+const WHITESPACE_SPLIT_REGEX = /\s+/;
+const COLOR_STOP_PARTS_REGEX = /\S+\([^)]*\)|\S+/g;
+const WHITESPACE_NORMALIZE_REGEX = /\s+/g;
+
+const LINEAR_GRADIENT_ANGLE_UNIT_REGEX =
+  /^([+-]?\d*\.?\d+)(deg|grad|rad|turn)$/;
+
+const DEFAULT_LINEAR_GRADIENT_DIRECTION: ProcessedLinearGradientDirection = {
+  type: 'angle',
+  value: 180,
+};
+const DEFAULT_RADIAL_SHAPE = 'ellipse';
+const DEFAULT_RADIAL_SIZE = 'farthest-corner';
+
+function getAngleInDegrees(angle: string): number | null {
+  'worklet';
+  const match = angle.match(LINEAR_GRADIENT_ANGLE_UNIT_REGEX);
+  if (!match) {
+    return null;
+  }
+
+  const [, value, unit] = match;
+  const numericValue = parseFloat(value);
+
+  switch (unit) {
+    case 'deg':
+      return numericValue;
+    case 'grad':
+      return numericValue * 0.9; // 1 grad = 0.9 degrees
+    case 'rad':
+      return (numericValue * 180) / Math.PI;
+    case 'turn':
+      return numericValue * 360; // 1 turn = 360 degrees
+    default:
+      return null;
+  }
+}
+
+function getDirectionForKeyword(
+  direction: string
+): ProcessedLinearGradientDirection | null {
+  'worklet';
+  const normalized = direction.replace(WHITESPACE_NORMALIZE_REGEX, ' ');
+
+  switch (normalized) {
+    case 'to top':
+      return { type: 'angle', value: 0 };
+    case 'to right':
+      return { type: 'angle', value: 90 };
+    case 'to bottom':
+      return { type: 'angle', value: 180 };
+    case 'to left':
+      return { type: 'angle', value: 270 };
+    case 'to top right':
+    case 'to right top':
+      return { type: 'keyword', value: 'to top right' };
+    case 'to bottom right':
+    case 'to right bottom':
+      return { type: 'keyword', value: 'to bottom right' };
+    case 'to top left':
+    case 'to left top':
+      return { type: 'keyword', value: 'to top left' };
+    case 'to bottom left':
+    case 'to left bottom':
+      return { type: 'keyword', value: 'to bottom left' };
+    default:
+      return null;
+  }
+}
+
+function getPositionFromCSSValue(position: string): number | string | null {
+  'worklet';
+  if (position.endsWith('px')) {
+    return parseFloat(position);
+  }
+  if (position.endsWith('%')) {
+    return position;
+  }
+  return null;
+}
+
+const ERROR_MESSAGES = {
+  invalidBackgroundImage(value: unknown) {
+    'worklet';
+    return `Background image value must be a string or an array of gradient objects (e.g. [{ type: 'linear-gradient', direction, colorStops }]). Received: ${JSON.stringify(value)}.`;
+  },
+  invalidDirection(direction: string) {
+    'worklet';
+    return `Invalid direction "${direction}" in a linear gradient. Expected an angle (e.g. "45deg") or a direction keyword (e.g. "to bottom right").`;
+  },
+  invalidGradientShape(shape: string) {
+    'worklet';
+    return `Invalid shape "${shape}" in a radial gradient. Expected "circle" or "ellipse".`;
+  },
+  invalidGradientSize(size: unknown) {
+    'worklet';
+    return `Invalid size ${JSON.stringify(size)} in a radial gradient. Expected an extent keyword (e.g. "farthest-corner"), a single non-negative length, or a pair of non-negative lengths.`;
+  },
+  invalidGradientPosition(position: unknown) {
+    'worklet';
+    return `Invalid position ${JSON.stringify(position)} in a radial gradient.`;
+  },
+  invalidColorStopPosition(position: unknown) {
+    'worklet';
+    return `Invalid color stop position ${JSON.stringify(position)} in a gradient. Expected a number (pixels) or a percentage string.`;
+  },
+  invalidTransitionHint(hint: unknown) {
+    'worklet';
+    return `Invalid transition hint ${JSON.stringify(hint)} in a gradient. A transition hint must be a single position placed between two color stops.`;
+  },
+  invalidColorStop(colorStop: unknown) {
+    'worklet';
+    return `Invalid color stop ${JSON.stringify(colorStop)} in a gradient.`;
+  },
+  invalidGradientString(gradient: string) {
+    'worklet';
+    return `Invalid gradient "${gradient}". Expected a comma-separated list of linear-gradient(...) or radial-gradient(...) functions.`;
+  },
+};
+
+function processColorStops(
+  colorStops: ReadonlyArray<GradientColorStop>,
+  context?: ValueProcessorContext
+): ProcessedGradientColorStop[] {
+  'worklet';
+  const processedColorStops: ProcessedGradientColorStop[] = [];
+
+  for (const colorStop of colorStops) {
+    const positions = colorStop.positions;
+    // Color transition hint syntax (red, 20%, blue)
+    if (
+      colorStop.color == null &&
+      Array.isArray(positions) &&
+      positions.length === 1
+    ) {
+      const position = positions[0];
+      if (
+        typeof position === 'number' ||
+        (typeof position === 'string' && position.endsWith('%'))
+      ) {
+        processedColorStops.push({ color: null, position });
+      } else {
+        throw new Error(
+          `[Reanimated] ${ERROR_MESSAGES.invalidTransitionHint(position)}`
+        );
+      }
+    } else {
+      const processedColor = processColor(colorStop.color, context);
+      if (processedColor == null) {
+        throw new Error(
+          `[Reanimated] ${ERROR_MESSAGES.invalidColorStop(colorStop)}`
+        );
+      }
+      if (positions && positions.length > 0) {
+        for (const position of positions) {
+          if (
+            typeof position === 'number' ||
+            (typeof position === 'string' && position.endsWith('%'))
+          ) {
+            processedColorStops.push({ color: processedColor, position });
+          } else {
+            throw new Error(
+              `[Reanimated] ${ERROR_MESSAGES.invalidColorStopPosition(position)}`
+            );
+          }
+        }
+      } else {
+        processedColorStops.push({ color: processedColor, position: null });
+      }
+    }
+  }
+
+  return processedColorStops;
+}
+
+function parseColorStopsCSSString(
+  parts: string[],
+  context?: ValueProcessorContext
+): ProcessedGradientColorStop[] {
+  'worklet';
+  const colorStopsString = parts.join(',');
+  const colorStops: ProcessedGradientColorStop[] = [];
+  // split by comma, but not if it's inside parentheses
+  // e.g. red, rgba(0, 0, 0, 0.5), green => ["red", "rgba(0, 0, 0, 0.5)", "green"]
+  const stops = colorStopsString.split(COMMA_SPLIT_REGEX);
+  let prevStop: RegExpMatchArray | null = null;
+
+  for (let i = 0; i < stops.length; i++) {
+    const trimmedStop = stops[i].trim();
+    // Match function like pattern or single words
+    const colorStopParts = trimmedStop.match(COLOR_STOP_PARTS_REGEX);
+    if (colorStopParts == null) {
+      throw new Error(
+        `[Reanimated] ${ERROR_MESSAGES.invalidColorStop(trimmedStop)}`
+      );
+    }
+    // Case 1: [color, position, position]
+    if (colorStopParts.length === 3) {
+      const position1 = getPositionFromCSSValue(colorStopParts[1]);
+      const position2 = getPositionFromCSSValue(colorStopParts[2]);
+      if (position1 == null || position2 == null) {
+        throw new Error(
+          `[Reanimated] ${ERROR_MESSAGES.invalidColorStopPosition(trimmedStop)}`
+        );
+      }
+      const processedColor = processColor(colorStopParts[0], context);
+      colorStops.push({ color: processedColor, position: position1 });
+      colorStops.push({ color: processedColor, position: position2 });
+    }
+    // Case 2: [color, position]
+    else if (colorStopParts.length === 2) {
+      const position = getPositionFromCSSValue(colorStopParts[1]);
+      if (position == null) {
+        throw new Error(
+          `[Reanimated] ${ERROR_MESSAGES.invalidColorStopPosition(trimmedStop)}`
+        );
+      }
+      const processedColor = processColor(colorStopParts[0], context);
+      colorStops.push({ color: processedColor, position });
+    }
+    // Case 3: [color]
+    // Case 4: [position] => transition hint syntax
+    else if (colorStopParts.length === 1) {
+      const position = getPositionFromCSSValue(colorStopParts[0]);
+      if (position != null) {
+        // A transition hint must have a color stop before and after it
+        // (e.g. red, 20%, blue)
+        if (
+          (prevStop != null &&
+            prevStop.length === 1 &&
+            getPositionFromCSSValue(prevStop[0]) != null) ||
+          i === stops.length - 1 ||
+          i === 0
+        ) {
+          throw new Error(
+            `[Reanimated] ${ERROR_MESSAGES.invalidTransitionHint(trimmedStop)}`
+          );
+        }
+        colorStops.push({ color: null, position });
+      } else {
+        colorStops.push({
+          color: processColor(colorStopParts[0], context),
+          position: null,
+        });
+      }
+    } else {
+      throw new Error(
+        `[Reanimated] ${ERROR_MESSAGES.invalidColorStop(trimmedStop)}`
+      );
+    }
+    prevStop = colorStopParts;
+  }
+
+  return colorStops;
+}
+
+function parseLinearGradientCSSString(
+  gradientContent: string,
+  context?: ValueProcessorContext
+): ProcessedLinearGradient {
+  'worklet';
+  const parts = gradientContent.split(',');
+  let direction: ProcessedLinearGradientDirection =
+    DEFAULT_LINEAR_GRADIENT_DIRECTION;
+  const trimmedDirection = parts[0].trim();
+
+  if (LINEAR_GRADIENT_ANGLE_UNIT_REGEX.test(trimmedDirection)) {
+    const parsedAngle = getAngleInDegrees(trimmedDirection);
+    if (parsedAngle == null) {
+      throw new Error(
+        `[Reanimated] ${ERROR_MESSAGES.invalidDirection(trimmedDirection)}`
+      );
+    }
+    direction = { type: 'angle', value: parsedAngle };
+    parts.shift();
+  } else if (trimmedDirection.startsWith('to ')) {
+    const parsedDirection = getDirectionForKeyword(trimmedDirection);
+    if (parsedDirection == null) {
+      throw new Error(
+        `[Reanimated] ${ERROR_MESSAGES.invalidDirection(trimmedDirection)}`
+      );
+    }
+    direction = parsedDirection;
+    parts.shift();
+  }
+
+  return {
+    type: 'linear-gradient',
+    direction,
+    colorStops: parseColorStopsCSSString(parts, context),
+  };
+}
+
+function parseRadialGradientCSSString(
+  gradientContent: string,
+  context?: ValueProcessorContext
+): ProcessedRadialGradient {
+  'worklet';
+  let shape: RadialGradientShape = DEFAULT_RADIAL_SHAPE;
+  let size: RadialGradientSize = DEFAULT_RADIAL_SIZE;
+  let position: RadialGradientPosition = { top: '50%', left: '50%' };
+
+  // split the content by commas, but not if inside parentheses (for color values)
+  const parts = gradientContent.split(COMMA_SPLIT_REGEX);
+  // first part may contain shape, size, and position
+  // [ <radial-shape> || <radial-size> ]? [ at <position> ]?
+  const firstPartStr = parts[0].trim();
+  const remainingParts = [...parts];
+  let hasShapeSizeOrPositionString = false;
+  let hasExplicitSingleSize = false;
+  let hasExplicitShape = false;
+  const firstPartTokens = firstPartStr.split(WHITESPACE_SPLIT_REGEX);
+
+  const invalidGradient = () => {
+    'worklet';
+    return new Error(
+      `[Reanimated] ${ERROR_MESSAGES.invalidGradientString(`radial-gradient(${gradientContent})`)}`
+    );
+  };
+
+  while (firstPartTokens.length > 0) {
+    let token = firstPartTokens.shift();
+    if (token == null) {
+      continue;
+    }
+    let tokenTrimmed = token.trim();
+
+    if (tokenTrimmed === 'circle' || tokenTrimmed === 'ellipse') {
+      shape = tokenTrimmed;
+      hasShapeSizeOrPositionString = true;
+      hasExplicitShape = true;
+    } else if (
+      tokenTrimmed === 'closest-corner' ||
+      tokenTrimmed === 'farthest-corner' ||
+      tokenTrimmed === 'closest-side' ||
+      tokenTrimmed === 'farthest-side'
+    ) {
+      size = tokenTrimmed;
+      hasShapeSizeOrPositionString = true;
+    } else if (tokenTrimmed.endsWith('px') || tokenTrimmed.endsWith('%')) {
+      const sizeX = getPositionFromCSSValue(tokenTrimmed);
+      if (sizeX == null || (typeof sizeX === 'number' && sizeX < 0)) {
+        throw invalidGradient();
+      }
+      hasShapeSizeOrPositionString = true;
+      size = { x: sizeX, y: sizeX };
+      token = firstPartTokens.shift();
+      if (token == null) {
+        hasExplicitSingleSize = true;
+        continue;
+      }
+      tokenTrimmed = token.trim();
+      if (tokenTrimmed.endsWith('px') || tokenTrimmed.endsWith('%')) {
+        const sizeY = getPositionFromCSSValue(tokenTrimmed);
+        if (sizeY == null || (typeof sizeY === 'number' && sizeY < 0)) {
+          throw invalidGradient();
+        }
+        size = { x: sizeX, y: sizeY };
+      } else {
+        hasExplicitSingleSize = true;
+      }
+    } else if (tokenTrimmed === 'at') {
+      let top: string | number | undefined;
+      let left: string | number | undefined;
+      let right: string | number | undefined;
+      let bottom: string | number | undefined;
+      hasShapeSizeOrPositionString = true;
+
+      if (firstPartTokens.length === 0) {
+        // 'at' must be followed by a position
+        throw invalidGradient();
+      }
+
+      // 1. [ left | center | right | top | bottom | <length-percentage> ]
+      if (firstPartTokens.length === 1) {
+        token = firstPartTokens.shift();
+        if (token == null) {
+          throw invalidGradient();
+        }
+        tokenTrimmed = token.trim();
+        if (tokenTrimmed === 'left') {
+          left = '0%';
+          top = '50%';
+        } else if (tokenTrimmed === 'center') {
+          left = '50%';
+          top = '50%';
+        } else if (tokenTrimmed === 'right') {
+          left = '100%';
+          top = '50%';
+        } else if (tokenTrimmed === 'top') {
+          left = '50%';
+          top = '0%';
+        } else if (tokenTrimmed === 'bottom') {
+          left = '50%';
+          top = '100%';
+        } else if (tokenTrimmed.endsWith('px') || tokenTrimmed.endsWith('%')) {
+          const value = getPositionFromCSSValue(tokenTrimmed);
+          if (value == null) {
+            throw invalidGradient();
+          }
+          left = value;
+          top = '50%';
+        }
+      }
+
+      if (firstPartTokens.length === 2) {
+        const t1 = firstPartTokens.shift();
+        const t2 = firstPartTokens.shift();
+        if (t1 == null || t2 == null) {
+          throw invalidGradient();
+        }
+
+        const token1 = t1.trim();
+        const token2 = t2.trim();
+
+        // 2. [ left | center | right ] && [ top | center | bottom ]
+        const horizontalPositions = ['left', 'center', 'right'];
+        const verticalPositions = ['top', 'center', 'bottom'];
+
+        if (
+          horizontalPositions.includes(token1) &&
+          verticalPositions.includes(token2)
+        ) {
+          left =
+            token1 === 'left' ? '0%' : token1 === 'center' ? '50%' : '100%';
+          top = token2 === 'top' ? '0%' : token2 === 'center' ? '50%' : '100%';
+        } else if (
+          verticalPositions.includes(token1) &&
+          horizontalPositions.includes(token2)
+        ) {
+          left =
+            token2 === 'left' ? '0%' : token2 === 'center' ? '50%' : '100%';
+          top = token1 === 'top' ? '0%' : token1 === 'center' ? '50%' : '100%';
+        }
+        // 3. [ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ]
+        else {
+          if (token1 === 'left') {
+            left = '0%';
+          } else if (token1 === 'center') {
+            left = '50%';
+          } else if (token1 === 'right') {
+            left = '100%';
+          } else if (token1.endsWith('px') || token1.endsWith('%')) {
+            const value = getPositionFromCSSValue(token1);
+            if (value == null) {
+              throw invalidGradient();
+            }
+            left = value;
+          } else {
+            throw invalidGradient();
+          }
+
+          if (token2 === 'top') {
+            top = '0%';
+          } else if (token2 === 'center') {
+            top = '50%';
+          } else if (token2 === 'bottom') {
+            top = '100%';
+          } else if (token2.endsWith('px') || token2.endsWith('%')) {
+            const value = getPositionFromCSSValue(token2);
+            if (value == null) {
+              throw invalidGradient();
+            }
+            top = value;
+          } else {
+            throw invalidGradient();
+          }
+        }
+      }
+
+      // 4. [ [ left | right ] <length-percentage> ] && [ [ top | bottom ] <length-percentage> ]
+      if (firstPartTokens.length === 4) {
+        const t1 = firstPartTokens.shift();
+        const t2 = firstPartTokens.shift();
+        const t3 = firstPartTokens.shift();
+        const t4 = firstPartTokens.shift();
+
+        if (t1 == null || t2 == null || t3 == null || t4 == null) {
+          throw invalidGradient();
+        }
+        const keyword1 = t1.trim();
+        const value1 = getPositionFromCSSValue(t2.trim());
+        const keyword2 = t3.trim();
+        const value2 = getPositionFromCSSValue(t4.trim());
+        if (value1 == null || value2 == null) {
+          throw invalidGradient();
+        }
+
+        if (keyword1 === 'left') {
+          left = value1;
+        } else if (keyword1 === 'right') {
+          right = value1;
+        } else if (keyword1 === 'top') {
+          top = value1;
+        } else if (keyword1 === 'bottom') {
+          bottom = value1;
+        } else {
+          throw invalidGradient();
+        }
+
+        if (keyword2 === 'left') {
+          left = value2;
+        } else if (keyword2 === 'right') {
+          right = value2;
+        } else if (keyword2 === 'top') {
+          top = value2;
+        } else if (keyword2 === 'bottom') {
+          bottom = value2;
+        } else {
+          throw invalidGradient();
+        }
+      }
+
+      if (top != null && left != null) {
+        position = { top, left };
+      } else if (bottom != null && right != null) {
+        position = { bottom, right };
+      } else if (top != null && right != null) {
+        position = { top, right };
+      } else if (bottom != null && left != null) {
+        position = { bottom, left };
+      } else {
+        throw invalidGradient();
+      }
+      // 'at' comes at the end of the first part of the radial gradient syntax
+      break;
+    }
+
+    // if there is no shape, size, or position string found in the first
+    // token, break as it might be a color stop
+    if (!hasShapeSizeOrPositionString) {
+      break;
+    }
+  }
+
+  if (hasShapeSizeOrPositionString) {
+    remainingParts.shift();
+
+    if (!hasExplicitShape && hasExplicitSingleSize) {
+      shape = 'circle';
+    }
+
+    if (hasExplicitSingleSize && hasExplicitShape && shape === 'ellipse') {
+      // A single size can be used only with the circle shape
+      throw invalidGradient();
+    }
+  }
+
+  return {
+    type: 'radial-gradient',
+    shape,
+    size,
+    position,
+    colorStops: parseColorStopsCSSString(remainingParts, context),
+  };
+}
+
+function splitGradients(input: string): string[] {
+  'worklet';
+  const result: string[] = [];
+  let current = '';
+  let depth = 0;
+
+  for (let i = 0; i < input.length; i++) {
+    const char = input[i];
+
+    if (char === '(') {
+      depth++;
+    } else if (char === ')') {
+      depth--;
+    } else if (char === ',' && depth === 0) {
+      result.push(current.trim());
+      current = '';
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (current.trim() !== '') {
+    result.push(current.trim());
+  }
+
+  return result;
+}
+
+function parseBackgroundImageCSSString(
+  cssString: string,
+  context?: ValueProcessorContext
+): ProcessedBackgroundImage {
+  'worklet';
+  const gradients: ProcessedBackgroundImage = [];
+  const bgImageStrings = splitGradients(cssString);
+
+  for (const bgImageString of bgImageStrings) {
+    const bgImage = bgImageString.toLowerCase();
+    const match = GRADIENT_REGEX.exec(bgImage);
+    if (!match) {
+      throw new Error(
+        `[Reanimated] ${ERROR_MESSAGES.invalidGradientString(bgImageString)}`
+      );
+    }
+    const [, type, gradientContent] = match;
+    gradients.push(
+      type === 'radial'
+        ? parseRadialGradientCSSString(gradientContent, context)
+        : parseLinearGradientCSSString(gradientContent, context)
+    );
+  }
+  return gradients;
+}
+
+function processBackgroundImageObjects(
+  backgroundImage: ReadonlyArray<BackgroundImageValue>,
+  context?: ValueProcessorContext
+): ProcessedBackgroundImage {
+  'worklet';
+  const result: ProcessedBackgroundImage = [];
+
+  for (const bgImage of backgroundImage) {
+    const processedColorStops = processColorStops(bgImage.colorStops, context);
+
+    if (bgImage.type === 'linear-gradient') {
+      let direction: ProcessedLinearGradientDirection =
+        DEFAULT_LINEAR_GRADIENT_DIRECTION;
+      const bgDirection =
+        bgImage.direction != null ? bgImage.direction.toLowerCase() : null;
+
+      if (bgDirection != null) {
+        if (LINEAR_GRADIENT_ANGLE_UNIT_REGEX.test(bgDirection)) {
+          const parsedAngle = getAngleInDegrees(bgDirection);
+          if (parsedAngle == null) {
+            throw new Error(
+              `[Reanimated] ${ERROR_MESSAGES.invalidDirection(bgDirection)}`
+            );
+          }
+          direction = { type: 'angle', value: parsedAngle };
+        } else {
+          const parsedDirection = getDirectionForKeyword(bgDirection);
+          if (parsedDirection == null) {
+            throw new Error(
+              `[Reanimated] ${ERROR_MESSAGES.invalidDirection(bgDirection)}`
+            );
+          }
+          direction = parsedDirection;
+        }
+      }
+
+      result.push({
+        type: 'linear-gradient',
+        direction,
+        colorStops: processedColorStops,
+      });
+    } else if (bgImage.type === 'radial-gradient') {
+      let shape: RadialGradientShape = DEFAULT_RADIAL_SHAPE;
+      let size: RadialGradientSize = DEFAULT_RADIAL_SIZE;
+      let position: RadialGradientPosition = { top: '50%', left: '50%' };
+
+      if (bgImage.shape != null) {
+        if (bgImage.shape === 'circle' || bgImage.shape === 'ellipse') {
+          shape = bgImage.shape;
+        } else {
+          throw new Error(
+            `[Reanimated] ${ERROR_MESSAGES.invalidGradientShape(bgImage.shape)}`
+          );
+        }
+      }
+
+      if (bgImage.size != null) {
+        if (
+          bgImage.size === 'closest-side' ||
+          bgImage.size === 'closest-corner' ||
+          bgImage.size === 'farthest-side' ||
+          bgImage.size === 'farthest-corner'
+        ) {
+          size = bgImage.size;
+        } else if (
+          typeof bgImage.size === 'object' &&
+          bgImage.size.x != null &&
+          bgImage.size.y != null
+        ) {
+          size = { x: bgImage.size.x, y: bgImage.size.y };
+        } else {
+          throw new Error(
+            `[Reanimated] ${ERROR_MESSAGES.invalidGradientSize(bgImage.size)}`
+          );
+        }
+      }
+
+      if (bgImage.position != null) {
+        position = bgImage.position;
+      }
+
+      result.push({
+        type: 'radial-gradient',
+        shape,
+        size,
+        position,
+        colorStops: processedColorStops,
+      });
+    } else {
+      throw new Error(
+        `[Reanimated] ${ERROR_MESSAGES.invalidBackgroundImage(bgImage)}`
+      );
+    }
+  }
+
+  return result;
+}
+
+export const processBackgroundImage: ValueProcessor<
+  ReadonlyArray<BackgroundImageValue> | string,
+  ProcessedBackgroundImage | undefined
+> = (value, context) => {
+  'worklet';
+  if (value === 'none') {
+    return [];
+  }
+  if (typeof value === 'string') {
+    return parseBackgroundImageCSSString(
+      value.replace(NEWLINE_REGEX, ' '),
+      context
+    );
+  }
+  if (Array.isArray(value)) {
+    return processBackgroundImageObjects(value, context);
+  }
+
+  throw new Error(
+    `[Reanimated] ${ERROR_MESSAGES.invalidBackgroundImage(value)}`
+  );
+};

--- a/packages/react-native-reanimated/src/common/style/processors/colors.ts
+++ b/packages/react-native-reanimated/src/common/style/processors/colors.ts
@@ -165,7 +165,7 @@ function unprocessDynamicColorObjectIOS(
   };
 }
 
-type ProcessedColor =
+export type ProcessedColor =
   | number
   | PlatformColorObject
   | ProcessedDynamicColorObjectIOS;

--- a/packages/react-native-reanimated/src/common/style/processors/index.ts
+++ b/packages/react-native-reanimated/src/common/style/processors/index.ts
@@ -1,4 +1,5 @@
 'use strict';
+export { processBackgroundImage } from './backgroundImage';
 export {
   DynamicColorIOS,
   PlatformColor,

--- a/packages/react-native-reanimated/src/common/style/registry.ts
+++ b/packages/react-native-reanimated/src/common/style/registry.ts
@@ -9,7 +9,9 @@ import {
 } from './propsBuilder';
 
 const DEFAULT_SEPARATELY_INTERPOLATED_NESTED_PROPERTIES = new Set<string>([
+  'backgroundImage',
   'boxShadow',
+  'experimental_backgroundImage',
   'shadowOffset',
   'textShadowOffset',
   'transformOrigin',

--- a/packages/react-native-reanimated/src/common/web/style/config.ts
+++ b/packages/react-native-reanimated/src/common/web/style/config.ts
@@ -7,6 +7,7 @@ import {
   textShadowBuilder,
 } from './builders';
 import {
+  processBackgroundImageWeb,
   processBoxShadowWeb,
   processColor,
   processFilterWeb,
@@ -192,8 +193,13 @@ export const PROPERTIES_CONFIG: PropsBuilderConfig<AllStyleProps> = {
   backfaceVisibility: true,
   opacity: true,
   mixBlendMode: true,
+  // @ts-ignore Available since RN 0.87
+  backgroundImage: { process: processBackgroundImageWeb },
   // eslint-disable-next-line camelcase
-  experimental_backgroundImage: false, // TODO
+  experimental_backgroundImage: {
+    name: 'backgroundImage',
+    process: processBackgroundImageWeb,
+  },
 
   /** Typography */
   // Font

--- a/packages/react-native-reanimated/src/common/web/style/processors/__tests__/backgroundImage.test.ts
+++ b/packages/react-native-reanimated/src/common/web/style/processors/__tests__/backgroundImage.test.ts
@@ -53,13 +53,44 @@ describe(processBackgroundImageWeb, () => {
       processBackgroundImageWeb([
         {
           type: 'radial-gradient',
-          shape: 'circle',
+          shape: 'ellipse',
           size: { x: 100, y: '50%' },
           position: { top: '10%', left: 20 },
           colorStops: [{ color: 'red' }, { color: 'blue' }],
         },
       ])
-    ).toBe('radial-gradient(circle 100px 50% at top 10% left 20px, red, blue)');
+    ).toBe(
+      'radial-gradient(ellipse 100px 50% at top 10% left 20px, red, blue)'
+    );
+  });
+
+  test('serializes a circle size as a single radius', () => {
+    expect(
+      processBackgroundImageWeb([
+        {
+          type: 'radial-gradient',
+          shape: 'circle',
+          size: { x: 100, y: 100 },
+          colorStops: [{ color: 'red' }, { color: 'blue' }],
+        },
+      ])
+    ).toBe('radial-gradient(circle 100px, red, blue)');
+  });
+
+  test.each([
+    [{ x: 100, y: 50 }], // unequal axes cannot describe a circle
+    [{ x: '50%', y: '50%' }], // a circle radius cannot be a percentage
+  ])('throws for an invalid circle size %j', (size) => {
+    expect(() =>
+      processBackgroundImageWeb([
+        {
+          type: 'radial-gradient',
+          shape: 'circle',
+          size,
+          colorStops: [{ color: 'red' }, { color: 'blue' }],
+        },
+      ])
+    ).toThrow();
   });
 
   test('serializes multiple gradients', () => {

--- a/packages/react-native-reanimated/src/common/web/style/processors/__tests__/backgroundImage.test.ts
+++ b/packages/react-native-reanimated/src/common/web/style/processors/__tests__/backgroundImage.test.ts
@@ -1,0 +1,93 @@
+'use strict';
+import { processBackgroundImageWeb } from '../backgroundImage';
+
+describe(processBackgroundImageWeb, () => {
+  test('passes strings through unchanged', () => {
+    const value = 'linear-gradient(45deg, red, blue)';
+    expect(processBackgroundImageWeb(value)).toBe(value);
+  });
+
+  test('serializes a linear gradient without a direction', () => {
+    expect(
+      processBackgroundImageWeb([
+        {
+          type: 'linear-gradient',
+          colorStops: [{ color: 'red' }, { color: 'blue' }],
+        },
+      ])
+    ).toBe('linear-gradient(red, blue)');
+  });
+
+  test('serializes a linear gradient with a direction and positions', () => {
+    expect(
+      processBackgroundImageWeb([
+        {
+          type: 'linear-gradient',
+          direction: 'to bottom right',
+          colorStops: [
+            { color: 'red', positions: ['0%', '20%'] },
+            { color: 'blue', positions: ['100%'] },
+          ],
+        },
+      ])
+    ).toBe('linear-gradient(to bottom right, red 0% 20%, blue 100%)');
+  });
+
+  test('serializes transition hints', () => {
+    expect(
+      processBackgroundImageWeb([
+        {
+          type: 'linear-gradient',
+          colorStops: [
+            { color: 'red' },
+            { color: null, positions: ['30%'] },
+            { color: 'blue' },
+          ],
+        },
+      ])
+    ).toBe('linear-gradient(red, 30%, blue)');
+  });
+
+  test('serializes a radial gradient', () => {
+    expect(
+      processBackgroundImageWeb([
+        {
+          type: 'radial-gradient',
+          shape: 'circle',
+          size: { x: 100, y: '50%' },
+          position: { top: '10%', left: 20 },
+          colorStops: [{ color: 'red' }, { color: 'blue' }],
+        },
+      ])
+    ).toBe('radial-gradient(circle 100px 50% at top 10% left 20px, red, blue)');
+  });
+
+  test('serializes multiple gradients', () => {
+    expect(
+      processBackgroundImageWeb([
+        {
+          type: 'linear-gradient',
+          colorStops: [{ color: 'red' }, { color: 'blue' }],
+        },
+        {
+          type: 'radial-gradient',
+          size: 'closest-side',
+          colorStops: [{ color: 'green' }, { color: 'blue' }],
+        },
+      ])
+    ).toBe(
+      'linear-gradient(red, blue), radial-gradient(closest-side, green, blue)'
+    );
+  });
+
+  test('converts number colors to rgba strings', () => {
+    expect(
+      processBackgroundImageWeb([
+        {
+          type: 'linear-gradient',
+          colorStops: [{ color: 0xff0000ff }, { color: 0x0000ffff }],
+        },
+      ])
+    ).toBe('linear-gradient(rgba(255, 0, 0, 1), rgba(0, 0, 255, 1))');
+  });
+});

--- a/packages/react-native-reanimated/src/common/web/style/processors/backgroundImage.ts
+++ b/packages/react-native-reanimated/src/common/web/style/processors/backgroundImage.ts
@@ -70,6 +70,18 @@ function serializeRadialGradientPrelude({
   if (size) {
     if (typeof size === 'string') {
       parts.push(size);
+    } else if (shape === 'circle') {
+      // The CSS grammar allows only a single non-negative <length> as an
+      // explicit circle radius - two values describe an ellipse and a
+      // percentage radius is invalid, so browsers would reject the whole
+      // declaration.
+      const isPercent = typeof size.x === 'string' && size.x.endsWith('%');
+      if (size.x !== size.y || isPercent) {
+        throw new Error(
+          `[Reanimated] Invalid circle size ${JSON.stringify(size)} in a radial gradient. A circle radius must be a single length (e.g. 100 or "100px").`
+        );
+      }
+      parts.push(maybeAddSuffix(size.x, 'px'));
     } else {
       parts.push(
         `${maybeAddSuffix(size.x, 'px')} ${maybeAddSuffix(size.y, 'px')}`

--- a/packages/react-native-reanimated/src/common/web/style/processors/backgroundImage.ts
+++ b/packages/react-native-reanimated/src/common/web/style/processors/backgroundImage.ts
@@ -1,0 +1,112 @@
+'use strict';
+import type { ColorValue } from 'react-native';
+
+import type { ValueProcessor } from '../../../types';
+import { maybeAddSuffix } from '../../../utils';
+import { processColor } from './colors';
+
+// Types are defined locally instead of being imported from `react-native`
+// because the stable `backgroundImage` style prop (and its types) is
+// available only since react-native 0.87.
+type GradientColorStop = {
+  color: ColorValue | number | null;
+  positions?: ReadonlyArray<string>;
+};
+
+type LinearGradientValue = {
+  type: 'linear-gradient';
+  direction?: string;
+  colorStops: ReadonlyArray<GradientColorStop>;
+};
+
+type RadialGradientValue = {
+  type: 'radial-gradient';
+  shape?: 'circle' | 'ellipse';
+  size?:
+    | 'closest-corner'
+    | 'closest-side'
+    | 'farthest-corner'
+    | 'farthest-side'
+    | { x: string | number; y: string | number };
+  position?: {
+    top?: number | string;
+    left?: number | string;
+    bottom?: number | string;
+    right?: number | string;
+  };
+  colorStops: ReadonlyArray<GradientColorStop>;
+};
+
+type BackgroundImageValue = LinearGradientValue | RadialGradientValue;
+
+function serializeColorStops(
+  colorStops: ReadonlyArray<GradientColorStop>
+): string {
+  return colorStops
+    .map(({ color, positions }) => {
+      const positionsString = positions?.join(' ') ?? '';
+      if (color == null) {
+        // Transition hint syntax (e.g. red, 20%, blue)
+        return positionsString;
+      }
+      const processedColor = processColor(color as ColorValue);
+      const colorString =
+        typeof processedColor === 'string' ? processedColor : String(color);
+      return [colorString, positionsString].filter(Boolean).join(' ');
+    })
+    .join(', ');
+}
+
+function serializeRadialGradientPrelude({
+  shape,
+  size,
+  position,
+}: RadialGradientValue): string {
+  const parts: string[] = [];
+
+  if (shape) {
+    parts.push(shape);
+  }
+  if (size) {
+    if (typeof size === 'string') {
+      parts.push(size);
+    } else {
+      parts.push(
+        `${maybeAddSuffix(size.x, 'px')} ${maybeAddSuffix(size.y, 'px')}`
+      );
+    }
+  }
+  if (position) {
+    const positionParts = Object.entries(position).map(
+      ([side, value]) => `${side} ${maybeAddSuffix(value, 'px')}`
+    );
+    if (positionParts.length > 0) {
+      parts.push(`at ${positionParts.join(' ')}`);
+    }
+  }
+
+  return parts.join(' ');
+}
+
+export const processBackgroundImageWeb: ValueProcessor<
+  string | ReadonlyArray<BackgroundImageValue>,
+  string
+> = (value) => {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  return value
+    .map((gradient) => {
+      const colorStops = serializeColorStops(gradient.colorStops);
+
+      if (gradient.type === 'linear-gradient') {
+        const prelude = gradient.direction ? `${gradient.direction}, ` : '';
+        return `linear-gradient(${prelude}${colorStops})`;
+      }
+
+      const prelude = serializeRadialGradientPrelude(gradient);
+      return `radial-gradient(${prelude ? `${prelude}, ` : ''}${colorStops})`;
+    })
+    .join(', ');
+};

--- a/packages/react-native-reanimated/src/common/web/style/processors/index.ts
+++ b/packages/react-native-reanimated/src/common/web/style/processors/index.ts
@@ -1,4 +1,5 @@
 'use strict';
+export * from './backgroundImage';
 export * from './colors';
 export * from './filter';
 export * from './font';

--- a/packages/react-native-reanimated/src/css/native/__tests__/registry.test.ts
+++ b/packages/react-native-reanimated/src/css/native/__tests__/registry.test.ts
@@ -155,7 +155,9 @@ describe('registry', () => {
       );
       expect(props).toEqual(
         new Set([
+          'backgroundImage',
           'boxShadow',
+          'experimental_backgroundImage',
           'shadowOffset',
           'textShadowOffset',
           'transformOrigin',

--- a/packages/react-native-reanimated/src/css/native/normalization/animation/__tests__/keyframes.test.ts
+++ b/packages/react-native-reanimated/src/css/native/normalization/animation/__tests__/keyframes.test.ts
@@ -283,6 +283,59 @@ describe(processKeyframes, () => {
         },
       ]);
     });
+
+    test('backgroundImage preserves nested object structure', () => {
+      const keyframes = {
+        from: { backgroundImage: 'linear-gradient(0deg, red, blue)' },
+        to: {
+          backgroundImage: [
+            {
+              type: 'linear-gradient' as const,
+              direction: '90deg',
+              colorStops: [
+                { color: 'blue', positions: ['25%'] },
+                { color: 'red' },
+              ],
+            },
+          ],
+        },
+      };
+
+      const result = processKeyframes(keyframes, propsBuilder);
+
+      expect(result).toEqual([
+        {
+          offset: 0,
+          props: {
+            backgroundImage: [
+              {
+                type: 'linear-gradient',
+                direction: { type: 'angle', value: 0 },
+                colorStops: [
+                  { color: 0xffff0000, position: null },
+                  { color: 0xff0000ff, position: null },
+                ],
+              },
+            ],
+          },
+        },
+        {
+          offset: 1,
+          props: {
+            backgroundImage: [
+              {
+                type: 'linear-gradient',
+                direction: { type: 'angle', value: 90 },
+                colorStops: [
+                  { color: 0xff0000ff, position: '25%' },
+                  { color: 0xffff0000, position: null },
+                ],
+              },
+            ],
+          },
+        },
+      ]);
+    });
   });
 
   test('drops keyframes when processed props are undefined', () => {


### PR DESCRIPTION
> [!NOTE]
> This pull request was authored by AI on behalf of @Titozzz.

## Summary

Adds support for animating the `backgroundImage` style prop (and its pre-0.87 `experimental_backgroundImage` alias) across all animation paths. Both props were registered as unsupported (`backgroundImage: false // TODO`) and stripped from every animated style — including plain `useAnimatedStyle`. Fixes #8297.

**JS** — a new `processBackgroundImage` worklet processor (a port of React Native's own parser) normalizes both the CSS string syntax (`linear-gradient(...)` / `radial-gradient(...)`, including transition hints and the full radial `<shape> <size> at <position>` grammar) and the object syntax into the processed structure RN's `parseProcessedBackgroundImage` accepts, with colors run through `processColor`. Wired into `STYLE_PROPERTIES_CONFIG`, so it covers `useAnimatedStyle` (per-frame values computed in the worklet), CSS animations, and CSS transitions (automatic gradient-to-gradient interpolation). Both prop names are registered as separately interpolated nested properties so each gradient layer animates independently.

**C++** — new `CSSLinearGradient` / `CSSRadialGradient` value types (modeled on `CSSBoxShadow`) registered in the interpolator registry, with the corresponding explicit template instantiations of `CSSValueVariant` / `SimpleValueInterpolator`. When two gradients are structurally compatible (same gradient type, direction kind, shape, stop count, and matching units), colors, stop positions, angles, and radial sizes/positions interpolate smoothly; anything incompatible falls back to the engine's standard discrete flip. `backgroundImage: 'none'` and layer-count mismatches also resolve through the discrete path.

**Web** — the object syntax serializes back to a CSS gradient string; strings pass through unchanged.

### Note on React Native's own parser

Porting RN's parser surfaced two upstream bugs, fixed here and submitted to React Native separately — the parser in this PR already includes both:

- facebook/react-native#57873 — `<explicit-size> at <position>` in a radial gradient string swallows the `at` token: the position clause is silently dropped and its values are re-parsed as a new size (affects static styles in stock RN, verified on device on 0.87.0-rc.4).
- facebook/react-native#57874 — RN accepts a percentage radius for circles (`circle 50%`), which the CSS spec and browsers reject; the same style silently diverges between native and web. This parser rejects it.

## Test plan

```tsx
// CSS animation - endpoints interpolate automatically (colors, angle, stops)
const keyframes = css.keyframes({
  from: { experimental_backgroundImage: 'linear-gradient(0deg, red, blue)' },
  to: { experimental_backgroundImage: 'linear-gradient(180deg, yellow, green)' },
});

// useAnimatedStyle - values computed per frame in the worklet
const style = useAnimatedStyle(() => ({
  experimental_backgroundImage: [{
    type: 'linear-gradient',
    direction: `${progress.value * 360}deg`,
    colorStops: [
      { color: interpolateColor(progress.value, [0, 1], ['red', 'blue']) },
      { color: 'green' },
    ],
  }],
}));
```

- 46 unit tests for the processor (string + object syntax, all radial grammar branches, transition hints, error cases incl. the two upstream bugs above), 7 for the web serializer, plus keyframes-normalization and registry coverage — 1482 tests green across the package, with lint, clang-format, and all four type-check targets (incl. legacy RN types).
- New example screen: `Animations → Animated Properties → Appearance → Background Image` (smooth linear/radial interpolation, object syntax, and a discrete-fallback case).
- Verified on the iOS simulator (FabricExample, RN 0.87.0-rc.4): linear gradients animate colors/angle/stop positions end-to-end; radial position animation measured moving (25%, 25%) → (75%, 75%); mismatched stop counts flip discretely at 50%.
- Docs: `backgroundImage` row + a note on naming across RN versions and the smooth-vs-discrete rules in `supported-properties`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011p2PjxNunbHriH5853qssK
