### PR TITLE
ci: patch nightly expo

### DIFF
--- a/.github/workflows/expo-devclient-build-check-nightly.yml
+++ b/.github/workflows/expo-devclient-build-check-nightly.yml
@@ -67,6 +67,10 @@ jobs:
       - name: Install Worklets
         working-directory: ${{ env.APP_NAME }}
         run: npm install react-native-worklets@nightly
+      # TODO: Remove when https://github.com/expo/expo/pull/48691 is released.
+      - name: Patch Expo Modules Core Worklets API usage
+        working-directory: ${{ env.APP_NAME }}
+        run: node --experimental-strip-types ${{ env.SCRIPT_PATH }} patchExpoModulesCore
       - name: Expo prebuild
         working-directory: ${{ env.APP_NAME }}
         run: npx expo prebuild

--- a/.github/workflows/helper/configureDevClient.ts
+++ b/.github/workflows/helper/configureDevClient.ts
@@ -17,8 +17,7 @@ function patchFile(filePath: string, find: string, replace: string): void {
 }
 
 function patchExpoModulesCore(): void {
-  const iosSourcePath =
-    'ios/WorkletsAdapter/ExpoWorkletsBridgeProvider.mm';
+  const iosSourcePath = 'ios/WorkletsAdapter/ExpoWorkletsBridgeProvider.mm';
   const androidSourcePath =
     'android/src/main/cpp/worklets/WorkletJSCallInvoker.cpp';
   const candidates = [

--- a/.github/workflows/helper/configureDevClient.ts
+++ b/.github/workflows/helper/configureDevClient.ts
@@ -1,9 +1,62 @@
 import fs from 'node:fs';
+import path from 'node:path';
 
-function patchFile(path: string, find: string, replace: string): void {
-  let data = fs.readFileSync(path, 'utf8');
+function patchFile(filePath: string, find: string, replace: string): void {
+  let data = fs.readFileSync(filePath, 'utf8');
+
+  if (!data.includes(find)) {
+    if (data.includes(replace)) {
+      return;
+    }
+
+    throw new Error(`Could not find the expected contents in ${filePath}`);
+  }
+
   data = data.replace(find, replace);
-  fs.writeFileSync(path, data);
+  fs.writeFileSync(filePath, data);
+}
+
+function patchExpoModulesCore(): void {
+  const iosSourcePath =
+    'ios/WorkletsAdapter/ExpoWorkletsBridgeProvider.mm';
+  const androidSourcePath =
+    'android/src/main/cpp/worklets/WorkletJSCallInvoker.cpp';
+  const candidates = [
+    'node_modules/expo/node_modules/expo-modules-core',
+    'node_modules/expo-modules-core',
+  ];
+  const packagePaths = [
+    ...new Set(
+      candidates
+        .filter(
+          (candidate) =>
+            fs.existsSync(path.join(candidate, iosSourcePath)) &&
+            fs.existsSync(path.join(candidate, androidSourcePath))
+        )
+        .map((candidate) => fs.realpathSync(candidate))
+    ),
+  ];
+
+  if (packagePaths.length === 0) {
+    throw new Error('Could not find the installed expo-modules-core package');
+  }
+
+  for (const packagePath of packagePaths) {
+    patchFile(
+      path.join(packagePath, iosSourcePath),
+      'workletRuntime->executeSync([worklet, arguments]',
+      'workletRuntime->runSync([worklet, arguments]'
+    );
+
+    patchFile(
+      path.join(packagePath, androidSourcePath),
+      `workletRuntime->executeSync([func = std::move(func)](jsi::Runtime &rt) -> jsi::Value {
+      func(rt);
+      return jsi::Value::undefined();
+    });`,
+      'workletRuntime->runSync(func);'
+    );
+  }
 }
 
 const command = process.argv[2];
@@ -20,4 +73,8 @@ if (command === 'setBundleIdentifier') {
     '"android": {',
     '"android": {"package": "com.swmansion.app",'
   );
+}
+
+if (command === 'patchExpoModulesCore') {
+  patchExpoModulesCore();
 }


### PR DESCRIPTION
## Summary

Fixes nightly CI runs until https://github.com/expo/expo/pull/48691 is released.

## Test plan

CI

## Changelog

- [x] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.
