### PR TITLE
chore: pass the CSS callback presence change as one object

### DIFF
--- a/packages/react-native-reanimated/src/css/models/CSSCallbackStore.ts
+++ b/packages/react-native-reanimated/src/css/models/CSSCallbackStore.ts
@@ -5,6 +5,17 @@ type CSSCallbackMap<Prop extends string, Payload> = Partial<
 >;
 
 /**
+ * Which callbacks a sync changed, and which are present after it. Subclasses
+ * need different parts of this, so it arrives as one object rather than as
+ * positional arguments that half of them would have to name and ignore.
+ */
+export type CSSCallbackPresenceChange<Prop extends string> = {
+  present: ReadonlySet<Prop>;
+  added: readonly Prop[];
+  removed: readonly Prop[];
+};
+
+/**
  * Holds the user's CSS callbacks and tracks which of them are present.
  *
  * Callbacks are read from a mutable slot at fire time, so a callback replaced
@@ -40,7 +51,7 @@ export default abstract class CSSCallbackStore<Prop extends string, Payload> {
     }
 
     if (added.length > 0 || removed.length > 0) {
-      this.onPresenceChanged(this.present, added, removed);
+      this.onPresenceChanged({ present: this.present, added, removed });
     }
   }
 
@@ -52,14 +63,7 @@ export default abstract class CSSCallbackStore<Prop extends string, Payload> {
     this.callbacks[prop]?.(payload);
   }
 
-  /**
-   * The set comes first because a subclass whose subscription is derived from
-   * all of the present props can then take it alone, and leave the rest of the
-   * signature off.
-   */
   protected abstract onPresenceChanged(
-    present: ReadonlySet<Prop>,
-    added: readonly Prop[],
-    removed: readonly Prop[]
+    change: CSSCallbackPresenceChange<Prop>
   ): void;
 }

--- a/packages/react-native-reanimated/src/css/models/CSSCallbackStore.ts
+++ b/packages/react-native-reanimated/src/css/models/CSSCallbackStore.ts
@@ -5,17 +5,6 @@ type CSSCallbackMap<Prop extends string, Payload> = Partial<
 >;
 
 /**
- * Which callbacks a sync changed, and which are present after it. Subclasses
- * need different parts of this, so it arrives as one object rather than as
- * positional arguments that half of them would have to name and ignore.
- */
-export type CSSCallbackPresenceChange<Prop extends string> = {
-  present: ReadonlySet<Prop>;
-  added: readonly Prop[];
-  removed: readonly Prop[];
-};
-
-/**
  * Holds the user's CSS callbacks and tracks which of them are present.
  *
  * Callbacks are read from a mutable slot at fire time, so a callback replaced
@@ -51,7 +40,7 @@ export default abstract class CSSCallbackStore<Prop extends string, Payload> {
     }
 
     if (added.length > 0 || removed.length > 0) {
-      this.onPresenceChanged({ present: this.present, added, removed });
+      this.onPresenceChanged(this.present, added, removed);
     }
   }
 
@@ -63,7 +52,14 @@ export default abstract class CSSCallbackStore<Prop extends string, Payload> {
     this.callbacks[prop]?.(payload);
   }
 
+  /**
+   * The set comes first because a subclass whose subscription is derived from
+   * all of the present props can then take it alone, and leave the rest of the
+   * signature off.
+   */
   protected abstract onPresenceChanged(
-    change: CSSCallbackPresenceChange<Prop>
+    present: ReadonlySet<Prop>,
+    added: readonly Prop[],
+    removed: readonly Prop[]
   ): void;
 }

--- a/packages/react-native-reanimated/src/css/models/CSSCallbackStore.ts
+++ b/packages/react-native-reanimated/src/css/models/CSSCallbackStore.ts
@@ -5,17 +5,6 @@ type CSSCallbackMap<Prop extends string, Payload> = Partial<
 >;
 
 /**
- * Which callbacks a sync changed, and which are present after it. Subclasses
- * need different parts of this, so it arrives as one object rather than as
- * positional arguments that half of them would have to name and ignore.
- */
-export type CSSCallbackPresenceChange<Prop extends string> = {
-  present: ReadonlySet<Prop>;
-  added: readonly Prop[];
-  removed: readonly Prop[];
-};
-
-/**
  * Holds the user's CSS callbacks and tracks which of them are present.
  *
  * Callbacks are read from a mutable slot at fire time, so a callback replaced
@@ -34,24 +23,22 @@ export default abstract class CSSCallbackStore<Prop extends string, Payload> {
 
   sync(callbacks: CSSCallbackMap<Prop, Payload>): void {
     this.callbacks = callbacks;
-
-    const added: Prop[] = [];
-    const removed: Prop[] = [];
+    let changed = false;
 
     for (const prop of this.props) {
       const hasCallback = typeof callbacks[prop] === 'function';
 
       if (hasCallback && !this.present.has(prop)) {
         this.present.add(prop);
-        added.push(prop);
+        changed = true;
       } else if (!hasCallback && this.present.has(prop)) {
         this.present.delete(prop);
-        removed.push(prop);
+        changed = true;
       }
     }
 
-    if (added.length > 0 || removed.length > 0) {
-      this.onPresenceChanged({ present: this.present, added, removed });
+    if (changed) {
+      this.onPresenceChanged(this.present);
     }
   }
 
@@ -63,7 +50,6 @@ export default abstract class CSSCallbackStore<Prop extends string, Payload> {
     this.callbacks[prop]?.(payload);
   }
 
-  protected abstract onPresenceChanged(
-    change: CSSCallbackPresenceChange<Prop>
-  ): void;
+  /** Called only when the set changed, never when a callback is replaced. */
+  protected abstract onPresenceChanged(present: ReadonlySet<Prop>): void;
 }

--- a/packages/react-native-reanimated/src/css/models/CSSCallbackStore.ts
+++ b/packages/react-native-reanimated/src/css/models/CSSCallbackStore.ts
@@ -5,6 +5,17 @@ type CSSCallbackMap<Prop extends string, Payload> = Partial<
 >;
 
 /**
+ * Which callbacks a sync changed, and which are present after it. Subclasses
+ * need different parts of this, so it arrives as one object rather than as
+ * positional arguments that half of them would have to name and ignore.
+ */
+export type CSSCallbackPresenceChange<Prop extends string> = {
+  present: ReadonlySet<Prop>;
+  added: readonly Prop[];
+  removed: readonly Prop[];
+};
+
+/**
  * Holds the user's CSS callbacks and tracks which of them are present.
  *
  * Callbacks are read from a mutable slot at fire time, so a callback replaced
@@ -40,7 +51,7 @@ export default abstract class CSSCallbackStore<Prop extends string, Payload> {
     }
 
     if (added.length > 0 || removed.length > 0) {
-      this.onPresenceChanged(added, removed, this.present);
+      this.onPresenceChanged({ present: this.present, added, removed });
     }
   }
 
@@ -53,8 +64,6 @@ export default abstract class CSSCallbackStore<Prop extends string, Payload> {
   }
 
   protected abstract onPresenceChanged(
-    added: readonly Prop[],
-    removed: readonly Prop[],
-    present: ReadonlySet<Prop>
+    change: CSSCallbackPresenceChange<Prop>
   ): void;
 }

--- a/packages/react-native-reanimated/src/css/models/__tests__/CSSCallbackStore.test.ts
+++ b/packages/react-native-reanimated/src/css/models/__tests__/CSSCallbackStore.test.ts
@@ -1,4 +1,5 @@
 'use strict';
+import type { CSSCallbackPresenceChange } from '../CSSCallbackStore';
 import CSSCallbackStore from '../CSSCallbackStore';
 
 type Prop = 'onFoo' | 'onBar';
@@ -22,11 +23,11 @@ class TestStore extends CSSCallbackStore<Prop, Payload> {
     this.invoke(prop, payload);
   }
 
-  protected onPresenceChanged(
-    present: ReadonlySet<Prop>,
-    added: readonly Prop[],
-    removed: readonly Prop[]
-  ): void {
+  protected onPresenceChanged({
+    present,
+    added,
+    removed,
+  }: CSSCallbackPresenceChange<Prop>): void {
     this.changes.push({
       added: [...added],
       present: [...present],

--- a/packages/react-native-reanimated/src/css/models/__tests__/CSSCallbackStore.test.ts
+++ b/packages/react-native-reanimated/src/css/models/__tests__/CSSCallbackStore.test.ts
@@ -1,4 +1,5 @@
 'use strict';
+import type { CSSCallbackPresenceChange } from '../CSSCallbackStore';
 import CSSCallbackStore from '../CSSCallbackStore';
 
 type Prop = 'onFoo' | 'onBar';
@@ -22,11 +23,11 @@ class TestStore extends CSSCallbackStore<Prop, Payload> {
     this.invoke(prop, payload);
   }
 
-  protected onPresenceChanged(
-    added: readonly Prop[],
-    removed: readonly Prop[],
-    present: ReadonlySet<Prop>
-  ): void {
+  protected onPresenceChanged({
+    present,
+    added,
+    removed,
+  }: CSSCallbackPresenceChange<Prop>): void {
     this.changes.push({
       added: [...added],
       present: [...present],

--- a/packages/react-native-reanimated/src/css/models/__tests__/CSSCallbackStore.test.ts
+++ b/packages/react-native-reanimated/src/css/models/__tests__/CSSCallbackStore.test.ts
@@ -69,6 +69,14 @@ describe('CSSCallbackStore', () => {
     expect(store.changes[1]).toEqual(['onBar']);
   });
 
+  // Every other case reports a set that happens to equal the props just added.
+  test('reports a prop that was already present alongside the new one', () => {
+    store.sync({ onFoo: jest.fn() });
+    store.sync({ onBar: jest.fn(), onFoo: jest.fn() });
+
+    expect(store.changes[1]).toEqual(['onFoo', 'onBar']);
+  });
+
   test('ignores props that the store does not manage', () => {
     store.sync({ onBaz: jest.fn() } as never);
 

--- a/packages/react-native-reanimated/src/css/models/__tests__/CSSCallbackStore.test.ts
+++ b/packages/react-native-reanimated/src/css/models/__tests__/CSSCallbackStore.test.ts
@@ -1,16 +1,11 @@
 'use strict';
-import type { CSSCallbackPresenceChange } from '../CSSCallbackStore';
 import CSSCallbackStore from '../CSSCallbackStore';
 
 type Prop = 'onFoo' | 'onBar';
 
 type Payload = { detail: string };
 
-type PresenceChange = {
-  added: Prop[];
-  removed: Prop[];
-  present: Prop[];
-};
+type PresenceChange = Prop[];
 
 class TestStore extends CSSCallbackStore<Prop, Payload> {
   readonly changes: PresenceChange[] = [];
@@ -23,16 +18,8 @@ class TestStore extends CSSCallbackStore<Prop, Payload> {
     this.invoke(prop, payload);
   }
 
-  protected onPresenceChanged({
-    present,
-    added,
-    removed,
-  }: CSSCallbackPresenceChange<Prop>): void {
-    this.changes.push({
-      added: [...added],
-      present: [...present],
-      removed: [...removed],
-    });
+  protected onPresenceChanged(present: ReadonlySet<Prop>): void {
+    this.changes.push([...present]);
   }
 }
 
@@ -43,12 +30,10 @@ describe('CSSCallbackStore', () => {
     store = new TestStore();
   });
 
-  test('reports a prop as added the first time a callback is provided', () => {
+  test('reports the prop as present the first time a callback is provided', () => {
     store.sync({ onFoo: jest.fn() });
 
-    expect(store.changes).toEqual([
-      { added: ['onFoo'], present: ['onFoo'], removed: [] },
-    ]);
+    expect(store.changes).toEqual([['onFoo']]);
   });
 
   test('does not report a change when only the callback identity changes', () => {
@@ -70,26 +55,18 @@ describe('CSSCallbackStore', () => {
     expect(second).toHaveBeenCalledWith({ detail: 'x' });
   });
 
-  test('reports a prop as removed when its callback becomes undefined', () => {
+  test('drops the prop from the set when its callback becomes undefined', () => {
     store.sync({ onFoo: jest.fn() });
     store.sync({ onFoo: undefined });
 
-    expect(store.changes[1]).toEqual({
-      added: [],
-      present: [],
-      removed: ['onFoo'],
-    });
+    expect(store.changes[1]).toEqual([]);
   });
 
-  test('reports additions and removals from a single sync together', () => {
+  test('reports the whole set after a sync that both adds and removes', () => {
     store.sync({ onFoo: jest.fn() });
     store.sync({ onBar: jest.fn() });
 
-    expect(store.changes[1]).toEqual({
-      added: ['onBar'],
-      present: ['onBar'],
-      removed: ['onFoo'],
-    });
+    expect(store.changes[1]).toEqual(['onBar']);
   });
 
   test('ignores props that the store does not manage', () => {
@@ -103,11 +80,7 @@ describe('CSSCallbackStore', () => {
     store.sync({ onFoo, onBar: jest.fn() });
     store.detach();
 
-    expect(store.changes[1]).toEqual({
-      added: [],
-      present: [],
-      removed: ['onFoo', 'onBar'],
-    });
+    expect(store.changes[1]).toEqual([]);
 
     store.fire('onFoo', { detail: 'x' });
     expect(onFoo).not.toHaveBeenCalled();
@@ -118,11 +91,7 @@ describe('CSSCallbackStore', () => {
     store.detach();
     store.sync({ onFoo: jest.fn() });
 
-    expect(store.changes[2]).toEqual({
-      added: ['onFoo'],
-      present: ['onFoo'],
-      removed: [],
-    });
+    expect(store.changes[2]).toEqual(['onFoo']);
   });
 
   test('detach on an empty store reports nothing', () => {

--- a/packages/react-native-reanimated/src/css/models/__tests__/CSSCallbackStore.test.ts
+++ b/packages/react-native-reanimated/src/css/models/__tests__/CSSCallbackStore.test.ts
@@ -1,5 +1,4 @@
 'use strict';
-import type { CSSCallbackPresenceChange } from '../CSSCallbackStore';
 import CSSCallbackStore from '../CSSCallbackStore';
 
 type Prop = 'onFoo' | 'onBar';
@@ -23,11 +22,11 @@ class TestStore extends CSSCallbackStore<Prop, Payload> {
     this.invoke(prop, payload);
   }
 
-  protected onPresenceChanged({
-    present,
-    added,
-    removed,
-  }: CSSCallbackPresenceChange<Prop>): void {
+  protected onPresenceChanged(
+    present: ReadonlySet<Prop>,
+    added: readonly Prop[],
+    removed: readonly Prop[]
+  ): void {
     this.changes.push({
       added: [...added],
       present: [...present],

--- a/packages/react-native-reanimated/src/css/models/index.ts
+++ b/packages/react-native-reanimated/src/css/models/index.ts
@@ -1,3 +1,4 @@
 'use strict';
+export type { CSSCallbackPresenceChange } from './CSSCallbackStore';
 export { default as CSSCallbackStore } from './CSSCallbackStore';
 export { default as CSSKeyframesRuleBase } from './CSSKeyframesRuleBase';

--- a/packages/react-native-reanimated/src/css/models/index.ts
+++ b/packages/react-native-reanimated/src/css/models/index.ts
@@ -1,4 +1,3 @@
 'use strict';
-export type { CSSCallbackPresenceChange } from './CSSCallbackStore';
 export { default as CSSCallbackStore } from './CSSCallbackStore';
 export { default as CSSKeyframesRuleBase } from './CSSKeyframesRuleBase';

--- a/packages/react-native-reanimated/src/css/native/managers/CSSCallbacksManager.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/CSSCallbacksManager.ts
@@ -54,8 +54,6 @@ export default class CSSCallbacksManager
   }
 
   protected onPresenceChanged(
-    _added: readonly CSSAnimationCallbackProp[],
-    _removed: readonly CSSAnimationCallbackProp[],
     present: ReadonlySet<CSSAnimationCallbackProp>
   ): void {
     this.eventMask = getAnimationEventMaskFromProps(present);

--- a/packages/react-native-reanimated/src/css/web/managers/CSSCallbackListeners.ts
+++ b/packages/react-native-reanimated/src/css/web/managers/CSSCallbackListeners.ts
@@ -17,7 +17,7 @@ export class CSSCallbackListeners<
   }
 
   protected onPresenceChanged(present: ReadonlySet<Prop>): void {
-    for (const [prop, listener] of [...this.attachedListeners]) {
+    for (const [prop, listener] of this.attachedListeners) {
       if (!present.has(prop)) {
         this.attachedListeners.delete(prop);
         this.element.removeEventListener(this.eventNameByProp[prop], listener);

--- a/packages/react-native-reanimated/src/css/web/managers/CSSCallbackListeners.ts
+++ b/packages/react-native-reanimated/src/css/web/managers/CSSCallbackListeners.ts
@@ -16,8 +16,6 @@ export class CSSCallbackListeners<
     super(Object.keys(eventNameByProp) as Prop[]);
   }
 
-  // What is attached is already recorded, so the set of present callbacks is
-  // all this needs to work out which listeners to drop and which to add.
   protected onPresenceChanged(present: ReadonlySet<Prop>): void {
     for (const [prop, listener] of [...this.attachedListeners]) {
       if (!present.has(prop)) {

--- a/packages/react-native-reanimated/src/css/web/managers/CSSCallbackListeners.ts
+++ b/packages/react-native-reanimated/src/css/web/managers/CSSCallbackListeners.ts
@@ -1,6 +1,5 @@
 'use strict';
 import type { ReanimatedHTMLElement } from '../../../ReanimatedModule/js-reanimated';
-import type { CSSCallbackPresenceChange } from '../../models';
 import { CSSCallbackStore } from '../../models';
 
 export class CSSCallbackListeners<
@@ -17,10 +16,11 @@ export class CSSCallbackListeners<
     super(Object.keys(eventNameByProp) as Prop[]);
   }
 
-  protected onPresenceChanged({
-    added,
-    removed,
-  }: CSSCallbackPresenceChange<Prop>): void {
+  protected onPresenceChanged(
+    _present: ReadonlySet<Prop>,
+    added: readonly Prop[],
+    removed: readonly Prop[]
+  ): void {
     for (const prop of removed) {
       const listener = this.attachedListeners.get(prop);
       if (listener) {

--- a/packages/react-native-reanimated/src/css/web/managers/CSSCallbackListeners.ts
+++ b/packages/react-native-reanimated/src/css/web/managers/CSSCallbackListeners.ts
@@ -1,5 +1,6 @@
 'use strict';
 import type { ReanimatedHTMLElement } from '../../../ReanimatedModule/js-reanimated';
+import type { CSSCallbackPresenceChange } from '../../models';
 import { CSSCallbackStore } from '../../models';
 
 export class CSSCallbackListeners<
@@ -16,10 +17,10 @@ export class CSSCallbackListeners<
     super(Object.keys(eventNameByProp) as Prop[]);
   }
 
-  protected onPresenceChanged(
-    added: readonly Prop[],
-    removed: readonly Prop[]
-  ): void {
+  protected onPresenceChanged({
+    added,
+    removed,
+  }: CSSCallbackPresenceChange<Prop>): void {
     for (const prop of removed) {
       const listener = this.attachedListeners.get(prop);
       if (listener) {

--- a/packages/react-native-reanimated/src/css/web/managers/CSSCallbackListeners.ts
+++ b/packages/react-native-reanimated/src/css/web/managers/CSSCallbackListeners.ts
@@ -1,5 +1,6 @@
 'use strict';
 import type { ReanimatedHTMLElement } from '../../../ReanimatedModule/js-reanimated';
+import type { CSSCallbackPresenceChange } from '../../models';
 import { CSSCallbackStore } from '../../models';
 
 export class CSSCallbackListeners<
@@ -16,11 +17,10 @@ export class CSSCallbackListeners<
     super(Object.keys(eventNameByProp) as Prop[]);
   }
 
-  protected onPresenceChanged(
-    _present: ReadonlySet<Prop>,
-    added: readonly Prop[],
-    removed: readonly Prop[]
-  ): void {
+  protected onPresenceChanged({
+    added,
+    removed,
+  }: CSSCallbackPresenceChange<Prop>): void {
     for (const prop of removed) {
       const listener = this.attachedListeners.get(prop);
       if (listener) {

--- a/packages/react-native-reanimated/src/css/web/managers/CSSCallbackListeners.ts
+++ b/packages/react-native-reanimated/src/css/web/managers/CSSCallbackListeners.ts
@@ -1,6 +1,5 @@
 'use strict';
 import type { ReanimatedHTMLElement } from '../../../ReanimatedModule/js-reanimated';
-import type { CSSCallbackPresenceChange } from '../../models';
 import { CSSCallbackStore } from '../../models';
 
 export class CSSCallbackListeners<
@@ -17,19 +16,20 @@ export class CSSCallbackListeners<
     super(Object.keys(eventNameByProp) as Prop[]);
   }
 
-  protected onPresenceChanged({
-    added,
-    removed,
-  }: CSSCallbackPresenceChange<Prop>): void {
-    for (const prop of removed) {
-      const listener = this.attachedListeners.get(prop);
-      if (listener) {
+  // What is attached is already recorded, so the set of present callbacks is
+  // all this needs to work out which listeners to drop and which to add.
+  protected onPresenceChanged(present: ReadonlySet<Prop>): void {
+    for (const [prop, listener] of [...this.attachedListeners]) {
+      if (!present.has(prop)) {
         this.attachedListeners.delete(prop);
         this.element.removeEventListener(this.eventNameByProp[prop], listener);
       }
     }
 
-    for (const prop of added) {
+    for (const prop of present) {
+      if (this.attachedListeners.has(prop)) {
+        continue;
+      }
       const listener = this.createListener(prop);
       this.attachedListeners.set(prop, listener);
       this.element.addEventListener(this.eventNameByProp[prop], listener);


### PR DESCRIPTION
The `onPresenceChanged` hook took `added`, `removed` and `present` positionally, but its subclasses read different parts: the web listeners attach and remove a DOM listener per prop and want the delta, while a subscription mask is computed from the whole present set. Whichever of the two came last had to be reached past, so one subclass always named parameters it ignores.

Reordering could only ever move that between them. It now takes a single object, so each subclass destructures what it uses and names nothing else.