### PR TITLE
fix: Derive the persistent CSS transition hold from the pseudo lock

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.cpp
@@ -24,8 +24,10 @@ bool CSSPlatformTransitionProxy::apply(
     const PlatformValue &fromValue,
     const PlatformValue &toValue,
     const CSSTransitionPropertySettings *settings,
+    const bool persistent,
     const double timestamp) const {
-  return applyTransition_ && applyTransition_(viewTag, propertyName, fromValue, toValue, settings, timestamp);
+  return applyTransition_ &&
+      applyTransition_(viewTag, propertyName, fromValue, toValue, settings, persistent, timestamp);
 }
 
 void CSSPlatformTransitionProxy::remove(const Tag viewTag, const std::string &propertyName) const {
@@ -57,7 +59,8 @@ CSSTransitionConfig CSSPlatformTransitionProxy::processConfig(
     bool routable = canRoute(propertyName, settings.easingConfig);
     if (routable && hasValue) {
       const auto values = parsePlatformValues(rt, propertyName, valueIt->second.first, valueIt->second.second);
-      routable = values && apply(viewTag, propertyName, values->first, values->second, &settings, timestamp);
+      // React commits the config path's target, so there is nothing to hold afterwards.
+      routable = values && apply(viewTag, propertyName, values->first, values->second, &settings, false, timestamp);
     } else if (routable) {
       // Settings-only: stay on the platform only if already animating there.
       routable = routing.platform.contains(propertyName);
@@ -102,6 +105,7 @@ CSSTransitionConfig CSSPlatformTransitionProxy::processConfig(
 PropertyValueDynamicDiffsMap CSSPlatformTransitionProxy::processDynamicDiffs(
     const Tag viewTag,
     const PropertyValueDynamicDiffsMap &propertyDiffs,
+    const TransitionProperties &pseudoLockedProperties,
     CSSTransitionRouting &routing,
     const double timestamp) const {
   PropertyValueDynamicDiffsMap loopDiffs;
@@ -110,7 +114,9 @@ PropertyValueDynamicDiffsMap CSSPlatformTransitionProxy::processDynamicDiffs(
     // still express the toggled value; otherwise it migrates to the loop.
     if (routing.platform.contains(propertyName)) {
       const auto values = parsePlatformValues(propertyName, propertyDiff.first, propertyDiff.second);
-      if (values && apply(viewTag, propertyName, values->first, values->second, nullptr, timestamp)) {
+      // Releasing the last selector targets the committed style, which needs no hold.
+      const bool persistent = pseudoLockedProperties.contains(propertyName);
+      if (values && apply(viewTag, propertyName, values->first, values->second, nullptr, persistent, timestamp)) {
         continue;
       }
       routing.platform.erase(propertyName);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.h
@@ -21,13 +21,15 @@ using namespace react;
 using CSSCanRoutePropertyFunction = std::function<bool(const std::string &propertyName, const EasingConfig &easing)>;
 /// Animates a routed property natively; a false return falls back to the loop.
 /// `settings` is null on the pseudo-selector toggle path, where the backend reuses
-/// the settings captured at config-apply time and holds the animation persistently.
+/// the settings captured at config-apply time. `persistent` means the target has no
+/// committed style behind it, so the backend must hold the value past the animation.
 using CSSApplyTransitionFunction = std::function<bool(
     Tag viewTag,
     const std::string &propertyName,
     const PlatformValue &fromValue,
     const PlatformValue &toValue,
     const CSSTransitionPropertySettings *settings,
+    bool persistent,
     double timestamp)>;
 /// Cancels the property's native transition and drops its platform-side state.
 using CSSRemoveTransitionFunction = std::function<void(Tag viewTag, const std::string &propertyName)>;
@@ -61,9 +63,11 @@ class CSSPlatformTransitionProxy {
 
   /// Re-routes pseudo-selector toggle diffs: a property the platform can no longer
   /// express migrates to the loop. Updates `routing`, returns the loop diffs.
+  /// Only a property still pseudo-locked after the toggle needs its value held.
   PropertyValueDynamicDiffsMap processDynamicDiffs(
       Tag viewTag,
       const PropertyValueDynamicDiffsMap &propertyDiffs,
+      const TransitionProperties &pseudoLockedProperties,
       CSSTransitionRouting &routing,
       double timestamp) const;
 
@@ -78,6 +82,7 @@ class CSSPlatformTransitionProxy {
       const PlatformValue &fromValue,
       const PlatformValue &toValue,
       const CSSTransitionPropertySettings *settings,
+      bool persistent,
       double timestamp) const;
   void remove(Tag viewTag, const std::string &propertyName) const;
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.cpp
@@ -61,7 +61,8 @@ folly::dynamic CSSTransition::run(
     const folly::dynamic &lastUpdates) {
   const auto timestamp = loop_->resolveTimestamp();
 
-  auto loopDiffs = platformTransitionProxy_->processDynamicDiffs(getViewTag(), propertyDiffs, routing_, timestamp);
+  auto loopDiffs = platformTransitionProxy_->processDynamicDiffs(
+      getViewTag(), propertyDiffs, pseudoLockedProperties_, routing_, timestamp);
   if (loopDiffs.empty() && !loopTransition_) {
     return folly::dynamic::object();
   }

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
@@ -53,6 +53,7 @@ bool CSSPlatformTransitions::applyTransition(
     const css::PlatformValue &fromValue,
     const css::PlatformValue &toValue,
     const css::CSSTransitionPropertySettings *settings,
+    const bool persistent,
     const double timestamp) {
   // Only scalars are routed today (opacity); anything else stays on the loop.
   const auto *from = std::get_if<double>(&fromValue);
@@ -99,7 +100,7 @@ bool CSSPlatformTransitions::applyTransition(
           reversing.duration,
           reversing.startTimestamp,
           toPlatformEasing(resolvedSettings.easingConfig),
-          settings == nullptr)) {
+          persistent)) {
     return false;
   }
 

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
@@ -54,6 +54,7 @@ class CSSPlatformTransitions {
       const css::PlatformValue &fromValue,
       const css::PlatformValue &toValue,
       const css::CSSTransitionPropertySettings *settings,
+      bool persistent,
       double timestamp);
 
   void removeTransition(Tag viewTag, const std::string &propertyName);

--- a/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.h
@@ -18,13 +18,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithSurfacePresenter:(RCTSurfacePresenter *)surfacePresenter;
 
 /// Animates the property natively and remembers its settings for later toggles.
-/// A null `settings` marks the toggle path: the stored settings are reused and the
-/// animation is held persistently. Returns NO when there are none to reuse.
+/// A null `settings` marks the toggle path, where the stored settings are reused;
+/// returns NO when there are none. `persistent` holds the value past the animation.
 - (BOOL)applyTransitionForTag:(facebook::react::Tag)viewTag
                  propertyName:(const std::string &)propertyName
                     fromValue:(const reanimated::css::PlatformValue &)fromValue
                       toValue:(const reanimated::css::PlatformValue &)toValue
                      settings:(nullable const reanimated::css::CSSTransitionPropertySettings *)settings
+                   persistent:(BOOL)persistent
                     timestamp:(double)timestamp;
 
 - (void)removeTransitionForTag:(facebook::react::Tag)viewTag propertyName:(const std::string &)propertyName;

--- a/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.mm
@@ -73,17 +73,18 @@ struct ActiveTransition {
                     fromValue:(const PlatformValue &)fromValue
                       toValue:(const PlatformValue &)toValue
                      settings:(const CSSTransitionPropertySettings *)settings
+                   persistent:(BOOL)persistent
                     timestamp:(double)timestamp
 {
   const ActiveTransition *active = [self activeTransitionForTag:viewTag propertyName:propertyName];
 
-  // The toggle path has no settings of its own and holds its value indefinitely.
-  const BOOL persistent = settings == nullptr;
-  if (persistent && active == nullptr) {
+  // The toggle path has no settings of its own, so it reuses the stored ones.
+  const BOOL reusesStoredSettings = settings == nullptr;
+  if (reusesStoredSettings && active == nullptr) {
     return NO;
   }
   // Copy: the active entry is re-assigned below.
-  const CSSTransitionPropertySettings resolvedSettings = persistent ? active->settings : *settings;
+  const CSSTransitionPropertySettings resolvedSettings = reusesStoredSettings ? active->settings : *settings;
 
   // Targeting the in-flight transition's start value means this is a reversal.
   const bool isReversal = active != nullptr && active->adjustedStart && toValue == *active->adjustedStart;

--- a/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.mm
@@ -140,12 +140,14 @@ css::CSSApplyTransitionFunction makeCSSApplyTransition(REACSSPlatformTransitions
              const css::PlatformValue &fromValue,
              const css::PlatformValue &toValue,
              const css::CSSTransitionPropertySettings *settings,
+             bool persistent,
              double timestamp) {
     return [platformTransitions applyTransitionForTag:viewTag
                                          propertyName:propertyName
                                             fromValue:fromValue
                                               toValue:toValue
                                              settings:settings
+                                           persistent:persistent
                                             timestamp:timestamp];
   };
 }


### PR DESCRIPTION
A pseudo transition holds its value past the animation because the pseudo value has no committed style behind it. On release the target value is the committed style, so the hold is wrong: the finished animator keeps owning the property and every other writer loses it.

`persistent` was derived from `settings == nullptr`, which is true for press and release alike. It now comes from the pseudo lock, so the hold is dropped once no active selector claims the property.

Effect: after a single press, a later animation of that view's opacity never runs.

### Before / After

Route opacity, press and release the blue box, then pulse both. Only the green control survives the press.

<img width="2688" height="896" alt="comparison" src="https://github.com/user-attachments/assets/950207f9-4353-4b61-aa8c-4d567c52e02a" />

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/5343f4b8-6a85-4e6f-8aa0-43ffc6431a64" /> | <video src="https://github.com/user-attachments/assets/92327979-1e29-4711-8717-b08328baa142" /> |

<details>
<summary>Example source code</summary>

```tsx
// Repro for PR #10243 - drop it into a CSS example screen and render <BugProbe />.
// Requires ANDROID_CSS_PLATFORM_TRANSITIONS: true in the app's staticFeatureFlags.
//
// Steps: 1) tap "Route opacity"  2) press and release the SUBJECT  3) tap "Pulse both"
// Before the fix: SUBJECT is frozen at the held value while CONTROL pulses.
// After  the fix: both pulse identically.

import { useState } from 'react';
import { Pressable, StyleSheet, Text } from 'react-native';
import Animated from 'react-native-reanimated';
import { Section } from '@/apps/css/components';

/**
 * REPRO for the #10243 leak, and the reason it is normally invisible.
 *
 * The stale entry left by a pseudo release only shows up when something OTHER than the CSS
 * transition config path writes the same property, because that path replaces the entry and
 * self-heals. A CSS keyframe animation is such a writer: it runs on the loop and lands through
 * the shadow tree, so the pre-draw repair overwrites it with the held value every frame.
 *
 * SUBJECT has the pseudo transition; CONTROL has only the animation. Both pulse identically
 * until the subject is pressed once.
 */
const PULSE = {
  animationDuration: '1200ms',
  animationIterationCount: 'infinite',
  animationName: {
    '0%': { opacity: 1 },
    '50%': { opacity: 0.15 },
    '100%': { opacity: 1 },
  },
} as const;

function BugProbe() {
  const [routed, setRouted] = useState(false);
  const [pulsing, setPulsing] = useState(false);

  return (
    <Section description="probe" title="PROBE: stale hold vs a competing writer">
      <Pressable onPress={() => setRouted((v) => !v)} style={bp.btn}>
        <Text style={bp.txt}>1. Route opacity (default {routed ? '0.8' : '1'})</Text>
      </Pressable>
      <Pressable onPress={() => setPulsing((v) => !v)} style={bp.btn}>
        <Text style={bp.txt}>3. Pulse both ({pulsing ? 'on' : 'off'})</Text>
      </Pressable>

      <Text style={bp.label}>SUBJECT - pseudo transition (press me at step 2)</Text>
      <Animated.View
        style={[
          bp.subject,
          {
            opacity: { ':active': 0.5, default: routed ? 0.8 : 1 },
            transitionDuration: '250ms',
          },
          pulsing ? PULSE : null,
        ]}
      />

      <Text style={bp.label}>CONTROL - animation only</Text>
      <Animated.View style={[bp.control, pulsing ? PULSE : null]} />
    </Section>
  );
}

const bp = StyleSheet.create({
  btn: { backgroundColor: 'rgb(200,0,0)', height: 54, justifyContent: 'center', marginBottom: 4, width: 320 },
  control: { backgroundColor: 'rgb(0,170,0)', height: 110, width: 320 },
  label: { color: '#333', fontSize: 12, marginTop: 6 },
  subject: { backgroundColor: 'rgb(0,0,220)', height: 110, width: 320 },
  txt: { color: 'white', fontSize: 13, textAlign: 'center' },
});
```

</details>
