### PR TITLE
fix: deliver the CSS animation cancel emitted while a view unmounts

### DIFF
--- a/packages/react-native-reanimated/src/css/native/events/CSSCallbacksRegistry.ts
+++ b/packages/react-native-reanimated/src/css/native/events/CSSCallbacksRegistry.ts
@@ -13,14 +13,12 @@ class CSSCallbacksRegistry {
   >();
 
   /**
-   * Subscribers of unmounting views, kept until one batch has been dispatched.
-   * The engine emits their cancel as the view tears down, but the batch
-   * carrying it arrives after the view is already gone.
+   * Unsubscribed views that still hear one batch, because the engine emits
+   * their cancel as they tear down but the batch carrying it arrives later.
    */
   private retiringByTag = new Map<number, Set<CSSEventSubscriber>>();
 
   register(viewTag: number, subscriber: CSSEventSubscriber): void {
-    // A view that mounts again is no longer retiring, so it stays in one set.
     this.retiringByTag.get(viewTag)?.delete(subscriber);
     addToTag(this.subscribersByTag, viewTag, subscriber);
   }
@@ -38,10 +36,8 @@ class CSSCallbacksRegistry {
   }
 
   /**
-   * Unsubscribes an unmounting view, but lets it hear one more batch so the
-   * cancel already emitted for it still arrives. Unsubscribing right away,
-   * rather than queueing the removal, is what lets a view that mounts again
-   * stay subscribed by simply registering.
+   * Unsubscribing here, rather than after the batch, is what lets a view that
+   * mounts again stay subscribed by simply registering.
    */
   retire(viewTag: number, subscriber: CSSEventSubscriber): void {
     this.unregister(viewTag, subscriber);
@@ -49,16 +45,15 @@ class CSSCallbacksRegistry {
   }
 
   dispatch(events: NativeCSSEvent[]): void {
-    // Taken before dispatching, so a view retired by a callback in this batch
-    // is heard in the next one rather than this one.
+    // Taken up front, so a view retired by a callback in this batch is heard in
+    // the next one rather than this one.
     const retiring = this.retiringByTag;
     this.retiringByTag = new Map();
 
     for (const event of events) {
       const subscribed = this.subscribersByTag.get(event.tag);
       this.notifySubscribers(subscribed, event);
-      // A callback in this batch can register a retiring view again, and it is
-      // then in both, so the ones just notified are skipped here.
+      // Registering again during the batch puts a view in both sets.
       this.notifySubscribers(retiring.get(event.tag), event, subscribed);
     }
   }

--- a/packages/react-native-reanimated/src/css/native/events/CSSCallbacksRegistry.ts
+++ b/packages/react-native-reanimated/src/css/native/events/CSSCallbacksRegistry.ts
@@ -51,10 +51,7 @@ class CSSCallbacksRegistry {
     this.retiringByTag = new Map();
 
     for (const event of events) {
-      const subscribed = this.subscribersByTag.get(event.tag);
-      this.notifySubscribers(subscribed, event);
-      // Registering again during the batch puts a view in both sets.
-      this.notifySubscribers(retiring.get(event.tag), event, subscribed);
+      this.notifySubscribers(this.listenersFor(event.tag, retiring), event);
     }
   }
 
@@ -63,21 +60,33 @@ class CSSCallbacksRegistry {
     this.retiringByTag.clear();
   }
 
+  /**
+   * Everyone a view's event goes to. Taken as one set because a view that
+   * registers again while retiring is in both, and must still be heard once.
+   */
+  private listenersFor(
+    viewTag: number,
+    retiring: Map<number, Set<CSSEventSubscriber>>
+  ): Set<CSSEventSubscriber> | undefined {
+    const subscribed = this.subscribersByTag.get(viewTag);
+    const retired = retiring.get(viewTag);
+
+    if (!retired) {
+      return subscribed;
+    }
+    return subscribed ? new Set([...subscribed, ...retired]) : retired;
+  }
+
   /** Missing when the event outlived the view it was emitted for. */
   private notifySubscribers(
     subscribers: Set<CSSEventSubscriber> | undefined,
-    event: NativeCSSEvent,
-    alreadyNotified?: Set<CSSEventSubscriber>
+    event: NativeCSSEvent
   ): void {
     if (!subscribers) {
       return;
     }
 
     for (const subscriber of subscribers) {
-      if (alreadyNotified?.has(subscriber)) {
-        continue;
-      }
-
       try {
         subscriber.handleCSSEvent(event);
       } catch (error) {

--- a/packages/react-native-reanimated/src/css/native/events/CSSCallbacksRegistry.ts
+++ b/packages/react-native-reanimated/src/css/native/events/CSSCallbacksRegistry.ts
@@ -12,6 +12,9 @@ class CSSCallbacksRegistry {
     Set<CSSEventSubscriber>
   >();
 
+  /** Subscribers to unregister once the batch in flight has been delivered. */
+  private expiringByTag_ = new Map<number, Set<CSSEventSubscriber>>();
+
   register(viewTag: number, subscriber: CSSEventSubscriber): void {
     const subscribers = this.subscribersByTag_.get(viewTag);
     if (subscribers) {
@@ -33,7 +36,25 @@ class CSSCallbacksRegistry {
     }
   }
 
+  /**
+   * Unregisters a subscriber only after the next batch. The engine emits the
+   * cancel of an unmounting view while it tears down, but the batch carrying it
+   * is dispatched afterwards, so removing the subscriber now would drop it.
+   * Only called while a view unmounts, which never re-registers.
+   */
+  retire(viewTag: number, subscriber: CSSEventSubscriber): void {
+    const expiring = this.expiringByTag_.get(viewTag);
+    if (expiring) {
+      expiring.add(subscriber);
+    } else {
+      this.expiringByTag_.set(viewTag, new Set([subscriber]));
+    }
+  }
+
   dispatch(events: NativeCSSEvent[]): void {
+    const expiring = this.expiringByTag_;
+    this.expiringByTag_ = new Map();
+
     for (const event of events) {
       const subscribers = this.subscribersByTag_.get(event.tag);
       if (!subscribers) {
@@ -53,10 +74,17 @@ class CSSCallbacksRegistry {
         }
       }
     }
+
+    for (const [viewTag, subscribers] of expiring) {
+      for (const subscriber of subscribers) {
+        this.unregister(viewTag, subscriber);
+      }
+    }
   }
 
   clear(): void {
     this.subscribersByTag_.clear();
+    this.expiringByTag_.clear();
   }
 }
 

--- a/packages/react-native-reanimated/src/css/native/events/CSSCallbacksRegistry.ts
+++ b/packages/react-native-reanimated/src/css/native/events/CSSCallbacksRegistry.ts
@@ -5,22 +5,21 @@ import type { CSSEventSubscriber, NativeCSSEvent } from './types';
  * Routes CSS events emitted by the native side to the objects interested in a
  * given view. Nested animated components can share a view tag, so every tag
  * keeps a set of subscribers rather than a single one.
+ *
+ * A view that unmounts is retired instead of unregistered: it stops being a
+ * subscriber, but still hears the batch after, because the engine emits its
+ * cancel as it tears down and that batch arrives once the view is gone.
  */
 class CSSCallbacksRegistry {
   private readonly subscribersByTag = new Map<
     number,
     Set<CSSEventSubscriber>
   >();
-
-  /**
-   * Unsubscribed views that still hear one batch, because the engine emits
-   * their cancel as they tear down but the batch carrying it arrives later.
-   */
   private retiringByTag = new Map<number, Set<CSSEventSubscriber>>();
 
   register(viewTag: number, subscriber: CSSEventSubscriber): void {
     this.retiringByTag.get(viewTag)?.delete(subscriber);
-    addToTag(this.subscribersByTag, viewTag, subscriber);
+    addSubscriber(this.subscribersByTag, viewTag, subscriber);
   }
 
   unregister(viewTag: number, subscriber: CSSEventSubscriber): void {
@@ -36,22 +35,42 @@ class CSSCallbacksRegistry {
   }
 
   /**
-   * Unsubscribing here, rather than after the batch, is what lets a view that
-   * mounts again stay subscribed by simply registering.
+   * Unregistering now, rather than after the batch it still hears, is what lets
+   * a view that mounts again stay subscribed by simply registering.
    */
   retire(viewTag: number, subscriber: CSSEventSubscriber): void {
     this.unregister(viewTag, subscriber);
-    addToTag(this.retiringByTag, viewTag, subscriber);
+    addSubscriber(this.retiringByTag, viewTag, subscriber);
   }
 
   dispatch(events: NativeCSSEvent[]): void {
-    // Taken up front, so a view retired by a callback in this batch is heard in
-    // the next one rather than this one.
+    // Taken up front, so a view retired by a callback in this batch hears the
+    // next one rather than this one.
     const retiring = this.retiringByTag;
     this.retiringByTag = new Map();
 
     for (const event of events) {
-      this.notifySubscribers(this.listenersFor(event.tag, retiring), event);
+      const subscribers = subscribersFor(
+        event.tag,
+        this.subscribersByTag,
+        retiring
+      );
+
+      // Absent once the event outlives the view it was emitted for.
+      if (!subscribers) {
+        continue;
+      }
+
+      for (const subscriber of subscribers) {
+        try {
+          subscriber.handleCSSEvent(event);
+        } catch (error) {
+          // Reported the way an uncaught error would be anyway, so one broken
+          // callback stays fatal without starving the views queued behind it.
+          // @ts-expect-error React Native's `ErrorUtils` are hidden from the global scope.
+          globalThis.ErrorUtils.reportFatalError(error);
+        }
+      }
     }
   }
 
@@ -59,47 +78,9 @@ class CSSCallbacksRegistry {
     this.subscribersByTag.clear();
     this.retiringByTag.clear();
   }
-
-  /**
-   * Everyone a view's event goes to. Taken as one set because a view that
-   * registers again while retiring is in both, and must still be heard once.
-   */
-  private listenersFor(
-    viewTag: number,
-    retiring: Map<number, Set<CSSEventSubscriber>>
-  ): Set<CSSEventSubscriber> | undefined {
-    const subscribed = this.subscribersByTag.get(viewTag);
-    const retired = retiring.get(viewTag);
-
-    if (!retired) {
-      return subscribed;
-    }
-    return subscribed ? new Set([...subscribed, ...retired]) : retired;
-  }
-
-  /** Missing when the event outlived the view it was emitted for. */
-  private notifySubscribers(
-    subscribers: Set<CSSEventSubscriber> | undefined,
-    event: NativeCSSEvent
-  ): void {
-    if (!subscribers) {
-      return;
-    }
-
-    for (const subscriber of subscribers) {
-      try {
-        subscriber.handleCSSEvent(event);
-      } catch (error) {
-        // Reported the way an uncaught error would be anyway, so one broken
-        // callback stays fatal without starving the views queued behind it.
-        // @ts-expect-error React Native's `ErrorUtils` are hidden from the global scope.
-        globalThis.ErrorUtils.reportFatalError(error);
-      }
-    }
-  }
 }
 
-function addToTag(
+function addSubscriber(
   byTag: Map<number, Set<CSSEventSubscriber>>,
   viewTag: number,
   subscriber: CSSEventSubscriber
@@ -110,6 +91,21 @@ function addToTag(
   } else {
     byTag.set(viewTag, new Set([subscriber]));
   }
+}
+
+/** One set, because a view that registers again while retiring is in both. */
+function subscribersFor(
+  viewTag: number,
+  subscribed: Map<number, Set<CSSEventSubscriber>>,
+  retiring: Map<number, Set<CSSEventSubscriber>>
+): Set<CSSEventSubscriber> | undefined {
+  const current = subscribed.get(viewTag);
+  const retired = retiring.get(viewTag);
+
+  if (!retired) {
+    return current;
+  }
+  return current ? new Set([...current, ...retired]) : retired;
 }
 
 const cssCallbacksRegistry = new CSSCallbacksRegistry();

--- a/packages/react-native-reanimated/src/css/native/events/CSSCallbacksRegistry.ts
+++ b/packages/react-native-reanimated/src/css/native/events/CSSCallbacksRegistry.ts
@@ -7,79 +7,66 @@ import type { CSSEventSubscriber, NativeCSSEvent } from './types';
  * keeps a set of subscribers rather than a single one.
  */
 class CSSCallbacksRegistry {
-  private readonly subscribersByTag_ = new Map<
+  private readonly subscribersByTag = new Map<
     number,
     Set<CSSEventSubscriber>
   >();
 
   /**
-   * Subscribers of views being torn down. The engine emits their cancel while
-   * they unmount, but the batch carrying it is dispatched afterwards, so they
-   * keep receiving until one batch has gone out.
+   * Subscribers of unmounting views, kept until one batch has been dispatched.
+   * The engine emits their cancel as the view tears down, but the batch
+   * carrying it arrives after the view is already gone.
    */
-  private retiringByTag_ = new Map<number, Set<CSSEventSubscriber>>();
+  private retiringByTag = new Map<number, Set<CSSEventSubscriber>>();
 
   register(viewTag: number, subscriber: CSSEventSubscriber): void {
-    // A view that mounts again is no longer retiring, and must not be heard
-    // twice for the batch it comes back in.
-    this.retiringByTag_.get(viewTag)?.delete(subscriber);
-
-    const subscribers = this.subscribersByTag_.get(viewTag);
-    if (subscribers) {
-      subscribers.add(subscriber);
-    } else {
-      this.subscribersByTag_.set(viewTag, new Set([subscriber]));
-    }
+    // A view that mounts again is no longer retiring, so it stays in one set.
+    this.retiringByTag.get(viewTag)?.delete(subscriber);
+    addToTag(this.subscribersByTag, viewTag, subscriber);
   }
 
   unregister(viewTag: number, subscriber: CSSEventSubscriber): void {
-    const subscribers = this.subscribersByTag_.get(viewTag);
+    const subscribers = this.subscribersByTag.get(viewTag);
     if (!subscribers) {
       return;
     }
 
     subscribers.delete(subscriber);
     if (subscribers.size === 0) {
-      this.subscribersByTag_.delete(viewTag);
+      this.subscribersByTag.delete(viewTag);
     }
   }
 
   /**
-   * Unsubscribes a view being torn down without dropping it from the next
-   * batch. Removing it eagerly, rather than queueing the removal, is what lets
-   * a frozen view that remounts re-register itself and stay subscribed.
+   * Unsubscribes an unmounting view, but lets it hear one more batch so the
+   * cancel already emitted for it still arrives. Unsubscribing right away,
+   * rather than queueing the removal, is what lets a view that mounts again
+   * stay subscribed by simply registering.
    */
   retire(viewTag: number, subscriber: CSSEventSubscriber): void {
     this.unregister(viewTag, subscriber);
-
-    const retiring = this.retiringByTag_.get(viewTag);
-    if (retiring) {
-      retiring.add(subscriber);
-    } else {
-      this.retiringByTag_.set(viewTag, new Set([subscriber]));
-    }
+    addToTag(this.retiringByTag, viewTag, subscriber);
   }
 
   dispatch(events: NativeCSSEvent[]): void {
-    // Swapped before dispatching, so a view retired by a callback in this batch
-    // is still heard in the next one rather than this one.
-    const retiring = this.retiringByTag_;
-    this.retiringByTag_ = new Map();
+    // Taken before dispatching, so a view retired by a callback in this batch
+    // is heard in the next one rather than this one.
+    const retiring = this.retiringByTag;
+    this.retiringByTag = new Map();
 
     for (const event of events) {
-      // An event can outlive the view it was emitted for, so either set may be
-      // missing. They never share a subscriber: registering again un-retires it.
-      this.deliver_(this.subscribersByTag_.get(event.tag), event);
-      this.deliver_(retiring.get(event.tag), event);
+      this.notifySubscribers(this.subscribersByTag.get(event.tag), event);
+      this.notifySubscribers(retiring.get(event.tag), event);
     }
   }
 
   clear(): void {
-    this.subscribersByTag_.clear();
-    this.retiringByTag_.clear();
+    this.subscribersByTag.clear();
+    this.retiringByTag.clear();
   }
 
-  private deliver_(
+  /** Missing when the event outlived the view it was emitted for. */
+  private notifySubscribers(
     subscribers: Set<CSSEventSubscriber> | undefined,
     event: NativeCSSEvent
   ): void {
@@ -91,13 +78,25 @@ class CSSCallbacksRegistry {
       try {
         subscriber.handleCSSEvent(event);
       } catch (error) {
-        // A batch carries events for unrelated views, so the error is
-        // reported the way an uncaught one would be anyway. That keeps a
-        // broken callback fatal without starving the views queued behind it.
+        // Reported the way an uncaught error would be anyway, so one broken
+        // callback stays fatal without starving the views queued behind it.
         // @ts-expect-error React Native's `ErrorUtils` are hidden from the global scope.
         globalThis.ErrorUtils.reportFatalError(error);
       }
     }
+  }
+}
+
+function addToTag(
+  byTag: Map<number, Set<CSSEventSubscriber>>,
+  viewTag: number,
+  subscriber: CSSEventSubscriber
+): void {
+  const subscribers = byTag.get(viewTag);
+  if (subscribers) {
+    subscribers.add(subscriber);
+  } else {
+    byTag.set(viewTag, new Set([subscriber]));
   }
 }
 

--- a/packages/react-native-reanimated/src/css/native/events/CSSCallbacksRegistry.ts
+++ b/packages/react-native-reanimated/src/css/native/events/CSSCallbacksRegistry.ts
@@ -20,6 +20,10 @@ class CSSCallbacksRegistry {
   private retiringByTag_ = new Map<number, Set<CSSEventSubscriber>>();
 
   register(viewTag: number, subscriber: CSSEventSubscriber): void {
+    // A view that mounts again is no longer retiring, and must not be heard
+    // twice for the batch it comes back in.
+    this.retiringByTag_.get(viewTag)?.delete(subscriber);
+
     const subscribers = this.subscribersByTag_.get(viewTag);
     if (subscribers) {
       subscribers.add(subscriber);
@@ -63,23 +67,10 @@ class CSSCallbacksRegistry {
     this.retiringByTag_ = new Map();
 
     for (const event of events) {
-      const subscribers = this.subscribersFor_(event.tag, retiring);
-      if (!subscribers) {
-        // An event can outlive the view it was emitted for.
-        continue;
-      }
-
-      for (const subscriber of subscribers) {
-        try {
-          subscriber.handleCSSEvent(event);
-        } catch (error) {
-          // A batch carries events for unrelated views, so the error is
-          // reported the way an uncaught one would be anyway. That keeps a
-          // broken callback fatal without starving the views queued behind it.
-          // @ts-expect-error React Native's `ErrorUtils` are hidden from the global scope.
-          globalThis.ErrorUtils.reportFatalError(error);
-        }
-      }
+      // An event can outlive the view it was emitted for, so either set may be
+      // missing. They never share a subscriber: registering again un-retires it.
+      this.deliver_(this.subscribersByTag_.get(event.tag), event);
+      this.deliver_(retiring.get(event.tag), event);
     }
   }
 
@@ -88,17 +79,25 @@ class CSSCallbacksRegistry {
     this.retiringByTag_.clear();
   }
 
-  private subscribersFor_(
-    viewTag: number,
-    retiring: Map<number, Set<CSSEventSubscriber>>
-  ): Set<CSSEventSubscriber> | undefined {
-    const active = this.subscribersByTag_.get(viewTag);
-    const retired = retiring.get(viewTag);
-    if (!retired) {
-      return active;
+  private deliver_(
+    subscribers: Set<CSSEventSubscriber> | undefined,
+    event: NativeCSSEvent
+  ): void {
+    if (!subscribers) {
+      return;
     }
-    // A remounted view is in both, and must still be heard exactly once.
-    return active ? new Set([...active, ...retired]) : retired;
+
+    for (const subscriber of subscribers) {
+      try {
+        subscriber.handleCSSEvent(event);
+      } catch (error) {
+        // A batch carries events for unrelated views, so the error is
+        // reported the way an uncaught one would be anyway. That keeps a
+        // broken callback fatal without starving the views queued behind it.
+        // @ts-expect-error React Native's `ErrorUtils` are hidden from the global scope.
+        globalThis.ErrorUtils.reportFatalError(error);
+      }
+    }
   }
 }
 

--- a/packages/react-native-reanimated/src/css/native/events/CSSCallbacksRegistry.ts
+++ b/packages/react-native-reanimated/src/css/native/events/CSSCallbacksRegistry.ts
@@ -55,8 +55,11 @@ class CSSCallbacksRegistry {
     this.retiringByTag = new Map();
 
     for (const event of events) {
-      this.notifySubscribers(this.subscribersByTag.get(event.tag), event);
-      this.notifySubscribers(retiring.get(event.tag), event);
+      const subscribed = this.subscribersByTag.get(event.tag);
+      this.notifySubscribers(subscribed, event);
+      // A callback in this batch can register a retiring view again, and it is
+      // then in both, so the ones just notified are skipped here.
+      this.notifySubscribers(retiring.get(event.tag), event, subscribed);
     }
   }
 
@@ -68,13 +71,18 @@ class CSSCallbacksRegistry {
   /** Missing when the event outlived the view it was emitted for. */
   private notifySubscribers(
     subscribers: Set<CSSEventSubscriber> | undefined,
-    event: NativeCSSEvent
+    event: NativeCSSEvent,
+    alreadyNotified?: Set<CSSEventSubscriber>
   ): void {
     if (!subscribers) {
       return;
     }
 
     for (const subscriber of subscribers) {
+      if (alreadyNotified?.has(subscriber)) {
+        continue;
+      }
+
       try {
         subscriber.handleCSSEvent(event);
       } catch (error) {

--- a/packages/react-native-reanimated/src/css/native/events/CSSCallbacksRegistry.ts
+++ b/packages/react-native-reanimated/src/css/native/events/CSSCallbacksRegistry.ts
@@ -12,8 +12,12 @@ class CSSCallbacksRegistry {
     Set<CSSEventSubscriber>
   >();
 
-  /** Subscribers to unregister once the batch in flight has been delivered. */
-  private expiringByTag_ = new Map<number, Set<CSSEventSubscriber>>();
+  /**
+   * Subscribers of views being torn down. The engine emits their cancel while
+   * they unmount, but the batch carrying it is dispatched afterwards, so they
+   * keep receiving until one batch has gone out.
+   */
+  private retiringByTag_ = new Map<number, Set<CSSEventSubscriber>>();
 
   register(viewTag: number, subscriber: CSSEventSubscriber): void {
     const subscribers = this.subscribersByTag_.get(viewTag);
@@ -37,26 +41,29 @@ class CSSCallbacksRegistry {
   }
 
   /**
-   * Unregisters a subscriber only after the next batch. The engine emits the
-   * cancel of an unmounting view while it tears down, but the batch carrying it
-   * is dispatched afterwards, so removing the subscriber now would drop it.
-   * Only called while a view unmounts, which never re-registers.
+   * Unsubscribes a view being torn down without dropping it from the next
+   * batch. Removing it eagerly, rather than queueing the removal, is what lets
+   * a frozen view that remounts re-register itself and stay subscribed.
    */
   retire(viewTag: number, subscriber: CSSEventSubscriber): void {
-    const expiring = this.expiringByTag_.get(viewTag);
-    if (expiring) {
-      expiring.add(subscriber);
+    this.unregister(viewTag, subscriber);
+
+    const retiring = this.retiringByTag_.get(viewTag);
+    if (retiring) {
+      retiring.add(subscriber);
     } else {
-      this.expiringByTag_.set(viewTag, new Set([subscriber]));
+      this.retiringByTag_.set(viewTag, new Set([subscriber]));
     }
   }
 
   dispatch(events: NativeCSSEvent[]): void {
-    const expiring = this.expiringByTag_;
-    this.expiringByTag_ = new Map();
+    // Swapped before dispatching, so a view retired by a callback in this batch
+    // is still heard in the next one rather than this one.
+    const retiring = this.retiringByTag_;
+    this.retiringByTag_ = new Map();
 
     for (const event of events) {
-      const subscribers = this.subscribersByTag_.get(event.tag);
+      const subscribers = this.subscribersFor_(event.tag, retiring);
       if (!subscribers) {
         // An event can outlive the view it was emitted for.
         continue;
@@ -74,17 +81,24 @@ class CSSCallbacksRegistry {
         }
       }
     }
-
-    for (const [viewTag, subscribers] of expiring) {
-      for (const subscriber of subscribers) {
-        this.unregister(viewTag, subscriber);
-      }
-    }
   }
 
   clear(): void {
     this.subscribersByTag_.clear();
-    this.expiringByTag_.clear();
+    this.retiringByTag_.clear();
+  }
+
+  private subscribersFor_(
+    viewTag: number,
+    retiring: Map<number, Set<CSSEventSubscriber>>
+  ): Set<CSSEventSubscriber> | undefined {
+    const active = this.subscribersByTag_.get(viewTag);
+    const retired = retiring.get(viewTag);
+    if (!retired) {
+      return active;
+    }
+    // A remounted view is in both, and must still be heard exactly once.
+    return active ? new Set([...active, ...retired]) : retired;
   }
 }
 

--- a/packages/react-native-reanimated/src/css/native/events/__tests__/CSSCallbacksRegistry.test.ts
+++ b/packages/react-native-reanimated/src/css/native/events/__tests__/CSSCallbacksRegistry.test.ts
@@ -182,4 +182,41 @@ describe('cssCallbacksRegistry', () => {
 
     expect(sub.handleCSSEvent).not.toHaveBeenCalled();
   });
+
+  describe('retire', () => {
+    test('a retired subscriber still hears the batch emitted during teardown', () => {
+      const sub = subscriber();
+      cssCallbacksRegistry.register(1, sub);
+      cssCallbacksRegistry.retire(1, sub);
+
+      cssCallbacksRegistry.dispatch([event(1)]);
+
+      expect(sub.handleCSSEvent).toHaveBeenCalledTimes(1);
+    });
+
+    test('and stops hearing from the batch after that', () => {
+      const sub = subscriber();
+      cssCallbacksRegistry.register(1, sub);
+      cssCallbacksRegistry.retire(1, sub);
+
+      cssCallbacksRegistry.dispatch([event(1)]);
+      cssCallbacksRegistry.dispatch([event(1)]);
+
+      expect(sub.handleCSSEvent).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not disturb a subscriber still attached to the same tag', () => {
+      const outer = subscriber();
+      const inner = subscriber();
+      cssCallbacksRegistry.register(1, outer);
+      cssCallbacksRegistry.register(1, inner);
+      cssCallbacksRegistry.retire(1, outer);
+
+      cssCallbacksRegistry.dispatch([event(1)]);
+      cssCallbacksRegistry.dispatch([event(1)]);
+
+      expect(outer.handleCSSEvent).toHaveBeenCalledTimes(1);
+      expect(inner.handleCSSEvent).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/packages/react-native-reanimated/src/css/native/events/__tests__/CSSCallbacksRegistry.test.ts
+++ b/packages/react-native-reanimated/src/css/native/events/__tests__/CSSCallbacksRegistry.test.ts
@@ -231,5 +231,16 @@ describe('cssCallbacksRegistry', () => {
 
       expect(sub.handleCSSEvent).toHaveBeenCalledTimes(2);
     });
+
+    test('and hears the batch it registered again for exactly once', () => {
+      const sub = subscriber();
+      cssCallbacksRegistry.register(1, sub);
+      cssCallbacksRegistry.retire(1, sub);
+      cssCallbacksRegistry.register(1, sub);
+
+      cssCallbacksRegistry.dispatch([event(1)]);
+
+      expect(sub.handleCSSEvent).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/react-native-reanimated/src/css/native/events/__tests__/CSSCallbacksRegistry.test.ts
+++ b/packages/react-native-reanimated/src/css/native/events/__tests__/CSSCallbacksRegistry.test.ts
@@ -80,7 +80,7 @@ describe('cssCallbacksRegistry', () => {
     cssCallbacksRegistry.unregister(1, sub);
 
     // @ts-expect-error - reading a private field to assert there is no leak
-    expect(cssCallbacksRegistry.subscribersByTag_.has(1)).toBe(false);
+    expect(cssCallbacksRegistry.subscribersByTag.has(1)).toBe(false);
   });
 
   test('unregistering an unknown tag or subscriber is a no-op', () => {

--- a/packages/react-native-reanimated/src/css/native/events/__tests__/CSSCallbacksRegistry.test.ts
+++ b/packages/react-native-reanimated/src/css/native/events/__tests__/CSSCallbacksRegistry.test.ts
@@ -242,5 +242,21 @@ describe('cssCallbacksRegistry', () => {
 
       expect(sub.handleCSSEvent).toHaveBeenCalledTimes(1);
     });
+
+    test('and hears it once even when registered again mid batch', () => {
+      const remounted = subscriber();
+      const remounting: CSSEventSubscriber = {
+        handleCSSEvent: jest.fn(() => {
+          cssCallbacksRegistry.register(1, remounted);
+        }),
+      };
+      cssCallbacksRegistry.register(1, remounting);
+      cssCallbacksRegistry.register(1, remounted);
+      cssCallbacksRegistry.retire(1, remounted);
+
+      cssCallbacksRegistry.dispatch([event(1)]);
+
+      expect(remounted.handleCSSEvent).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/react-native-reanimated/src/css/native/events/__tests__/CSSCallbacksRegistry.test.ts
+++ b/packages/react-native-reanimated/src/css/native/events/__tests__/CSSCallbacksRegistry.test.ts
@@ -218,5 +218,18 @@ describe('cssCallbacksRegistry', () => {
       expect(outer.handleCSSEvent).toHaveBeenCalledTimes(1);
       expect(inner.handleCSSEvent).toHaveBeenCalledTimes(2);
     });
+
+    // A frozen view is retired and then mounted again on the same manager.
+    test('a subscriber that registers again stays subscribed', () => {
+      const sub = subscriber();
+      cssCallbacksRegistry.register(1, sub);
+      cssCallbacksRegistry.retire(1, sub);
+      cssCallbacksRegistry.register(1, sub);
+
+      cssCallbacksRegistry.dispatch([event(1)]);
+      cssCallbacksRegistry.dispatch([event(1)]);
+
+      expect(sub.handleCSSEvent).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/packages/react-native-reanimated/src/css/native/managers/CSSCallbacksManager.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/CSSCallbacksManager.ts
@@ -39,6 +39,16 @@ export default class CSSCallbacksManager
     return this.eventMask;
   }
 
+  /**
+   * Unsubscribes without dropping the callbacks, so a cancel already emitted
+   * for the unmounting view still reaches the user.
+   */
+  retire(): void {
+    if (this.viewTag !== NO_VIEW_TAG) {
+      cssCallbacksRegistry.retire(this.viewTag, this);
+    }
+  }
+
   handleCSSEvent(event: NativeCSSEvent): void {
     // TODO: transition events arrive here too and are dropped, so transition
     // callbacks never fire on native. They should reach the user once the

--- a/packages/react-native-reanimated/src/css/native/managers/CSSCallbacksManager.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/CSSCallbacksManager.ts
@@ -44,7 +44,7 @@ export default class CSSCallbacksManager
    * for the unmounting view still reaches the user.
    */
   retire(): void {
-    if (this.viewTag !== NO_VIEW_TAG) {
+    if (this.viewTag !== -1) {
       cssCallbacksRegistry.retire(this.viewTag, this);
     }
   }

--- a/packages/react-native-reanimated/src/css/native/managers/CSSManager.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/CSSManager.ts
@@ -104,7 +104,7 @@ export default class CSSManager implements ICSSManager {
   }
 
   unmountCleanup(): void {
-    this.cssCallbacksManager?.detach();
+    this.cssCallbacksManager?.retire();
     this.cssAnimationsManager.unmountCleanup();
     this.cssTransitionsManager.unmountCleanup();
     this.cssPseudoStylesManager.unmountCleanup();

--- a/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSManager.test.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSManager.test.ts
@@ -140,14 +140,16 @@ describe('CSSManager', () => {
       expect(onAnimationCancel).not.toHaveBeenCalled();
     });
 
-    test('stops delivering events after unmount cleanup', () => {
-      const onAnimationEnd = jest.fn();
-      manager.update({ ...ANIMATION, onAnimationEnd });
+    test('delivers the cancel the engine emits while the view unmounts', () => {
+      const onAnimationCancel = jest.fn();
+      manager.update({ ...ANIMATION, onAnimationCancel });
+      // The engine emits the cancel during cleanup, but its batch is dispatched
+      // after cleanup has already returned.
       manager.unmountCleanup();
 
-      cssCallbacksRegistry.dispatch([event('animationEnd')]);
+      cssCallbacksRegistry.dispatch([event('animationCancel')]);
 
-      expect(onAnimationEnd).not.toHaveBeenCalled();
+      expect(onAnimationCancel).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
The engine emits an animation cancel as the view tears down, but the batch carrying it is dispatched once the view is already gone, so unregistering the subscriber at unmount dropped it and the callback never fired.

Unmounting now retires the subscriber: it is unsubscribed straight away and kept aside, and the next batch is delivered to both the subscribed and the retired sets before the retired ones are let go. Unsubscribing eagerly rather than queueing the removal is what lets a frozen view that mounts again on the same manager stay subscribed by simply registering itself.

This matches the web, where removing an element with a running animation fires `animationcancel`.