### PR TITLE
chore: inline compiler get/set api for mutable

### DIFF
--- a/packages/react-native-reanimated/src/mutables.native.ts
+++ b/packages/react-native-reanimated/src/mutables.native.ts
@@ -12,7 +12,6 @@ import {
 import type { Mutable } from './commonTypes';
 import { getStaticFeatureFlag } from './featureFlags';
 import {
-  addCompilerSafeGetAndSet,
   checkInvalidReadDuringRender,
   checkInvalidWriteDuringRender,
   mutableHostDecorator,
@@ -61,6 +60,31 @@ function mutableGuestDecorator<TValue>(
       },
       enumerable: true,
       configurable: true,
+    },
+
+    get: {
+      value() {
+        return mutable.value;
+      },
+      configurable: false,
+      enumerable: false,
+    },
+
+    set: {
+      value(newValue: TValue | ((value: TValue) => TValue)) {
+        if (
+          typeof newValue === 'function' &&
+          !(newValue as Record<string, unknown>).__isAnimationDefinition
+        ) {
+          mutable.value = (newValue as (value: TValue) => TValue)(
+            mutable.value
+          );
+        } else {
+          mutable.value = newValue as TValue;
+        }
+      },
+      configurable: false,
+      enumerable: false,
     },
 
     _value: {
@@ -116,8 +140,6 @@ function mutableGuestDecorator<TValue>(
       configurable: true,
     },
   });
-
-  addCompilerSafeGetAndSet(mutable);
 
   return mutable;
 }

--- a/packages/react-native-reanimated/src/mutables.ts
+++ b/packages/react-native-reanimated/src/mutables.ts
@@ -2,9 +2,8 @@
 
 import { IS_JEST } from './common';
 import type { Mutable } from './commonTypes';
-import type { Listener, PartialMutable } from './mutablesCommon';
+import type { Listener } from './mutablesCommon';
 import {
-  addCompilerSafeGetAndSet,
   checkInvalidReadDuringRender,
   checkInvalidWriteDuringRender,
 } from './mutablesCommon';
@@ -22,14 +21,28 @@ export function makeMutable<TValue>(initial: TValue): Mutable<TValue> {
   let value: TValue = initial;
   const listeners = new Map<number, Listener<TValue>>();
 
-  const mutable: PartialMutable<TValue> = {
+  const mutable: Mutable<TValue> = {
     get value(): TValue {
       checkInvalidReadDuringRender();
       return value;
     },
     set value(newValue) {
       checkInvalidWriteDuringRender();
-      valueSetter(mutable as Mutable<TValue>, newValue);
+      valueSetter(mutable, newValue);
+    },
+
+    get() {
+      return mutable.value;
+    },
+    set(newValue) {
+      if (
+        typeof newValue === 'function' &&
+        !(newValue as Record<string, unknown>).__isAnimationDefinition
+      ) {
+        mutable.value = (newValue as (value: TValue) => TValue)(mutable.value);
+      } else {
+        mutable.value = newValue as TValue;
+      }
     },
 
     get _value(): TValue {
@@ -44,7 +57,7 @@ export function makeMutable<TValue>(initial: TValue): Mutable<TValue> {
 
     modify: (modifier, forceUpdate = true) => {
       valueSetter(
-        mutable as Mutable<TValue>,
+        mutable,
         modifier !== undefined ? modifier(mutable.value) : mutable.value,
         forceUpdate
       );
@@ -60,16 +73,26 @@ export function makeMutable<TValue>(initial: TValue): Mutable<TValue> {
   };
 
   // Hide `_value` from accidental enumeration.
-  Object.defineProperty(mutable, '_value', {
-    configurable: false,
-    enumerable: false,
+  Object.defineProperties(mutable, {
+    _value: {
+      configurable: false,
+      enumerable: false,
+    },
+    get: {
+      configurable: false,
+      enumerable: false,
+      writable: false,
+    },
+    set: {
+      configurable: false,
+      enumerable: false,
+      writable: false,
+    },
   });
-
-  addCompilerSafeGetAndSet(mutable);
 
   if (IS_JEST) {
     (mutable as JestMutable<TValue>).toJSON = () => mutableToJSON(value);
   }
 
-  return mutable as Mutable<TValue>;
+  return mutable;
 }

--- a/packages/react-native-reanimated/src/mutablesCommon.ts
+++ b/packages/react-native-reanimated/src/mutablesCommon.ts
@@ -31,49 +31,6 @@ export function checkInvalidWriteDuringRender() {
 
 export type Listener<TValue> = (newValue: TValue) => void;
 
-export type PartialMutable<TValue> = Omit<Mutable<TValue>, 'get' | 'set'>;
-
-/**
- * Adds `get` and `set` methods to the mutable object to handle access to
- * `value` property.
- *
- * React Compiler disallows modifying return values of hooks. Even though
- * assignment to `value` is a setter invocation, Compiler's static analysis
- * doesn't detect it. That's why we provide a second API for users using the
- * Compiler.
- */
-export function addCompilerSafeGetAndSet<TValue>(
-  mutable: PartialMutable<TValue>
-): void {
-  'worklet';
-  Object.defineProperties(mutable, {
-    get: {
-      value() {
-        return mutable.value;
-      },
-      configurable: false,
-      enumerable: false,
-    },
-    set: {
-      value(newValue: TValue | ((value: TValue) => TValue)) {
-        if (
-          typeof newValue === 'function' &&
-          // If we have an animation definition, we don't want to call it here.
-          !(newValue as Record<string, unknown>).__isAnimationDefinition
-        ) {
-          mutable.value = (newValue as (value: TValue) => TValue)(
-            mutable.value
-          );
-        } else {
-          mutable.value = newValue as TValue;
-        }
-      },
-      configurable: false,
-      enumerable: false,
-    },
-  });
-}
-
 export function mutableHostDecorator<TValue>(
   mutable: ShareableHost<TValue> & Mutable<TValue>,
   dirtyFlag?: Synchronizable<boolean>
@@ -93,6 +50,31 @@ export function mutableHostDecorator<TValue>(
       },
       enumerable: true,
       configurable: true,
+    },
+
+    get: {
+      value() {
+        return mutable.value;
+      },
+      configurable: false,
+      enumerable: false,
+    },
+
+    set: {
+      value(newValue: TValue | ((value: TValue) => TValue)) {
+        if (
+          typeof newValue === 'function' &&
+          !(newValue as Record<string, unknown>).__isAnimationDefinition
+        ) {
+          mutable.value = (newValue as (value: TValue) => TValue)(
+            mutable.value
+          );
+        } else {
+          mutable.value = newValue as TValue;
+        }
+      },
+      configurable: false,
+      enumerable: false,
     },
 
     _value: {
@@ -165,8 +147,6 @@ export function mutableHostDecorator<TValue>(
       configurable: true,
     },
   });
-
-  addCompilerSafeGetAndSet(mutable);
 
   return mutable;
 }


### PR DESCRIPTION
## Summary

I inline compiler `get/set` methods for slightly better performance of creating mutables.

## Test plan

CI

## Changelog

- [x] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.
