### PR TITLE
fix(CSS): backgroundImage gradient parsing and web serialization

### DIFF
--- a/docs/docs-reanimated/docs/guides/supported-properties.mdx
+++ b/docs/docs-reanimated/docs/guides/supported-properties.mdx
@@ -260,7 +260,9 @@ We highly recommend to use [the `boxShadow` property](https://reactnative.dev/bl
 
 ### Animating background image gradients
 
-The `backgroundImage` style property (linear and radial gradients) is available under this name since React Native 0.87. On older React Native versions use the `experimental_backgroundImage` property instead - both names are supported and animate the same way. Gradients interpolate smoothly when both keyframes use the same gradient type, direction kind, number of color stops and compatible units; otherwise the value changes discretely in the middle of the animation.
+The `backgroundImage` style property (linear and radial gradients) is available under this name since React Native 0.87. On older React Native versions use the `experimental_backgroundImage` property instead - both names are supported and animate the same way.
+
+Two gradients interpolate smoothly only when they line up: the same gradient type, the same number of color stops, and the same unit on every length. Angles, radial sizes and radial positions all interpolate, as long as the sizes and positions use the same units and the same edges. What has to match exactly is the corner keyword (e.g. `to top right`), the radial shape, and the extent keyword (e.g. `farthest-corner`). Anything else steps from one gradient to the other instead of interpolating: halfway between the surrounding keyframes in an animation, and at the very start of a transition, or halfway through it with [`transitionBehavior: 'allow-discrete'`](/docs/css-transitions/transition-behavior).
 
 ### Animating image tint color
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/complex/CSSBackgroundImage.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/complex/CSSBackgroundImage.cpp
@@ -34,9 +34,8 @@ bool hasGradientType(jsi::Runtime &rt, const jsi::Value &jsiValue, const char *g
   return type.isString() && type.asString(rt).utf8(rt) == gradientType;
 }
 
-/// A stop with no color is a transition hint, so a color CSSColor cannot
-/// represent has to reject the whole gradient rather than be serialized back
-/// as a hint.
+/// A stop with no color is a transition hint. Serializing an unsupported color
+/// back would drop it and turn the stop into one, so reject the gradient.
 bool areColorStopsConstructible(const folly::dynamic &value) {
   const auto stopsIt = value.find("colorStops");
   if (stopsIt == value.items().end()) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/complex/CSSBackgroundImage.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/complex/CSSBackgroundImage.cpp
@@ -34,6 +34,57 @@ bool hasGradientType(jsi::Runtime &rt, const jsi::Value &jsiValue, const char *g
   return type.isString() && type.asString(rt).utf8(rt) == gradientType;
 }
 
+/// A stop with no color is a transition hint, so a color CSSColor cannot
+/// represent has to reject the whole gradient rather than be serialized back
+/// as a hint.
+bool areColorStopsConstructible(const folly::dynamic &value) {
+  const auto stopsIt = value.find("colorStops");
+  if (stopsIt == value.items().end()) {
+    return true;
+  }
+  if (!stopsIt->second.isArray()) {
+    return false;
+  }
+
+  for (const auto &stop : stopsIt->second) {
+    if (!stop.isObject()) {
+      return false;
+    }
+    const auto colorIt = stop.find("color");
+    if (colorIt != stop.items().end() && !colorIt->second.isNull() && !CSSColor::canConstruct(colorIt->second)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool areColorStopsConstructible(jsi::Runtime &rt, const jsi::Value &jsiValue) {
+  const auto stops = jsiValue.asObject(rt).getProperty(rt, "colorStops");
+  if (stops.isUndefined() || stops.isNull()) {
+    return true;
+  }
+  if (!stops.isObject() || !stops.asObject(rt).isArray(rt)) {
+    return false;
+  }
+
+  const auto stopsArray = stops.asObject(rt).asArray(rt);
+  const auto stopsCount = stopsArray.size(rt);
+
+  for (size_t i = 0; i < stopsCount; ++i) {
+    const auto stop = stopsArray.getValueAtIndex(rt, i);
+    if (!stop.isObject()) {
+      return false;
+    }
+    const auto color = stop.asObject(rt).getProperty(rt, "color");
+    if (!color.isUndefined() && !color.isNull() && !CSSColor::canConstruct(rt, color)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 std::vector<GradientColorStop> colorStopsFromDynamic(const folly::dynamic &value) {
   std::vector<GradientColorStop> result;
 
@@ -206,11 +257,11 @@ CSSLinearGradient::CSSLinearGradient(const folly::dynamic &value) {
 }
 
 bool CSSLinearGradient::canConstruct(jsi::Runtime &rt, const jsi::Value &jsiValue) {
-  return hasGradientType(rt, jsiValue, LINEAR_GRADIENT_TYPE);
+  return hasGradientType(rt, jsiValue, LINEAR_GRADIENT_TYPE) && areColorStopsConstructible(rt, jsiValue);
 }
 
 bool CSSLinearGradient::canConstruct(const folly::dynamic &value) {
-  return hasGradientType(value, LINEAR_GRADIENT_TYPE);
+  return hasGradientType(value, LINEAR_GRADIENT_TYPE) && areColorStopsConstructible(value);
 }
 
 folly::dynamic CSSLinearGradient::toDynamic() const {
@@ -330,11 +381,11 @@ CSSRadialGradient::CSSRadialGradient(const folly::dynamic &value) {
 }
 
 bool CSSRadialGradient::canConstruct(jsi::Runtime &rt, const jsi::Value &jsiValue) {
-  return hasGradientType(rt, jsiValue, RADIAL_GRADIENT_TYPE);
+  return hasGradientType(rt, jsiValue, RADIAL_GRADIENT_TYPE) && areColorStopsConstructible(rt, jsiValue);
 }
 
 bool CSSRadialGradient::canConstruct(const folly::dynamic &value) {
-  return hasGradientType(value, RADIAL_GRADIENT_TYPE);
+  return hasGradientType(value, RADIAL_GRADIENT_TYPE) && areColorStopsConstructible(value);
 }
 
 folly::dynamic CSSRadialGradient::toDynamic() const {

--- a/packages/react-native-reanimated/src/common/style/processors/__tests__/backgroundImage.test.ts
+++ b/packages/react-native-reanimated/src/common/style/processors/__tests__/backgroundImage.test.ts
@@ -219,11 +219,47 @@ describe(processBackgroundImage, () => {
       'linear-gradient(20%, red, blue)', // hint without a preceding color
       'radial-gradient(square, red, blue)', // invalid color
       'radial-gradient(ellipse 100px, red, blue)', // single size with ellipse
-      'radial-gradient(circle 50%, red, blue)', // circle with percentage radius
-      'radial-gradient(50%, red, blue)', // inferred circle with percentage radius
+      'radial-gradient(ellipse -50px 60px, red, blue)', // negative length size
     ])('throws for invalid input "%s"', (input) => {
       expect(() => processBackgroundImage(input)).toThrow();
     });
+
+    // Invalid CSS that React Native renders anyway - it must not start throwing
+    // once the same style is animated
+    test.each([
+      ['radial-gradient(circle 50%, red, blue)', { x: '50%', y: '50%' }],
+      ['radial-gradient(50%, red, blue)', { x: '50%', y: '50%' }],
+      ['radial-gradient(circle 50% 100px, red, blue)', { x: '50%', y: 100 }],
+      ['radial-gradient(circle 100px 50%, red, blue)', { x: 100, y: '50%' }],
+    ])('accepts the percentage circle radius in "%s"', (input, size) => {
+      expect(processBackgroundImage(input)).toEqual([
+        expect.objectContaining({
+          type: 'radial-gradient',
+          shape: 'circle',
+          size,
+        }),
+      ]);
+    });
+
+    test.each(['\t', '\v', '\f', '  '])(
+      'accepts %j between "to" and the direction keyword',
+      (whitespace) => {
+        expect(
+          processBackgroundImage(
+            `linear-gradient(to${whitespace}right, red, blue)`
+          )
+        ).toEqual([
+          {
+            type: 'linear-gradient',
+            direction: { type: 'angle', value: 90 },
+            colorStops: [
+              { color: 0xffff0000, position: null },
+              { color: 0xff0000ff, position: null },
+            ],
+          },
+        ]);
+      }
+    );
   });
 
   describe('when input is an array of objects', () => {
@@ -364,6 +400,38 @@ describe(processBackgroundImage, () => {
       [{ type: 'radial-gradient', shape: 'square', colorStops: [] }],
       [{ type: 'radial-gradient', size: 'huge', colorStops: [] }],
       [{ type: 'conic-gradient', colorStops: [] }],
+      // A transition hint must sit between two color stops
+      [
+        {
+          type: 'linear-gradient',
+          colorStops: [
+            { color: null, positions: ['20%'] },
+            { color: 'red' },
+            { color: 'blue' },
+          ],
+        },
+      ],
+      [
+        {
+          type: 'linear-gradient',
+          colorStops: [
+            { color: 'red' },
+            { color: 'blue' },
+            { color: null, positions: ['80%'] },
+          ],
+        },
+      ],
+      [
+        {
+          type: 'linear-gradient',
+          colorStops: [
+            { color: 'red' },
+            { color: null, positions: ['20%'] },
+            { color: null, positions: ['80%'] },
+            { color: 'blue' },
+          ],
+        },
+      ],
     ] as unknown as [BackgroundImageValue][])(
       'throws for invalid input %j',
       (input) => {

--- a/packages/react-native-reanimated/src/common/style/processors/backgroundImage.ts
+++ b/packages/react-native-reanimated/src/common/style/processors/backgroundImage.ts
@@ -182,10 +182,6 @@ const ERROR_MESSAGES = {
     'worklet';
     return `Invalid size ${JSON.stringify(size)} in a radial gradient. Expected an extent keyword (e.g. "farthest-corner"), a single non-negative length, or a pair of non-negative lengths.`;
   },
-  invalidGradientPosition(position: unknown) {
-    'worklet';
-    return `Invalid position ${JSON.stringify(position)} in a radial gradient.`;
-  },
   invalidColorStopPosition(position: unknown) {
     'worklet';
     return `Invalid color stop position ${JSON.stringify(position)} in a gradient. Expected a number (pixels) or a percentage string.`;

--- a/packages/react-native-reanimated/src/common/style/processors/backgroundImage.ts
+++ b/packages/react-native-reanimated/src/common/style/processors/backgroundImage.ts
@@ -89,6 +89,7 @@ const WHITESPACE_NORMALIZE_REGEX = /\s+/g;
 
 const LINEAR_GRADIENT_ANGLE_UNIT_REGEX =
   /^([+-]?\d*\.?\d+)(deg|grad|rad|turn)$/;
+const LINEAR_GRADIENT_DIRECTION_PREFIX_REGEX = /^to\s/;
 
 const DEFAULT_LINEAR_GRADIENT_DIRECTION: ProcessedLinearGradientDirection = {
   type: 'angle',
@@ -255,6 +256,22 @@ function processColorStops(
     }
   }
 
+  // React Native does not fix up an edge stop with no color: iOS throws on a
+  // leading one and silently draws a trailing one as transparent.
+  for (let i = 0; i < processedColorStops.length; i++) {
+    const { color, position } = processedColorStops[i];
+    if (
+      color === null &&
+      (i === 0 ||
+        i === processedColorStops.length - 1 ||
+        processedColorStops[i - 1].color === null)
+    ) {
+      throw new Error(
+        `[Reanimated] ${ERROR_MESSAGES.invalidTransitionHint(position)}`
+      );
+    }
+  }
+
   return processedColorStops;
 }
 
@@ -358,7 +375,7 @@ function parseLinearGradientCSSString(
     }
     direction = { type: 'angle', value: parsedAngle };
     parts.shift();
-  } else if (trimmedDirection.startsWith('to ')) {
+  } else if (LINEAR_GRADIENT_DIRECTION_PREFIX_REGEX.test(trimmedDirection)) {
     const parsedDirection = getDirectionForKeyword(trimmedDirection);
     if (parsedDirection == null) {
       throw new Error(
@@ -633,18 +650,6 @@ function parseRadialGradientCSSString(
     if (hasExplicitSingleSize && hasExplicitShape && shape === 'ellipse') {
       // A single size can be used only with the circle shape
       throw invalidGradient();
-    }
-
-    if (
-      shape === 'circle' &&
-      typeof size === 'object' &&
-      (typeof size.x === 'string' || typeof size.y === 'string')
-    ) {
-      // A circle radius must be a <length>. Percentages are only valid for
-      // ellipses, so browsers reject the whole declaration.
-      throw new Error(
-        `[Reanimated] ${ERROR_MESSAGES.invalidGradientSize(size)}`
-      );
     }
   }
 

--- a/packages/react-native-reanimated/src/common/web/style/processors/__tests__/backgroundImage.test.ts
+++ b/packages/react-native-reanimated/src/common/web/style/processors/__tests__/backgroundImage.test.ts
@@ -60,9 +60,33 @@ describe(processBackgroundImageWeb, () => {
         },
       ])
     ).toBe(
-      'radial-gradient(ellipse 100px 50% at top 10% left 20px, red, blue)'
+      'radial-gradient(ellipse 100px 50% at left 20px top 10%, red, blue)'
     );
   });
+
+  test.each([
+    [{ top: '10%' }, 'at left 50% top 10%'],
+    [{ left: '10%' }, 'at left 10% top 50%'],
+    [{ bottom: '10%' }, 'at left 50% bottom 10%'],
+    [{ right: 20 }, 'at right 20px top 50%'],
+    [{ bottom: '10%', right: 20 }, 'at right 20px bottom 10%'],
+    // Native prefers left over right and top over bottom
+    [{ left: 10, right: 20, top: 30, bottom: 40 }, 'at left 10px top 30px'],
+    [{}, ''],
+  ])(
+    'serializes the partial radial gradient position %j with both axes',
+    (position, expected) => {
+      expect(
+        processBackgroundImageWeb([
+          {
+            type: 'radial-gradient',
+            position,
+            colorStops: [{ color: 'red' }, { color: 'blue' }],
+          },
+        ])
+      ).toBe(`radial-gradient(${expected ? `${expected}, ` : ''}red, blue)`);
+    }
+  );
 
   test('serializes a circle size as a single radius', () => {
     expect(
@@ -78,10 +102,13 @@ describe(processBackgroundImageWeb, () => {
   });
 
   test.each([
-    [{ x: 100, y: 50 }], // unequal axes cannot describe a circle
-    [{ x: '50%', y: '50%' }], // a circle radius cannot be a percentage
-  ])('throws for an invalid circle size %j', (size) => {
-    expect(() =>
+    [{ x: 100, y: 50 }, 'circle 100px'], // max(x, y)
+    [{ x: '100px', y: '50px' }, 'circle 100px'],
+    [{ x: '100', y: '100' }, 'circle 100px'],
+    [{ x: '50%', y: '50%' }, '50% 50%'], // no CSS spelling, degrades to an ellipse
+    [{ x: '50%', y: 100 }, '50% 100px'],
+  ])('serializes the circle size %j as %s', (size, expected) => {
+    expect(
       processBackgroundImageWeb([
         {
           type: 'radial-gradient',
@@ -90,7 +117,7 @@ describe(processBackgroundImageWeb, () => {
           colorStops: [{ color: 'red' }, { color: 'blue' }],
         },
       ])
-    ).toThrow();
+    ).toBe(`radial-gradient(${expected}, red, blue)`);
   });
 
   test('serializes multiple gradients', () => {

--- a/packages/react-native-reanimated/src/common/web/style/processors/backgroundImage.ts
+++ b/packages/react-native-reanimated/src/common/web/style/processors/backgroundImage.ts
@@ -57,6 +57,60 @@ function serializeColorStops(
     .join(', ');
 }
 
+type RadialGradientPosition = NonNullable<RadialGradientValue['position']>;
+
+// A one-axis clause means something else in CSS: `at top 10%` is invalid and
+// `at left 10%` reads as x=0%, y=10% rather than the x=10%, y=50% native
+// resolves it to. Both axes are spelled out so the two agree.
+function serializeRadialGradientPosition({
+  top,
+  left,
+  bottom,
+  right,
+}: RadialGradientPosition): string {
+  if (top == null && left == null && bottom == null && right == null) {
+    return '';
+  }
+
+  const horizontal =
+    right != null && left == null
+      ? `right ${maybeAddSuffix(right, 'px')}`
+      : `left ${maybeAddSuffix(left ?? '50%', 'px')}`;
+  const vertical =
+    bottom != null && top == null
+      ? `bottom ${maybeAddSuffix(bottom, 'px')}`
+      : `top ${maybeAddSuffix(top ?? '50%', 'px')}`;
+
+  return `at ${horizontal} ${vertical}`;
+}
+
+function isPercentage(value: string | number): boolean {
+  return typeof value === 'string' && value.endsWith('%');
+}
+
+// CSS allows only one non-negative <length> as an explicit circle radius, while
+// React Native draws max(x, y). A percentage radius has no CSS spelling at all,
+// so it degrades to the equivalent ellipse rather than making the browser drop
+// the whole declaration.
+function serializeRadialGradientLengthSize(
+  shape: RadialGradientValue['shape'],
+  size: Exclude<NonNullable<RadialGradientValue['size']>, string>
+): string {
+  const radii = `${maybeAddSuffix(size.x, 'px')} ${maybeAddSuffix(size.y, 'px')}`;
+
+  if (shape !== 'circle') {
+    return shape ? `${shape} ${radii}` : radii;
+  }
+  if (isPercentage(size.x) || isPercentage(size.y)) {
+    return radii;
+  }
+  const radius = Math.max(
+    parseFloat(String(size.x)),
+    parseFloat(String(size.y))
+  );
+  return `circle ${maybeAddSuffix(radius, 'px')}`;
+}
+
 function serializeRadialGradientPrelude({
   shape,
   size,
@@ -64,36 +118,20 @@ function serializeRadialGradientPrelude({
 }: RadialGradientValue): string {
   const parts: string[] = [];
 
-  if (shape) {
-    parts.push(shape);
-  }
-  if (size) {
-    if (typeof size === 'string') {
+  if (size != null && typeof size === 'object') {
+    parts.push(serializeRadialGradientLengthSize(shape, size));
+  } else {
+    if (shape) {
+      parts.push(shape);
+    }
+    if (size) {
       parts.push(size);
-    } else if (shape === 'circle') {
-      // The CSS grammar allows only a single non-negative <length> as an
-      // explicit circle radius - two values describe an ellipse and a
-      // percentage radius is invalid, so browsers would reject the whole
-      // declaration.
-      const isPercent = typeof size.x === 'string' && size.x.endsWith('%');
-      if (size.x !== size.y || isPercent) {
-        throw new Error(
-          `[Reanimated] Invalid circle size ${JSON.stringify(size)} in a radial gradient. A circle radius must be a single length (e.g. 100 or "100px").`
-        );
-      }
-      parts.push(maybeAddSuffix(size.x, 'px'));
-    } else {
-      parts.push(
-        `${maybeAddSuffix(size.x, 'px')} ${maybeAddSuffix(size.y, 'px')}`
-      );
     }
   }
   if (position) {
-    const positionParts = Object.entries(position).map(
-      ([side, value]) => `${side} ${maybeAddSuffix(value, 'px')}`
-    );
-    if (positionParts.length > 0) {
-      parts.push(`at ${positionParts.join(' ')}`);
+    const serializedPosition = serializeRadialGradientPosition(position);
+    if (serializedPosition) {
+      parts.push(serializedPosition);
     }
   }
 

--- a/packages/react-native-reanimated/src/common/web/style/processors/backgroundImage.ts
+++ b/packages/react-native-reanimated/src/common/web/style/processors/backgroundImage.ts
@@ -59,9 +59,8 @@ function serializeColorStops(
 
 type RadialGradientPosition = NonNullable<RadialGradientValue['position']>;
 
-// A one-axis clause means something else in CSS: `at top 10%` is invalid and
-// `at left 10%` reads as x=0%, y=10% rather than the x=10%, y=50% native
-// resolves it to. Both axes are spelled out so the two agree.
+// CSS reads a one-axis clause differently: `at top 10%` is invalid and
+// `at left 10%` means x=0%, y=10%, not the x=10%, y=50% native resolves.
 function serializeRadialGradientPosition({
   top,
   left,
@@ -88,10 +87,8 @@ function isPercentage(value: string | number): boolean {
   return typeof value === 'string' && value.endsWith('%');
 }
 
-// CSS allows only one non-negative <length> as an explicit circle radius, while
-// React Native draws max(x, y). A percentage radius has no CSS spelling at all,
-// so it degrades to the equivalent ellipse rather than making the browser drop
-// the whole declaration.
+// CSS allows only one non-negative <length> as a circle radius, React Native
+// draws max(x, y), and a percentage radius has no CSS spelling at all.
 function serializeRadialGradientLengthSize(
   shape: RadialGradientValue['shape'],
   size: Exclude<NonNullable<RadialGradientValue['size']>, string>


### PR DESCRIPTION
Fixes found while reviewing #10193. That PR comes from a fork, which GitHub will not accept as a base, so its head is mirrored as `@matipl01/base-10193-background-image` to keep this diff to its own six files. Retarget to `main` and delete that branch once #10193 lands.

**Parser** - a style that renders in a static `backgroundImage` must not start throwing once it is animated, since the processor runs every frame. `radial-gradient(50%, ...)` and `circle 50%` are invalid CSS but React Native renders them, so they are accepted rather than rejected. `linear-gradient(to<TAB>right, ...)` parses too - the direction check hard-coded a single space.

**Color stops** - the object syntax now rejects a transition hint that is not between two color stops, matching the CSS string path. Colors `CSSColor` cannot represent (`PlatformColor`, `DynamicColorIOS`) raise the same error `boxShadow` already does, instead of being serialized back as a null color and drawn as a hint.

**Web serialization** - radial positions emit both axes: `{ top: '10%' }` produced `at top 10%`, which Chrome rejects outright, dropping the whole `background-image` with it, and `{ left: '10%' }` meant x=0%, y=10% where native means x=10%, y=50%. Circle sizes degrade to `circle max(x,y)px`, or to the equivalent ellipse when a percentage radius makes it inexpressible.

```jsx
<Animated.View
  style={{
    width: 84,
    height: 84,
    backgroundImage: [
      {
        type: 'radial-gradient',
        position: { top: '10%' },
        colorStops: [{ color: 'red' }, { color: 'blue' }],
      },
    ],
  }}
/>
```

> 🖼️ _placeholder - upload the web before/after screenshot here_

**Docs** - radial sizes and positions do interpolate when their units and edges match; only the corner keyword, shape and extent keyword must be identical. The flip point differs per mode.

## Testing

1505 jest tests, both typechecks, eslint and the formatters pass. Every serialized string was checked against `CSS.supports` in headless Chrome, and the parser and color-stop changes were exercised on the iOS simulator.

Left for a separate decision: `processBackgroundImageObjects` forwards `position` unvalidated, so an unrecognised side is silently dropped and, because `canInterpolateTo` compares side names, a dropped side turns a smooth animation into a discrete step. Closing that adds new throws.

`to`-only keyframes for `backgroundImage` still resolve to the interpolator default rather than the element's own gradient - a separate defect in the property path lookup, fixed in #10253.
