### PR TITLE
fix: run transitions with callbacks on the loop instead of the platform

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSLoopTransition.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSLoopTransition.cpp
@@ -76,17 +76,6 @@ void CSSLoopTransition::updateSettings(
   progressProvider_.setPropertySettings(changedPropertiesSettings);
 }
 
-void CSSLoopTransition::trackProperties(
-    const PropertiesSettingsMap &propertiesSettings,
-    const std::vector<std::string> &propertyNames,
-    const double timestamp) {
-  progressProvider_.setPropertySettings(propertiesSettings);
-  for (const auto &propertyName : propertyNames) {
-    // The platform gets no reversing state, so it always runs the full duration.
-    progressProvider_.runProgressProvider(propertyName, false, timestamp);
-  }
-}
-
 folly::dynamic CSSLoopTransition::computeCurrentStyle(const std::shared_ptr<const ShadowNode> &shadowNode) {
   auto result = styleInterpolator_.interpolate(shadowNode, progressProvider_);
   // Remove interpolators for which interpolation has finished

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSLoopTransition.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSLoopTransition.h
@@ -50,10 +50,6 @@ class CSSLoopTransition : public OperationsLoop::LoopOperation, public std::enab
       double timestamp);
 
   /// Tracks the lifecycle of properties whose rendering is routed to the platform.
-  void trackProperties(
-      const PropertiesSettingsMap &propertiesSettings,
-      const std::vector<std::string> &propertyNames,
-      double timestamp);
 
   folly::dynamic computeCurrentStyle(const std::shared_ptr<const ShadowNode> &shadowNode);
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.cpp
@@ -41,6 +41,7 @@ CSSTransitionConfig CSSPlatformTransitionProxy::processConfig(
     const Tag viewTag,
     const CSSTransitionConfig &config,
     CSSTransitionRouting &routing,
+    const bool allowPlatform,
     const double timestamp) const {
   CSSTransitionConfig loopConfig;
 #ifndef NDEBUG
@@ -56,7 +57,7 @@ CSSTransitionConfig CSSPlatformTransitionProxy::processConfig(
     }
 #endif // NDEBUG
 
-    bool routable = canRoute(propertyName, settings.easingConfig);
+    bool routable = allowPlatform && canRoute(propertyName, settings.easingConfig);
     if (routable && hasValue) {
       const auto values = parsePlatformValues(rt, propertyName, valueIt->second.first, valueIt->second.second);
       // React commits the config path's target, so there is nothing to hold afterwards.
@@ -107,17 +108,20 @@ PropertyValueDynamicDiffsMap CSSPlatformTransitionProxy::processDynamicDiffs(
     const PropertyValueDynamicDiffsMap &propertyDiffs,
     const TransitionProperties &pseudoLockedProperties,
     CSSTransitionRouting &routing,
+    const bool allowPlatform,
     const double timestamp) const {
   PropertyValueDynamicDiffsMap loopDiffs;
   for (const auto &[propertyName, propertyDiff] : propertyDiffs) {
     // A platform-routed property keeps animating natively while the platform can
     // still express the toggled value; otherwise it migrates to the loop.
     if (routing.platform.contains(propertyName)) {
-      const auto values = parsePlatformValues(propertyName, propertyDiff.first, propertyDiff.second);
-      // Releasing the last selector targets the committed style, which needs no hold.
-      const bool persistent = pseudoLockedProperties.contains(propertyName);
-      if (values && apply(viewTag, propertyName, values->first, values->second, nullptr, persistent, timestamp)) {
-        continue;
+      if (allowPlatform) {
+        const auto values = parsePlatformValues(propertyName, propertyDiff.first, propertyDiff.second);
+        // Releasing the last selector targets the committed style, which needs no hold.
+        const bool persistent = pseudoLockedProperties.contains(propertyName);
+        if (values && apply(viewTag, propertyName, values->first, values->second, nullptr, persistent, timestamp)) {
+          continue;
+        }
       }
       routing.platform.erase(propertyName);
       remove(viewTag, propertyName);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.h
@@ -59,6 +59,7 @@ class CSSPlatformTransitionProxy {
       Tag viewTag,
       const CSSTransitionConfig &config,
       CSSTransitionRouting &routing,
+      bool allowPlatform,
       double timestamp) const;
 
   /// Re-routes pseudo-selector toggle diffs: a property the platform can no longer
@@ -69,6 +70,7 @@ class CSSPlatformTransitionProxy {
       const PropertyValueDynamicDiffsMap &propertyDiffs,
       const TransitionProperties &pseudoLockedProperties,
       CSSTransitionRouting &routing,
+      bool allowPlatform,
       double timestamp) const;
 
   /// Cancels the native transition of every given property (teardown).

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.cpp
@@ -44,13 +44,16 @@ folly::dynamic CSSTransition::run(jsi::Runtime &rt, CSSTransitionConfig &&config
     std::erase(config.removedProperties, propertyName);
   }
 
-  auto loopConfig = platformTransitionProxy_->processConfig(rt, getViewTag(), config, routing_, timestamp);
+  // TODO: add support for events reported by the platform itself; until then
+  // a view with transition callbacks keeps every property on the loop, where
+  // timing and events already pair up.
+  auto loopConfig =
+      platformTransitionProxy_->processConfig(rt, getViewTag(), config, routing_, eventMask_ == 0, timestamp);
 
   if (!loopConfig.empty()) {
     ensureLoopTransition().updateSettings(
         loopConfig.changedPropertiesSettings, loopConfig.removedProperties, timestamp);
   }
-  trackPlatformLifecycles(config, timestamp);
 
   // Settings-only configs reconfigure without running.
   if (!loopConfig.hasValueUpdates()) {
@@ -63,40 +66,13 @@ folly::dynamic CSSTransition::run(jsi::Runtime &rt, CSSTransitionConfig &&config
   return initialUpdate;
 }
 
-// TODO: add support for events reported by the platform itself; until then
-// the lifecycle of platform-routed properties temporarily runs on the loop path.
-void CSSTransition::trackPlatformLifecycles(const CSSTransitionConfig &config, const double timestamp) {
-  if (eventMask_ == 0) {
-    return;
-  }
-
-  if (loopTransition_ && !config.removedProperties.empty()) {
-    loopTransition_->removeProperties(config.removedProperties, timestamp);
-  }
-
-  PropertiesSettingsMap propertiesSettings;
-  std::vector<std::string> propertyNames;
-  for (const auto &[propertyName, value] : config.changedProperties) {
-    if (routing_.platform.contains(propertyName)) {
-      propertyNames.push_back(propertyName);
-      propertiesSettings.emplace(propertyName, config.changedPropertiesSettings.at(propertyName));
-    }
-  }
-  if (propertyNames.empty()) {
-    return;
-  }
-
-  ensureLoopTransition().trackProperties(propertiesSettings, propertyNames, timestamp);
-  scheduleLoop(timestamp);
-}
-
 folly::dynamic CSSTransition::run(
     const PropertyValueDynamicDiffsMap &propertyDiffs,
     const folly::dynamic &lastUpdates) {
   const auto timestamp = loop_->resolveTimestamp();
 
   auto loopDiffs = platformTransitionProxy_->processDynamicDiffs(
-      getViewTag(), propertyDiffs, pseudoLockedProperties_, routing_, timestamp);
+      getViewTag(), propertyDiffs, pseudoLockedProperties_, routing_, eventMask_ == 0, timestamp);
   if (loopDiffs.empty() && !loopTransition_) {
     return folly::dynamic::object();
   }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.h
@@ -79,7 +79,6 @@ class CSSTransition {
 
   CSSLoopTransition &ensureLoopTransition();
   void scheduleLoop(double timestamp);
-  void trackPlatformLifecycles(const CSSTransitionConfig &config, double timestamp);
   void observeMilestones(CSSLoopTransition &loopTransition);
   void reportMilestone(RunMilestone milestone, const std::string &propertyName, double elapsedTime);
   void emitEvent(CSSEventType type, const std::string &propertyName, double elapsedTime) const;


### PR DESCRIPTION
A CSS transition on a platform-routed property crashes the app when the view also has a transition callback prop:

```
libc++abi: terminating due to uncaught exception of type
std::out_of_range: unordered_map::at: key not found
```

Since the platform cannot report transition events yet, `trackPlatformLifecycles` registered a loop progress provider for routed properties just to fire their lifecycle events. Such a provider has no matching interpolator, and `interpolate()` looks one up for every provider, so it threw.

Instead of guarding the lookup, keep every property of a view with transition callbacks on the loop and remove the lifecycle-only tracking. Properties already routed when a callback shows up migrate through the existing demotion path in `processConfig`. Platform routing can come back for these views once the platform reports events itself.

Verified on the iOS simulator: the repro (`onCSSTransitionEnd` + `opacity` transition, toggled every 500ms) crashes main within 10s. With this change: 228 toggles, 228 start and 228 end events, no crash. Attaching the callback mid-flight also works (every transition after the attach reported its end).