### PR TITLE
fix(Worklets): UI loop not pausing when the app is backgrounded

### DIFF
--- a/packages/react-native-worklets/android/src/networking/com/swmansion/worklets/WorkletsModule.kt
+++ b/packages/react-native-worklets/android/src/networking/com/swmansion/worklets/WorkletsModule.kt
@@ -14,7 +14,6 @@ import com.facebook.react.turbomodule.core.CallInvokerHolderImpl
 import com.facebook.soloader.SoLoader
 import com.swmansion.worklets.runloop.AnimationFrameCallback
 import com.swmansion.worklets.runloop.AnimationFrameQueue
-import java.util.concurrent.atomic.AtomicBoolean
 
 @Suppress("KotlinJniMissingFunction")
 @ReactModule(name = WorkletsModule.NAME)
@@ -50,7 +49,8 @@ class WorkletsModule(
      * Invalidating concurrently could be fatal. It shouldn't happen in a normal flow, but it doesn't
      * cost us much to add synchronization for extra safety.
      */
-    private val mInvalidated = AtomicBoolean(false)
+    private val mInvalidationLock = Any()
+    private var mInvalidated = false
 
     @OptIn(FrameworkAPI::class)
     private external fun initHybrid(
@@ -164,10 +164,13 @@ class WorkletsModule(
     }
 
     override fun invalidate() {
-        if (mInvalidated.getAndSet(true)) {
-            return
+        synchronized(mInvalidationLock) {
+            if (mInvalidated) {
+                return
+            }
+            mInvalidated = true
+            reactApplicationContext.removeLifecycleEventListener(this)
         }
-        reactApplicationContext.removeLifecycleEventListener(this)
         if (mHybridData != null && mHybridData!!.isValid) {
             invalidateCpp()
         }
@@ -179,17 +182,21 @@ class WorkletsModule(
     private external fun startCpp()
 
     override fun onHostResume() {
-        if (mInvalidated.get()) {
-            return
+        synchronized(mInvalidationLock) {
+            if (mInvalidated) {
+                return
+            }
+            mAnimationFrameQueue.resume()
         }
-        mAnimationFrameQueue.resume()
     }
 
     override fun onHostPause() {
-        if (mInvalidated.get()) {
-            return
+        synchronized(mInvalidationLock) {
+            if (mInvalidated) {
+                return
+            }
+            mAnimationFrameQueue.pause()
         }
-        mAnimationFrameQueue.pause()
     }
 
     override fun onHostDestroy() {}

--- a/packages/react-native-worklets/android/src/networking/com/swmansion/worklets/WorkletsModule.kt
+++ b/packages/react-native-worklets/android/src/networking/com/swmansion/worklets/WorkletsModule.kt
@@ -46,10 +46,6 @@ class WorkletsModule(
     private val mWorkletsNetworking = WorkletsNetworking()
     private var mSlowAnimationsEnabled = false
 
-    init {
-        reactContext.addLifecycleEventListener(this)
-    }
-
     /**
      * Invalidating concurrently could be fatal. It shouldn't happen in a normal flow, but it doesn't
      * cost us much to add synchronization for extra safety.
@@ -163,6 +159,10 @@ class WorkletsModule(
         return mSlowAnimationsEnabled
     }
 
+    override fun initialize() {
+        reactApplicationContext.addLifecycleEventListener(this)
+    }
+
     override fun invalidate() {
         if (mInvalidated.getAndSet(true)) {
             return
@@ -179,10 +179,16 @@ class WorkletsModule(
     private external fun startCpp()
 
     override fun onHostResume() {
+        if (mInvalidated.get()) {
+            return
+        }
         mAnimationFrameQueue.resume()
     }
 
     override fun onHostPause() {
+        if (mInvalidated.get()) {
+            return
+        }
         mAnimationFrameQueue.pause()
     }
 

--- a/packages/react-native-worklets/android/src/networking/com/swmansion/worklets/WorkletsModule.kt
+++ b/packages/react-native-worklets/android/src/networking/com/swmansion/worklets/WorkletsModule.kt
@@ -46,6 +46,10 @@ class WorkletsModule(
     private val mWorkletsNetworking = WorkletsNetworking()
     private var mSlowAnimationsEnabled = false
 
+    init {
+        reactContext.addLifecycleEventListener(this)
+    }
+
     /**
      * Invalidating concurrently could be fatal. It shouldn't happen in a normal flow, but it doesn't
      * cost us much to add synchronization for extra safety.
@@ -163,6 +167,7 @@ class WorkletsModule(
         if (mInvalidated.getAndSet(true)) {
             return
         }
+        reactApplicationContext.removeLifecycleEventListener(this)
         if (mHybridData != null && mHybridData!!.isValid) {
             invalidateCpp()
         }

--- a/packages/react-native-worklets/android/src/no-networking/com/swmansion/worklets/WorkletsModule.kt
+++ b/packages/react-native-worklets/android/src/no-networking/com/swmansion/worklets/WorkletsModule.kt
@@ -11,7 +11,6 @@ import com.facebook.react.turbomodule.core.CallInvokerHolderImpl
 import com.facebook.soloader.SoLoader
 import com.swmansion.worklets.runloop.AnimationFrameCallback
 import com.swmansion.worklets.runloop.AnimationFrameQueue
-import java.util.concurrent.atomic.AtomicBoolean
 
 @Suppress("KotlinJniMissingFunction")
 @ReactModule(name = WorkletsModule.NAME)
@@ -46,7 +45,8 @@ class WorkletsModule(
      * Invalidating concurrently could be fatal. It shouldn't happen in a normal flow, but it doesn't
      * cost us much to add synchronization for extra safety.
      */
-    private val mInvalidated = AtomicBoolean(false)
+    private val mInvalidationLock = Any()
+    private var mInvalidated = false
 
     @OptIn(FrameworkAPI::class)
     private external fun initHybrid(
@@ -120,10 +120,13 @@ class WorkletsModule(
     }
 
     override fun invalidate() {
-        if (mInvalidated.getAndSet(true)) {
-            return
+        synchronized(mInvalidationLock) {
+            if (mInvalidated) {
+                return
+            }
+            mInvalidated = true
+            reactApplicationContext.removeLifecycleEventListener(this)
         }
-        reactApplicationContext.removeLifecycleEventListener(this)
         if (mHybridData != null && mHybridData!!.isValid) {
             invalidateCpp()
         }
@@ -135,17 +138,21 @@ class WorkletsModule(
     private external fun startCpp()
 
     override fun onHostResume() {
-        if (mInvalidated.get()) {
-            return
+        synchronized(mInvalidationLock) {
+            if (mInvalidated) {
+                return
+            }
+            mAnimationFrameQueue.resume()
         }
-        mAnimationFrameQueue.resume()
     }
 
     override fun onHostPause() {
-        if (mInvalidated.get()) {
-            return
+        synchronized(mInvalidationLock) {
+            if (mInvalidated) {
+                return
+            }
+            mAnimationFrameQueue.pause()
         }
-        mAnimationFrameQueue.pause()
     }
 
     override fun onHostDestroy() {}

--- a/packages/react-native-worklets/android/src/no-networking/com/swmansion/worklets/WorkletsModule.kt
+++ b/packages/react-native-worklets/android/src/no-networking/com/swmansion/worklets/WorkletsModule.kt
@@ -42,10 +42,6 @@ class WorkletsModule(
     private val mAnimationFrameQueue = AnimationFrameQueue(reactContext)
     private var mSlowAnimationsEnabled = false
 
-    init {
-        reactContext.addLifecycleEventListener(this)
-    }
-
     /**
      * Invalidating concurrently could be fatal. It shouldn't happen in a normal flow, but it doesn't
      * cost us much to add synchronization for extra safety.
@@ -119,6 +115,10 @@ class WorkletsModule(
         return mSlowAnimationsEnabled
     }
 
+    override fun initialize() {
+        reactApplicationContext.addLifecycleEventListener(this)
+    }
+
     override fun invalidate() {
         if (mInvalidated.getAndSet(true)) {
             return
@@ -135,10 +135,16 @@ class WorkletsModule(
     private external fun startCpp()
 
     override fun onHostResume() {
+        if (mInvalidated.get()) {
+            return
+        }
         mAnimationFrameQueue.resume()
     }
 
     override fun onHostPause() {
+        if (mInvalidated.get()) {
+            return
+        }
         mAnimationFrameQueue.pause()
     }
 

--- a/packages/react-native-worklets/android/src/no-networking/com/swmansion/worklets/WorkletsModule.kt
+++ b/packages/react-native-worklets/android/src/no-networking/com/swmansion/worklets/WorkletsModule.kt
@@ -42,6 +42,10 @@ class WorkletsModule(
     private val mAnimationFrameQueue = AnimationFrameQueue(reactContext)
     private var mSlowAnimationsEnabled = false
 
+    init {
+        reactContext.addLifecycleEventListener(this)
+    }
+
     /**
      * Invalidating concurrently could be fatal. It shouldn't happen in a normal flow, but it doesn't
      * cost us much to add synchronization for extra safety.
@@ -119,6 +123,7 @@ class WorkletsModule(
         if (mInvalidated.getAndSet(true)) {
             return
         }
+        reactApplicationContext.removeLifecycleEventListener(this)
         if (mHybridData != null && mHybridData!!.isValid) {
             invalidateCpp()
         }


### PR DESCRIPTION
## Summary

I fixed an issue where backgrounded app on Android would keep spinning the UI Runtime loop - an event listener for `onHost.pause` and `onHost.resume` wasn't wired in.

## Test plan

I verified that backgrounded app no longer spins on an Android emulator.
