### PR TITLE
fix: read array-typed style props from the view's own style

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/definitions.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/definitions.h
@@ -4,13 +4,17 @@
 #include <jsi/jsi.h>
 #include <string>
 #include <unordered_set>
+#include <variant>
 #include <vector>
 
 namespace reanimated::css {
 
 using namespace facebook;
 
-using PropertyPath = std::vector<std::string>;
+/// A record key (e.g. "boxShadow") or an index into an array-typed property
+/// (e.g. the 0 in boxShadow[0]).
+using PropertyPathSegment = std::variant<std::string, size_t>;
+using PropertyPath = std::vector<PropertyPathSegment>;
 using TransitionProperties = std::unordered_set<std::string>;
 
 using EasingFunction = std::function<double(double)>;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/PropertyInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/PropertyInterpolator.cpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <variant>
 
 namespace reanimated::css {
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/PropertyInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/PropertyInterpolator.cpp
@@ -2,6 +2,7 @@
 #include <reanimated/Compat/WorkletsApi.h>
 
 #include <memory>
+#include <string>
 #include <utility>
 
 namespace reanimated::css {
@@ -16,14 +17,19 @@ bool PropertyInterpolatorFactory::isDiscreteProperty() const {
 }
 
 std::string PropertyInterpolator::getPropertyPathString() const {
-  if (propertyPath_.empty()) {
-    return "";
+  std::string result;
+
+  for (const auto &segment : propertyPath_) {
+    if (const auto *arrayIndex = std::get_if<size_t>(&segment)) {
+      result += "[" + std::to_string(*arrayIndex) + "]";
+    } else {
+      if (!result.empty()) {
+        result += ".";
+      }
+      result += std::get<std::string>(segment);
+    }
   }
 
-  std::string result = propertyPath_[0];
-  for (size_t i = 1; i < propertyPath_.size(); ++i) {
-    result += "." + propertyPath_[i];
-  }
   return result;
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.cpp
@@ -1,10 +1,28 @@
 #include <reanimated/CSS/misc/ViewStylesRepository.h>
 #include <reanimated/Tools/FeatureFlags.h>
 
+#include <charconv>
 #include <memory>
+#include <optional>
 #include <string>
+#include <system_error>
 
 namespace reanimated::css {
+
+namespace {
+
+std::optional<size_t> tryParseArrayIndex(const std::string &pathSegment) {
+  size_t index = 0;
+  const auto *const end = pathSegment.data() + pathSegment.size();
+  const auto [parseEnd, errorCode] = std::from_chars(pathSegment.data(), end, index);
+
+  if (errorCode != std::errc{} || parseEnd != end) {
+    return std::nullopt;
+  }
+  return index;
+}
+
+} // namespace
 
 ViewStylesRepository::ViewStylesRepository(
     const std::shared_ptr<StaticPropsRegistry> &staticPropsRegistry,
@@ -134,6 +152,17 @@ folly::dynamic ViewStylesRepository::getPropertyValue(const folly::dynamic &valu
     }
 
     const auto &propName = propertyPath[i];
+
+    // Array-typed props (boxShadow, backgroundImage, transformOrigin) get a
+    // numeric path segment from createPropertyInterpolator.
+    if (currentValue->isArray()) {
+      const auto index = tryParseArrayIndex(propName);
+      if (!index.has_value() || *index >= currentValue->size()) {
+        return {};
+      }
+      currentValue = &(*currentValue)[*index];
+      continue;
+    }
 
     if (!currentValue->isObject()) {
       return {};

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.cpp
@@ -130,13 +130,6 @@ folly::dynamic ViewStylesRepository::getPropertyValue(const folly::dynamic &valu
   const folly::dynamic *currentValue = &value;
 
   for (const auto &segment : propertyPath) {
-    // folly::dynamic::empty() throws for scalars, and the animated props
-    // registry stores unnormalized worklet output, so a path can descend onto
-    // one.
-    if (!currentValue->isObject() && !currentValue->isArray()) {
-      return {};
-    }
-
     if (const auto *arrayIndex = std::get_if<size_t>(&segment)) {
       if (!currentValue->isArray() || *arrayIndex >= currentValue->size()) {
         return {};

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.cpp
@@ -129,12 +129,15 @@ folly::dynamic ViewStylesRepository::getStyleProp(const Tag tag, const PropertyP
 folly::dynamic ViewStylesRepository::getPropertyValue(const folly::dynamic &value, const PropertyPath &propertyPath) {
   const folly::dynamic *currentValue = &value;
 
-  for (size_t i = 0; i < propertyPath.size(); ++i) {
-    if (currentValue->isNull() || currentValue->empty()) {
+  for (const auto &segment : propertyPath) {
+    // folly::dynamic::empty() throws for scalars, and the animated props
+    // registry stores unnormalized worklet output, so a path can descend onto
+    // one.
+    if (!currentValue->isObject() && !currentValue->isArray()) {
       return {};
     }
 
-    if (const auto *arrayIndex = std::get_if<size_t>(&propertyPath[i])) {
+    if (const auto *arrayIndex = std::get_if<size_t>(&segment)) {
       if (!currentValue->isArray() || *arrayIndex >= currentValue->size()) {
         return {};
       }
@@ -142,7 +145,7 @@ folly::dynamic ViewStylesRepository::getPropertyValue(const folly::dynamic &valu
       continue;
     }
 
-    const auto &propName = std::get<std::string>(propertyPath[i]);
+    const auto &propName = std::get<std::string>(segment);
 
     if (!currentValue->isObject()) {
       return {};
@@ -159,25 +162,7 @@ folly::dynamic ViewStylesRepository::getPropertyValue(const folly::dynamic &valu
         return {};
       }
 
-      if (i + 1 >= propertyPath.size()) {
-        return transform;
-      }
-
-      const auto *transformPropName = std::get_if<std::string>(&propertyPath[i + 1]);
-      if (transformPropName == nullptr) {
-        return {};
-      }
-
-      for (const auto &transformEntry : transform) {
-        if (transformEntry.isObject()) {
-          auto transformPropIt = transformEntry.find(*transformPropName);
-          if (transformPropIt != transformEntry.items().end()) {
-            return transformPropIt->second;
-          }
-        }
-      }
-
-      return {};
+      return transform;
     }
 
     auto propIt = currentValue->find(propName);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.cpp
@@ -1,28 +1,11 @@
 #include <reanimated/CSS/misc/ViewStylesRepository.h>
 #include <reanimated/Tools/FeatureFlags.h>
 
-#include <charconv>
 #include <memory>
-#include <optional>
 #include <string>
-#include <system_error>
+#include <variant>
 
 namespace reanimated::css {
-
-namespace {
-
-std::optional<size_t> tryParseArrayIndex(const std::string &pathSegment) {
-  size_t index = 0;
-  const auto *const end = pathSegment.data() + pathSegment.size();
-  const auto [parseEnd, errorCode] = std::from_chars(pathSegment.data(), end, index);
-
-  if (errorCode != std::errc{} || parseEnd != end) {
-    return std::nullopt;
-  }
-  return index;
-}
-
-} // namespace
 
 ViewStylesRepository::ViewStylesRepository(
     const std::shared_ptr<StaticPropsRegistry> &staticPropsRegistry,
@@ -151,18 +134,15 @@ folly::dynamic ViewStylesRepository::getPropertyValue(const folly::dynamic &valu
       return {};
     }
 
-    const auto &propName = propertyPath[i];
-
-    // Array-typed props (boxShadow, backgroundImage, transformOrigin) get a
-    // numeric path segment from createPropertyInterpolator.
-    if (currentValue->isArray()) {
-      const auto index = tryParseArrayIndex(propName);
-      if (!index.has_value() || *index >= currentValue->size()) {
+    if (const auto *arrayIndex = std::get_if<size_t>(&propertyPath[i])) {
+      if (!currentValue->isArray() || *arrayIndex >= currentValue->size()) {
         return {};
       }
-      currentValue = &(*currentValue)[*index];
+      currentValue = &(*currentValue)[*arrayIndex];
       continue;
     }
+
+    const auto &propName = std::get<std::string>(propertyPath[i]);
 
     if (!currentValue->isObject()) {
       return {};
@@ -183,11 +163,14 @@ folly::dynamic ViewStylesRepository::getPropertyValue(const folly::dynamic &valu
         return transform;
       }
 
-      const std::string &transformPropName = propertyPath[i + 1];
+      const auto *transformPropName = std::get_if<std::string>(&propertyPath[i + 1]);
+      if (transformPropName == nullptr) {
+        return {};
+      }
 
       for (const auto &transformEntry : transform) {
         if (transformEntry.isObject()) {
-          auto transformPropIt = transformEntry.find(transformPropName);
+          auto transformPropIt = transformEntry.find(*transformPropName);
           if (transformPropIt != transformEntry.items().end()) {
             return transformPropIt->second;
           }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/interpolators.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/interpolators.cpp
@@ -28,7 +28,7 @@ std::shared_ptr<PropertyInterpolator> createPropertyInterpolator(
     const InterpolatorFactoriesArray &factories,
     const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) {
   PropertyPath newPath = propertyPath;
-  newPath.emplace_back(std::to_string(arrayIndex));
+  newPath.emplace_back(arrayIndex);
 
   return factories[arrayIndex % factories.size()]->create(newPath, viewStylesRepository);
 }


### PR DESCRIPTION
`PropertyPath` was a `vector<std::string>`, so `ViewStylesRepository::getPropertyValue` could not tell an array index from a record key and bailed out whenever a segment landed on an array. Array-typed props (`boxShadow`, `transformOrigin`, `backgroundImage`) could therefore never read the view's own style, so implicit keyframes (`getFallbackValue`) and the `animationFillMode: 'none'` revert (`getResetStyle`) silently used the interpolator's default instead.

A segment is now `std::variant<std::string, size_t>`, so an index stays an index end to end. The loop's `isNull() || empty()` guard is dropped rather than replaced: each branch already checks the type it needs, and `folly::dynamic::empty()` throws for scalars.

One consequence: a `boxShadow` implicit keyframe can now be discrete where it used to tween, because the view's own value always carries an `inset` and the old default left it unset.

## Examples

The left box is a static `View` for reference. Each recording shows the broken run, then the fixed one.

**1. `boxShadow`, only `to` declared** - swings between no shadow and lime, never reaching the view's red.

```jsx
<Animated.View
  style={{
    width: 84,
    height: 84,
    boxShadow: '0px 0px 12px 6px red',
    animationName: { to: { boxShadow: '0px 0px 24px 12px lime' } },
    animationDuration: 1600,
    animationDirection: 'alternate',
    animationIterationCount: 'infinite',
  }}
/>
```

https://github.com/user-attachments/assets/02d4ce40-95f4-4e79-bb01-158acd0deff2

**2. `transformOrigin`, only `to` declared** - swings from the centre of its bounds, never reaching `0% 0%`.

```jsx
<Animated.View
  style={{
    width: 84,
    height: 84,
    backgroundColor: 'orange',
    transformOrigin: '0% 0%',
    transform: [{ scale: 0.3 }],
    animationName: { to: { transformOrigin: '100% 100%' } },
    animationDuration: 1600,
    animationDirection: 'alternate',
    animationIterationCount: 'infinite',
  }}
/>
```

https://github.com/user-attachments/assets/f56814e7-4e88-4621-a71c-c513f8c9ad6f

**3. `boxShadow` with `animationFillMode: 'none'`** - left with no shadow once the animation finishes.

```jsx
<Animated.View
  style={{
    width: 84,
    height: 84,
    boxShadow: '0px 0px 12px 6px red',
    animationName: {
      from: { boxShadow: '0px 0px 4px 2px blue' },
      to: { boxShadow: '0px 0px 24px 12px lime' },
    },
    animationDuration: 2000,
    animationDelay: 1000,
    animationFillMode: 'none',
  }}
/>
```

https://github.com/user-attachments/assets/d21e9188-a5ef-4e06-81cc-7f7e326d538f

**4. `transformOrigin` with `animationFillMode: 'none'`** - lands in the centre of its bounds instead of returning to `0% 0%`.

```jsx
<Animated.View
  style={{
    width: 84,
    height: 84,
    backgroundColor: 'orange',
    transformOrigin: '0% 0%',
    transform: [{ scale: 0.3 }],
    animationName: {
      from: { transformOrigin: '100% 0%' },
      to: { transformOrigin: '100% 100%' },
    },
    animationDuration: 2000,
    animationDelay: 1000,
    animationFillMode: 'none',
  }}
/>
```

https://github.com/user-attachments/assets/8aff2b42-a47f-4076-ad3c-4095f86b6c57

## Testing

Ran the four cases on the iOS simulator with and without the change, so `ViewStylesRepository.cpp` is the only difference between the runs. No automated coverage - the repo has no C++ test target and ReJest has no CSS category. Not exercised on Android, though the change is platform-agnostic C++.
