### PR TITLE
fix(ci): list up to 100 digest entries per category instead of 10

### DIFF
--- a/.github/workflows/helper/daily-report-notification.ts
+++ b/.github/workflows/helper/daily-report-notification.ts
@@ -249,7 +249,7 @@ async function getRNNightlyFailures(): Promise<NightlyStatus> {
 
 const DIGEST_REPO = 'software-mansion/react-native-reanimated';
 const DIGEST_WINDOW_HOURS = 24;
-const DIGEST_LIST_LIMIT = 10;
+const DIGEST_LIST_LIMIT = 100;
 
 async function getDailyDigest(): Promise<DigestStatus> {
   const since = new Date(Date.now() - DIGEST_WINDOW_HOURS * 60 * 60 * 1000)


### PR DESCRIPTION
> [!NOTE] **This PR description is AI-generated.**

## Summary

Follow-up to #10223. The daily digest capped each category (merged PRs, new issues, closed issues) at 10 entries and appended an "…and N more" line, which truncated the lists on busy days.

I raised `DIGEST_LIST_LIMIT` to 100 — the GitHub Search API's maximum `per_page` — so a 24-hour window lists in full in a single request. The overflow line now only appears if a category somehow exceeds 100 items in one day.

## Test plan

Rendered the digest from live data — all merged PRs list without the "…and N more" line. `oxfmt --check` and `tsc` pass.
