### PR TITLE
chore: describe the CSS animation callbacks example without calling the engine native

### DIFF
--- a/apps/common-app/src/apps/css/examples/animations/screens/miscellaneous/AnimationCallbacks.tsx
+++ b/apps/common-app/src/apps/css/examples/animations/screens/miscellaneous/AnimationCallbacks.tsx
@@ -88,7 +88,7 @@ export default function AnimationCallbacks() {
   return (
     <Screen style={styles.screen}>
       <Section
-        description="Animation lifecycle callbacks fired by the **native** CSS engine. `elapsedTime` is reported in **seconds**."
+        description="Lifecycle callbacks of a **CSS animation**. `elapsedTime` is reported in **seconds**."
         title="Animation Callbacks">
         <View style={styles.content}>
           <View style={styles.buttons}>


### PR DESCRIPTION
The example screen says the callbacks are fired by the native CSS engine, but `common-app` is also what the web example renders, and there the callbacks come from DOM listeners. Describes what fires them instead of where they are implemented.