### PR TITLE
fix: Play CSS transition delays inside the animation

### DIFF
--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
@@ -42,6 +42,20 @@ internal class CSSPlatformTransitionsManager(
         fun currentValue(): Float = heldValue ?: if (animator.isRunning) animator.animatedValue as Float else startValue
     }
 
+    /** Holds the start value for [delayFraction], then plays [inner] over the rest. */
+    private class HoldThenEase(
+        private val delayFraction: Float,
+        private val inner: TimeInterpolator,
+    ) : TimeInterpolator {
+        override fun getInterpolation(input: Float): Float {
+            if (input < delayFraction) return 0f
+            // A zero duration is all delay, so the target only lands on the final frame.
+            if (delayFraction >= 1f) return 1f
+            // Not `<=` above: at the boundary a jump-start step already owes its first step.
+            return inner.getInterpolation((input - delayFraction) / (1f - delayFraction))
+        }
+    }
+
     private data class InterpolatorKey(
         val type: Int,
         val pointsX: List<Float>,
@@ -133,8 +147,6 @@ internal class CSSPlatformTransitionsManager(
         writer.setValue(view, startValue)
 
         val animator = ObjectAnimator.ofFloat(view, writer, startValue, toValue.toFloat())
-        animator.interpolator = interpolator
-        animator.duration = (durationMs / scale).toLong().coerceAtLeast(1L)
         animator.addListener(
             object : AnimatorListenerAdapter() {
                 override fun onAnimationEnd(animation: Animator) {
@@ -153,7 +165,12 @@ internal class CSSPlatformTransitionsManager(
         // ObjectAnimator has no absolute start time, so resolve it after the thread hop
         // rather than in C++, which would shift the timeline late.
         val elapsedMs = animationTimestamp().toDouble() - startTimestampMs
-        if (elapsedMs < 0) animator.startDelay = (-elapsedMs / scale).toLong()
+        val delayMs = if (elapsedMs < 0) -elapsedMs else 0.0
+        // startDelay writes nothing while it waits, so a commit landing in the delay would
+        // stay on screen. Folding the delay into the curve rewrites the property instead.
+        animator.duration = ((delayMs + durationMs) / scale).toLong().coerceAtLeast(1L)
+        animator.interpolator =
+            if (delayMs > 0) HoldThenEase((delayMs / (delayMs + durationMs)).toFloat(), interpolator) else interpolator
         if (elapsedMs > 0 && durationMs > 0) {
             // Seek first: start() gates on `mSeekFraction >= 0`, so a later seek races frame one.
             animator.setCurrentFraction((elapsedMs / durationMs).toFloat().coerceIn(0f, 1f))


### PR DESCRIPTION
A delayed `ObjectAnimator` writes nothing while it waits, so a React commit landing inside the delay window stays on screen until the animation finally starts.

Drops `startDelay` and folds the delay into the curve instead: the animator runs for delay + duration, and a composed interpolator holds the start value over the leading fraction, so the property is rewritten every frame including throughout the delay. This is what `kCAFillModeBackwards` gives us on Apple.