### PR TITLE
fix: account for Yoga pixel grid rounding in native snapshot comparison

### DIFF
--- a/apps/common-app/runtime-tests/ReJest/matchers/Comparators.ts
+++ b/apps/common-app/runtime-tests/ReJest/matchers/Comparators.ts
@@ -1,9 +1,20 @@
+import { PixelRatio } from 'react-native';
+
 import { colorsAreClose, isColor } from '../utils/colorUtils';
 
 import type { TestValue, ValidPropNames } from '../types';
 import { ComparisonMode, isValidPropName } from '../types';
 
 const DISTANCE_TOLERANCE = 0.5;
+
+const YOGA_PIXEL_GRID_ROUNDING_SLACK = 0.0001;
+
+const PIXEL_GRID_ROUNDED_EDGE_COUNT: Partial<Record<ValidPropNames, number>> = {
+  top: 1,
+  left: 1,
+  width: 2,
+  height: 2,
+};
 
 const COMPARATORS: {
   [Key: string]: (expected: TestValue, value: TestValue) => boolean;
@@ -44,11 +55,7 @@ const COMPARATORS: {
   },
 
   [ComparisonMode.PIXEL]: (expected, value) => {
-    const valueAsNumber = Number(value);
-    return (
-      !isNaN(valueAsNumber) &&
-      Math.abs(valueAsNumber - Number(expected)) < DISTANCE_TOLERANCE
-    );
+    return comparePixelValues(expected, value, DISTANCE_TOLERANCE);
   },
 
   [ComparisonMode.FLOAT_DISTANCE]: (expected, value) => {
@@ -132,6 +139,15 @@ export function getComparator(mode: ComparisonMode) {
   return COMPARATORS[mode];
 }
 
+export function getNativeComparator(mode: ComparisonMode, prop: string) {
+  if (mode !== ComparisonMode.PIXEL || !isValidPropName(prop)) {
+    return COMPARATORS[mode];
+  }
+  const tolerance = getPixelGridTolerance(prop);
+  return (expected: TestValue, value: TestValue) =>
+    comparePixelValues(expected, value, tolerance);
+}
+
 export function getComparisonModeForProp(prop: ValidPropNames): ComparisonMode {
   const propToComparisonModeDict = {
     zIndex: ComparisonMode.NUMBER,
@@ -144,4 +160,27 @@ export function getComparisonModeForProp(prop: ValidPropNames): ComparisonMode {
     boxShadow: ComparisonMode.ARRAY,
   };
   return propToComparisonModeDict[prop];
+}
+
+function getPixelGridTolerance(prop: ValidPropNames) {
+  const roundedEdgeCount = PIXEL_GRID_ROUNDED_EDGE_COUNT[prop];
+  if (roundedEdgeCount === undefined) {
+    return DISTANCE_TOLERANCE;
+  }
+  const pixelGridTolerance =
+    (roundedEdgeCount * (DISTANCE_TOLERANCE + YOGA_PIXEL_GRID_ROUNDING_SLACK)) /
+    PixelRatio.get();
+  return Math.max(DISTANCE_TOLERANCE, pixelGridTolerance);
+}
+
+function comparePixelValues(
+  expected: TestValue,
+  value: TestValue,
+  tolerance: number
+) {
+  const valueAsNumber = Number(value);
+  return (
+    !isNaN(valueAsNumber) &&
+    Math.abs(valueAsNumber - Number(expected)) < tolerance
+  );
 }

--- a/apps/common-app/runtime-tests/ReJest/matchers/snapshotMatchers.ts
+++ b/apps/common-app/runtime-tests/ReJest/matchers/snapshotMatchers.ts
@@ -3,11 +3,16 @@ import type { Mismatch, OperationUpdate } from '../types';
 import { ComparisonMode, isValidPropName } from '../types';
 import { formatSnapshotMismatch } from '../utils/drawSnapshotTable';
 import { green, red, yellow } from '../utils/stringFormatUtils';
-import { getComparator, getComparisonModeForProp } from './Comparators';
+import {
+  getComparator,
+  getComparisonModeForProp,
+  getNativeComparator,
+} from './Comparators';
 
 function compareSnapshot(
   expectedSnapshot: OperationUpdate,
   capturedSnapshot: OperationUpdate,
+  native: boolean,
   expectNegativeValueMismatch: boolean
 ) {
   const keys = Object.keys(capturedSnapshot) as Array<keyof OperationUpdate>;
@@ -17,7 +22,9 @@ function compareSnapshot(
     const comparisonMode = isValidPropName(key)
       ? getComparisonModeForProp(key)
       : ComparisonMode.AUTO;
-    const isEqual = getComparator(comparisonMode);
+    const isEqual = native
+      ? getNativeComparator(comparisonMode, key)
+      : getComparator(comparisonMode);
     const expectMismatch = jsValue < 0 && expectNegativeValueMismatch;
     const valuesAreMatching = isEqual(jsValue, nativeValue);
     if (
@@ -69,6 +76,7 @@ function compareSingleViewSnapshots(
     const snapshotMatching = compareSnapshot(
       expectedSnapshot,
       capturedSnapshot,
+      native,
       expectNegativeValueMismatch
     );
     if (!snapshotMatching) {
@@ -81,7 +89,7 @@ function compareSingleViewSnapshots(
   }
 
   if (mismatchedSnapshots.length > 0) {
-    return formatSnapshotMismatch(mismatchedSnapshots, false);
+    return formatSnapshotMismatch(mismatchedSnapshots, native);
   }
 }
 

--- a/apps/common-app/runtime-tests/ReJest/utils/drawSnapshotTable.ts
+++ b/apps/common-app/runtime-tests/ReJest/utils/drawSnapshotTable.ts
@@ -3,6 +3,7 @@ import { isColor } from './colorUtils';
 import {
   getComparator,
   getComparisonModeForProp,
+  getNativeComparator,
 } from '../matchers/Comparators';
 import type { Mismatch, TestValue } from '../types';
 import { ComparisonMode, isValidPropName } from '../types';
@@ -117,7 +118,11 @@ function withSideBorders(line: string) {
   return VERTICAL_LINE + line + VERTICAL_LINE;
 }
 
-function getComparisonRow(mismatch: Mismatch, keys: Array<string>) {
+function getComparisonRow(
+  mismatch: Mismatch,
+  keys: Array<string>,
+  native: boolean
+) {
   const { index, capturedSnapshot, expectedSnapshot } = mismatch;
   const indexColumn = adjustValueToLength(index.toString(), INDEX_COLUMN_WIDTH);
   const formattedCells = keys.map((key) => {
@@ -130,7 +135,11 @@ function getComparisonRow(mismatch: Mismatch, keys: Array<string>) {
       ? getComparisonModeForProp(key)
       : ComparisonMode.AUTO;
 
-    const match = getComparator(comparisonMode)(expectedValue, capturedValue);
+    const comparator = native
+      ? getNativeComparator(comparisonMode, key)
+      : getComparator(comparisonMode);
+
+    const match = comparator(expectedValue, capturedValue);
 
     const expectedAdjusted = adjustValueToLength(
       expectedValue,
@@ -179,7 +188,7 @@ export function formatSnapshotMismatch(
   const lowerHeader = withSideBorders(getLowerTableHeader(keysToPrint, native));
   const separatorLine = getBorderLine(keysToPrint, 'mid');
   const mismatchRows = mismatches.map((mismatch) =>
-    withSideBorders(getComparisonRow(mismatch, keysToPrint))
+    withSideBorders(getComparisonRow(mismatch, keysToPrint, native))
   );
   const bottomLine = getBorderLine(keysToPrint, 'bottom');
 


### PR DESCRIPTION
> [!NOTE]
> This pull request was authored by AI on behalf of tjzel.

Failing nightly: https://github.com/software-mansion/react-native-reanimated/actions/runs/31458256411

## Summary

Every Android runtime tests job has failed since #10125 re-enabled `withDecay/basic` and `withSequence/callbackCascade`. `toMatchNativeSnapshots` compares the values an animation produced against layout metrics that Yoga already rounded to the physical pixel grid, but it did so with a fixed 0.5 dp tolerance. The CI emulator runs at 160 dpi, so one pixel is one dp and that rounding exceeds the tolerance: `top` and `left` are rounded once with half-up and Yoga's `inexactEquals` slack, while `width` and `height` are the difference of two independently rounded edges and drift by up to a full pixel.

I scaled the tolerance of native snapshot comparisons by `PixelRatio.get()` and by how many edges Yoga rounds for a given prop, keeping the current 0.5 dp as a floor so no platform ends up stricter than before. JS snapshot comparisons keep the old tolerance, since no rounding happens there.

I also passed the existing `native` flag down to the mismatch table, which was hardcoded to `false` and therefore printed the native column as "expected" and the JS column as "captured".

## Test plan

Ran the reanimated runtime tests on an Android emulator at 160 dpi, matching CI:

- On `main`: both tests fail with the same frames and values as the nightly, e.g. `left` at index 58 is `305.000000` natively against `304.49999765` in JS.
- With this change: `8 passed, 0 failed`.

## Changelog

- [x] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.
