### PR TITLE
docs: document SVG pseudo selectors on animatedProps

### DIFF
--- a/docs/docs-reanimated/docs/css-transitions/pseudo-selectors.mdx
+++ b/docs/docs-reanimated/docs/css-transitions/pseudo-selectors.mdx
@@ -195,7 +195,9 @@ The button drifts between colors over 600ms, but snaps down in 100ms when presse
 
 ## Animating SVG components
 
-Pseudo selectors work on [`react-native-svg`](https://github.com/software-mansion/react-native-svg) components too. Put the pseudo objects for SVG attributes like `fill` or `r` in `style`, and keep the resting geometry on the props themselves so the shape still renders before any interaction. For everything else about animating SVG, see [Animating SVG](/docs/guides/animating-svg).
+Pseudo selectors work on [`react-native-svg`](https://github.com/software-mansion/react-native-svg) components too. SVG attributes such as `fill` or `r` are component props rather than React Native `style` keys, so their pseudo objects go in `animatedProps`, not in `style`. For everything else about animating SVG, see [Animating SVG](/docs/guides/animating-svg).
+
+Give every animated attribute a resting value, either as `default` inside the pseudo object or as the plain prop - both work, and `default` wins when you write both. With neither, the attribute falls back to its own default, which for `r` means the shape renders at `0`.
 
 import PseudoSelectorsSvg from '@site/src/examples/css-transitions/PseudoSelectorsSvg';
 import PseudoSelectorsSvgSrc from '!!raw-loader!@site/src/examples/css-transitions/PseudoSelectorsSvg';

--- a/docs/docs-reanimated/src/examples/css-transitions/PseudoSelectorsSvg.tsx
+++ b/docs/docs-reanimated/src/examples/css-transitions/PseudoSelectorsSvg.tsx
@@ -1,13 +1,8 @@
-import type React from 'react';
 import { StyleSheet, View } from 'react-native';
 import Animated from 'react-native-reanimated';
-import type { CircleProps } from 'react-native-svg';
 import { Circle, Svg } from 'react-native-svg';
 
-// react-native-svg accepts `style`, but its prop types don't declare it yet.
-const AnimatedCircle = Animated.createAnimatedComponent(
-  Circle
-) as React.ComponentType<CircleProps & { style?: object }>;
+const AnimatedCircle = Animated.createAnimatedComponent(Circle);
 
 const CIRCLES = [
   { cx: '20%', color: '#fa7f7c' },
@@ -20,14 +15,15 @@ export default function App() {
     <View style={styles.container}>
       <Svg style={styles.svg}>
         {CIRCLES.map(({ cx, color }) => (
-          // Base geometry stays on the props so the circle renders at rest.
+          // `default` inside each pseudo object is the resting value, so the
+          // plain `r` and `fill` props below are optional here.
           <AnimatedCircle
             key={cx}
             cx={cx}
             cy="50%"
             r={28}
             fill={color}
-            style={{
+            animatedProps={{
               // highlight-start
               fill: { default: color, ':hover': '#ffe780' },
               r: { default: 28, ':hover': 44 },


### PR DESCRIPTION
The pseudo selectors page tells users to put the pseudo objects for SVG attributes in `style`, which contradicts the Animating SVG guide - SVG attributes are component props, so their CSS goes in `animatedProps`. The page example only compiled because it cast `style?: object` onto `CircleProps`.

Rewrites that section and its example, and drops the cast.

This PR is stacked on #10516, which bumps the docs site to Reanimated 4.6.0 and includes the required fix from #10123. Merge #10516 first.