### PR TITLE
perf: Skip the pre-draw repair on frames without React mounts

### DIFF
--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
@@ -256,6 +256,7 @@ open class NativeProxy {
         intBuffer: IntArray,
         doubleBuffer: DoubleArray,
     ) {
+        cssPlatformTransitionsManager.onPropsWrittenSynchronously()
         SynchronousPropsBufferParser.parse(intBuffer, doubleBuffer) { viewTag, props ->
             if (BuildConfig.IS_REACT_NATIVE_86_OR_NEWER) {
                 try {

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
@@ -24,10 +24,10 @@ internal class CSSPlatformTransitionsManager(
     private val animators = HashMap<Key, RunningTransition>()
 
     /**
-     * React can overwrite an animated value only on frames where a mount ran, so the
+     * React can overwrite an animated value only on frames where it wrote props, so the
      * pre-draw repair is skipped on all others. Everything here runs on the UI thread.
      */
-    private var mountedSinceLastDraw = true
+    private var reactWroteSinceLastDraw = true
 
     @OptIn(UnstableReactNativeAPI::class)
     private val mountListener =
@@ -37,7 +37,7 @@ internal class CSSPlatformTransitionsManager(
             override fun willMountItems(uiManager: UIManager) = Unit
 
             override fun didMountItems(uiManager: UIManager) {
-                mountedSinceLastDraw = true
+                reactWroteSinceLastDraw = true
             }
 
             override fun didDispatchMountItems(uiManager: UIManager) = Unit
@@ -233,10 +233,15 @@ internal class CSSPlatformTransitionsManager(
         reconciler.track(view)
     }
 
+    /** Synchronous prop writes run their mount item inline, so no listener reports them. */
+    fun onPropsWrittenSynchronously() {
+        reactWroteSinceLastDraw = true
+    }
+
     /** Re-asserts each animator's own value wherever a commit overwrote it. */
     private fun repairClobberedValues(): Boolean {
-        if (!mountedSinceLastDraw) return animators.isNotEmpty()
-        mountedSinceLastDraw = false
+        if (!reactWroteSinceLastDraw) return animators.isNotEmpty()
+        reactWroteSinceLastDraw = false
         animators.values.forEach { running ->
             // target is held weakly, so read the View through it rather than keeping one.
             val view = running.animator.target as? View ?: return@forEach

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
@@ -8,7 +8,10 @@ import android.util.FloatProperty
 import android.view.Choreographer
 import android.view.View
 import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.UIManager
+import com.facebook.react.bridge.UIManagerListener
 import com.facebook.react.bridge.UiThreadUtil
+import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.fabric.FabricUIManager
 import com.facebook.react.uimanager.IllegalViewOperationException
 import java.lang.ref.WeakReference
@@ -19,6 +22,34 @@ internal class CSSPlatformTransitionsManager(
     private val animationTimestamp: () -> Long,
 ) {
     private val animators = HashMap<Key, RunningTransition>()
+
+    /**
+     * React can overwrite an animated value only on frames where a mount ran, so the
+     * pre-draw repair is skipped on all others. Everything here runs on the UI thread.
+     */
+    private var mountedSinceLastDraw = true
+
+    @OptIn(UnstableReactNativeAPI::class)
+    private val mountListener =
+        object : UIManagerListener {
+            override fun willDispatchViewUpdates(uiManager: UIManager) = Unit
+
+            override fun willMountItems(uiManager: UIManager) = Unit
+
+            override fun didMountItems(uiManager: UIManager) {
+                mountedSinceLastDraw = true
+            }
+
+            override fun didDispatchMountItems(uiManager: UIManager) = Unit
+
+            override fun didScheduleMountItems(uiManager: UIManager) = Unit
+        }
+
+    init {
+        @OptIn(UnstableReactNativeAPI::class)
+        fabricUIManager.addUIManagerEventListener(mountListener)
+    }
+
     private val reconciler = CSSPlatformTransitionReconciler(::repairClobberedValues)
     private val startTokens = HashMap<Key, Long>()
 
@@ -106,6 +137,8 @@ internal class CSSPlatformTransitionsManager(
         // Set before posting: a start already queued would otherwise register a new
         // animator and listener behind the cleanup.
         invalidated = true
+        @OptIn(UnstableReactNativeAPI::class)
+        fabricUIManager.removeUIManagerEventListener(mountListener)
         UiThreadUtil.runOnUiThread {
             startTokens.clear()
             // Snapshot first: cancel() runs onAnimationEnd, which reads the map.
@@ -202,6 +235,8 @@ internal class CSSPlatformTransitionsManager(
 
     /** Re-asserts each animator's own value wherever a commit overwrote it. */
     private fun repairClobberedValues(): Boolean {
+        if (!mountedSinceLastDraw) return animators.isNotEmpty()
+        mountedSinceLastDraw = false
         animators.values.forEach { running ->
             // target is held weakly, so read the View through it rather than keeping one.
             val view = running.animator.target as? View ?: return@forEach


### PR DESCRIPTION
The pre-draw repair re-asserts every running platform transition on every frame, but React can only overwrite an animated value on frames where it wrote props. A `UIManagerListener` records mounts and the repair returns immediately on all other frames, so the walk over running transitions happens at write rate rather than at the display refresh rate.

That matters most after a transition settles: a persistent hold keeps its entry, so without the gate every later frame the window draws keeps walking the map. Measured on an emulator during a 3s transition, 201 of 240 pre-draw callbacks returned early.

Synchronous updates run their mount item inline (`FabricUIManager.synchronouslyUpdateViewOnUIThread`), bypassing `MountItemDispatcher`, so no listener fires for them even though `opacity` is one of the props they carry. They therefore open the gate explicitly, which makes the invariant true by construction rather than by coincidence. Measured on device, such writes are rare and always landed on a frame where a mount had already opened the gate, so this is insurance rather than an observed fix.

Identical in content to #10168, which this replaces. That one was based on the head branch of #10061, and closing #10061 instead of merging it left the base pointing at a branch with no live PR, so merging would not have reached `main`. GitHub refuses to change the base of a pull request that belongs to a stack, so recreating it was the only way to target `main`.
