### PR TITLE
feat: changelogs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,3 +20,7 @@
 ## Test plan
 
 <!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
+
+## Changelog
+
+- [ ] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -1,9 +1,6 @@
 name: Changelog check
 
 on:
-  merge_group:
-    branches:
-      - main
   pull_request:
 
 permissions:
@@ -23,5 +20,5 @@ jobs:
           node-version-file: '.nvmrc'
       - name: Require changelog entries
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: node --experimental-strip-types scripts/check-changelog.mts "$BASE_SHA"

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -1,0 +1,27 @@
+name: Changelog check
+
+on:
+  merge_group:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  changelog-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
+      - name: Use Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version-file: '.nvmrc'
+      - name: Require changelog entries
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+        run: node --experimental-strip-types scripts/check-changelog.mts "$BASE_SHA"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "build-apps": "yarn workspaces foreach --all --parallel --topological-dev --include '{common-app,*-example}' run build",
     "build-docs": "yarn workspaces foreach --all --parallel --topological-dev --include 'docs-*' run build",
     "build-packages": "yarn workspace react-native-reanimated build",
+    "check:changelog": "node --experimental-strip-types scripts/check-changelog.mts",
     "format": "yarn format:root && yarn format:workspaces",
     "format:root": "yarn run --top-level oxfmt --ignore-path .prettiereslintignore .",
     "format:md": "remark --output --ext md . && remark --rc-path .remarkrc.mdx.mjs --output --ext mdx .",

--- a/packages/react-native-reanimated/CHANGELOG.md
+++ b/packages/react-native-reanimated/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## Unpublished
+
+<!-- Add a concise entry under the appropriate category. Include links to the pull request and author when available. -->
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes
+
+### 💡 Others

--- a/packages/react-native-worklets/CHANGELOG.md
+++ b/packages/react-native-worklets/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## Unpublished
+
+<!-- Add a concise entry under the appropriate category. Include links to the pull request and author when available. -->
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes
+
+### 💡 Others

--- a/scripts/__tests__/check-changelog.test.mts
+++ b/scripts/__tests__/check-changelog.test.mts
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { findMissingChangelogs } from '../check-changelog.mts';
+
+describe('check-changelog', () => {
+  it('requires the Reanimated changelog for Reanimated changes', () => {
+    assert.deepEqual(
+      findMissingChangelogs(['packages/react-native-reanimated/src/index.ts']),
+      ['packages/react-native-reanimated/CHANGELOG.md']
+    );
+  });
+
+  it('requires the Worklets changelog for Worklets changes', () => {
+    assert.deepEqual(
+      findMissingChangelogs([
+        'packages/react-native-worklets/plugin/src/index.ts',
+      ]),
+      ['packages/react-native-worklets/CHANGELOG.md']
+    );
+  });
+
+  it('requires both changelogs when both packages change', () => {
+    assert.deepEqual(
+      findMissingChangelogs([
+        'packages/react-native-reanimated/src/index.ts',
+        'packages/react-native-worklets/src/index.ts',
+      ]),
+      [
+        'packages/react-native-reanimated/CHANGELOG.md',
+        'packages/react-native-worklets/CHANGELOG.md',
+      ]
+    );
+  });
+
+  it('accepts a changelog update for each changed package', () => {
+    assert.deepEqual(
+      findMissingChangelogs([
+        'packages/react-native-reanimated/src/index.ts',
+        'packages/react-native-reanimated/CHANGELOG.md',
+        'packages/react-native-worklets/src/index.ts',
+        'packages/react-native-worklets/CHANGELOG.md',
+      ]),
+      []
+    );
+  });
+
+  it('ignores changes outside the two published packages', () => {
+    assert.deepEqual(
+      findMissingChangelogs([
+        'docs/docs-reanimated/docs/fundamentals/getting-started.mdx',
+        'apps/common-app/src/App.tsx',
+      ]),
+      []
+    );
+  });
+});

--- a/scripts/__tests__/check-changelog.test.mts
+++ b/scripts/__tests__/check-changelog.test.mts
@@ -45,6 +45,61 @@ describe('check-changelog', () => {
     );
   });
 
+  it('temporarily exempts Reanimated 4.6.0-main', () => {
+    assert.deepEqual(
+      findMissingChangelogs(
+        ['packages/react-native-reanimated/src/index.ts'],
+        new Map([['packages/react-native-reanimated', '4.6.0-main']])
+      ),
+      []
+    );
+  });
+
+  it('temporarily exempts Worklets 0.12.0-main', () => {
+    assert.deepEqual(
+      findMissingChangelogs(
+        ['packages/react-native-worklets/src/index.ts'],
+        new Map([['packages/react-native-worklets', '0.12.0-main']])
+      ),
+      []
+    );
+  });
+
+  it('enables enforcement after both package versions change', () => {
+    assert.deepEqual(
+      findMissingChangelogs(
+        [
+          'packages/react-native-reanimated/src/index.ts',
+          'packages/react-native-worklets/src/index.ts',
+        ],
+        new Map([
+          ['packages/react-native-reanimated', '4.7.0-main'],
+          ['packages/react-native-worklets', '0.13.0-main'],
+        ])
+      ),
+      [
+        'packages/react-native-reanimated/CHANGELOG.md',
+        'packages/react-native-worklets/CHANGELOG.md',
+      ]
+    );
+  });
+
+  it('keeps enforcement package-specific', () => {
+    assert.deepEqual(
+      findMissingChangelogs(
+        [
+          'packages/react-native-reanimated/src/index.ts',
+          'packages/react-native-worklets/src/index.ts',
+        ],
+        new Map([
+          ['packages/react-native-reanimated', '4.6.0-main'],
+          ['packages/react-native-worklets', '0.13.0-main'],
+        ])
+      ),
+      ['packages/react-native-worklets/CHANGELOG.md']
+    );
+  });
+
   it('ignores changes outside the two published packages', () => {
     assert.deepEqual(
       findMissingChangelogs([

--- a/scripts/check-changelog.mts
+++ b/scripts/check-changelog.mts
@@ -1,0 +1,66 @@
+import { execFileSync } from 'node:child_process';
+
+const PACKAGE_CHANGELOGS = new Map([
+  [
+    'packages/react-native-reanimated',
+    'packages/react-native-reanimated/CHANGELOG.md',
+  ],
+  [
+    'packages/react-native-worklets',
+    'packages/react-native-worklets/CHANGELOG.md',
+  ],
+]);
+
+export function findMissingChangelogs(changedFiles: string[]) {
+  return [...PACKAGE_CHANGELOGS].flatMap(([packagePath, changelogPath]) => {
+    const packagePrefix = `${packagePath}/`;
+    const packageChanged = changedFiles.some((file) =>
+      file.startsWith(packagePrefix)
+    );
+    const changelogChanged = changedFiles.includes(changelogPath);
+
+    return packageChanged && !changelogChanged ? [changelogPath] : [];
+  });
+}
+
+export function getChangedFiles(base: string, head = 'HEAD') {
+  return execFileSync(
+    'git',
+    ['diff', '--name-only', '--diff-filter=ACDMRTUXB', `${base}...${head}`],
+    { encoding: 'utf8' }
+  )
+    .split('\n')
+    .filter(Boolean);
+}
+
+function main() {
+  const [base, head = 'HEAD'] = process.argv.slice(2);
+
+  if (!base) {
+    console.error(
+      'Usage: node --experimental-strip-types scripts/check-changelog.mts <base> [head]'
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const missingChangelogs = findMissingChangelogs(getChangedFiles(base, head));
+
+  if (missingChangelogs.length === 0) {
+    console.log('All changed packages include a changelog update.');
+    return;
+  }
+
+  console.error(
+    [
+      'Changes to Reanimated and Worklets must be documented for the next release.',
+      'Add a concise bullet under an appropriate section in `## Unpublished` in:',
+      ...missingChangelogs.map((changelog) => `- ${changelog}`),
+    ].join('\n')
+  );
+  process.exitCode = 1;
+}
+
+if (import.meta.filename === process.argv[1]) {
+  main();
+}

--- a/scripts/check-changelog.mts
+++ b/scripts/check-changelog.mts
@@ -1,26 +1,38 @@
 import { execFileSync } from 'node:child_process';
 
-const PACKAGE_CHANGELOGS = new Map([
-  [
-    'packages/react-native-reanimated',
-    'packages/react-native-reanimated/CHANGELOG.md',
-  ],
-  [
-    'packages/react-native-worklets',
-    'packages/react-native-worklets/CHANGELOG.md',
-  ],
-]);
+// These exemptions expire automatically when the packages move to their next versions.
+const PACKAGE_RULES = [
+  {
+    packagePath: 'packages/react-native-reanimated',
+    changelogPath: 'packages/react-native-reanimated/CHANGELOG.md',
+    exemptVersion: '4.6.0-main',
+  },
+  {
+    packagePath: 'packages/react-native-worklets',
+    changelogPath: 'packages/react-native-worklets/CHANGELOG.md',
+    exemptVersion: '0.12.0-main',
+  },
+];
 
-export function findMissingChangelogs(changedFiles: string[]) {
-  return [...PACKAGE_CHANGELOGS].flatMap(([packagePath, changelogPath]) => {
-    const packagePrefix = `${packagePath}/`;
-    const packageChanged = changedFiles.some((file) =>
-      file.startsWith(packagePrefix)
-    );
-    const changelogChanged = changedFiles.includes(changelogPath);
+export function findMissingChangelogs(
+  changedFiles: string[],
+  packageVersions = new Map<string, string>()
+) {
+  return PACKAGE_RULES.flatMap(
+    ({ packagePath, changelogPath, exemptVersion }) => {
+      if (packageVersions.get(packagePath) === exemptVersion) {
+        return [];
+      }
 
-    return packageChanged && !changelogChanged ? [changelogPath] : [];
-  });
+      const packagePrefix = `${packagePath}/`;
+      const packageChanged = changedFiles.some((file) =>
+        file.startsWith(packagePrefix)
+      );
+      const changelogChanged = changedFiles.includes(changelogPath);
+
+      return packageChanged && !changelogChanged ? [changelogPath] : [];
+    }
+  );
 }
 
 export function getChangedFiles(base: string, head = 'HEAD') {
@@ -31,6 +43,20 @@ export function getChangedFiles(base: string, head = 'HEAD') {
   )
     .split('\n')
     .filter(Boolean);
+}
+
+export function getPackageVersions(ref = 'HEAD') {
+  return new Map(
+    PACKAGE_RULES.map(({ packagePath }) => {
+      const packageJson = execFileSync(
+        'git',
+        ['show', `${ref}:${packagePath}/package.json`],
+        { encoding: 'utf8' }
+      );
+      const { version } = JSON.parse(packageJson) as { version: string };
+      return [packagePath, version];
+    })
+  );
 }
 
 function main() {
@@ -44,10 +70,15 @@ function main() {
     return;
   }
 
-  const missingChangelogs = findMissingChangelogs(getChangedFiles(base, head));
+  const missingChangelogs = findMissingChangelogs(
+    getChangedFiles(base, head),
+    getPackageVersions(head)
+  );
 
   if (missingChangelogs.length === 0) {
-    console.log('All changed packages include a changelog update.');
+    console.log(
+      'All changed packages include a changelog update or are temporarily exempt.'
+    );
     return;
   }
 


### PR DESCRIPTION
## Summary

I added changelogs for Reanimated and Worklets packages that have to be updated when you contribute something in their respective directories.

This should help us streamline generating good release notes.

The changelogs will be after we release next minor versions of Reanimated and Worklets - this way we don't have to backport current changes to the changelogs.

## Test plan

CI + tests
