### PR TITLE
chore: animate SVG pseudo selectors through animatedProps

### DIFF
--- a/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/Active.tsx
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/Active.tsx
@@ -1,4 +1,3 @@
-import type { ComponentType } from 'react';
 import { StyleSheet } from 'react-native';
 import Animated from 'react-native-reanimated';
 // TODO: Fix me
@@ -14,9 +13,7 @@ import {
 } from '@/apps/css/components';
 import { colors, radius, sizes, spacing } from '@/theme';
 
-const AnimatedCircle = Animated.createAnimatedComponent(
-  Circle
-) as ComponentType<Record<string, unknown>>;
+const AnimatedCircle = Animated.createAnimatedComponent(Circle);
 
 export default function Active() {
   return (
@@ -202,12 +199,13 @@ transform: {
 
           <VerticalExampleCard
             title="SVG fill"
-            code={`// Base geometry stays as real props so it renders at rest;
-// the ':active' style only swaps the changing prop.
+            code={`// SVG components are styled through props, so their CSS goes
+// in 'animatedProps'. Base geometry stays as real props so the
+// circle renders at rest.
 <AnimatedCircle
   cx={20} cy={20} r={18}
   fill={colors.primary}
-  style={{
+  animatedProps={{
     fill: { default: colors.primary, ':active': colors.primaryDark },
     transitionDuration: '200ms',
   }}
@@ -219,17 +217,17 @@ transform: {
 },`}>
             <Svg height={sizes.md} width={sizes.md}>
               <AnimatedCircle
-                cx={sizes.md / 2}
-                cy={sizes.md / 2}
-                fill={colors.primary}
-                r={sizes.md / 2 - 2}
-                style={{
+                animatedProps={{
                   fill: {
                     ':active': colors.primaryDark,
                     default: colors.primary,
                   },
                   transitionDuration: '200ms',
                 }}
+                cx={sizes.md / 2}
+                cy={sizes.md / 2}
+                fill={colors.primary}
+                r={sizes.md / 2 - 2}
                 onStartShouldSetResponder={() => true}
               />
             </Svg>
@@ -241,7 +239,7 @@ transform: {
 <AnimatedCircle
   cx={24} cy={24} fill={colors.primary}
   r={22}
-  style={{
+  animatedProps={{
     r: { default: 22, ':active': 12 },
     transitionDuration: '200ms',
   }}
@@ -253,14 +251,14 @@ transform: {
 },`}>
             <Svg height={sizes.md} width={sizes.md}>
               <AnimatedCircle
+                animatedProps={{
+                  r: { ':active': sizes.md / 4, default: sizes.md / 2 - 2 },
+                  transitionDuration: '200ms',
+                }}
                 cx={sizes.md / 2}
                 cy={sizes.md / 2}
                 fill={colors.primary}
                 r={sizes.md / 2 - 2}
-                style={{
-                  r: { ':active': sizes.md / 4, default: sizes.md / 2 - 2 },
-                  transitionDuration: '200ms',
-                }}
                 onStartShouldSetResponder={() => true}
               />
             </Svg>

--- a/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/Active.tsx
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/Active.tsx
@@ -217,6 +217,10 @@ transform: {
 },`}>
             <Svg height={sizes.md} width={sizes.md}>
               <AnimatedCircle
+                cx={sizes.md / 2}
+                cy={sizes.md / 2}
+                fill={colors.primary}
+                r={sizes.md / 2 - 2}
                 animatedProps={{
                   fill: {
                     ':active': colors.primaryDark,
@@ -224,10 +228,6 @@ transform: {
                   },
                   transitionDuration: '200ms',
                 }}
-                cx={sizes.md / 2}
-                cy={sizes.md / 2}
-                fill={colors.primary}
-                r={sizes.md / 2 - 2}
                 onStartShouldSetResponder={() => true}
               />
             </Svg>
@@ -251,14 +251,14 @@ transform: {
 },`}>
             <Svg height={sizes.md} width={sizes.md}>
               <AnimatedCircle
-                animatedProps={{
-                  r: { ':active': sizes.md / 4, default: sizes.md / 2 - 2 },
-                  transitionDuration: '200ms',
-                }}
                 cx={sizes.md / 2}
                 cy={sizes.md / 2}
                 fill={colors.primary}
                 r={sizes.md / 2 - 2}
+                animatedProps={{
+                  r: { ':active': sizes.md / 4, default: sizes.md / 2 - 2 },
+                  transitionDuration: '200ms',
+                }}
                 onStartShouldSetResponder={() => true}
               />
             </Svg>

--- a/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/Hover.tsx
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/Hover.tsx
@@ -1,4 +1,3 @@
-import type { ComponentType } from 'react';
 import { StyleSheet, View } from 'react-native';
 import Animated from 'react-native-reanimated';
 /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
@@ -14,9 +13,7 @@ import {
 } from '@/apps/css/components';
 import { colors, radius, sizes, spacing } from '@/theme';
 
-const AnimatedCircle = Animated.createAnimatedComponent(
-  Circle
-) as ComponentType<Record<string, unknown>>;
+const AnimatedCircle = Animated.createAnimatedComponent(Circle);
 
 export default function Hover() {
   return (
@@ -286,7 +283,7 @@ shadowOpacity: {
   {/* Back circle - drawn first, so it sits underneath */}
   <AnimatedCircle
     cx={95} cy={90} r={65} fill="#fca5a5"
-    style={{
+    animatedProps={{
       fill: { default: '#fca5a5', ':hover': '#dc2626' },
       transitionDuration: '150ms',
     }}
@@ -295,7 +292,7 @@ shadowOpacity: {
   {/* Front circle - drawn last, so it sits on top */}
   <AnimatedCircle
     cx={145} cy={90} r={65} fill="#93c5fd"
-    style={{
+    animatedProps={{
       fill: { default: '#93c5fd', ':hover': '#2563eb' },
       transitionDuration: '150ms',
     }}
@@ -309,31 +306,31 @@ shadowOpacity: {
             <View style={styles.stage}>
               <Svg height={180} width={240}>
                 <AnimatedCircle
-                  cx={95}
-                  cy={90}
-                  fill="#fca5a5"
-                  r={65}
-                  style={{
+                  animatedProps={{
                     fill: {
                       ':hover': '#dc2626',
                       default: '#fca5a5',
                     },
                     transitionDuration: '150ms',
                   }}
+                  cx={95}
+                  cy={90}
+                  fill="#fca5a5"
+                  r={65}
                   onStartShouldSetResponder={() => true}
                 />
                 <AnimatedCircle
-                  cx={145}
-                  cy={90}
-                  fill="#93c5fd"
-                  r={65}
-                  style={{
+                  animatedProps={{
                     fill: {
                       ':hover': '#2563eb',
                       default: '#93c5fd',
                     },
                     transitionDuration: '150ms',
                   }}
+                  cx={145}
+                  cy={90}
+                  fill="#93c5fd"
+                  r={65}
                   onStartShouldSetResponder={() => true}
                 />
               </Svg>

--- a/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/Hover.tsx
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/Hover.tsx
@@ -306,6 +306,10 @@ shadowOpacity: {
             <View style={styles.stage}>
               <Svg height={180} width={240}>
                 <AnimatedCircle
+                  cx={95}
+                  cy={90}
+                  fill="#fca5a5"
+                  r={65}
                   animatedProps={{
                     fill: {
                       ':hover': '#dc2626',
@@ -313,13 +317,13 @@ shadowOpacity: {
                     },
                     transitionDuration: '150ms',
                   }}
-                  cx={95}
-                  cy={90}
-                  fill="#fca5a5"
-                  r={65}
                   onStartShouldSetResponder={() => true}
                 />
                 <AnimatedCircle
+                  cx={145}
+                  cy={90}
+                  fill="#93c5fd"
+                  r={65}
                   animatedProps={{
                     fill: {
                       ':hover': '#2563eb',
@@ -327,10 +331,6 @@ shadowOpacity: {
                     },
                     transitionDuration: '150ms',
                   }}
-                  cx={145}
-                  cy={90}
-                  fill="#93c5fd"
-                  r={65}
                   onStartShouldSetResponder={() => true}
                 />
               </Svg>


### PR DESCRIPTION
SVG attributes are component props, not React Native `style` keys, so their CSS belongs in `animatedProps`. The pseudo selector examples used `style` instead, which only compiled because `AnimatedCircle` was cast to `ComponentType<Record<string, unknown>>` and lost all prop checking.

Moves those examples onto `animatedProps` and drops the cast, so `style` on an animated SVG component is a type error again.