### PR TITLE
fix(iOS): guard against nil _performOperations block in REANodesManager

### DIFF
--- a/packages/react-native-reanimated/CHANGELOG.md
+++ b/packages/react-native-reanimated/CHANGELOG.md
@@ -10,4 +10,6 @@
 
 ### 🐛 Bug fixes
 
+- Fix `EXC_BAD_ACCESS` crash in `-[REANodesManager performOperations]` when called before the `_performOperations` block is registered on iOS. ([#10229](https://github.com/software-mansion/react-native-reanimated/pull/10229) by [@tomekzaw](https://github.com/tomekzaw))
+
 ### 💡 Others

--- a/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.mm
@@ -125,7 +125,11 @@ using namespace facebook::react;
 - (void)performOperations
 {
   RCTAssertMainQueue();
-  _performOperations(); // calls ReanimatedModuleProxy::performOperations
+  REAPerformOperations performOperations = _performOperations;
+  if (performOperations == nil) {
+    return;
+  }
+  performOperations(); // calls ReanimatedModuleProxy::performOperations
 }
 
 - (void)dispatchEvent:(id<RCTEvent>)event


### PR DESCRIPTION
> [!NOTE]
> This pull request was authored by AI on behalf of @tomekzaw.

## Summary

Fixes #10135.

`-[REANodesManager performOperations]` can be invoked on the main queue before `registerPerformOperations:` has run on the JS queue, in which case calling the nil `_performOperations` block crashes with `EXC_BAD_ACCESS` at `0x10`. This PR reads the block ivar into a local and returns early when it is nil. Skipping a flush is harmless — pending updates are picked up on the next drain.

This fix was tested and proved to be successful in a production app that we develop at Software Mansion.

## Test plan

Trigger an early main-queue drain (e.g. `maybeFlushUIUpdatesQueue` racing module initialization, as described in #10135) before the JS queue registers the block — the app no longer crashes on launch and animations work as expected afterwards.

## Changelog

- [x] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.