### PR TITLE
feat(ci): add daily activity digest to the Slack report

### DIFF
--- a/.github/workflows/helper/daily-report-notification.ts
+++ b/.github/workflows/helper/daily-report-notification.ts
@@ -256,23 +256,51 @@ async function getDailyDigest(): Promise<DigestStatus> {
     .toISOString()
     .replace(/\.\d{3}Z$/, 'Z');
 
-  const [mergedPullRequests, newIssues, closedIssues] = await Promise.all([
-    searchDigestItems(`repo:${DIGEST_REPO} type:pr is:merged merged:>=${since}`),
-    searchDigestItems(`repo:${DIGEST_REPO} type:issue created:>=${since}`),
-    searchDigestItems(`repo:${DIGEST_REPO} type:issue is:closed closed:>=${since}`),
+  const [
+    mergedPullRequests,
+    newIssues,
+    closedIssues,
+    openPullRequests,
+    openIssues,
+  ] = await Promise.all([
+    searchDigestItems(
+      `repo:${DIGEST_REPO} type:pr is:merged merged:>=${since}`
+    ),
+    searchDigestItems(
+      `repo:${DIGEST_REPO} type:issue is:open created:>=${since}`
+    ),
+    searchDigestItems(
+      `repo:${DIGEST_REPO} type:issue is:closed closed:>=${since}`
+    ),
+    countMatches(`repo:${DIGEST_REPO} type:pr is:open`),
+    countMatches(`repo:${DIGEST_REPO} type:issue is:open`),
   ]);
 
-  if (!mergedPullRequests || !newIssues || !closedIssues) {
+  if (
+    !mergedPullRequests ||
+    !newIssues ||
+    !closedIssues ||
+    openPullRequests === null ||
+    openIssues === null
+  ) {
     return { kind: 'unknown' };
   }
 
   return {
     kind: 'ok',
-    digest: { mergedPullRequests, newIssues, closedIssues },
+    digest: {
+      mergedPullRequests,
+      newIssues,
+      closedIssues: annotateOpenedInWindow(closedIssues, since),
+      openPullRequests,
+      openIssues,
+    },
   };
 }
 
-async function searchDigestItems(query: string): Promise<DigestCategory | null> {
+async function searchDigestItems(
+  query: string
+): Promise<DigestCategory | null> {
   const response = await githubApi<IssueSearchResponse>(
     `/search/issues?q=${encodeURIComponent(query)}&per_page=${DIGEST_LIST_LIMIT}`
   );
@@ -286,7 +314,30 @@ async function searchDigestItems(query: string): Promise<DigestCategory | null> 
       number: item.number,
       title: item.title,
       url: item.html_url,
+      createdAt: item.created_at,
     })),
+  };
+}
+
+async function countMatches(query: string): Promise<number | null> {
+  const response = await githubApi<IssueSearchResponse>(
+    `/search/issues?q=${encodeURIComponent(query)}&per_page=1`
+  );
+  return response ? response.total_count : null;
+}
+
+function annotateOpenedInWindow(
+  category: DigestCategory,
+  since: string
+): DigestCategory {
+  const cutoff = new Date(since).getTime();
+  return {
+    total: category.total,
+    items: category.items.map((item) =>
+      new Date(item.createdAt).getTime() >= cutoff
+        ? { ...item, note: 'opened same day' }
+        : item
+    ),
   };
 }
 
@@ -363,12 +414,19 @@ function formatDigestSection(status: DigestStatus): string {
     ].join('\n');
   }
 
-  const { mergedPullRequests, newIssues, closedIssues } = status.digest;
+  const {
+    mergedPullRequests,
+    newIssues,
+    closedIssues,
+    openPullRequests,
+    openIssues,
+  } = status.digest;
   return [
     '*Daily digest (last 24h)*',
     formatDigestCategory('🔀 Merged pull requests', mergedPullRequests),
     formatDigestCategory('🆕 New issues', newIssues),
     formatDigestCategory('☑️ Closed issues', closedIssues),
+    `📂 Currently open: ${openPullRequests} pull requests · ${openIssues} issues`,
   ].join('\n\n');
 }
 
@@ -379,8 +437,9 @@ function formatDigestCategory(
   const lines = [`${heading}: ${category.total}`];
 
   for (const item of category.items) {
+    const note = item.note ? ` — ${item.note}` : '';
     lines.push(
-      `• <${item.url}|#${item.number}> ${escapeSlackText(item.title)}`
+      `• <${item.url}|#${item.number}> ${escapeSlackText(item.title)}${note}`
     );
   }
 
@@ -472,6 +531,8 @@ type DigestItem = {
   number: number;
   title: string;
   url: string;
+  createdAt: string;
+  note?: string;
 };
 
 type DigestCategory = {
@@ -483,16 +544,17 @@ type DailyDigest = {
   mergedPullRequests: DigestCategory;
   newIssues: DigestCategory;
   closedIssues: DigestCategory;
+  openPullRequests: number;
+  openIssues: number;
 };
 
-type DigestStatus =
-  | { kind: 'ok'; digest: DailyDigest }
-  | { kind: 'unknown' };
+type DigestStatus = { kind: 'ok'; digest: DailyDigest } | { kind: 'unknown' };
 
 type IssueSearchItem = {
   number: number;
   title: string;
   html_url: string;
+  created_at: string;
 };
 
 type IssueSearchResponse = {

--- a/.github/workflows/helper/daily-report-notification.ts
+++ b/.github/workflows/helper/daily-report-notification.ts
@@ -7,12 +7,14 @@ import { postToSlack } from './slack.ts';
 
 async function main(): Promise<void> {
   const badges = await getActionsBadgesFromReadme();
-  const [failingBadges, nightly] = await Promise.all([
+  const [failingBadges, nightly, digest] = await Promise.all([
     getFailingBadges(badges),
     getRNNightlyFailures(),
+    getDailyDigest(),
   ]);
   const text = [
     formatSlackMessage(failingBadges, nightly),
+    formatDigestSection(digest),
     buildBundleCostSection(),
   ].join('\n\n');
 
@@ -245,6 +247,49 @@ async function getRNNightlyFailures(): Promise<NightlyStatus> {
   return { kind: 'ok', failures };
 }
 
+const DIGEST_REPO = 'software-mansion/react-native-reanimated';
+const DIGEST_WINDOW_HOURS = 24;
+const DIGEST_LIST_LIMIT = 10;
+
+async function getDailyDigest(): Promise<DigestStatus> {
+  const since = new Date(Date.now() - DIGEST_WINDOW_HOURS * 60 * 60 * 1000)
+    .toISOString()
+    .replace(/\.\d{3}Z$/, 'Z');
+
+  const [mergedPullRequests, newIssues, closedIssues] = await Promise.all([
+    searchDigestItems(`repo:${DIGEST_REPO} type:pr is:merged merged:>=${since}`),
+    searchDigestItems(`repo:${DIGEST_REPO} type:issue created:>=${since}`),
+    searchDigestItems(`repo:${DIGEST_REPO} type:issue is:closed closed:>=${since}`),
+  ]);
+
+  if (!mergedPullRequests || !newIssues || !closedIssues) {
+    return { kind: 'unknown' };
+  }
+
+  return {
+    kind: 'ok',
+    digest: { mergedPullRequests, newIssues, closedIssues },
+  };
+}
+
+async function searchDigestItems(query: string): Promise<DigestCategory | null> {
+  const response = await githubApi<IssueSearchResponse>(
+    `/search/issues?q=${encodeURIComponent(query)}&per_page=${DIGEST_LIST_LIMIT}`
+  );
+  if (!response) {
+    return null;
+  }
+
+  return {
+    total: response.total_count,
+    items: response.items.map((item) => ({
+      number: item.number,
+      title: item.title,
+      url: item.html_url,
+    })),
+  };
+}
+
 const NIGHTLY_TESTS_WEBSITE_URL =
   'https://react-native-community.github.io/nightly-tests/';
 
@@ -310,8 +355,52 @@ function formatFailingBadge(badge: BadgeResult): string[] {
   return lines;
 }
 
+function formatDigestSection(status: DigestStatus): string {
+  if (status.kind === 'unknown') {
+    return [
+      '*Daily digest (last 24h)*',
+      '⚠️ Could not fetch repository activity from the GitHub API.',
+    ].join('\n');
+  }
+
+  const { mergedPullRequests, newIssues, closedIssues } = status.digest;
+  return [
+    '*Daily digest (last 24h)*',
+    formatDigestCategory('🔀 Merged pull requests', mergedPullRequests),
+    formatDigestCategory('🆕 New issues', newIssues),
+    formatDigestCategory('☑️ Closed issues', closedIssues),
+  ].join('\n\n');
+}
+
+function formatDigestCategory(
+  heading: string,
+  category: DigestCategory
+): string {
+  const lines = [`${heading}: ${category.total}`];
+
+  for (const item of category.items) {
+    lines.push(
+      `• <${item.url}|#${item.number}> ${escapeSlackText(item.title)}`
+    );
+  }
+
+  const hidden = category.total - category.items.length;
+  if (hidden > 0) {
+    lines.push(`• …and ${hidden} more`);
+  }
+
+  return lines.join('\n');
+}
+
+function escapeSlackText(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
 main().catch((err: unknown) => {
-  console.error('Error posting GitHub Actions badge status to Slack:', err);
+  console.error('Error posting daily report to Slack:', err);
   process.exitCode = 1;
 });
 
@@ -378,3 +467,35 @@ type NightlyFailure = {
 type NightlyStatus =
   | { kind: 'ok'; failures: NightlyFailure[] }
   | { kind: 'unknown' };
+
+type DigestItem = {
+  number: number;
+  title: string;
+  url: string;
+};
+
+type DigestCategory = {
+  total: number;
+  items: DigestItem[];
+};
+
+type DailyDigest = {
+  mergedPullRequests: DigestCategory;
+  newIssues: DigestCategory;
+  closedIssues: DigestCategory;
+};
+
+type DigestStatus =
+  | { kind: 'ok'; digest: DailyDigest }
+  | { kind: 'unknown' };
+
+type IssueSearchItem = {
+  number: number;
+  title: string;
+  html_url: string;
+};
+
+type IssueSearchResponse = {
+  total_count: number;
+  items: IssueSearchItem[];
+};

--- a/.github/workflows/slack-integration.yml
+++ b/.github/workflows/slack-integration.yml
@@ -156,6 +156,8 @@ jobs:
     permissions:
       contents: read
       actions: read
+      issues: read
+      pull-requests: read
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
@@ -176,14 +178,14 @@ jobs:
           pattern: bundle-cost-*
         continue-on-error: true
 
-      - name: Report failing badges, RN nightly tests and bundle cost
+      - name: Report failing badges, RN nightly tests, bundle cost and daily digest
         env:
           BUNDLE_COST_DIR: /tmp/bundle-cost-results
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           EXPECTED_MATRIX: ${{ needs.read-bundle-cost-matrix.outputs.matrix }}
           MEASURE_RESULT: ${{ needs.measure-bundle-cost.result }}
-        run: node --experimental-strip-types .github/workflows/helper/nightly-fail-notification.ts
+        run: node --experimental-strip-types .github/workflows/helper/daily-report-notification.ts
 
   issue-opened-report:
     if: github.repository == 'software-mansion/react-native-reanimated' && github.event_name == 'issues'


### PR DESCRIPTION
> [!NOTE] **This PR description is AI-generated.**

## Summary

The daily Slack report covered CI health (failing badges, RN nightly tests, bundle cost) but gave no view of repository activity. I added a digest of the last 24 hours — merged pull requests, new issues, and closed issues — appended as a section to the same daily message.

The digest reuses the existing `githubApi` helper to query the GitHub Search API for the three categories, listing each category's total and linking up to 10 items with an "…and N more" overflow line. Fetch failures collapse to a single "status unknown" line via the same `{ kind: 'ok' | 'unknown' }` pattern the nightly section uses. I renamed `nightly-fail-notification.ts` to `daily-report-notification.ts` since it now covers more than failures, and gave the daily job `issues: read` / `pull-requests: read` for the search queries.

## Test plan

Ran the three search queries against the live API (16 merged PRs / 6 new issues / 5 closed issues in the last day) and rendered the Slack section from that data — counts, the per-category cap, and mrkdwn links format correctly. `tsc` over the helper scripts passes.
