### PR TITLE
ci: Run the iOS runtime tests on remote simulators (Argent Cloud)

### DIFF
--- a/.github/actions/install-sim-remote/action.yml
+++ b/.github/actions/install-sim-remote/action.yml
@@ -5,10 +5,10 @@ inputs:
   release-tag:
     description: Release tag in software-mansion/sim-remote-releases to install
     required: false
-    default: "softu"
+    default: 'softu'
 
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - name: Install sim-remote CLI + daemon
       shell: bash

--- a/.github/actions/install-sim-remote/action.yml
+++ b/.github/actions/install-sim-remote/action.yml
@@ -1,0 +1,34 @@
+name: Install sim-remote
+description: Install the sim-remote CLI + daemon (argent cloud client) and add them to PATH
+
+inputs:
+  release-tag:
+    description: Release tag in software-mansion/sim-remote-releases to install
+    required: false
+    default: "softu"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install sim-remote CLI + daemon
+      shell: bash
+      run: |
+        case "$(uname -s)-$(uname -m)" in
+          Darwin-arm64) TARGET=aarch64-apple-darwin ;;
+          Linux-x86_64) TARGET=x86_64-unknown-linux-gnu ;;
+          Linux-aarch64) TARGET=aarch64-unknown-linux-gnu ;;
+          *)
+            echo "::error::no sim-remote build for $(uname -s)/$(uname -m)"
+            exit 1
+            ;;
+        esac
+
+        REL="https://github.com/software-mansion/sim-remote-releases/releases/download/${{ inputs.release-tag }}"
+        mkdir -p "$HOME/.local/bin"
+        curl -fsSL -o "$HOME/.local/bin/sim-remote" "$REL/sim-remote-$TARGET"
+        curl -fsSL -o "$HOME/.local/bin/sim-remote-daemon" "$REL/sim-remote-daemon-$TARGET"
+        chmod +x "$HOME/.local/bin/sim-remote" "$HOME/.local/bin/sim-remote-daemon"
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+        # smoke check: the CLI has no --version flag; --help exits 0
+        "$HOME/.local/bin/sim-remote" --help > /dev/null

--- a/.github/workflows/runtime-tests-ios-remote.yml
+++ b/.github/workflows/runtime-tests-ios-remote.yml
@@ -1,0 +1,290 @@
+name: Remote runtime tests iOS
+env:
+  YARN_ENABLE_HARDENED_MODE: 0
+on:
+  workflow_call:
+    inputs:
+      bundleMode:
+        required: false
+        type: boolean
+        default: false
+      configuration:
+        required: false
+        type: string
+        default: ReleaseRuntimeTests
+      udid:
+        required: false
+        type: string
+        default: ""
+  workflow_dispatch:
+    inputs:
+      bundleMode:
+        description: Run with Bundle Mode enabled (false = Legacy Eval)
+        required: false
+        type: boolean
+        default: false
+      configuration:
+        description: Build configuration (Debug* legs serve JS from Metro on the test runner)
+        required: false
+        type: string
+        default: ReleaseRuntimeTests
+      udid:
+        description: Remote simulator UUID (blank = first available iPhone)
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  group: runtime-tests-ios-remote-${{ github.ref }}-${{ inputs.bundleMode }}-${{ inputs.configuration || 'ReleaseRuntimeTests' }}
+  cancel-in-progress: true
+
+jobs:
+  # Check if we have all must-have credentials
+  # before running the workflow. Also the fork guard: skipping preflight
+  # skips every job that needs it.
+  preflight:
+    if: github.repository == 'software-mansion/react-native-reanimated'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      HAS_USERNAME: ${{ secrets.SIM_ROUTER_USERNAME != '' }}
+      HAS_API_KEY: ${{ secrets.SIM_ROUTER_API_KEY != '' }}
+    steps:
+      - name: Check cloud credentials are configured
+        run: |
+          if [ "$HAS_USERNAME" != "true" ] || [ "$HAS_API_KEY" != "true" ]; then
+            echo "::error::SIM_ROUTER_USERNAME and/or SIM_ROUTER_API_KEY secrets are not set — configure them in the repo settings before running this workflow"
+            exit 1
+          fi
+
+  build-app:
+    needs: preflight
+    name: Build app (${{ matrix.configuration }}, ${{ matrix.bundleMode && 'Bundle Mode' || 'Legacy Eval' }})
+    runs-on: macos-26
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        bundleMode: ${{ fromJSON(format('[{0}]', inputs.bundleMode || false)) }}
+        configuration: ${{ fromJSON(format('["{0}"]', inputs.configuration || 'ReleaseRuntimeTests')) }}
+    env:
+      WORKING_DIRECTORY: apps/fabric-example
+      CONFIGURATION: ${{ matrix.configuration }}
+    steps:
+      - name: checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+
+      - name: Restore packaged app from cache
+        id: appcache
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c
+        with:
+          path: apps/fabric-example/dist/FabricExample.app.zip
+          # scripts/ is excluded: the driver/export/server scripts orchestrate
+          # builds and test runs but never ship inside the .app, so editing
+          # them must not invalidate four app caches. Caveat: a change to the
+          # xcodebuild flags inside runtime-tests-server.js would alter the
+          # app without changing this key — delete the caches manually then.
+          key:
+            runtime-tests-app-zip-${{ env.CONFIGURATION }}-bundle-${{ matrix.bundleMode }}-${{ hashFiles(
+            'yarn.lock',
+            'apps/fabric-example/**',
+            '!apps/fabric-example/scripts/**',
+            'apps/common-app/**',
+            'packages/react-native-reanimated/**',
+            'packages/react-native-worklets/**'
+            ) }}
+
+      - name: Use Ruby version from `.ruby-version` file
+        if: steps.appcache.outputs.cache-hit != 'true'
+        uses: ruby/setup-ruby@6aaa311d81eba98ae12eaffbcb63296ace0efcde
+        with:
+          bundler-cache: true
+
+      - name: Install monorepo node dependencies
+        if: steps.appcache.outputs.cache-hit != 'true'
+        run: yarn install --immutable
+
+      - name: Toggle Bundle Mode off (Legacy Eval)
+        if: steps.appcache.outputs.cache-hit != 'true' && !matrix.bundleMode
+        run: yarn toggle-bundle-mode
+
+      - name: Build Reanimated package
+        if: steps.appcache.outputs.cache-hit != 'true'
+        working-directory: packages/react-native-reanimated
+        run: yarn build
+
+      - name: Install Pods
+        if: steps.appcache.outputs.cache-hit != 'true'
+        uses: ./.github/actions/install-pods
+        with:
+          working-directory: ${{ env.WORKING_DIRECTORY }}
+          pod-directory: ios
+
+      - name: Cache DerivedData
+        if: steps.appcache.outputs.cache-hit != 'true'
+        uses: ./.github/actions/cache-derived-data
+        with:
+          platform: ios
+          working-directory: ${{ env.WORKING_DIRECTORY }}
+          pod-directory: ios
+
+      - name: Build runtime-tests app
+        if: steps.appcache.outputs.cache-hit != 'true'
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+        run: node scripts/runtime-tests-server.js --build-only --configuration "$CONFIGURATION"
+
+      - name: Package app artifact
+        if: steps.appcache.outputs.cache-hit != 'true'
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+        run: |
+          # Debug apps are deliberately Metro-fed here (the test job runs
+          # Metro and tunnels it) — override the export script's guard.
+          EXPORT_FLAGS=""
+          case "$CONFIGURATION" in
+            Debug*) EXPORT_FLAGS="--allow-debug" ;;
+          esac
+          node scripts/export-runtime-tests-app.js --configuration "$CONFIGURATION" --out dist/FabricExample.app.zip $EXPORT_FLAGS
+
+      - name: Upload app artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: runtime-tests-app-remote-${{ env.CONFIGURATION }}-bundle-${{ matrix.bundleMode }}
+          path: apps/fabric-example/dist/FabricExample.app.zip
+          if-no-files-found: error
+          retention-days: 3
+
+  run-tests-remote:
+    needs: build-app
+    name: Remote tests (${{ matrix.configuration }}, ${{ matrix.bundleMode && 'Bundle Mode' || 'Legacy Eval' }})
+    runs-on: ubuntu-latest # <- the whole point: no macOS, no local simulator
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      # Concurrent runs each acquire their own cloud Mac at login; when the
+      # pool is exhausted, the surplus wait in the router's acquire queue
+      # (see the login step's --timeout).
+      matrix:
+        bundleMode: ${{ fromJSON(format('[{0}]', inputs.bundleMode || false)) }}
+        configuration: ${{ fromJSON(format('["{0}"]', inputs.configuration || 'ReleaseRuntimeTests')) }}
+    env:
+      WORKING_DIRECTORY: apps/fabric-example
+      CONFIGURATION: ${{ matrix.configuration }}
+      # Job-level on purpose: the sim-remote daemon is spawned by the first
+      # CLI call and persists across steps — it must always see credentials.
+      SIM_ROUTER_USERNAME: ${{ secrets.SIM_ROUTER_USERNAME }}
+      SIM_ROUTER_API_KEY: ${{ secrets.SIM_ROUTER_API_KEY }}
+    steps:
+      - name: checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+
+      - name: Install monorepo node dependencies
+        run: yarn install --immutable
+
+      # Debug legs serve JS from Metro running on THIS runner, so this
+      # checkout's JS must match the native app's bundle mode: the build job
+      # toggled its own tree before compiling the Legacy binary, and Metro
+      # would otherwise serve Bundle Mode JS (the checked-in default) to it.
+      # Release legs never execute this checkout's JS — no toggle needed.
+      - name: Toggle Bundle Mode off (Legacy Eval Metro parity)
+        if: ${{ !matrix.bundleMode && startsWith(matrix.configuration, 'Debug') }}
+        run: yarn toggle-bundle-mode
+
+      - name: Install sim-remote CLI + daemon
+        uses: ./.github/actions/install-sim-remote
+
+      - name: Log in and acquire a cloud machine
+        shell: bash # explicit: adds pipefail, so the sim-remote|jq pipe can't hide a failure
+        run: |
+          # --timeout is the queue: when all pool machines are busy (e.g.
+          # sibling matrix legs hold them), this leg waits up to 30 min for
+          # a free one instead of failing after the default 120 s.
+          sim-remote login --timeout 1800
+          sim-remote simctl list devices --json | jq -e '.devices' > /dev/null
+          echo "logged in, machine acquired"
+
+      - name: Download app artifact
+        uses: actions/download-artifact@448e3f862ab3ef47aa50ff917776823c9946035b
+        with:
+          name: runtime-tests-app-remote-${{ env.CONFIGURATION }}-bundle-${{ matrix.bundleMode }}
+          path: apps/fabric-example/dist
+
+      - name: Unpack app artifact
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+        run: |
+          # unzip (not ditto — this is Linux); the zip was created with
+          # ditto --keepParent so it unpacks to unpacked/FabricExample.app
+
+          unzip -q dist/FabricExample.app.zip -d dist/unpacked
+
+      - name: Pick remote simulator and install app
+        id: sim
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+        env:
+          INPUT_UDID: ${{ inputs.udid }}
+        run: |
+          # Device-pick logic lives in the driver (`pick` subcommand) so it
+          # is testable and reusable outside CI.
+          if [ -n "$INPUT_UDID" ]; then
+            UDID=$(node scripts/runtime-tests-remote.mjs pick --udid "$INPUT_UDID")
+          else
+            UDID=$(node scripts/runtime-tests-remote.mjs pick)
+          fi
+
+          echo "using remote simulator $UDID"
+          echo "udid=$UDID" >> "$GITHUB_OUTPUT"
+
+          node scripts/runtime-tests-remote.mjs install --udid "$UDID" \
+            --app-path dist/unpacked/FabricExample.app
+
+      - name: Run ReJest self-tests on the remote simulator
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+        run: >
+          node scripts/runtime-tests-remote.mjs run --udid "${{ steps.sim.outputs.udid }}"
+          --library self-tests --configuration "$CONFIGURATION"
+
+      - name: Verify CI catches failing tests
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+        run: |
+          if node scripts/runtime-tests-remote.mjs run --udid "${{ steps.sim.outputs.udid }}" \
+            --library self-tests --configuration "$CONFIGURATION" \
+            --only "intentional failures";
+          then
+            echo "A failing suite did not fail the runner" && exit 1
+          else
+            echo "Failing tests correctly failed the runner"
+          fi
+
+      - name: Run Worklets runtime tests on the remote simulator
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+        run: >
+          node scripts/runtime-tests-remote.mjs run --udid "${{ steps.sim.outputs.udid }}"
+          --library worklets --configuration "$CONFIGURATION"
+
+      - name: Run Reanimated runtime tests on the remote simulator
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+        run: >
+          node scripts/runtime-tests-remote.mjs run --udid "${{ steps.sim.outputs.udid }}"
+          --library reanimated --configuration "$CONFIGURATION"
+
+      - name: Release remote simulator
+        if: always()
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+        run: |
+          UDID="${{ steps.sim.outputs.udid }}"
+
+          if command -v sim-remote >/dev/null; then
+            if [ -n "$UDID" ]; then
+              sim-remote proxy stop "$UDID" 8082 || true
+              sim-remote proxy stop "$UDID" 8081 || true # Metro tunnel (Debug legs)
+              sim-remote simctl shutdown "$UDID" || true
+            fi
+
+            sim-remote logout || true
+          fi

--- a/.github/workflows/runtime-tests-ios-remote.yml
+++ b/.github/workflows/runtime-tests-ios-remote.yml
@@ -3,6 +3,11 @@ env:
   YARN_ENABLE_HARDENED_MODE: 0
 on:
   workflow_call:
+    secrets:
+      SIM_ROUTER_USERNAME:
+        required: true
+      SIM_ROUTER_API_KEY:
+        required: true
     inputs:
       bundleMode:
         required: false

--- a/.github/workflows/runtime-tests-ios-remote.yml
+++ b/.github/workflows/runtime-tests-ios-remote.yml
@@ -47,9 +47,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Check if we have all must-have credentials
-  # before running the workflow. Also the fork guard: skipping preflight
-  # skips every job that needs it.
+  # Check if we have all must-have credentials before running the workflow.
+  # Also the fork guard: skipping preflight skips every job that needs it.
   preflight:
     if: github.repository == 'software-mansion/react-native-reanimated'
     runs-on: ubuntu-latest
@@ -89,11 +88,6 @@ jobs:
         uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c
         with:
           path: apps/fabric-example/dist/FabricExample.app.zip
-          # scripts/ is excluded: the driver/export/server scripts orchestrate
-          # builds and test runs but never ship inside the .app, so editing
-          # them must not invalidate four app caches. Caveat: a change to the
-          # xcodebuild flags inside runtime-tests-server.js would alter the
-          # app without changing this key — delete the caches manually then.
           key:
             runtime-tests-app-zip-${{ env.CONFIGURATION }}-bundle-${{ matrix.bundleMode }}-${{ hashFiles(
             'yarn.lock',
@@ -170,17 +164,12 @@ jobs:
     timeout-minutes: 60
     strategy:
       fail-fast: false
-      # Concurrent runs each acquire their own cloud Mac at login; when the
-      # pool is exhausted, the surplus wait in the router's acquire queue
-      # (see the login step's --timeout).
       matrix:
         bundleMode: ${{ fromJSON(format('[{0}]', inputs.bundleMode || false)) }}
         configuration: ${{ fromJSON(format('["{0}"]', inputs.configuration || 'ReleaseRuntimeTests')) }}
     env:
       WORKING_DIRECTORY: apps/fabric-example
       CONFIGURATION: ${{ matrix.configuration }}
-      # Job-level on purpose: the sim-remote daemon is spawned by the first
-      # CLI call and persists across steps — it must always see credentials.
       SIM_ROUTER_USERNAME: ${{ secrets.SIM_ROUTER_USERNAME }}
       SIM_ROUTER_API_KEY: ${{ secrets.SIM_ROUTER_API_KEY }}
     steps:

--- a/.github/workflows/runtime-tests-ios-remote.yml
+++ b/.github/workflows/runtime-tests-ios-remote.yml
@@ -42,13 +42,8 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: runtime-tests-ios-remote-${{ github.ref }}-${{ inputs.bundleMode }}-${{ inputs.configuration || 'ReleaseRuntimeTests' }}
-  cancel-in-progress: true
-
 jobs:
   # Check if we have all must-have credentials before running the workflow.
-  # Also the fork guard: skipping preflight skips every job that needs it.
   preflight:
     if: github.repository == 'software-mansion/react-native-reanimated'
     runs-on: ubuntu-latest
@@ -64,11 +59,15 @@ jobs:
             exit 1
           fi
 
+  # Build on macos runner
   build-app:
     needs: preflight
     name: Build app (${{ matrix.configuration }}, ${{ matrix.bundleMode && 'Bundle Mode' || 'Legacy Eval' }})
     runs-on: macos-26
     timeout-minutes: 90
+    concurrency:
+      group: runtime-tests-ios-remote-${{ github.ref }}-${{ matrix.bundleMode }}-${{ matrix.configuration }}
+      cancel-in-progress: true
     strategy:
       fail-fast: false
       matrix:
@@ -157,11 +156,15 @@ jobs:
           if-no-files-found: error
           retention-days: 3
 
+  # Test on remote simulator running on Argent Cloud
   run-tests-remote:
     needs: build-app
     name: Remote tests (${{ matrix.configuration }}, ${{ matrix.bundleMode && 'Bundle Mode' || 'Legacy Eval' }})
     runs-on: ubuntu-latest # <- the whole point: no macOS, no local simulator
     timeout-minutes: 60
+    concurrency:
+      group: runtime-tests-ios-remote-${{ github.ref }}-${{ matrix.bundleMode }}-${{ matrix.configuration }}
+      cancel-in-progress: true
     strategy:
       fail-fast: false
       matrix:
@@ -181,10 +184,12 @@ jobs:
       - name: Install monorepo node dependencies
         run: yarn install --immutable
 
-      # Debug legs serve JS from Metro running on THIS runner, so this
-      # checkout's JS must match the native app's bundle mode: the build job
-      # toggled its own tree before compiling the Legacy binary, and Metro
-      # would otherwise serve Bundle Mode JS (the checked-in default) to it.
+      # Debug legs serve JS from Metro running on this runner, so this
+      # checkout's js must match the native app's bundle mode.
+      #
+      # The build job toggled its own tree before compiling the Legacy binary,
+      # and Metro would otherwise serve Bundle Mode JS (the checked-in default) to it.
+      #
       # Release legs never execute this checkout's JS — no toggle needed.
       - name: Toggle Bundle Mode off (Legacy Eval Metro parity)
         if: ${{ !matrix.bundleMode && startsWith(matrix.configuration, 'Debug') }}
@@ -194,7 +199,7 @@ jobs:
         uses: ./.github/actions/install-sim-remote
 
       - name: Log in and acquire a cloud machine
-        shell: bash # explicit: adds pipefail, so the sim-remote|jq pipe can't hide a failure
+        shell: bash
         run: |
           # --timeout is the queue: when all pool machines are busy (e.g.
           # sibling matrix legs hold them), this leg waits up to 30 min for

--- a/.github/workflows/runtime-tests-ios-remote.yml
+++ b/.github/workflows/runtime-tests-ios-remote.yml
@@ -2,6 +2,15 @@ name: Remote runtime tests iOS
 env:
   YARN_ENABLE_HARDENED_MODE: 0
 on:
+  pull_request:
+    paths:
+      - .github/workflows/runtime-tests-ios-remote.yml
+      - .github/actions/install-sim-remote/**
+      - apps/common-app/runtime-tests/**
+      - apps/fabric-example/scripts/runtime-tests-server.js
+      - apps/fabric-example/scripts/runtime-tests-remote.mjs
+      - apps/fabric-example/scripts/export-runtime-tests-app.js
+      - apps/fabric-example/ios/**
   workflow_call:
     secrets:
       SIM_ROUTER_USERNAME:
@@ -71,7 +80,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        bundleMode: ${{ fromJSON(format('[{0}]', inputs.bundleMode || false)) }}
+        # Direct PR runs gate both bundle modes on the default (Release)
+        # configuration. The workflow-name check is required: legs called by
+        # another workflow that itself runs on pull_request must keep their
+        # explicit inputs.bundleMode instead of fanning out both modes.
+        bundleMode: ${{ fromJSON((github.event_name == 'pull_request' && github.workflow == 'Remote runtime tests iOS') && '[false, true]' || format('[{0}]', inputs.bundleMode || false)) }}
         configuration: ${{ fromJSON(format('["{0}"]', inputs.configuration || 'ReleaseRuntimeTests')) }}
     env:
       WORKING_DIRECTORY: apps/fabric-example
@@ -168,7 +181,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        bundleMode: ${{ fromJSON(format('[{0}]', inputs.bundleMode || false)) }}
+        # Must mirror build-app's matrix exactly — see the comment there.
+        bundleMode: ${{ fromJSON((github.event_name == 'pull_request' && github.workflow == 'Remote runtime tests iOS') && '[false, true]' || format('[{0}]', inputs.bundleMode || false)) }}
         configuration: ${{ fromJSON(format('["{0}"]', inputs.configuration || 'ReleaseRuntimeTests')) }}
     env:
       WORKING_DIRECTORY: apps/fabric-example

--- a/.github/workflows/runtime-tests-ios-remote.yml
+++ b/.github/workflows/runtime-tests-ios-remote.yml
@@ -20,7 +20,7 @@ on:
       udid:
         required: false
         type: string
-        default: ""
+        default: ''
   workflow_dispatch:
     inputs:
       bundleMode:
@@ -37,7 +37,7 @@ on:
         description: Remote simulator UUID (blank = first available iPhone)
         required: false
         type: string
-        default: ""
+        default: ''
 
 permissions:
   contents: read

--- a/.github/workflows/runtime-tests-ios.yml
+++ b/.github/workflows/runtime-tests-ios.yml
@@ -2,12 +2,6 @@ name: Runtime tests iOS
 env:
   YARN_ENABLE_HARDENED_MODE: 0
 on:
-  pull_request:
-    paths:
-      - .github/workflows/runtime-tests-ios.yml
-      - apps/common-app/runtime-tests/**
-      - apps/fabric-example/scripts/runtime-tests-server.js
-      - apps/fabric-example/ios/**
   workflow_call:
     inputs:
       bundleMode:
@@ -49,10 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # The workflow-name check is required: the nightly caller also runs on
-        # pull_request, and its workflow_call legs must keep their explicit
-        # inputs.bundleMode instead of fanning out both modes.
-        bundleMode: ${{ fromJSON((github.event_name == 'pull_request' && github.workflow == 'Runtime tests iOS') && '[false, true]' || format('[{0}]', inputs.bundleMode)) }}
+        bundleMode: ${{ fromJSON(format('[{0}]', inputs.bundleMode)) }}
     env:
       WORKING_DIRECTORY: apps/fabric-example
       REANIMATED_DIR: packages/react-native-reanimated

--- a/.github/workflows/runtime-tests-nightly.yml
+++ b/.github/workflows/runtime-tests-nightly.yml
@@ -12,17 +12,21 @@ permissions:
   contents: read
 
 jobs:
-  ios:
+  ios-remote:
     if: github.repository == 'software-mansion/react-native-reanimated'
     strategy:
       fail-fast: false
       matrix:
         configuration: [DebugRuntimeTests, ReleaseRuntimeTests]
         bundleMode: [false, true]
-    uses: ./.github/workflows/runtime-tests-ios.yml
+    uses: ./.github/workflows/runtime-tests-ios-remote.yml
     with:
       configuration: ${{ matrix.configuration }}
       bundleMode: ${{ matrix.bundleMode }}
+    secrets:
+      # Explicit secrets match contract declared in runtime-tests-ios-remote.yaml
+      SIM_ROUTER_USERNAME: ${{ secrets.SIM_ROUTER_USERNAME }}
+      SIM_ROUTER_API_KEY: ${{ secrets.SIM_ROUTER_API_KEY }}
 
   android:
     if: github.repository == 'software-mansion/react-native-reanimated'

--- a/apps/fabric-example/.gitignore
+++ b/apps/fabric-example/.gitignore
@@ -68,3 +68,6 @@ yarn-error.log
 
 # Sanitizer reports from scripts/runtime-tests-server.js --sanitizer
 sanitizer-reports/
+
+# Packaged app artifacts from scripts/export-runtime-tests-app.js
+dist/

--- a/apps/fabric-example/scripts/export-runtime-tests-app.js
+++ b/apps/fabric-example/scripts/export-runtime-tests-app.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 // Packages the runtime-tests FabricExample.app into a zip for the CI artifact
-// hand-off between a build job and a test job (see runtime-tests-ios-split.yml).
+// hand-off between a build job and a test job (see runtime-tests-ios-remote.yml).
 //
 // Build the app first:
 //   node scripts/runtime-tests-server.js --build-only --configuration ReleaseRuntimeTests

--- a/apps/fabric-example/scripts/export-runtime-tests-app.js
+++ b/apps/fabric-example/scripts/export-runtime-tests-app.js
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+
+// Packages the runtime-tests FabricExample.app into a zip for the CI artifact
+// hand-off between a build job and a test job (see runtime-tests-ios-split.yml).
+//
+// Build the app first:
+//   node scripts/runtime-tests-server.js --build-only --configuration ReleaseRuntimeTests
+// Then export it:
+//   node scripts/export-runtime-tests-app.js --configuration ReleaseRuntimeTests --out dist/FabricExample.app.zip
+//
+// Only Release* configurations embed the three runtime-tests JS bundles and run
+// without Metro; a Debug artifact is refused unless --allow-debug is passed,
+// because it would silently depend on a Metro server wherever it is installed.
+
+const path = require('path');
+const fs = require('fs');
+const { execFile } = require('child_process');
+
+const LIBRARIES = ['reanimated', 'worklets', 'self-tests'];
+
+const projectRoot = path.resolve(__dirname, '..');
+const iosDir = path.join(projectRoot, 'ios');
+
+const args = {};
+const BOOLEAN_FLAGS = new Set(['print-path', 'allow-debug', 'help']);
+for (let i = 2; i < process.argv.length; i++) {
+  const arg = process.argv[i];
+  if (!arg.startsWith('--')) {
+    fail(`unexpected argument: ${arg} (see --help)`);
+  }
+  const name = arg.slice(2);
+  if (BOOLEAN_FLAGS.has(name)) {
+    args[name] = true;
+  } else {
+    args[name] = process.argv[++i];
+  }
+}
+
+if (args.help) {
+  console.log(`Usage: node scripts/export-runtime-tests-app.js [options]
+
+Options:
+  --configuration <cfg>  Build configuration to export (default: ReleaseRuntimeTests)
+  --out <path>           Output zip path, relative to apps/fabric-example
+                         (default: dist/FabricExample-<configuration>.app.zip)
+  --print-path           Print the resolved .app path and exit without zipping
+  --allow-debug          Permit exporting a Debug* configuration (needs Metro at runtime)
+  --help                 Show this message`);
+  process.exit(0);
+}
+
+const CONFIGURATION = args.configuration ?? 'ReleaseRuntimeTests';
+const OUT = path.resolve(
+  projectRoot,
+  args.out ?? path.join('dist', `FabricExample-${CONFIGURATION}.app.zip`)
+);
+
+function fail(message) {
+  console.error(`[export-app] ${message}`);
+  process.exit(1);
+}
+
+function run(command, argv, options = {}) {
+  return new Promise((resolve, reject) => {
+    execFile(
+      command,
+      argv,
+      { maxBuffer: 64 * 1024 * 1024, ...options },
+      (error, stdout, stderr) => {
+        if (error) {
+          reject(new Error(`${command} failed: ${stderr || error.message}`));
+        } else {
+          resolve({ stdout, stderr });
+        }
+      }
+    );
+  });
+}
+
+// Mirrors appPath() in runtime-tests-server.js: the scheme is always
+// DebugRuntimeTests; the configuration alone selects Debug/Release output.
+async function resolveAppPath() {
+  const { stdout } = await run(
+    'xcodebuild',
+    [
+      '-workspace',
+      'FabricExample.xcworkspace',
+      '-scheme',
+      'DebugRuntimeTests',
+      '-configuration',
+      CONFIGURATION,
+      '-destination',
+      'generic/platform=iOS Simulator',
+      '-showBuildSettings',
+      '-json',
+    ],
+    { cwd: iosDir }
+  );
+  const entries = JSON.parse(stdout.slice(stdout.indexOf('[')));
+  const entry =
+    entries.find(
+      (candidate) => candidate.buildSettings.WRAPPER_NAME === 'FabricExample.app'
+    ) ?? entries[0];
+  const { TARGET_BUILD_DIR, WRAPPER_NAME } = entry.buildSettings;
+  return path.join(TARGET_BUILD_DIR, WRAPPER_NAME);
+}
+
+function assertExportable(app) {
+  if (!fs.existsSync(app)) {
+    fail(
+      `no built app at ${app}\n` +
+        `[export-app] build it first: node scripts/runtime-tests-server.js --build-only --configuration ${CONFIGURATION}`
+    );
+  }
+  if (!/^Release/.test(CONFIGURATION)) {
+    if (!args['allow-debug']) {
+      fail(
+        `${CONFIGURATION} apps load their JS from Metro and are not self-contained; ` +
+          'export a Release* configuration, or pass --allow-debug if you know what you are doing'
+      );
+    }
+    return;
+  }
+  // A Release* runtime-tests app must carry all three embedded bundles —
+  // catch a mispackaged artifact here rather than as a connect-timeout in CI.
+  const missing = LIBRARIES.map(
+    (library) => `main.runtimeTests.${library}.jsbundle`
+  ).filter((bundle) => !fs.existsSync(path.join(app, bundle)));
+  if (missing.length > 0) {
+    fail(
+      `built app at ${app} is missing embedded bundles: ${missing.join(', ')}\n` +
+        '[export-app] was it built with a *RuntimeTests configuration?'
+    );
+  }
+}
+
+async function main() {
+  const app = await resolveAppPath();
+  if (args['print-path']) {
+    console.log(app);
+    return;
+  }
+  assertExportable(app);
+  fs.mkdirSync(path.dirname(OUT), { recursive: true });
+  fs.rmSync(OUT, { force: true });
+  // ditto preserves resource forks, symlinks, and permissions inside .app
+  // bundles; --keepParent makes the zip unpack to <dir>/FabricExample.app.
+  await run('ditto', ['-c', '-k', '--keepParent', app, OUT]);
+  const sizeMb = (fs.statSync(OUT).size / (1024 * 1024)).toFixed(1);
+  console.log(`[export-app] exported ${app}`);
+  console.log(`[export-app] -> ${OUT} (${sizeMb} MB)`);
+}
+
+main().catch((error) => {
+  fail(error.message);
+});

--- a/apps/fabric-example/scripts/export-runtime-tests-app.js
+++ b/apps/fabric-example/scripts/export-runtime-tests-app.js
@@ -23,16 +23,26 @@ const iosDir = path.join(projectRoot, 'ios');
 
 const args = {};
 const BOOLEAN_FLAGS = new Set(['print-path', 'allow-debug', 'help']);
+
 for (let i = 2; i < process.argv.length; i++) {
   const arg = process.argv[i];
+
   if (!arg.startsWith('--')) {
     fail(`unexpected argument: ${arg} (see --help)`);
   }
+
   const name = arg.slice(2);
+
   if (BOOLEAN_FLAGS.has(name)) {
     args[name] = true;
   } else {
-    args[name] = process.argv[++i];
+    const value = process.argv[++i];
+
+    if (value == undefined || value.startsWith('--')) {
+      fail(`missing value for --${name} (see --help)`);
+    }
+
+    args[name] = value;
   }
 }
 
@@ -96,12 +106,26 @@ async function resolveAppPath() {
     ],
     { cwd: iosDir }
   );
-  const entries = JSON.parse(stdout.slice(stdout.indexOf('[')));
+
+  const jsonStart = stdout.indexOf('[');
+
+  if (jsonStart < 0) {
+    fail(`xcodebuild -showBuildSettings returned no JSON payload`);
+  }
+
+  const entries = JSON.parse(stdout.slice(jsonStart));
+
   const entry =
     entries.find(
       (candidate) => candidate.buildSettings.WRAPPER_NAME === 'FabricExample.app'
     ) ?? entries[0];
+
+  if (!entry?.buildSettings) {
+    fail(`no build settings for configuration ${CONFIGURATION}`);
+  }
+
   const { TARGET_BUILD_DIR, WRAPPER_NAME } = entry.buildSettings;
+
   return path.join(TARGET_BUILD_DIR, WRAPPER_NAME);
 }
 
@@ -112,6 +136,7 @@ function assertExportable(app) {
         `[export-app] build it first: node scripts/runtime-tests-server.js --build-only --configuration ${CONFIGURATION}`
     );
   }
+
   if (!/^Release/.test(CONFIGURATION)) {
     if (!args['allow-debug']) {
       fail(
@@ -119,13 +144,16 @@ function assertExportable(app) {
           'export a Release* configuration, or pass --allow-debug if you know what you are doing'
       );
     }
+
     return;
   }
+
   // A Release* runtime-tests app must carry all three embedded bundles —
   // catch a mispackaged artifact here rather than as a connect-timeout in CI.
   const missing = LIBRARIES.map(
     (library) => `main.runtimeTests.${library}.jsbundle`
   ).filter((bundle) => !fs.existsSync(path.join(app, bundle)));
+
   if (missing.length > 0) {
     fail(
       `built app at ${app} is missing embedded bundles: ${missing.join(', ')}\n` +
@@ -136,17 +164,21 @@ function assertExportable(app) {
 
 async function main() {
   const app = await resolveAppPath();
+
   if (args['print-path']) {
     console.log(app);
     return;
   }
+
   assertExportable(app);
   fs.mkdirSync(path.dirname(OUT), { recursive: true });
   fs.rmSync(OUT, { force: true });
+
   // ditto preserves resource forks, symlinks, and permissions inside .app
   // bundles; --keepParent makes the zip unpack to <dir>/FabricExample.app.
   await run('ditto', ['-c', '-k', '--keepParent', app, OUT]);
   const sizeMb = (fs.statSync(OUT).size / (1024 * 1024)).toFixed(1);
+
   console.log(`[export-app] exported ${app}`);
   console.log(`[export-app] -> ${OUT} (${sizeMb} MB)`);
 }

--- a/apps/fabric-example/scripts/runtime-tests-remote.mjs
+++ b/apps/fabric-example/scripts/runtime-tests-remote.mjs
@@ -70,9 +70,20 @@ const APP_PATH = args['app-path'] ?? '';
 const LIBRARY = args.library ?? '';
 const CONFIGURATION = args.configuration ?? 'ReleaseRuntimeTests';
 const ONLY = args.only ?? '';
-const METRO_PORT = Number(args['metro-port'] ?? 8081);
-const CONNECT_TIMEOUT = Number(args['connect-timeout'] ?? 900);
-const IDLE_TIMEOUT = Number(args['idle-timeout'] ?? 900);
+
+function positiveInt(name, value) {
+  const parsed = Number(value);
+
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    fail(`--${name} must be a positive integer, got: ${value}`)
+  }
+
+  return parsed;
+}
+
+const METRO_PORT = positiveInt('metro-port', args['metro-port'] ?? 8081)
+const CONNECT_TIMEOUT = positiveInt('connect-timeout', args['connect-timeout'] ?? 900)
+const IDLE_TIMEOUT = positiveInt('idle-timeout', args['idle-timeout'] ?? 900)
 
 // ── process helpers ──
 
@@ -253,7 +264,16 @@ async function runLibrary() {
   if (ONLY) {
     serverArgs.push('--only', ONLY);
   }
-  const server = spawn('node', serverArgs, { stdio: 'inherit' });
+
+  const server = spawn('node', serverArgs, { cwd: projectRoot, stdio: 'inherit' });
+
+  for (const signal of ['SIGINT', 'SIGTERM']) {
+    process.once(signal, () => {
+      server.kill(signal);
+      process.exit(1);
+    });
+  }
+
   const serverExit = new Promise((resolve) => {
     server.on('exit', (code) => resolve(code ?? 1));
   });

--- a/apps/fabric-example/scripts/runtime-tests-remote.mjs
+++ b/apps/fabric-example/scripts/runtime-tests-remote.mjs
@@ -1,0 +1,285 @@
+#!/usr/bin/env node
+
+// Drive the iOS runtime tests against a REMOTE simulator (argent cloud).
+//
+// Runs from any OS that has node + the `sim-remote` CLI (authenticated via
+// SIM_ROUTER_USERNAME / SIM_ROUTER_API_KEY) — no Xcode, no xcrun, no macOS.
+//
+// The reporting path is unchanged from local runs: runtime-tests-server.js
+// listens on this host, and `sim-remote proxy` reverse-tunnels the sim's
+// localhost:<port> here, so the app's WebSocket dial arrives at this
+// machine. The library is selected via launchd env inside the remote sim
+// (`sim-remote setenv`), the remote analogue of SIMCTL_CHILD_*.
+//
+// Debug* configurations are supported: the app loads its JS from a Metro
+// server on THIS host at launch. `run` then starts (or reuses) Metro on
+// --metro-port, opens a second reverse tunnel for it, and points the app at
+// it via RCT_jsLocation. The reporting port becomes metro-port + 1 — that is
+// how Debug apps derive it from their Metro URL.
+//
+// Usage:
+//   node runtime-tests-remote.mjs pick    [--udid <UUID>]
+//   node runtime-tests-remote.mjs install --udid <UUID> --app-path <path/to/FabricExample.app>
+//   node runtime-tests-remote.mjs run     --udid <UUID> --library <reanimated|worklets|self-tests>
+//                                         [--configuration ReleaseRuntimeTests] [--only "<suites>"]
+//                                         [--metro-port <port>]
+//                                         [--connect-timeout <secs>] [--idle-timeout <secs>]
+//
+// `pick` prints the UDID of the best remote simulator (an explicit --udid
+// passes through; otherwise the first available iPhone, preferring booted);
+// `install` boots the sim and uploads the app (once per job);
+// `run` executes one library's suites (once per workflow step, like --launch).
+
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+import http from 'node:http';
+import { spawn, execFile, execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+
+const BUNDLE_ID = 'org.reactjs.native.example.FabricExample';
+const projectRoot = path.resolve(scriptDir, '..');
+const SERVER_SCRIPT = path.join(scriptDir, 'runtime-tests-server.js');
+const METRO_LOG = path.join(os.tmpdir(), 'metro-runtime-tests.log');
+
+function fail(message) {
+  console.error(`[runtime-tests-remote] ${message}`);
+  process.exit(1);
+}
+
+function log(message) {
+  console.log(`[runtime-tests-remote] ${message}`);
+}
+
+// ── argument parsing ──
+
+const [SUBCOMMAND, ...rest] = process.argv.slice(2);
+const args = {};
+for (let i = 0; i < rest.length; i++) {
+  const flag = rest[i];
+  if (!flag.startsWith('--') || rest[i + 1] === undefined) {
+    fail(`unknown or valueless flag: ${flag} (see the usage header)`);
+  }
+  args[flag.slice(2)] = rest[++i];
+}
+
+const UDID = args.udid ? args.udid.replace(/^remote:/, '') : '';
+const APP_PATH = args['app-path'] ?? '';
+const LIBRARY = args.library ?? '';
+const CONFIGURATION = args.configuration ?? 'ReleaseRuntimeTests';
+const ONLY = args.only ?? '';
+const METRO_PORT = Number(args['metro-port'] ?? 8081);
+const CONNECT_TIMEOUT = Number(args['connect-timeout'] ?? 900);
+const IDLE_TIMEOUT = Number(args['idle-timeout'] ?? 900);
+
+// ── process helpers ──
+
+function run(command, cmdArgs, options = {}) {
+  return new Promise((resolve, reject) => {
+    execFile(
+      command,
+      cmdArgs,
+      { maxBuffer: 16 * 1024 * 1024, timeout: 120_000, ...options },
+      (error, stdout, stderr) => {
+        if (error) {
+          reject(
+            new Error(
+              `${command} ${cmdArgs.join(' ')} failed: ${String(stderr || error.message).trim()}`
+            )
+          );
+        } else {
+          resolve({ stdout, stderr });
+        }
+      }
+    );
+  });
+}
+
+const simRemote = (cmdArgs, options) => run('sim-remote', cmdArgs, options);
+
+function assertSimRemote() {
+  try {
+    execFileSync('sim-remote', ['--help'], { stdio: 'ignore' });
+  } catch {
+    fail('sim-remote CLI not found on PATH');
+  }
+}
+
+// ── tunnels and Metro ──
+
+// Reverse tunnel: the sim's localhost:<port> -> this host. `proxy start`
+// errors with "tunnel already active" on re-runs — tolerate that (same
+// semantics as argent's proxyStart wrapper) so runs can blindly ensure
+// their tunnels exist.
+async function ensureTunnel(port) {
+  log(`ensuring reverse tunnel for port ${port}`);
+  try {
+    await simRemote(['proxy', 'start', UDID, String(port)]);
+  } catch (error) {
+    if (/already/i.test(error.message)) {
+      log(`tunnel already active on port ${port}`);
+      return;
+    }
+    throw error;
+  }
+}
+
+function metroRunning() {
+  return new Promise((resolve) => {
+    const request = http.get(
+      { host: '127.0.0.1', port: METRO_PORT, path: '/status', timeout: 2000 },
+      (response) => {
+        let body = '';
+        response.on('data', (chunk) => (body += chunk));
+        response.on('end', () =>
+          resolve(body.includes('packager-status:running'))
+        );
+      }
+    );
+    request.on('error', () => resolve(false));
+    request.on('timeout', () => {
+      request.destroy();
+      resolve(false);
+    });
+  });
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Start Metro on this host unless one is already serving. Mirrors the local
+// runner: --reset-cache because a Metro cache built under a different Bundle
+// Mode serves stale module maps. Left running on exit — later `run`
+// invocations (and re-runs) reuse it; CI job teardown reaps it.
+async function ensureMetro() {
+  if (await metroRunning()) {
+    log(`Metro already running on :${METRO_PORT}, reusing it`);
+    return;
+  }
+  log(`starting Metro on :${METRO_PORT} (log: ${METRO_LOG})`);
+  const logFd = fs.openSync(METRO_LOG, 'a');
+  const metro = spawn(
+    'yarn',
+    ['start', '--port', String(METRO_PORT), '--reset-cache'],
+    { cwd: projectRoot, detached: true, stdio: ['ignore', logFd, logFd] }
+  );
+  metro.unref();
+  for (let attempt = 0; attempt < 90; attempt++) {
+    await sleep(2000);
+    if (await metroRunning()) {
+      log('Metro is ready');
+      return;
+    }
+  }
+  fail(`Metro did not become ready within 180s (see ${METRO_LOG})`);
+}
+
+// ── subcommands ──
+
+async function pick() {
+  // stdout carries ONLY the udid — logs would pollute $(...) captures.
+  if (UDID) {
+    console.log(UDID);
+    return;
+  }
+  const { stdout } = await simRemote(['simctl', 'list', 'devices', '--json']);
+  const devices = Object.values(JSON.parse(stdout).devices).flat();
+  const candidates = devices
+    .filter((device) => device.isAvailable !== false)
+    .filter((device) => device.name.startsWith('iPhone'))
+    .sort((a, b) => (a.state === 'Booted' ? 0 : 1) - (b.state === 'Booted' ? 0 : 1));
+  if (candidates.length === 0) {
+    fail('no available remote iPhone simulator found');
+  }
+  console.log(candidates[0].udid);
+}
+
+async function install() {
+  if (!UDID) fail('--udid is required (bare UUID or remote:<UUID>)');
+  if (!APP_PATH) fail('install requires --app-path');
+  if (!fs.existsSync(APP_PATH)) {
+    fail(`no .app at ${APP_PATH} (unpack the artifact first)`);
+  }
+  log(`booting remote simulator ${UDID}`);
+  await simRemote(['simctl', 'boot', UDID]).catch(() => {}); // tolerate already-booted
+  await simRemote(['simctl', 'bootstatus', '-b', UDID], { timeout: 300_000 });
+  log(`uploading ${APP_PATH} to the orchestrator (QUIC)`);
+  await simRemote(['simctl', 'uninstall', UDID, BUNDLE_ID]).catch(() => {});
+  await simRemote(['simctl', 'install', UDID, path.resolve(APP_PATH)], {
+    timeout: 300_000,
+  });
+  log('install done');
+}
+
+async function runLibrary() {
+  if (!UDID) fail('--udid is required (bare UUID or remote:<UUID>)');
+  if (!LIBRARY) fail('run requires --library');
+  const isRelease = /^Release/.test(CONFIGURATION);
+  if (!isRelease && !/^Debug/.test(CONFIGURATION)) {
+    fail(`unknown configuration: ${CONFIGURATION} (expected Debug*|Release*)`);
+  }
+
+  // Debug apps load their JS from Metro at launch and derive their
+  // reporting WebSocket port as metro-port + 1 (from the Metro URL).
+  let wsPort = 8082;
+  if (!isRelease) {
+    wsPort = METRO_PORT + 1;
+    await ensureMetro();
+    await ensureTunnel(METRO_PORT);
+    // Explicitly point the app at this Metro (inside the sim, localhost
+    // means the remote Mac — the tunnel makes this address land here).
+    await simRemote([
+      'spawn', UDID, '--',
+      'defaults', 'write', BUNDLE_ID, 'RCT_jsLocation', `localhost:${METRO_PORT}`,
+    ]);
+  }
+  await ensureTunnel(wsPort);
+
+  log(`selecting library '${LIBRARY}' via launchd env`);
+  await simRemote(['setenv', UDID, 'RUNTIME_TESTS_LIBRARY', LIBRARY]);
+
+  // Start the results collector BEFORE launching the app so the first dial
+  // cannot race the listener. Server mode: no --launch, the device is ours.
+  const serverArgs = [
+    SERVER_SCRIPT,
+    '--library', LIBRARY,
+    '--platform', 'ios',
+    '--configuration', CONFIGURATION,
+    '--port', String(wsPort),
+    '--connect-timeout', String(CONNECT_TIMEOUT),
+    '--idle-timeout', String(IDLE_TIMEOUT),
+  ];
+  if (ONLY) {
+    serverArgs.push('--only', ONLY);
+  }
+  const server = spawn('node', serverArgs, { stdio: 'inherit' });
+  const serverExit = new Promise((resolve) => {
+    server.on('exit', (code) => resolve(code ?? 1));
+  });
+
+  log(`launching ${BUNDLE_ID} (library: ${LIBRARY})`);
+  await simRemote(['simctl', 'terminate', UDID, BUNDLE_ID]).catch(() => {});
+  try {
+    await simRemote(['simctl', 'launch', UDID, BUNDLE_ID]);
+  } catch (error) {
+    // Don't leave the collector hanging for the full connect timeout.
+    server.kill();
+    fail(`launch failed: ${error.message}`);
+  }
+
+  const exitCode = await serverExit;
+  log(`library '${LIBRARY}' finished with exit code ${exitCode}`);
+  process.exit(exitCode);
+}
+
+// ── dispatch ──
+
+const subcommands = { pick, install, run: runLibrary };
+if (!subcommands[SUBCOMMAND]) {
+  fail(`unknown subcommand: ${SUBCOMMAND ?? '(none)'} (expected pick | install | run)`);
+}
+assertSimRemote();
+subcommands[SUBCOMMAND]().catch((error) => {
+  fail(error.message);
+});


### PR DESCRIPTION
Adds an experimental workflow that runs the iOS runtime tests (ReJest) on remote simulators in Argent Cloud. This setup requires the app to be build in a separate job and saved to artefact. At this moment building still needs to happen on GitHub’s MacOS runner. After building, a `ubuntu` runner  job is started, that connects with remote simulators running in Argent Cloud.

**Build half (macOS runner)** 

Builds the self-contained runtime-tests app, packages it via the new `scripts/export-runtime-tests-app.js`, caches the zip keyed on a hash of the build inputs, and uploads it as an artefact.

**Test half (ubuntu runner)**

 Installs `sim-remote` via the new `install-sim-remote` composite action, authenticates with the `SIM_ROUTER_USERNAME` & `SIM_ROUTER_API_KEY` secrets, acquires a cloud Mac, uploads the app, selects the test library via launchd env, reverse-tunnels the reporting dial and Metro for Debug legs. Collects results with existing `runtime-tests-server.js` in server mode.

**Scope** 

The full run includes 2x2 matrix that’s configurable with inputs to both `workflow_call` and `workflow_dispatch`. Full matrix run includes:

```yml
matrix:
    bundleMode: [true, false]
    configuration: [ReleaseRuntimeTests, DebugRuntimeTests]
```

A nightly can call this workflow once per cell, exactly like `runtime-tests-ios.yml`. 

**Current limitations (what’s up with sanitiser)**

As of now getting sanitiser runs to work is a bit hard as it’s not possible to access files created on the remote machine directly. This means that sanitiser runs are out of scope as of now and need to be looked into and patched later (or figured out here as the next step).

**Does it work?**

Workflow was run on a fork across all four matrix cells, including parallel machine acquisition: https://github.com/senicko/react-native-reanimated/actions/runs/31592955606. The two red legs there _are not pipeline failures_ but rather some flaky tests. 

**Why this is a draft**

All the little details need to be checked before merging to not break anything.

This PR does not remove old CI workflows. It still needs to be figured out how exactly this can replace existing workflows. Because of this there is no `pull_request`-related logic in matrix configuration as in current `runtime-tests-ios.yaml`.