### PR TITLE
feat(worklets): per-runtime cache in retainingSerializable

### DIFF
--- a/apps/common-app/runtime-tests/worklets/suites.ts
+++ b/apps/common-app/runtime-tests/worklets/suites.ts
@@ -9,6 +9,7 @@ export const WORKLETS_TEST_SUITES: RuntimeTestSuite[] = [
       require('./tests/memory/createSerializable.test');
       require('./tests/memory/createSerializableOnUI.test');
       require('./tests/memory/isSerializableRef.test');
+      require('./tests/memory/retainingSerializable.test');
       require('./tests/memory/synchronizable.test');
       require('./tests/memory/customSerializable.test');
       require('./tests/memory/hybridObjectSupport.test');

--- a/apps/common-app/runtime-tests/worklets/tests/memory/createSerializable.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/memory/createSerializable.test.tsx
@@ -5,6 +5,7 @@
 import { TurboModuleRegistry } from 'react-native';
 import {
   createSerializable,
+  runOnRuntimeAsync,
   scheduleOnRN,
   scheduleOnRuntime,
   scheduleOnUI,
@@ -656,6 +657,88 @@ describe('Test createSerializable', () => {
         expect(errorMessage).toInclude('on the ' + runtimeName + ' Runtime');
       });
     });
+  });
+});
+
+const RUNTIME_COUNT = 5;
+const SERIALIZABLE_COUNT = 1000;
+const PAYLOAD_ROW_COUNT = 24;
+const PAYLOAD_COLUMN_COUNT = 16;
+
+type PayloadRow = {
+  id: string;
+  label: string;
+  cells: number[];
+};
+
+type Batch = (() => number)[];
+
+function makePayload(seed: number): PayloadRow[] {
+  return Array.from({ length: PAYLOAD_ROW_COUNT }, (_, row) => ({
+    id: `payload-${seed}-${row}`,
+    label: `label-${seed}-${row}`.padEnd(32, '.'),
+    cells: Array.from(
+      { length: PAYLOAD_COLUMN_COUNT },
+      (_unused, column) => seed * PAYLOAD_ROW_COUNT + row * column
+    ),
+  }));
+}
+
+function makeBatch(): Batch {
+  return Array.from({ length: SERIALIZABLE_COUNT }, (_, index) => {
+    const payload = makePayload(index);
+
+    return () => {
+      'worklet';
+      let checksum = 0;
+      for (const row of payload) {
+        checksum += row.cells.length + row.label.length;
+      }
+      return checksum;
+    };
+  });
+}
+
+function consumeBatch(batch: Batch) {
+  'worklet';
+  let checksum = 0;
+  for (const worklet of batch) {
+    checksum += worklet();
+  }
+  return checksum;
+}
+
+describe('RetainingSerializable cache', () => {
+  const runtimes = Array.from({ length: RUNTIME_COUNT }, (_, index) =>
+    getWorkletRuntimeFromPool(`retainingSerializable${index}`)
+  );
+
+  const batch = makeBatch();
+  const expectedChecksum =
+    SERIALIZABLE_COUNT * (PAYLOAD_ROW_COUNT * (PAYLOAD_COLUMN_COUNT + 32));
+
+  test('unpacks one batch of retained worklets into every runtime at once', async () => {
+    const checksums = await Promise.all(
+      runtimes.map((runtime) => runOnRuntimeAsync(runtime, consumeBatch, batch))
+    );
+
+    for (const checksum of checksums) {
+      expect(checksum).toBe(expectedChecksum);
+    }
+  });
+
+  test('serves the same batch from the per-runtime cache on later passes', async () => {
+    for (let pass = 0; pass < RUNTIME_COUNT; pass++) {
+      const checksums = await Promise.all(
+        runtimes.map((runtime) =>
+          runOnRuntimeAsync(runtime, consumeBatch, batch)
+        )
+      );
+
+      for (const checksum of checksums) {
+        expect(checksum).toBe(expectedChecksum);
+      }
+    }
   });
 });
 

--- a/apps/common-app/runtime-tests/worklets/tests/memory/createSerializable.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/memory/createSerializable.test.tsx
@@ -5,7 +5,6 @@
 import { TurboModuleRegistry } from 'react-native';
 import {
   createSerializable,
-  runOnRuntimeAsync,
   scheduleOnRN,
   scheduleOnRuntime,
   scheduleOnUI,
@@ -657,88 +656,6 @@ describe('Test createSerializable', () => {
         expect(errorMessage).toInclude('on the ' + runtimeName + ' Runtime');
       });
     });
-  });
-});
-
-const RUNTIME_COUNT = 5;
-const SERIALIZABLE_COUNT = 1000;
-const PAYLOAD_ROW_COUNT = 24;
-const PAYLOAD_COLUMN_COUNT = 16;
-
-type PayloadRow = {
-  id: string;
-  label: string;
-  cells: number[];
-};
-
-type Batch = (() => number)[];
-
-function makePayload(seed: number): PayloadRow[] {
-  return Array.from({ length: PAYLOAD_ROW_COUNT }, (_, row) => ({
-    id: `payload-${seed}-${row}`,
-    label: `label-${seed}-${row}`.padEnd(32, '.'),
-    cells: Array.from(
-      { length: PAYLOAD_COLUMN_COUNT },
-      (_unused, column) => seed * PAYLOAD_ROW_COUNT + row * column
-    ),
-  }));
-}
-
-function makeBatch(): Batch {
-  return Array.from({ length: SERIALIZABLE_COUNT }, (_, index) => {
-    const payload = makePayload(index);
-
-    return () => {
-      'worklet';
-      let checksum = 0;
-      for (const row of payload) {
-        checksum += row.cells.length + row.label.length;
-      }
-      return checksum;
-    };
-  });
-}
-
-function consumeBatch(batch: Batch) {
-  'worklet';
-  let checksum = 0;
-  for (const worklet of batch) {
-    checksum += worklet();
-  }
-  return checksum;
-}
-
-describe('RetainingSerializable cache', () => {
-  const runtimes = Array.from({ length: RUNTIME_COUNT }, (_, index) =>
-    getWorkletRuntimeFromPool(`retainingSerializable${index}`)
-  );
-
-  const batch = makeBatch();
-  const expectedChecksum =
-    SERIALIZABLE_COUNT * (PAYLOAD_ROW_COUNT * (PAYLOAD_COLUMN_COUNT + 32));
-
-  test('unpacks one batch of retained worklets into every runtime at once', async () => {
-    const checksums = await Promise.all(
-      runtimes.map((runtime) => runOnRuntimeAsync(runtime, consumeBatch, batch))
-    );
-
-    for (const checksum of checksums) {
-      expect(checksum).toBe(expectedChecksum);
-    }
-  });
-
-  test('serves the same batch from the per-runtime cache on later passes', async () => {
-    for (let pass = 0; pass < RUNTIME_COUNT; pass++) {
-      const checksums = await Promise.all(
-        runtimes.map((runtime) =>
-          runOnRuntimeAsync(runtime, consumeBatch, batch)
-        )
-      );
-
-      for (const checksum of checksums) {
-        expect(checksum).toBe(expectedChecksum);
-      }
-    }
   });
 });
 

--- a/apps/common-app/runtime-tests/worklets/tests/memory/retainingSerializable.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/memory/retainingSerializable.test.tsx
@@ -1,0 +1,88 @@
+import { runOnRuntimeAsync } from 'react-native-worklets';
+
+import {
+  describe,
+  expect,
+  getWorkletRuntimesFromPool,
+  test,
+} from '../../../ReJest/RuntimeTestsApi';
+
+const RUNTIME_COUNT = 5;
+const SERIALIZABLE_COUNT = 1000;
+const PAYLOAD_ROW_COUNT = 24;
+const PAYLOAD_COLUMN_COUNT = 16;
+
+type PayloadRow = {
+  id: string;
+  label: string;
+  cells: number[];
+};
+
+type Batch = (() => number)[];
+
+function makePayload(seed: number): PayloadRow[] {
+  return Array.from({ length: PAYLOAD_ROW_COUNT }, (_, row) => ({
+    id: `payload-${seed}-${row}`,
+    label: `label-${seed}-${row}`.padEnd(32, '.'),
+    cells: Array.from(
+      { length: PAYLOAD_COLUMN_COUNT },
+      (_unused, column) => seed * PAYLOAD_ROW_COUNT + row * column
+    ),
+  }));
+}
+
+function makeBatch(): Batch {
+  return Array.from({ length: SERIALIZABLE_COUNT }, (_, index) => {
+    const payload = makePayload(index);
+
+    return () => {
+      'worklet';
+      let checksum = 0;
+      for (const row of payload) {
+        checksum += row.cells.length + row.label.length;
+      }
+      return checksum;
+    };
+  });
+}
+
+function consumeBatch(batch: Batch) {
+  'worklet';
+  let checksum = 0;
+  for (const worklet of batch) {
+    checksum += worklet();
+  }
+  return checksum;
+}
+
+describe('RetainingSerializable cache', () => {
+  const runtimes = getWorkletRuntimesFromPool(RUNTIME_COUNT);
+
+  const batch = makeBatch();
+  const expectedChecksum =
+    SERIALIZABLE_COUNT * (PAYLOAD_ROW_COUNT * (PAYLOAD_COLUMN_COUNT + 32));
+
+  test('unpacks one batch of retained worklets into every runtime at once', async () => {
+    const checksums = await Promise.all(
+      runtimes.map((runtime) => runOnRuntimeAsync(runtime, consumeBatch, batch))
+    );
+
+    for (const checksum of checksums) {
+      expect(checksum).toBe(expectedChecksum);
+    }
+  });
+
+  test('serves the same batch from the per-runtime cache on later passes', async () => {
+    for (let pass = 0; pass < RUNTIME_COUNT; pass++) {
+      const checksums = await Promise.all(
+        runtimes.map((runtime) =>
+          runOnRuntimeAsync(runtime, consumeBatch, batch)
+        )
+      );
+
+      for (const checksum of checksums) {
+        expect(checksum).toBe(expectedChecksum);
+      }
+    }
+  });
+});

--- a/packages/react-native-worklets/CHANGELOG.md
+++ b/packages/react-native-worklets/CHANGELOG.md
@@ -7,7 +7,8 @@
 ### 🛠 Breaking changes
 
 ### 🎉 New features
-[General] Per-runtime caching for RetainingSerializable
+
+\[General] Per-runtime caching for RetainingSerializable
 
 ### 🐛 Bug fixes
 

--- a/packages/react-native-worklets/CHANGELOG.md
+++ b/packages/react-native-worklets/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🛠 Breaking changes
 
 ### 🎉 New features
+[General] Per-runtime caching for RetainingSerializable
 
 ### 🐛 Bug fixes
 

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/RetainingSerializable.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/RetainingSerializable.h
@@ -5,48 +5,101 @@
 #include <worklets/Registries/WorkletRuntimeRegistry.h>
 #include <worklets/SharedItems/Serializable.h>
 #include <worklets/Tools/JSScheduler.h>
+#include <worklets/Tools/WorkletsSystraceSection.h>
 #include <worklets/WorkletRuntime/RuntimeData.h>
 
+#include <array>
 #include <atomic>
+#include <cstddef>
 #include <memory>
-#include <mutex>
+#include <type_traits>
 #include <utility>
 
 namespace worklets {
 
-template <typename BaseClass>
-class RetainingSerializable : virtual public BaseClass {
+template <typename TSerializable>
+  requires std::is_base_of_v<Serializable, TSerializable>
+class RetainingSerializableStore {
  private:
-  jsi::Runtime *primaryRuntime_;
-  std::unique_ptr<jsi::Value> secondaryValue_;
-  std::atomic<jsi::Runtime *> secondaryRuntime_{nullptr};
-  std::mutex secondaryCacheMutex_;
+  static constexpr std::size_t kSlotsPerChunk = 4;
+
+  struct Slot {
+    std::atomic<jsi::Runtime *> runtime{nullptr};
+    jsi::Value value{jsi::Value::undefined()};
+  };
+
+  std::array<Slot, kSlotsPerChunk> slots_{};
+
+  std::atomic<RetainingSerializableStore *> nextChunk_{nullptr};
+  std::unique_ptr<RetainingSerializableStore> nextChunkOwner_{};
+
+  std::pair<bool, const jsi::Value &> find(jsi::Runtime *rt) {
+    for (auto &slot : slots_) {
+      if (slot.runtime.load(std::memory_order_acquire) == rt) {
+        return {true, slot.value};
+      }
+    }
+    if (auto *next = nextChunk_.load(std::memory_order_acquire)) {
+      return next->find(rt);
+    }
+    return {false, jsi::Value::undefined()};
+  }
+
+  void store(jsi::Runtime *rt, jsi::Value value) {
+    for (auto &slot : slots_) {
+      if (slot.runtime.load(std::memory_order_relaxed) != nullptr) {
+        continue;
+      }
+      jsi::Runtime *expected = nullptr;
+      if (slot.runtime.compare_exchange_strong(expected, rt, std::memory_order_acq_rel)) {
+        slot.value = std::move(value);
+        return;
+      }
+    }
+
+    auto *next = nextChunk_.load(std::memory_order_acquire);
+    if (next == nullptr) {
+      auto fresh = std::make_unique<RetainingSerializableStore>();
+      auto *freshChunk = fresh.get();
+      if (nextChunk_.compare_exchange_strong(next, freshChunk, std::memory_order_acq_rel)) {
+        nextChunkOwner_ = std::move(fresh);
+        next = freshChunk;
+      }
+    }
+    next->store(rt, std::move(value));
+  }
+
+ public:
+  RetainingSerializableStore() = default;
+
+  jsi::Value getOrStore(jsi::Runtime &rt, TSerializable &serializable) {
+    auto [isCached, cachedValue] = find(&rt);
+    if (isCached) {
+      return jsi::Value(rt, cachedValue);
+    }
+
+    auto jsValue = serializable.TSerializable::toJSValue(rt);
+    store(&rt, jsi::Value(rt, jsValue));
+
+    return jsValue;
+  }
+};
+
+template <typename TSerializable>
+  requires std::is_base_of_v<Serializable, TSerializable>
+class RetainingSerializable : virtual public TSerializable {
+ private:
+  std::unique_ptr<RetainingSerializableStore<TSerializable>> store_{
+      std::make_unique<RetainingSerializableStore<TSerializable>>()};
 
  public:
   template <typename... Args>
-  explicit RetainingSerializable(jsi::Runtime &rt, Args &&...args)
-      : BaseClass(rt, std::forward<Args>(args)...), primaryRuntime_(&rt) {}
+  explicit RetainingSerializable(jsi::Runtime &rt, Args &&...args) : TSerializable(rt, std::forward<Args>(args)...) {}
+
+  ~RetainingSerializable() override = default;
 
   jsi::Value toJSValue(jsi::Runtime &rt) override {
-    if (&rt == primaryRuntime_) {
-      return BaseClass::toJSValue(rt);
-    }
-    if (secondaryRuntime_.load(std::memory_order_acquire) == &rt) {
-      return jsi::Value(rt, *secondaryValue_);
-    }
-    auto value = BaseClass::toJSValue(rt);
-    {
-      std::lock_guard<std::mutex> lock(secondaryCacheMutex_);
-      if (secondaryRuntime_.load(std::memory_order_relaxed) == nullptr) {
-        secondaryValue_ = std::make_unique<jsi::Value>(rt, value);
-        secondaryRuntime_.store(&rt, std::memory_order_release);
-      }
-    }
-    return value;
-  }
-
-  ~RetainingSerializable() override {
-    cleanupRuntimeAware(secondaryRuntime_.load(std::memory_order_relaxed), secondaryValue_);
+    return store_->getOrStore(rt, *this);
   }
 };
 

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/RetainingSerializable.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/RetainingSerializable.h
@@ -25,7 +25,7 @@ class RetainingSerializableStore {
 
   struct Slot {
     std::atomic<jsi::Runtime *> runtime{nullptr};
-    jsi::Value value{jsi::Value::undefined()};
+    std::unique_ptr<jsi::Value> value{};
   };
 
   std::array<Slot, kSlotsPerChunk> slots_{};
@@ -36,7 +36,7 @@ class RetainingSerializableStore {
   const jsi::Value *find(jsi::Runtime *rt) {
     for (auto &slot : slots_) {
       if (slot.runtime.load(std::memory_order_acquire) == rt) {
-        return &slot.value;
+        return slot.value.get();
       }
     }
     if (auto *next = nextChunk_.load(std::memory_order_acquire)) {
@@ -45,7 +45,7 @@ class RetainingSerializableStore {
     return nullptr;
   }
 
-  void store(jsi::Runtime *rt, jsi::Value value) {
+  void store(jsi::Runtime *rt, std::unique_ptr<jsi::Value> value) {
     for (auto &slot : slots_) {
       if (slot.runtime.load(std::memory_order_relaxed) != nullptr) {
         continue;
@@ -72,13 +72,19 @@ class RetainingSerializableStore {
  public:
   RetainingSerializableStore() = default;
 
+  ~RetainingSerializableStore() {
+    for (auto &slot : slots_) {
+      cleanupRuntimeAware(slot.runtime.load(std::memory_order_relaxed), slot.value);
+    }
+  }
+
   jsi::Value getOrStore(jsi::Runtime &rt, TSerializable &serializable) {
     if (const auto *cachedValue = find(&rt)) {
       return jsi::Value(rt, *cachedValue);
     }
 
     auto jsValue = serializable.TSerializable::toJSValue(rt);
-    store(&rt, jsi::Value(rt, jsValue));
+    store(&rt, std::make_unique<jsi::Value>(rt, jsValue));
 
     return jsValue;
   }

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/RetainingSerializable.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/RetainingSerializable.h
@@ -33,16 +33,16 @@ class RetainingSerializableStore {
   std::atomic<RetainingSerializableStore *> nextChunk_{nullptr};
   std::unique_ptr<RetainingSerializableStore> nextChunkOwner_{};
 
-  std::pair<bool, const jsi::Value &> find(jsi::Runtime *rt) {
+  const jsi::Value *find(jsi::Runtime *rt) {
     for (auto &slot : slots_) {
       if (slot.runtime.load(std::memory_order_acquire) == rt) {
-        return {true, slot.value};
+        return &slot.value;
       }
     }
     if (auto *next = nextChunk_.load(std::memory_order_acquire)) {
       return next->find(rt);
     }
-    return {false, jsi::Value::undefined()};
+    return nullptr;
   }
 
   void store(jsi::Runtime *rt, jsi::Value value) {
@@ -73,9 +73,8 @@ class RetainingSerializableStore {
   RetainingSerializableStore() = default;
 
   jsi::Value getOrStore(jsi::Runtime &rt, TSerializable &serializable) {
-    auto [isCached, cachedValue] = find(&rt);
-    if (isCached) {
-      return jsi::Value(rt, cachedValue);
+    if (const auto *cachedValue = find(&rt)) {
+      return jsi::Value(rt, *cachedValue);
     }
 
     auto jsValue = serializable.TSerializable::toJSValue(rt);

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/RetainingSerializable.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/RetainingSerializable.h
@@ -25,7 +25,7 @@ class RetainingSerializableStore {
 
   struct Slot {
     std::atomic<jsi::Runtime *> runtime{nullptr};
-    std::unique_ptr<jsi::Value> value{};
+    jsi::Value value{jsi::Value::undefined()};
   };
 
   std::array<Slot, kSlotsPerChunk> slots_{};
@@ -36,7 +36,7 @@ class RetainingSerializableStore {
   const jsi::Value *find(jsi::Runtime *rt) {
     for (auto &slot : slots_) {
       if (slot.runtime.load(std::memory_order_acquire) == rt) {
-        return slot.value.get();
+        return &slot.value;
       }
     }
     if (auto *next = nextChunk_.load(std::memory_order_acquire)) {
@@ -45,7 +45,7 @@ class RetainingSerializableStore {
     return nullptr;
   }
 
-  void store(jsi::Runtime *rt, std::unique_ptr<jsi::Value> value) {
+  void store(jsi::Runtime *rt, jsi::Value value) {
     for (auto &slot : slots_) {
       if (slot.runtime.load(std::memory_order_relaxed) != nullptr) {
         continue;
@@ -84,7 +84,7 @@ class RetainingSerializableStore {
     }
 
     auto jsValue = serializable.TSerializable::toJSValue(rt);
-    store(&rt, std::make_unique<jsi::Value>(rt, jsValue));
+    store(&rt, jsi::Value(rt, jsValue));
 
     return jsValue;
   }

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/RetainingSerializable.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/RetainingSerializable.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <jsi/jsi.h>
+#include <worklets/Compat/StableApi.h>
+#include <worklets/Registries/WorkletRuntimeRegistry.h>
+#include <worklets/SharedItems/Serializable.h>
+#include <worklets/Tools/JSScheduler.h>
+#include <worklets/WorkletRuntime/RuntimeData.h>
+
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <utility>
+
+namespace worklets {
+
+template <typename BaseClass>
+class RetainingSerializable : virtual public BaseClass {
+ private:
+  jsi::Runtime *primaryRuntime_;
+  std::unique_ptr<jsi::Value> secondaryValue_;
+  std::atomic<jsi::Runtime *> secondaryRuntime_{nullptr};
+  std::mutex secondaryCacheMutex_;
+
+ public:
+  template <typename... Args>
+  explicit RetainingSerializable(jsi::Runtime &rt, Args &&...args)
+      : BaseClass(rt, std::forward<Args>(args)...), primaryRuntime_(&rt) {}
+
+  jsi::Value toJSValue(jsi::Runtime &rt) override {
+    if (&rt == primaryRuntime_) {
+      return BaseClass::toJSValue(rt);
+    }
+    if (secondaryRuntime_.load(std::memory_order_acquire) == &rt) {
+      return jsi::Value(rt, *secondaryValue_);
+    }
+    auto value = BaseClass::toJSValue(rt);
+    {
+      std::lock_guard<std::mutex> lock(secondaryCacheMutex_);
+      if (secondaryRuntime_.load(std::memory_order_relaxed) == nullptr) {
+        secondaryValue_ = std::make_unique<jsi::Value>(rt, value);
+        secondaryRuntime_.store(&rt, std::memory_order_release);
+      }
+    }
+    return value;
+  }
+
+  ~RetainingSerializable() override {
+    cleanupRuntimeAware(secondaryRuntime_.load(std::memory_order_relaxed), secondaryValue_);
+  }
+};
+
+}

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/RetainingSerializable.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/RetainingSerializable.h
@@ -102,4 +102,4 @@ class RetainingSerializable : virtual public TSerializable {
   }
 };
 
-}
+} // namespace worklets

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Serializable.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Serializable.cpp
@@ -1,7 +1,7 @@
 #include <jsi/jsi.h>
 #include <react/debug/react_native_assert.h>
-#include <worklets/SharedItems/Serializable.h>
 #include <worklets/SharedItems/RetainingSerializable.h>
+#include <worklets/SharedItems/Serializable.h>
 #include <worklets/SharedItems/SerializableFactory.h>
 #include <worklets/WorkletRuntime/RuntimeData.h>
 #include <worklets/WorkletRuntime/RuntimeManager.h>

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Serializable.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Serializable.cpp
@@ -1,6 +1,7 @@
 #include <jsi/jsi.h>
 #include <react/debug/react_native_assert.h>
 #include <worklets/SharedItems/Serializable.h>
+#include <worklets/SharedItems/RetainingSerializable.h>
 #include <worklets/SharedItems/SerializableFactory.h>
 #include <worklets/WorkletRuntime/RuntimeData.h>
 #include <worklets/WorkletRuntime/RuntimeManager.h>

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Serializable.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Serializable.h
@@ -8,6 +8,7 @@
 
 #include <memory>
 #include <mutex>
+#include <new>
 #include <optional>
 #include <string>
 #include <utility>
@@ -39,6 +40,18 @@ inline void cleanupRuntimeAware(jsi::Runtime *rt, std::unique_ptr<jsi::Value> &v
     } else {
       freeWithoutCallingDestructor(value);
     }
+  });
+}
+
+inline void cleanupRuntimeAware(jsi::Runtime *rt, jsi::Value &value) {
+  if (rt == nullptr || value.isUndefined()) {
+    return;
+  }
+  WorkletRuntimeRegistry::runWhileLocked(rt, [&value](bool isAlive) {
+    if (isAlive) {
+      value.~Value();
+    }
+    new (&value) jsi::Value(jsi::Value::undefined());
   });
 }
 

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Serializable.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Serializable.h
@@ -6,7 +6,6 @@
 #include <worklets/Tools/JSScheduler.h>
 #include <worklets/WorkletRuntime/RuntimeData.h>
 
-#include <atomic>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -42,42 +41,6 @@ inline void cleanupRuntimeAware(jsi::Runtime *rt, std::unique_ptr<jsi::Value> &v
     }
   });
 }
-
-template <typename BaseClass>
-class RetainingSerializable : virtual public BaseClass {
- private:
-  jsi::Runtime *primaryRuntime_;
-  std::unique_ptr<jsi::Value> secondaryValue_;
-  std::atomic<jsi::Runtime *> secondaryRuntime_{nullptr};
-  std::mutex secondaryCacheMutex_;
-
- public:
-  template <typename... Args>
-  explicit RetainingSerializable(jsi::Runtime &rt, Args &&...args)
-      : BaseClass(rt, std::forward<Args>(args)...), primaryRuntime_(&rt) {}
-
-  jsi::Value toJSValue(jsi::Runtime &rt) override {
-    if (&rt == primaryRuntime_) {
-      return BaseClass::toJSValue(rt);
-    }
-    if (secondaryRuntime_.load(std::memory_order_acquire) == &rt) {
-      return jsi::Value(rt, *secondaryValue_);
-    }
-    auto value = BaseClass::toJSValue(rt);
-    {
-      std::lock_guard<std::mutex> lock(secondaryCacheMutex_);
-      if (secondaryRuntime_.load(std::memory_order_relaxed) == nullptr) {
-        secondaryValue_ = std::make_unique<jsi::Value>(rt, value);
-        secondaryRuntime_.store(&rt, std::memory_order_release);
-      }
-    }
-    return value;
-  }
-
-  ~RetainingSerializable() override {
-    cleanupRuntimeAware(secondaryRuntime_.load(std::memory_order_relaxed), secondaryValue_);
-  }
-};
 
 class SerializableJSRef : public jsi::NativeState {
  private:

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/SerializableFactory.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/SerializableFactory.cpp
@@ -1,4 +1,5 @@
 #include <jsi/jsi.h>
+#include <worklets/SharedItems/RetainingSerializable.h>
 #include <worklets/SharedItems/SerializableFactory.h>
 #include <worklets/SharedItems/SerializableRemoteFunction.h>
 


### PR DESCRIPTION
This PR is a complete rewrite of the RetainingSerializable class in worklets.
It introduces a variable-sized cache per-runtime, containing the deserialized jsi::Value for each runtime that tries to unpack the Serializable. This Cache is lock-free, as opposed to the previous implementation using a mutex.

This results in major performance gains in use cases where 2 or more runtimes use the serializable.

The following benchmark was performed to get a feel of the performance benefits:
2 runtimes accessing 1000 (same) serializables

After the first access, when the cache is warmed up, the latency is 5x better (8 microseconds vs 40 microseconds). The process of warming up the cache has the same performance as accessing the serializable in the legacy implementation