### PR TITLE
refactor(LayoutAnimations): keep ReanimatedCommitHook a pure commit hook

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.cpp
@@ -15,12 +15,13 @@ namespace reanimated {
 ReanimatedCommitHook::ReanimatedCommitHook(
     const std::shared_ptr<UIManager> &uiManager,
     const std::shared_ptr<UpdatesRegistryManager> &updatesRegistryManager,
-    const std::shared_ptr<LayoutAnimationsProxyCommon> &layoutAnimationsProxy)
+    const std::shared_ptr<LayoutAnimationsProxyCommon> &layoutAnimationsProxy,
+    const std::shared_ptr<ReanimatedSurfaceTracker> &surfaceTracker)
     : uiManager_(uiManager),
       updatesRegistryManager_(updatesRegistryManager),
-      layoutAnimationsProxy_(layoutAnimationsProxy) {
+      layoutAnimationsProxy_(layoutAnimationsProxy),
+      surfaceTracker_(surfaceTracker) {
   uiManager_->registerCommitHook(*this);
-  uiManager_->registerMountHook(*this);
   // Pick up surfaces that existed before Reanimated initialized. We're not
   // on a commit stack here, so reading the registry is safe.
   uiManager_->getShadowTreeRegistry().enumerate(
@@ -28,16 +29,12 @@ ReanimatedCommitHook::ReanimatedCommitHook(
 }
 
 ReanimatedCommitHook::~ReanimatedCommitHook() noexcept {
-  uiManager_->unregisterMountHook(*this);
   uiManager_->unregisterCommitHook(*this);
 }
 
 void ReanimatedCommitHook::maybeInitializeLayoutAnimations(const ShadowTree &shadowTree) {
-  {
-    auto lock = std::unique_lock<std::mutex>(mutex_);
-    if (!seenSurfaces_.insert(shadowTree.getSurfaceId()).second) {
-      return;
-    }
+  if (!surfaceTracker_->add(shadowTree.getSurfaceId())) {
+    return;
   }
   // Don't read the ShadowTreeRegistry here — commits run under its shared
   // lock and a nested acquisition deadlocks with a queued writer (#8579).
@@ -46,12 +43,6 @@ void ReanimatedCommitHook::maybeInitializeLayoutAnimations(const ShadowTree &sha
   // surfaces.
   layoutAnimationsProxy_->startSurface(shadowTree.getSurfaceId());
   shadowTree.getMountingCoordinator()->setMountingOverrideDelegate(layoutAnimationsProxy_);
-}
-
-void ReanimatedCommitHook::shadowTreeDidUnmount(SurfaceId surfaceId, HighResTimeStamp /*unmountTime*/) noexcept {
-  // Forget stopped surfaces so a reused surface id registers again.
-  auto lock = std::unique_lock<std::mutex>(mutex_);
-  seenSurfaces_.erase(surfaceId);
 }
 
 RootShadowNode::Unshared ReanimatedCommitHook::shadowTreeWillCommit(

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.h
@@ -1,24 +1,24 @@
 #pragma once
 
+#include <reanimated/Fabric/ReanimatedSurfaceTracker.h>
 #include <reanimated/Fabric/updates/UpdatesRegistryManager.h>
 #include <reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.h>
 
 #include <react/renderer/uimanager/UIManagerCommitHook.h>
-#include <react/renderer/uimanager/UIManagerMountHook.h>
 
 #include <memory>
-#include <unordered_set>
 
 using namespace facebook::react;
 
 namespace reanimated {
 
-class ReanimatedCommitHook : public UIManagerCommitHook, public UIManagerMountHook {
+class ReanimatedCommitHook : public UIManagerCommitHook {
  public:
   ReanimatedCommitHook(
       const std::shared_ptr<UIManager> &uiManager,
       const std::shared_ptr<UpdatesRegistryManager> &updatesRegistryManager,
-      const std::shared_ptr<LayoutAnimationsProxyCommon> &layoutAnimationsProxy);
+      const std::shared_ptr<LayoutAnimationsProxyCommon> &layoutAnimationsProxy,
+      const std::shared_ptr<ReanimatedSurfaceTracker> &surfaceTracker);
 
   ~ReanimatedCommitHook() noexcept override;
 
@@ -34,19 +34,11 @@ class ReanimatedCommitHook : public UIManagerCommitHook, public UIManagerMountHo
       RootShadowNode::Unshared const &newRootShadowNode,
       const ShadowTreeCommitOptions &commitOptions) noexcept override;
 
-  void shadowTreeDidMount(RootShadowNode::Shared const &, HighResTimeStamp) noexcept override {}
-
-  void shadowTreeDidUnmount(SurfaceId surfaceId, HighResTimeStamp unmountTime) noexcept override;
-
  private:
   std::shared_ptr<UIManager> uiManager_;
   std::shared_ptr<UpdatesRegistryManager> updatesRegistryManager_;
   std::shared_ptr<LayoutAnimationsProxyCommon> layoutAnimationsProxy_;
-
-  // Surfaces whose MountingCoordinator already has our override delegate.
-  std::unordered_set<SurfaceId> seenSurfaces_;
-
-  std::mutex mutex_; // Protects `seenSurfaces_`.
+  std::shared_ptr<ReanimatedSurfaceTracker> surfaceTracker_;
 };
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedMountHook.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedMountHook.cpp
@@ -1,5 +1,6 @@
 #include <reanimated/Fabric/ReanimatedCommitShadowNode.h>
 #include <reanimated/Fabric/ReanimatedMountHook.h>
+#include <reanimated/Tools/FeatureFlags.h>
 #include <reanimated/Tools/ReanimatedSystraceSection.h>
 
 #include <memory>
@@ -10,10 +11,12 @@ ReanimatedMountHook::ReanimatedMountHook(
     const std::shared_ptr<UIManager> &uiManager,
     const std::shared_ptr<UpdatesRegistryManager> &updatesRegistryManager,
     const std::shared_ptr<css::ViewStylesRepository> &viewStylesRepository,
+    const std::shared_ptr<ReanimatedSurfaceTracker> &surfaceTracker,
     const std::function<void()> &requestFlush)
     : uiManager_(uiManager),
       updatesRegistryManager_(updatesRegistryManager),
       viewStylesRepository_(viewStylesRepository),
+      surfaceTracker_(surfaceTracker),
       requestFlush_(requestFlush) {
   uiManager_->registerMountHook(*this);
 }
@@ -26,6 +29,11 @@ void ReanimatedMountHook::shadowTreeDidMount(
     const RootShadowNode::Shared &rootShadowNode,
     HighResTimeStamp mountTime) noexcept {
   ReanimatedSystraceSection s("ReanimatedMountHook::shadowTreeDidMount");
+
+  if constexpr (StaticFeatureFlags::getFlag("USE_ANIMATION_BACKEND")) {
+    // With the animation backend this hook only tracks surface unmounts.
+    return;
+  }
 
   auto reaShadowNode = std::reinterpret_pointer_cast<ReanimatedCommitShadowNode>(
       std::const_pointer_cast<RootShadowNode>(rootShadowNode));
@@ -59,6 +67,11 @@ void ReanimatedMountHook::shadowTreeDidMount(
       }
     }
   }
+}
+
+void ReanimatedMountHook::shadowTreeDidUnmount(SurfaceId surfaceId, HighResTimeStamp /*unmountTime*/) noexcept {
+  // Forget stopped surfaces so a reused surface id registers again.
+  surfaceTracker_->remove(surfaceId);
 }
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedMountHook.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedMountHook.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <reanimated/CSS/misc/ViewStylesRepository.h>
+#include <reanimated/Fabric/ReanimatedSurfaceTracker.h>
 #include <reanimated/Fabric/ShadowTreeCloner.h>
 #include <reanimated/Fabric/updates/UpdatesRegistryManager.h>
 
@@ -18,15 +19,19 @@ class ReanimatedMountHook : public UIManagerMountHook {
       const std::shared_ptr<UIManager> &uiManager,
       const std::shared_ptr<UpdatesRegistryManager> &updatesRegistryManager,
       const std::shared_ptr<css::ViewStylesRepository> &viewStylesRepository,
+      const std::shared_ptr<ReanimatedSurfaceTracker> &surfaceTracker,
       const std::function<void()> &requestFlush);
   ~ReanimatedMountHook() noexcept override;
 
   void shadowTreeDidMount(RootShadowNode::Shared const &rootShadowNode, HighResTimeStamp mountTime) noexcept override;
 
+  void shadowTreeDidUnmount(SurfaceId surfaceId, HighResTimeStamp unmountTime) noexcept override;
+
  private:
   const std::shared_ptr<UIManager> uiManager_;
   const std::shared_ptr<UpdatesRegistryManager> updatesRegistryManager_;
   const std::shared_ptr<css::ViewStylesRepository> viewStylesRepository_;
+  const std::shared_ptr<ReanimatedSurfaceTracker> surfaceTracker_;
   const std::function<void()> requestFlush_;
 };
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedSurfaceTracker.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedSurfaceTracker.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <react/renderer/core/ReactPrimitives.h>
+
+#include <mutex>
+#include <unordered_set>
+
+namespace reanimated {
+
+// Tracks surfaces that already have the LayoutAnimations mounting override
+// delegate registered. The commit hook adds, the mount hook removes on unmount.
+class ReanimatedSurfaceTracker {
+ public:
+  // Returns true if the surface wasn't tracked yet.
+  bool add(facebook::react::SurfaceId surfaceId) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return seenSurfaces_.insert(surfaceId).second;
+  }
+
+  void remove(facebook::react::SurfaceId surfaceId) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    seenSurfaces_.erase(surfaceId);
+  }
+
+ private:
+  std::mutex mutex_;
+  std::unordered_set<facebook::react::SurfaceId> seenSurfaces_;
+};
+
+} // namespace reanimated

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -1208,15 +1208,15 @@ void ReanimatedModuleProxy::initializeFabric(const std::shared_ptr<UIManager> &u
     strongThis->requestFlushRegistry();
   };
 
-  if constexpr (StaticFeatureFlags::getFlag("USE_ANIMATION_BACKEND")) {
-    // TODO: we don't use the mount hook here, but we still need a way to handleNodeRemovals
-    // for now we leave this to leak the memory, a fix will come in a follow-up
-  } else {
-    mountHook_ =
-        std::make_shared<ReanimatedMountHook>(uiManager_, updatesRegistryManager_, viewStylesRepository_, request);
-  }
+  const auto surfaceTracker = std::make_shared<ReanimatedSurfaceTracker>();
 
-  commitHook_ = std::make_shared<ReanimatedCommitHook>(uiManager_, updatesRegistryManager_, layoutAnimationsProxy_);
+  commitHook_ = std::make_shared<ReanimatedCommitHook>(
+      uiManager_, updatesRegistryManager_, layoutAnimationsProxy_, surfaceTracker);
+
+  // TODO: with the animation backend we still need a way to handleNodeRemovals,
+  // for now we leave this to leak the memory, a fix will come in a follow-up
+  mountHook_ = std::make_shared<ReanimatedMountHook>(
+      uiManager_, updatesRegistryManager_, viewStylesRepository_, surfaceTracker, request);
 }
 
 void ReanimatedModuleProxy::initializeLayoutAnimationsProxy() {


### PR DESCRIPTION
## Summary

Stacked on #9903.

#9903 made `ReanimatedCommitHook` implement `UIManagerMountHook` just to receive `shadowTreeDidUnmount` for its seen-surfaces set. This keeps the established commit-hook/mount-hook separation instead:

- New `ReanimatedSurfaceTracker` — a small mutex-guarded set of surface ids, owned by neither hook. Tracks which surfaces already have the LA mounting override delegate registered.
- `ReanimatedCommitHook` is a pure `UIManagerCommitHook` again; it adds surfaces on their first commit.
- `ReanimatedMountHook` gets the `shadowTreeDidUnmount` override (default no-op in RN's base class) and removes surfaces, so a reused surface id registers again.
- The mount hook is now registered also with `USE_ANIMATION_BACKEND`, with its `shadowTreeDidMount` work compiled out — it only tracks surface unmounts there. The `handleNodeRemovals` TODO for the backend path is unchanged.

## Test plan

Ran a manual test bench on fabric-example (iOS, iPhone 17 Pro sim) in both `ENABLE_SHARED_ELEMENT_TRANSITIONS:true` and `:false` configurations: entering/exiting/layout animations (verified frame-by-frame from recordings), `LayoutAnimation.configureNext`, empty-root commit with live surface, LogBox second-surface registration, and JS reload — confirming the surface re-registers after teardown via the new tracker path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QrLsNRCUJarW2uGrKYDM3f