### PR TITLE
perf: Intern easings and route properties by id across the transition JNI

### DIFF
--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformEasings.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformEasings.cpp
@@ -44,8 +44,7 @@ void CSSPlatformEasings::release(const int easingId) {
   interned_.erase(it);
   undefine_(easingId);
   if (interned_.empty()) {
-    // Nothing holds an id, so counting from zero again keeps them inside the range the
-    // platform side can look up without boxing.
+    // Small ids stay inside the platform side's key cache, so restart while none are in use.
     nextId_ = 0;
   }
 }

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformEasings.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformEasings.cpp
@@ -1,0 +1,53 @@
+#include <reanimated/android/CSS/CSSPlatformEasings.h>
+
+#include <utility>
+
+namespace reanimated {
+
+CSSPlatformEasings::CSSPlatformEasings(DefineFunction define, UndefineFunction undefine)
+    : define_(std::move(define)), undefine_(std::move(undefine)) {}
+
+std::size_t PlatformEasingHash::operator()(const PlatformEasing &easing) const {
+  std::size_t seed = std::hash<std::uint8_t>{}(static_cast<std::uint8_t>(easing.type));
+  const auto combine = [&seed](const float value) {
+    seed ^= std::hash<float>{}(value) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+  };
+  for (const float value : easing.pointsX) {
+    combine(value);
+  }
+  for (const float value : easing.pointsY) {
+    combine(value);
+  }
+  return seed;
+}
+
+int CSSPlatformEasings::acquire(const PlatformEasing &easing) {
+  const auto it = ids_.find(easing);
+  if (it != ids_.end()) {
+    ++interned_.at(it->second).refCount;
+    return it->second;
+  }
+
+  const int easingId = nextId_++;
+  define_(easingId, static_cast<int>(easing.type), easing.pointsX, easing.pointsY);
+  ids_.emplace(easing, easingId);
+  interned_.emplace(easingId, Interned{easing, 1});
+  return easingId;
+}
+
+void CSSPlatformEasings::release(const int easingId) {
+  const auto it = interned_.find(easingId);
+  if (--it->second.refCount > 0) {
+    return;
+  }
+  ids_.erase(it->second.easing);
+  interned_.erase(it);
+  undefine_(easingId);
+  if (interned_.empty()) {
+    // Nothing holds an id, so counting from zero again keeps them inside the range the
+    // platform side can look up without boxing.
+    nextId_ = 0;
+  }
+}
+
+} // namespace reanimated

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformEasings.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformEasings.h
@@ -28,7 +28,7 @@ class CSSPlatformEasings {
   using DefineFunction =
       std::function<void(int easingId, int type, const std::vector<float> &pointsX, const std::vector<float> &pointsY)>;
 
-  /// Ids are never reused, so a curve nobody needs has to be removed explicitly.
+  /// A live id is never handed to another curve, so nothing overwrites the platform's entry.
   using UndefineFunction = std::function<void(int easingId)>;
 
   CSSPlatformEasings(DefineFunction define, UndefineFunction undefine);

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformEasings.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformEasings.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <unordered_map>
+#include <vector>
+
+namespace reanimated {
+
+/// Carries the curve's own points rather than a sampled table, so a discontinuous
+/// steps() survives at any duration.
+struct PlatformEasing {
+  enum class Type : std::uint8_t { Linear = 0, CubicBezier = 1, Steps = 2, LinearStops = 3 };
+
+  Type type;
+  std::vector<float> pointsX;
+  std::vector<float> pointsY;
+
+  bool operator==(const PlatformEasing &other) const = default;
+};
+
+struct PlatformEasingHash {
+  std::size_t operator()(const PlatformEasing &easing) const;
+};
+
+/// Registers each distinct curve with the platform once and hands back an id, so a start
+/// crosses the JNI boundary carrying an int rather than two float arrays. Knows nothing about
+/// what is animating: any platform-driven animation kind can share one instance.
+class CSSPlatformEasings {
+ public:
+  /// Registers a curve under an id.
+  using DefineFunction =
+      std::function<void(int easingId, int type, const std::vector<float> &pointsX, const std::vector<float> &pointsY)>;
+
+  /// Drops a curve the platform no longer needs. Ids are never reused, so nothing overwrites it.
+  using UndefineFunction = std::function<void(int easingId)>;
+
+  CSSPlatformEasings(DefineFunction define, UndefineFunction undefine);
+
+  /// Interns the curve if it is new and takes a reference. Pair every call with release():
+  /// interning and retaining together means a caller cannot register a curve and then forget
+  /// to own it. Always succeeds; ids just keep counting up.
+  int acquire(const PlatformEasing &easing);
+
+  /// Hands a reference back, dropping the curve from both sides once none remain.
+  void release(int easingId);
+
+ private:
+  /// The curve behind an id, and how many holders still need it.
+  struct Interned {
+    PlatformEasing easing;
+    int refCount;
+  };
+
+  std::unordered_map<PlatformEasing, int, PlatformEasingHash> ids_;
+  std::unordered_map<int, Interned> interned_;
+  int nextId_{0};
+  DefineFunction define_;
+  UndefineFunction undefine_;
+};
+
+} // namespace reanimated

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformEasings.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformEasings.h
@@ -7,8 +7,7 @@
 
 namespace reanimated {
 
-/// Carries the curve's own points rather than a sampled table, so a discontinuous
-/// steps() survives at any duration.
+/// Raw points rather than a sampled table, so steps() keeps its discontinuities.
 struct PlatformEasing {
   enum class Type : std::uint8_t { Linear = 0, CubicBezier = 1, Steps = 2, LinearStops = 3 };
 
@@ -23,9 +22,7 @@ struct PlatformEasingHash {
   std::size_t operator()(const PlatformEasing &easing) const;
 };
 
-/// Registers each distinct curve with the platform once and hands back an id, so a start crosses
-/// JNI carrying an int rather than two float arrays. Knows nothing about what is animating, so
-/// every platform-driven animation kind can share one instance.
+/// Registers each distinct curve once so a start carries an id instead of its points.
 class CSSPlatformEasings {
  public:
   using DefineFunction =
@@ -36,11 +33,9 @@ class CSSPlatformEasings {
 
   CSSPlatformEasings(DefineFunction define, UndefineFunction undefine);
 
-  /// Interns on first sight and takes a reference; pair every call with release(). Always
-  /// succeeds, so a caller never has to handle a curve it could not register.
+  /// Interns on first sight and takes a reference; pair every call with release().
   int acquire(const PlatformEasing &easing);
 
-  /// Hands a reference back, dropping the curve from both sides once none remain.
   void release(int easingId);
 
  private:

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformEasings.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformEasings.h
@@ -23,30 +23,27 @@ struct PlatformEasingHash {
   std::size_t operator()(const PlatformEasing &easing) const;
 };
 
-/// Registers each distinct curve with the platform once and hands back an id, so a start
-/// crosses the JNI boundary carrying an int rather than two float arrays. Knows nothing about
-/// what is animating: any platform-driven animation kind can share one instance.
+/// Registers each distinct curve with the platform once and hands back an id, so a start crosses
+/// JNI carrying an int rather than two float arrays. Knows nothing about what is animating, so
+/// every platform-driven animation kind can share one instance.
 class CSSPlatformEasings {
  public:
-  /// Registers a curve under an id.
   using DefineFunction =
       std::function<void(int easingId, int type, const std::vector<float> &pointsX, const std::vector<float> &pointsY)>;
 
-  /// Drops a curve the platform no longer needs. Ids are never reused, so nothing overwrites it.
+  /// Ids are never reused, so a curve nobody needs has to be removed explicitly.
   using UndefineFunction = std::function<void(int easingId)>;
 
   CSSPlatformEasings(DefineFunction define, UndefineFunction undefine);
 
-  /// Interns the curve if it is new and takes a reference. Pair every call with release():
-  /// interning and retaining together means a caller cannot register a curve and then forget
-  /// to own it. Always succeeds; ids just keep counting up.
+  /// Interns on first sight and takes a reference; pair every call with release(). Always
+  /// succeeds, so a caller never has to handle a curve it could not register.
   int acquire(const PlatformEasing &easing);
 
   /// Hands a reference back, dropping the curve from both sides once none remain.
   void release(int easingId);
 
  private:
-  /// The curve behind an id, and how many holders still need it.
   struct Interned {
     PlatformEasing easing;
     int refCount;

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
@@ -123,8 +123,9 @@ bool CSSPlatformTransitions::applyTransition(
     return false;
   }
 
+  // has_value(), not a truthiness test: opacity's id is 0.
   const auto propertyId = platformPropertyId(propertyName);
-  if (!propertyId) {
+  if (!propertyId.has_value()) {
     return false;
   }
 
@@ -199,7 +200,7 @@ void CSSPlatformTransitions::removeTransition(const Tag viewTag, const std::stri
     }
   }
   // A property without an id was never routed, so there is nothing to remove.
-  if (const auto propertyId = platformPropertyId(propertyName)) {
+  if (const auto propertyId = platformPropertyId(propertyName); propertyId.has_value()) {
     remove_(static_cast<int>(viewTag), *propertyId);
   }
 }

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
@@ -2,8 +2,6 @@
 
 #include <reanimated/CSS/easing/EasingConfigs.h>
 
-#include <algorithm>
-
 #include <variant>
 #include <vector>
 
@@ -46,8 +44,12 @@ std::optional<int> platformPropertyId(const std::string &propertyName) {
 CSSPlatformTransitions::CSSPlatformTransitions(
     AnimateFunction animate,
     RemoveFunction remove,
-    DefineEasingFunction defineEasing)
-    : animate_(std::move(animate)), remove_(std::move(remove)), defineEasing_(std::move(defineEasing)) {}
+    DefineEasingFunction defineEasing,
+    UndefineEasingFunction undefineEasing)
+    : animate_(std::move(animate)),
+      remove_(std::move(remove)),
+      defineEasing_(std::move(defineEasing)),
+      undefineEasing_(std::move(undefineEasing)) {}
 
 std::size_t PlatformEasingHash::operator()(const PlatformEasing &easing) const {
   std::size_t seed = std::hash<std::uint8_t>{}(static_cast<std::uint8_t>(easing.type));
@@ -69,33 +71,25 @@ int CSSPlatformTransitions::easingIdFor(const PlatformEasing &easing) {
     return it->second;
   }
 
-  // Take back a slot nothing routes with before adding one, so the table settles at the most
-  // curves ever animating at once. Scanning rather than tracking freed ids also reclaims a slot
-  // interned for a start that then failed, which never passed through releaseEasing. Only runs
-  // when a curve is seen for the first time.
-  const auto unused = std::find(easingRefs_.begin(), easingRefs_.end(), 0);
-  int easingId;
-  if (unused != easingRefs_.end()) {
-    easingId = static_cast<int>(std::distance(easingRefs_.begin(), unused));
-    easingIds_.erase(easingKeys_[easingId]);
-    easingKeys_[easingId] = easing;
-  } else {
-    easingId = static_cast<int>(easingKeys_.size());
-    easingKeys_.push_back(easing);
-    easingRefs_.push_back(0);
-  }
-
+  const int easingId = nextEasingId_++;
   defineEasing_(easingId, static_cast<int>(easing.type), easing.pointsX, easing.pointsY);
   easingIds_.emplace(easing, easingId);
+  internedEasings_.emplace(easingId, InternedEasing{easing, 0});
   return easingId;
 }
 
 void CSSPlatformTransitions::retainEasing(const int easingId) {
-  ++easingRefs_[easingId];
+  ++internedEasings_.at(easingId).refCount;
 }
 
 void CSSPlatformTransitions::releaseEasing(const int easingId) {
-  --easingRefs_[easingId];
+  const auto it = internedEasings_.find(easingId);
+  if (--it->second.refCount > 0) {
+    return;
+  }
+  easingIds_.erase(it->second.easing);
+  internedEasings_.erase(it);
+  undefineEasing_(easingId);
 }
 
 const CSSPlatformTransitions::ActiveTransition *CSSPlatformTransitions::activeTransitionFor(
@@ -161,6 +155,8 @@ bool CSSPlatformTransitions::applyTransition(
   }
 
   const auto easingId = easingIdFor(toPlatformEasing(resolvedSettings.easingConfig));
+  // Retain before the start can fail, so a rejected start drops the curve it just interned.
+  retainEasing(easingId);
 
   if (!animate_(
           static_cast<int>(viewTag),
@@ -171,11 +167,11 @@ bool CSSPlatformTransitions::applyTransition(
           reversing.startTimestamp,
           easingId,
           persistent)) {
+    releaseEasing(easingId);
     return false;
   }
 
-  // Retain before releasing, so replacing a transition with the same curve never frees it.
-  retainEasing(easingId);
+  // Released after the retain above, so replacing a transition with the same curve never drops it.
   if (replacedEasingId >= 0) {
     releaseEasing(replacedEasingId);
   }

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
@@ -150,8 +150,8 @@ bool CSSPlatformTransitions::applyTransition(
           *to,
           reversing.duration,
           reversing.startTimestamp,
-              *easingId,
-              persistent)) {
+          *easingId,
+          persistent)) {
     return false;
   }
 

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
@@ -47,9 +47,13 @@ constexpr size_t kMaxInternedEasings = 256;
 
 CSSPlatformTransitions::CSSPlatformTransitions(
     AnimateFunction animate,
+    AnimateWithEasingFunction animateWithEasing,
     RemoveFunction remove,
     DefineEasingFunction defineEasing)
-    : animate_(std::move(animate)), remove_(std::move(remove)), defineEasing_(std::move(defineEasing)) {}
+    : animate_(std::move(animate)),
+      animateWithEasing_(std::move(animateWithEasing)),
+      remove_(std::move(remove)),
+      defineEasing_(std::move(defineEasing)) {}
 
 std::size_t PlatformEasingHash::operator()(const PlatformEasing &easing) const {
   std::size_t seed = std::hash<std::uint8_t>{}(static_cast<std::uint8_t>(easing.type));
@@ -162,31 +166,49 @@ bool CSSPlatformTransitions::applyTransition(
     adjustedStart = active->adjustedEnd;
   }
 
-  const auto easingId = easingIdFor(toPlatformEasing(resolvedSettings.easingConfig));
-  if (!easingId) {
-    return false;
-  }
+  const auto easing = toPlatformEasing(resolvedSettings.easingConfig);
+  const auto easingId = easingIdFor(easing);
 
-  if (!animate_(
-          static_cast<int>(viewTag),
-          *propertyId,
-          *from,
-          *to,
-          reversing.duration,
-          reversing.startTimestamp,
-          *easingId,
-          persistent)) {
+  bool started;
+  if (easingId.has_value()) {
+    started = animate_(
+        static_cast<int>(viewTag),
+        *propertyId,
+        *from,
+        *to,
+        reversing.duration,
+        reversing.startTimestamp,
+        *easingId,
+        persistent);
+  } else {
+    // An id is only an optimisation, so a full table sends the curve along rather than
+    // handing a platform-animatable property back to the loop.
+    started = animateWithEasing_(
+        static_cast<int>(viewTag),
+        *propertyId,
+        *from,
+        *to,
+        reversing.duration,
+        reversing.startTimestamp,
+        static_cast<int>(easing.type),
+        easing.pointsX,
+        easing.pointsY,
+        persistent);
+  }
+  if (!started) {
     return false;
   }
 
   // Retain before releasing, so replacing a transition with the same curve never frees it.
-  retainEasing(*easingId);
+  if (easingId.has_value()) {
+    retainEasing(*easingId);
+  }
   if (replacedEasingId >= 0) {
     releaseEasing(replacedEasingId);
   }
 
   active_[viewTag][propertyName] =
-      ActiveTransition{adjustedStart, toValue, std::move(reversing), resolvedSettings, *easingId};
+      ActiveTransition{adjustedStart, toValue, std::move(reversing), resolvedSettings, easingId.value_or(-1)};
   return true;
 }
 
@@ -195,7 +217,9 @@ void CSSPlatformTransitions::removeTransition(const Tag viewTag, const std::stri
   if (propertiesIt != active_.end()) {
     const auto activeIt = propertiesIt->second.find(propertyName);
     if (activeIt != propertiesIt->second.end()) {
-      releaseEasing(activeIt->second.easingId);
+      if (activeIt->second.easingId >= 0) {
+        releaseEasing(activeIt->second.easingId);
+      }
       propertiesIt->second.erase(activeIt);
     }
     if (propertiesIt->second.empty()) {

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
@@ -2,6 +2,7 @@
 
 #include <reanimated/CSS/easing/EasingConfigs.h>
 
+#include <algorithm>
 #include <variant>
 #include <vector>
 
@@ -69,13 +70,34 @@ std::optional<int> CSSPlatformTransitions::easingIdFor(const PlatformEasing &eas
   if (it != easingIds_.end()) {
     return it->second;
   }
-  if (easingIds_.size() >= kMaxInternedEasings) {
-    return std::nullopt;
+
+  int easingId;
+  if (easingKeys_.size() < kMaxInternedEasings) {
+    easingId = static_cast<int>(easingKeys_.size());
+    easingKeys_.push_back(easing);
+    easingRefs_.push_back(0);
+  } else {
+    // Only reached once kMaxInternedEasings distinct curves exist, so the scan is not a hot path.
+    const auto unused = std::find(easingRefs_.begin(), easingRefs_.end(), 0);
+    if (unused == easingRefs_.end()) {
+      return std::nullopt;
+    }
+    easingId = static_cast<int>(std::distance(easingRefs_.begin(), unused));
+    easingIds_.erase(easingKeys_[easingId]);
+    easingKeys_[easingId] = easing;
   }
-  const int easingId = static_cast<int>(easingIds_.size());
+
   defineEasing_(easingId, static_cast<int>(easing.type), easing.pointsX, easing.pointsY);
   easingIds_.emplace(easing, easingId);
   return easingId;
+}
+
+void CSSPlatformTransitions::retainEasing(const int easingId) {
+  ++easingRefs_[easingId];
+}
+
+void CSSPlatformTransitions::releaseEasing(const int easingId) {
+  --easingRefs_[easingId];
 }
 
 const CSSPlatformTransitions::ActiveTransition *CSSPlatformTransitions::activeTransitionFor(
@@ -116,6 +138,7 @@ bool CSSPlatformTransitions::applyTransition(
   }
   // Copy: the active entry is re-assigned below.
   const css::CSSTransitionPropertySettings resolvedSettings = settings == nullptr ? active->settings : *settings;
+  const int replacedEasingId = active != nullptr ? active->easingId : -1;
 
   // Targeting the in-flight transition's start value means this is a reversal.
   const bool isReversal = active != nullptr && active->adjustedStart && toValue == *active->adjustedStart;
@@ -156,14 +179,25 @@ bool CSSPlatformTransitions::applyTransition(
     return false;
   }
 
-  active_[viewTag][propertyName] = ActiveTransition{adjustedStart, toValue, std::move(reversing), resolvedSettings};
+  // Retain before releasing, so replacing a transition with the same curve never frees it.
+  retainEasing(*easingId);
+  if (replacedEasingId >= 0) {
+    releaseEasing(replacedEasingId);
+  }
+
+  active_[viewTag][propertyName] =
+      ActiveTransition{adjustedStart, toValue, std::move(reversing), resolvedSettings, *easingId};
   return true;
 }
 
 void CSSPlatformTransitions::removeTransition(const Tag viewTag, const std::string &propertyName) {
   const auto propertiesIt = active_.find(viewTag);
   if (propertiesIt != active_.end()) {
-    propertiesIt->second.erase(propertyName);
+    const auto activeIt = propertiesIt->second.find(propertyName);
+    if (activeIt != propertiesIt->second.end()) {
+      releaseEasing(activeIt->second.easingId);
+      propertiesIt->second.erase(activeIt);
+    }
     if (propertiesIt->second.empty()) {
       active_.erase(propertiesIt);
     }

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
@@ -31,10 +31,52 @@ PlatformEasing toPlatformEasing(const css::EasingConfig &easingConfig) {
   return {PlatformEasing::Type::Linear, {}, {}};
 }
 
+/// Must match cssPropertyWriterFor on the Kotlin side.
+std::optional<int> platformPropertyId(const std::string &propertyName) {
+  if (propertyName == "opacity") {
+    return 0;
+  }
+  return std::nullopt;
+}
+
+constexpr size_t kMaxInternedEasings = 256;
+
 } // namespace
 
-CSSPlatformTransitions::CSSPlatformTransitions(AnimateFunction animate, RemoveFunction remove)
-    : animate_(std::move(animate)), remove_(std::move(remove)) {}
+std::size_t CSSPlatformTransitions::EasingKeyHash::operator()(const EasingKey &key) const {
+  std::size_t seed = std::hash<int>{}(key.type);
+  const auto combine = [&seed](const float value) {
+    seed ^= std::hash<float>{}(value) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+  };
+  for (const float value : key.pointsX) {
+    combine(value);
+  }
+  for (const float value : key.pointsY) {
+    combine(value);
+  }
+  return seed;
+}
+
+CSSPlatformTransitions::CSSPlatformTransitions(
+    AnimateFunction animate,
+    RemoveFunction remove,
+    DefineEasingFunction defineEasing)
+    : animate_(std::move(animate)), remove_(std::move(remove)), defineEasing_(std::move(defineEasing)) {}
+
+std::optional<int> CSSPlatformTransitions::easingIdFor(const PlatformEasing &easing) {
+  EasingKey key{static_cast<std::uint8_t>(easing.type), easing.pointsX, easing.pointsY};
+  const auto it = easingIds_.find(key);
+  if (it != easingIds_.end()) {
+    return it->second;
+  }
+  if (easingIds_.size() >= kMaxInternedEasings) {
+    return std::nullopt;
+  }
+  const int easingId = static_cast<int>(easingIds_.size());
+  defineEasing_(easingId, static_cast<int>(easing.type), easing.pointsX, easing.pointsY);
+  easingIds_.emplace(std::move(key), easingId);
+  return easingId;
+}
 
 const CSSPlatformTransitions::ActiveTransition *CSSPlatformTransitions::activeTransitionFor(
     const Tag viewTag,
@@ -59,6 +101,11 @@ bool CSSPlatformTransitions::applyTransition(
   const auto *from = std::get_if<double>(&fromValue);
   const auto *to = std::get_if<double>(&toValue);
   if (from == nullptr || to == nullptr) {
+    return false;
+  }
+
+  const auto propertyId = platformPropertyId(propertyName);
+  if (!propertyId) {
     return false;
   }
 
@@ -92,15 +139,20 @@ bool CSSPlatformTransitions::applyTransition(
     adjustedStart = active->adjustedEnd;
   }
 
+  const auto easingId = easingIdFor(toPlatformEasing(resolvedSettings.easingConfig));
+  if (!easingId) {
+    return false;
+  }
+
   if (!animate_(
           static_cast<int>(viewTag),
-          propertyName,
+          *propertyId,
           *from,
           *to,
           reversing.duration,
           reversing.startTimestamp,
-          toPlatformEasing(resolvedSettings.easingConfig),
-          persistent)) {
+              *easingId,
+              persistent)) {
     return false;
   }
 
@@ -116,7 +168,10 @@ void CSSPlatformTransitions::removeTransition(const Tag viewTag, const std::stri
       active_.erase(propertiesIt);
     }
   }
-  remove_(static_cast<int>(viewTag), propertyName);
+  // A property without an id was never routed, so there is nothing to remove.
+  if (const auto propertyId = platformPropertyId(propertyName)) {
+    remove_(static_cast<int>(viewTag), *propertyId);
+  }
 }
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
@@ -43,20 +43,6 @@ constexpr size_t kMaxInternedEasings = 256;
 
 } // namespace
 
-std::size_t CSSPlatformTransitions::EasingKeyHash::operator()(const EasingKey &key) const {
-  std::size_t seed = std::hash<int>{}(key.type);
-  const auto combine = [&seed](const float value) {
-    seed ^= std::hash<float>{}(value) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-  };
-  for (const float value : key.pointsX) {
-    combine(value);
-  }
-  for (const float value : key.pointsY) {
-    combine(value);
-  }
-  return seed;
-}
-
 CSSPlatformTransitions::CSSPlatformTransitions(
     AnimateFunction animate,
     RemoveFunction remove,
@@ -64,17 +50,18 @@ CSSPlatformTransitions::CSSPlatformTransitions(
     : animate_(std::move(animate)), remove_(std::move(remove)), defineEasing_(std::move(defineEasing)) {}
 
 std::optional<int> CSSPlatformTransitions::easingIdFor(const PlatformEasing &easing) {
-  EasingKey key{static_cast<std::uint8_t>(easing.type), easing.pointsX, easing.pointsY};
-  const auto it = easingIds_.find(key);
-  if (it != easingIds_.end()) {
-    return it->second;
+  // A handful of curves in practice, so a scan beats hashing the point lists.
+  for (size_t i = 0; i < internedEasings_.size(); i++) {
+    if (internedEasings_[i] == easing) {
+      return static_cast<int>(i);
+    }
   }
-  if (easingIds_.size() >= kMaxInternedEasings) {
+  if (internedEasings_.size() >= kMaxInternedEasings) {
     return std::nullopt;
   }
-  const int easingId = static_cast<int>(easingIds_.size());
+  const int easingId = static_cast<int>(internedEasings_.size());
   defineEasing_(easingId, static_cast<int>(easing.type), easing.pointsX, easing.pointsY);
-  easingIds_.emplace(std::move(key), easingId);
+  internedEasings_.push_back(easing);
   return easingId;
 }
 

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
@@ -90,6 +90,11 @@ void CSSPlatformTransitions::releaseEasing(const int easingId) {
   easingIds_.erase(it->second.easing);
   internedEasings_.erase(it);
   undefineEasing_(easingId);
+  if (internedEasings_.empty()) {
+    // Nothing holds an id, so counting from zero again keeps them inside the range the
+    // platform side can look up without boxing.
+    nextEasingId_ = 0;
+  }
 }
 
 const CSSPlatformTransitions::ActiveTransition *CSSPlatformTransitions::activeTransitionFor(

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
@@ -40,8 +40,8 @@ std::optional<int> platformPropertyId(const std::string &propertyName) {
   return std::nullopt;
 }
 
-/// Must match MAX_INTERNED_EASINGS on the Kotlin side, which sizes its table to it.
-constexpr size_t kMaxInternedEasings = 256;
+/// Not a ceiling: past this many curves the table prefers reclaiming an unused slot to growing.
+constexpr size_t kEasingReuseThreshold = 256;
 
 } // namespace
 
@@ -65,28 +65,29 @@ std::size_t PlatformEasingHash::operator()(const PlatformEasing &easing) const {
   return seed;
 }
 
-std::optional<int> CSSPlatformTransitions::easingIdFor(const PlatformEasing &easing) {
+int CSSPlatformTransitions::easingIdFor(const PlatformEasing &easing) {
   const auto it = easingIds_.find(easing);
   if (it != easingIds_.end()) {
     return it->second;
   }
 
-  int easingId;
-  if (easingKeys_.size() < kMaxInternedEasings) {
-    easingId = static_cast<int>(easingKeys_.size());
-    easingKeys_.push_back(easing);
-    easingRefs_.push_back(0);
-  } else {
-    // Only reached once kMaxInternedEasings distinct curves exist, so the scan is not a hot path.
+  // Past the threshold, reclaim a curve nothing routes with before adding a slot, so a table
+  // that grew once settles back down. The scan needs that many distinct curves to run at all.
+  if (easingKeys_.size() >= kEasingReuseThreshold) {
     const auto unused = std::find(easingRefs_.begin(), easingRefs_.end(), 0);
-    if (unused == easingRefs_.end()) {
-      return std::nullopt;
+    if (unused != easingRefs_.end()) {
+      const auto easingId = static_cast<int>(std::distance(easingRefs_.begin(), unused));
+      easingIds_.erase(easingKeys_[easingId]);
+      easingKeys_[easingId] = easing;
+      defineEasing_(easingId, static_cast<int>(easing.type), easing.pointsX, easing.pointsY);
+      easingIds_.emplace(easing, easingId);
+      return easingId;
     }
-    easingId = static_cast<int>(std::distance(easingRefs_.begin(), unused));
-    easingIds_.erase(easingKeys_[easingId]);
-    easingKeys_[easingId] = easing;
   }
 
+  const auto easingId = static_cast<int>(easingKeys_.size());
+  easingKeys_.push_back(easing);
+  easingRefs_.push_back(0);
   defineEasing_(easingId, static_cast<int>(easing.type), easing.pointsX, easing.pointsY);
   easingIds_.emplace(easing, easingId);
   return easingId;
@@ -162,11 +163,8 @@ bool CSSPlatformTransitions::applyTransition(
     adjustedStart = active->adjustedEnd;
   }
 
-  const auto easing = toPlatformEasing(resolvedSettings.easingConfig);
-  const auto easingId = easingIdFor(easing);
+  const auto easingId = easingIdFor(toPlatformEasing(resolvedSettings.easingConfig));
 
-  // An id is only an optimisation, so a full table sends the curve along rather than handing a
-  // platform-animatable property back to the loop.
   if (!animate_(
           static_cast<int>(viewTag),
           *propertyId,
@@ -174,22 +172,19 @@ bool CSSPlatformTransitions::applyTransition(
           *to,
           reversing.duration,
           reversing.startTimestamp,
-          easingId.value_or(-1),
-          easing,
+          easingId,
           persistent)) {
     return false;
   }
 
   // Retain before releasing, so replacing a transition with the same curve never frees it.
-  if (easingId.has_value()) {
-    retainEasing(*easingId);
-  }
+  retainEasing(easingId);
   if (replacedEasingId >= 0) {
     releaseEasing(replacedEasingId);
   }
 
   active_[viewTag][propertyName] =
-      ActiveTransition{adjustedStart, toValue, std::move(reversing), resolvedSettings, easingId.value_or(-1)};
+      ActiveTransition{adjustedStart, toValue, std::move(reversing), resolvedSettings, easingId};
   return true;
 }
 

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
@@ -49,19 +49,31 @@ CSSPlatformTransitions::CSSPlatformTransitions(
     DefineEasingFunction defineEasing)
     : animate_(std::move(animate)), remove_(std::move(remove)), defineEasing_(std::move(defineEasing)) {}
 
-std::optional<int> CSSPlatformTransitions::easingIdFor(const PlatformEasing &easing) {
-  // A handful of curves in practice, so a scan beats hashing the point lists.
-  for (size_t i = 0; i < internedEasings_.size(); i++) {
-    if (internedEasings_[i] == easing) {
-      return static_cast<int>(i);
-    }
+std::size_t PlatformEasingHash::operator()(const PlatformEasing &easing) const {
+  std::size_t seed = std::hash<std::uint8_t>{}(static_cast<std::uint8_t>(easing.type));
+  const auto combine = [&seed](const float value) {
+    seed ^= std::hash<float>{}(value) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+  };
+  for (const float value : easing.pointsX) {
+    combine(value);
   }
-  if (internedEasings_.size() >= kMaxInternedEasings) {
+  for (const float value : easing.pointsY) {
+    combine(value);
+  }
+  return seed;
+}
+
+std::optional<int> CSSPlatformTransitions::easingIdFor(const PlatformEasing &easing) {
+  const auto it = easingIds_.find(easing);
+  if (it != easingIds_.end()) {
+    return it->second;
+  }
+  if (easingIds_.size() >= kMaxInternedEasings) {
     return std::nullopt;
   }
-  const int easingId = static_cast<int>(internedEasings_.size());
+  const int easingId = static_cast<int>(easingIds_.size());
   defineEasing_(easingId, static_cast<int>(easing.type), easing.pointsX, easing.pointsY);
-  internedEasings_.push_back(easing);
+  easingIds_.emplace(easing, easingId);
   return easingId;
 }
 

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
@@ -2,7 +2,6 @@
 
 #include <reanimated/CSS/easing/EasingConfigs.h>
 
-#include <algorithm>
 #include <variant>
 #include <vector>
 
@@ -40,9 +39,6 @@ std::optional<int> platformPropertyId(const std::string &propertyName) {
   return std::nullopt;
 }
 
-/// Not a ceiling: past this many curves the table prefers reclaiming an unused slot to growing.
-constexpr size_t kEasingReuseThreshold = 256;
-
 } // namespace
 
 CSSPlatformTransitions::CSSPlatformTransitions(
@@ -71,23 +67,25 @@ int CSSPlatformTransitions::easingIdFor(const PlatformEasing &easing) {
     return it->second;
   }
 
-  // Past the threshold, reclaim a curve nothing routes with before adding a slot, so a table
-  // that grew once settles back down. The scan needs that many distinct curves to run at all.
-  if (easingKeys_.size() >= kEasingReuseThreshold) {
-    const auto unused = std::find(easingRefs_.begin(), easingRefs_.end(), 0);
-    if (unused != easingRefs_.end()) {
-      const auto easingId = static_cast<int>(std::distance(easingRefs_.begin(), unused));
+  // Take back a slot nothing routes with before adding one, so the table settles at the most
+  // curves ever animating at once. Freed ids can be stale, hence the reference re-check.
+  int easingId = -1;
+  while (!freeEasingIds_.empty()) {
+    const int candidate = freeEasingIds_.back();
+    freeEasingIds_.pop_back();
+    if (easingRefs_[candidate] == 0) {
+      easingId = candidate;
       easingIds_.erase(easingKeys_[easingId]);
       easingKeys_[easingId] = easing;
-      defineEasing_(easingId, static_cast<int>(easing.type), easing.pointsX, easing.pointsY);
-      easingIds_.emplace(easing, easingId);
-      return easingId;
+      break;
     }
   }
+  if (easingId < 0) {
+    easingId = static_cast<int>(easingKeys_.size());
+    easingKeys_.push_back(easing);
+    easingRefs_.push_back(0);
+  }
 
-  const auto easingId = static_cast<int>(easingKeys_.size());
-  easingKeys_.push_back(easing);
-  easingRefs_.push_back(0);
   defineEasing_(easingId, static_cast<int>(easing.type), easing.pointsX, easing.pointsY);
   easingIds_.emplace(easing, easingId);
   return easingId;
@@ -98,7 +96,10 @@ void CSSPlatformTransitions::retainEasing(const int easingId) {
 }
 
 void CSSPlatformTransitions::releaseEasing(const int easingId) {
-  --easingRefs_[easingId];
+  // Still cached at zero references: only a curve needing a slot actually takes it.
+  if (--easingRefs_[easingId] == 0) {
+    freeEasingIds_.push_back(easingId);
+  }
 }
 
 const CSSPlatformTransitions::ActiveTransition *CSSPlatformTransitions::activeTransitionFor(

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
@@ -47,13 +47,9 @@ constexpr size_t kMaxInternedEasings = 256;
 
 CSSPlatformTransitions::CSSPlatformTransitions(
     AnimateFunction animate,
-    AnimateWithEasingFunction animateWithEasing,
     RemoveFunction remove,
     DefineEasingFunction defineEasing)
-    : animate_(std::move(animate)),
-      animateWithEasing_(std::move(animateWithEasing)),
-      remove_(std::move(remove)),
-      defineEasing_(std::move(defineEasing)) {}
+    : animate_(std::move(animate)), remove_(std::move(remove)), defineEasing_(std::move(defineEasing)) {}
 
 std::size_t PlatformEasingHash::operator()(const PlatformEasing &easing) const {
   std::size_t seed = std::hash<std::uint8_t>{}(static_cast<std::uint8_t>(easing.type));
@@ -169,33 +165,18 @@ bool CSSPlatformTransitions::applyTransition(
   const auto easing = toPlatformEasing(resolvedSettings.easingConfig);
   const auto easingId = easingIdFor(easing);
 
-  bool started;
-  if (easingId.has_value()) {
-    started = animate_(
-        static_cast<int>(viewTag),
-        *propertyId,
-        *from,
-        *to,
-        reversing.duration,
-        reversing.startTimestamp,
-        *easingId,
-        persistent);
-  } else {
-    // An id is only an optimisation, so a full table sends the curve along rather than
-    // handing a platform-animatable property back to the loop.
-    started = animateWithEasing_(
-        static_cast<int>(viewTag),
-        *propertyId,
-        *from,
-        *to,
-        reversing.duration,
-        reversing.startTimestamp,
-        static_cast<int>(easing.type),
-        easing.pointsX,
-        easing.pointsY,
-        persistent);
-  }
-  if (!started) {
+  // An id is only an optimisation, so a full table sends the curve along rather than handing a
+  // platform-animatable property back to the loop.
+  if (!animate_(
+          static_cast<int>(viewTag),
+          *propertyId,
+          *from,
+          *to,
+          reversing.duration,
+          reversing.startTimestamp,
+          easingId.value_or(-1),
+          easing,
+          persistent)) {
     return false;
   }
 

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
@@ -39,6 +39,7 @@ std::optional<int> platformPropertyId(const std::string &propertyName) {
   return std::nullopt;
 }
 
+/// Must match MAX_INTERNED_EASINGS on the Kotlin side, which sizes its table to it.
 constexpr size_t kMaxInternedEasings = 256;
 
 } // namespace

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
@@ -2,6 +2,8 @@
 
 #include <reanimated/CSS/easing/EasingConfigs.h>
 
+#include <algorithm>
+
 #include <variant>
 #include <vector>
 
@@ -68,19 +70,16 @@ int CSSPlatformTransitions::easingIdFor(const PlatformEasing &easing) {
   }
 
   // Take back a slot nothing routes with before adding one, so the table settles at the most
-  // curves ever animating at once. Freed ids can be stale, hence the reference re-check.
-  int easingId = -1;
-  while (!freeEasingIds_.empty()) {
-    const int candidate = freeEasingIds_.back();
-    freeEasingIds_.pop_back();
-    if (easingRefs_[candidate] == 0) {
-      easingId = candidate;
-      easingIds_.erase(easingKeys_[easingId]);
-      easingKeys_[easingId] = easing;
-      break;
-    }
-  }
-  if (easingId < 0) {
+  // curves ever animating at once. Scanning rather than tracking freed ids also reclaims a slot
+  // interned for a start that then failed, which never passed through releaseEasing. Only runs
+  // when a curve is seen for the first time.
+  const auto unused = std::find(easingRefs_.begin(), easingRefs_.end(), 0);
+  int easingId;
+  if (unused != easingRefs_.end()) {
+    easingId = static_cast<int>(std::distance(easingRefs_.begin(), unused));
+    easingIds_.erase(easingKeys_[easingId]);
+    easingKeys_[easingId] = easing;
+  } else {
     easingId = static_cast<int>(easingKeys_.size());
     easingKeys_.push_back(easing);
     easingRefs_.push_back(0);
@@ -96,10 +95,7 @@ void CSSPlatformTransitions::retainEasing(const int easingId) {
 }
 
 void CSSPlatformTransitions::releaseEasing(const int easingId) {
-  // Still cached at zero references: only a curve needing a slot actually takes it.
-  if (--easingRefs_[easingId] == 0) {
-    freeEasingIds_.push_back(easingId);
-  }
+  --easingRefs_[easingId];
 }
 
 const CSSPlatformTransitions::ActiveTransition *CSSPlatformTransitions::activeTransitionFor(
@@ -194,9 +190,7 @@ void CSSPlatformTransitions::removeTransition(const Tag viewTag, const std::stri
   if (propertiesIt != active_.end()) {
     const auto activeIt = propertiesIt->second.find(propertyName);
     if (activeIt != propertiesIt->second.end()) {
-      if (activeIt->second.easingId >= 0) {
-        releaseEasing(activeIt->second.easingId);
-      }
+      releaseEasing(activeIt->second.easingId);
       propertiesIt->second.erase(activeIt);
     }
     if (propertiesIt->second.empty()) {

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
@@ -110,7 +110,6 @@ bool CSSPlatformTransitions::applyTransition(
     adjustedStart = active->adjustedEnd;
   }
 
-  // Acquired before the start can fail, so a rejected start hands the curve straight back.
   const int easingId = easings_->acquire(toPlatformEasing(resolvedSettings.easingConfig));
 
   if (!animate_(
@@ -126,7 +125,8 @@ bool CSSPlatformTransitions::applyTransition(
     return false;
   }
 
-  // Released after the acquire above, so replacing a transition with the same curve never drops it.
+  // After the acquire above: a retrigger with the same curve would otherwise drop it to zero
+  // and rebuild the interpolator.
   if (replacedEasingId >= 0) {
     easings_->release(replacedEasingId);
   }

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
@@ -44,58 +44,8 @@ std::optional<int> platformPropertyId(const std::string &propertyName) {
 CSSPlatformTransitions::CSSPlatformTransitions(
     AnimateFunction animate,
     RemoveFunction remove,
-    DefineEasingFunction defineEasing,
-    UndefineEasingFunction undefineEasing)
-    : animate_(std::move(animate)),
-      remove_(std::move(remove)),
-      defineEasing_(std::move(defineEasing)),
-      undefineEasing_(std::move(undefineEasing)) {}
-
-std::size_t PlatformEasingHash::operator()(const PlatformEasing &easing) const {
-  std::size_t seed = std::hash<std::uint8_t>{}(static_cast<std::uint8_t>(easing.type));
-  const auto combine = [&seed](const float value) {
-    seed ^= std::hash<float>{}(value) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-  };
-  for (const float value : easing.pointsX) {
-    combine(value);
-  }
-  for (const float value : easing.pointsY) {
-    combine(value);
-  }
-  return seed;
-}
-
-int CSSPlatformTransitions::easingIdFor(const PlatformEasing &easing) {
-  const auto it = easingIds_.find(easing);
-  if (it != easingIds_.end()) {
-    return it->second;
-  }
-
-  const int easingId = nextEasingId_++;
-  defineEasing_(easingId, static_cast<int>(easing.type), easing.pointsX, easing.pointsY);
-  easingIds_.emplace(easing, easingId);
-  internedEasings_.emplace(easingId, InternedEasing{easing, 0});
-  return easingId;
-}
-
-void CSSPlatformTransitions::retainEasing(const int easingId) {
-  ++internedEasings_.at(easingId).refCount;
-}
-
-void CSSPlatformTransitions::releaseEasing(const int easingId) {
-  const auto it = internedEasings_.find(easingId);
-  if (--it->second.refCount > 0) {
-    return;
-  }
-  easingIds_.erase(it->second.easing);
-  internedEasings_.erase(it);
-  undefineEasing_(easingId);
-  if (internedEasings_.empty()) {
-    // Nothing holds an id, so counting from zero again keeps them inside the range the
-    // platform side can look up without boxing.
-    nextEasingId_ = 0;
-  }
-}
+    std::shared_ptr<CSSPlatformEasings> easings)
+    : easings_(std::move(easings)), animate_(std::move(animate)), remove_(std::move(remove)) {}
 
 const CSSPlatformTransitions::ActiveTransition *CSSPlatformTransitions::activeTransitionFor(
     const Tag viewTag,
@@ -160,9 +110,8 @@ bool CSSPlatformTransitions::applyTransition(
     adjustedStart = active->adjustedEnd;
   }
 
-  const auto easingId = easingIdFor(toPlatformEasing(resolvedSettings.easingConfig));
-  // Retain before the start can fail, so a rejected start drops the curve it just interned.
-  retainEasing(easingId);
+  // Acquired before the start can fail, so a rejected start hands the curve straight back.
+  const int easingId = easings_->acquire(toPlatformEasing(resolvedSettings.easingConfig));
 
   if (!animate_(
           static_cast<int>(viewTag),
@@ -173,13 +122,13 @@ bool CSSPlatformTransitions::applyTransition(
           reversing.startTimestamp,
           easingId,
           persistent)) {
-    releaseEasing(easingId);
+    easings_->release(easingId);
     return false;
   }
 
-  // Released after the retain above, so replacing a transition with the same curve never drops it.
+  // Released after the acquire above, so replacing a transition with the same curve never drops it.
   if (replacedEasingId >= 0) {
-    releaseEasing(replacedEasingId);
+    easings_->release(replacedEasingId);
   }
 
   active_[viewTag][propertyName] =
@@ -192,7 +141,7 @@ void CSSPlatformTransitions::removeTransition(const Tag viewTag, const std::stri
   if (propertiesIt != active_.end()) {
     const auto activeIt = propertiesIt->second.find(propertyName);
     if (activeIt != propertiesIt->second.end()) {
-      releaseEasing(activeIt->second.easingId);
+      easings_->release(activeIt->second.easingId);
       propertiesIt->second.erase(activeIt);
     }
     if (propertiesIt->second.empty()) {

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
@@ -81,8 +81,8 @@ class CSSPlatformTransitions {
   const ActiveTransition *activeTransitionFor(Tag viewTag, const std::string &propertyName) const;
 
   /// Interns the curve, registering it with the platform on first sight. An unused curve stays
-  /// cached so a screen returning to it reuses the flattened interpolator, and a grown table
-  /// reclaims those slots before adding more. Always succeeds: the table has no ceiling.
+  /// cached so a screen returning to it reuses the flattened interpolator, and its slot is only
+  /// taken when another curve needs one. Always succeeds: the table has no ceiling.
   int easingIdFor(const PlatformEasing &easing);
 
   void retainEasing(int easingId);
@@ -95,6 +95,8 @@ class CSSPlatformTransitions {
   /// Indexed by easing id: the curve occupying the slot, and how many properties route with it.
   std::vector<PlatformEasing> easingKeys_;
   std::vector<int> easingRefs_;
+  /// Slots at zero references, newest first. May name a slot since re-retained, so re-check.
+  std::vector<int> freeEasingIds_;
   AnimateFunction animate_;
   RemoveFunction remove_;
   DefineEasingFunction defineEasing_;

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
@@ -25,6 +25,8 @@ struct PlatformEasing {
   Type type;
   std::vector<float> pointsX;
   std::vector<float> pointsY;
+
+  bool operator==(const PlatformEasing &other) const = default;
 };
 
 class CSSPlatformTransitions {
@@ -72,27 +74,16 @@ class CSSPlatformTransitions {
     css::CSSTransitionPropertySettings settings;
   };
 
-  struct EasingKey {
-    std::uint8_t type;
-    std::vector<float> pointsX;
-    std::vector<float> pointsY;
-
-    bool operator==(const EasingKey &other) const = default;
-  };
-
-  struct EasingKeyHash {
-    std::size_t operator()(const EasingKey &key) const;
-  };
-
   const ActiveTransition *activeTransitionFor(Tag viewTag, const std::string &propertyName) const;
 
-  /// Interns the curve, registering it on first sight. Returns nullopt once the
-  /// table is full (an app computing easing points at runtime could otherwise grow
-  /// it forever); such transitions fall back to the loop, which plays any easing.
+  /// Interns the curve, registering it on first sight; the id is its index. Returns
+  /// nullopt once the table is full (an app computing easing points at runtime could
+  /// otherwise grow it forever); such transitions fall back to the loop, which plays
+  /// any easing.
   std::optional<int> easingIdFor(const PlatformEasing &easing);
 
   std::unordered_map<Tag, std::unordered_map<std::string, ActiveTransition>> active_;
-  std::unordered_map<EasingKey, int, EasingKeyHash> easingIds_;
+  std::vector<PlatformEasing> internedEasings_;
   AnimateFunction animate_;
   RemoveFunction remove_;
   DefineEasingFunction defineEasing_;

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
@@ -29,12 +29,14 @@ struct PlatformEasing {
   bool operator==(const PlatformEasing &other) const = default;
 };
 
+struct PlatformEasingHash {
+  std::size_t operator()(const PlatformEasing &easing) const;
+};
+
 class CSSPlatformTransitions {
  public:
-  /// False means the view can't carry the animation and the property falls back to
-  /// the loop. All-primitive (easing and property pre-registered by id), so the hot
-  /// per-transition JNI hop allocates nothing. A `persistent` value must outlive the
-  /// animation itself.
+  /// False means the property falls back to the loop. Ids and scalars only, so the
+  /// per-transition JNI hop allocates nothing.
   using AnimateFunction = std::function<bool(
       int viewTag,
       int propertyId,
@@ -46,7 +48,7 @@ class CSSPlatformTransitions {
       bool persistent)>;
   using RemoveFunction = std::function<void(int viewTag, int propertyId)>;
 
-  /// Registers an easing curve once; later transitions reference it by id.
+  /// Registers a curve on the platform under an id.
   using DefineEasingFunction =
       std::function<void(int easingId, int type, const std::vector<float> &pointsX, const std::vector<float> &pointsY)>;
 
@@ -76,14 +78,13 @@ class CSSPlatformTransitions {
 
   const ActiveTransition *activeTransitionFor(Tag viewTag, const std::string &propertyName) const;
 
-  /// Interns the curve, registering it on first sight; the id is its index. Returns
-  /// nullopt once the table is full (an app computing easing points at runtime could
-  /// otherwise grow it forever); such transitions fall back to the loop, which plays
-  /// any easing.
+  /// Interns the curve, registering it on first sight. Returns nullopt once the table is
+  /// full, which an app computing easing points at runtime could otherwise grow forever;
+  /// those transitions fall back to the loop, which plays any easing.
   std::optional<int> easingIdFor(const PlatformEasing &easing);
 
   std::unordered_map<Tag, std::unordered_map<std::string, ActiveTransition>> active_;
-  std::vector<PlatformEasing> internedEasings_;
+  std::unordered_map<PlatformEasing, int, PlatformEasingHash> easingIds_;
   AnimateFunction animate_;
   RemoveFunction remove_;
   DefineEasingFunction defineEasing_;

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
@@ -21,8 +21,7 @@ using namespace facebook::react;
 
 class CSSPlatformTransitions {
  public:
-  /// False means the property falls back to the loop. Ids and scalars only, so the
-  /// per-transition JNI hop allocates nothing.
+  /// False means the property falls back to the loop.
   using AnimateFunction = std::function<bool(
       int viewTag,
       int propertyId,
@@ -56,14 +55,12 @@ class CSSPlatformTransitions {
     css::PlatformValue adjustedEnd;
     css::ReversingState reversing;
     css::CSSTransitionPropertySettings settings;
-    /// Holds a reference to the curve for as long as this property is routed.
     int easingId;
   };
 
   const ActiveTransition *activeTransitionFor(Tag viewTag, const std::string &propertyName) const;
 
   std::unordered_map<Tag, std::unordered_map<std::string, ActiveTransition>> active_;
-  /// Shared so every platform animation kind interns against one table.
   std::shared_ptr<CSSPlatformEasings> easings_;
   AnimateFunction animate_;
   RemoveFunction remove_;

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
@@ -29,21 +29,26 @@ struct PlatformEasing {
 
 class CSSPlatformTransitions {
  public:
-  /// Returns false when the view can't carry the animation, in which case the
-  /// property falls back to the loop. A `persistent` transition has no committed
-  /// style behind it, so its value must outlive the animation itself.
+  /// False means the view can't carry the animation and the property falls back to
+  /// the loop. All-primitive (easing and property pre-registered by id), so the hot
+  /// per-transition JNI hop allocates nothing. A `persistent` value must outlive the
+  /// animation itself.
   using AnimateFunction = std::function<bool(
       int viewTag,
-      const std::string &propertyName,
+      int propertyId,
       double fromValue,
       double toValue,
       double durationMs,
       double startTimestampMs,
-      const PlatformEasing &easing,
+      int easingId,
       bool persistent)>;
-  using RemoveFunction = std::function<void(int viewTag, const std::string &propertyName)>;
+  using RemoveFunction = std::function<void(int viewTag, int propertyId)>;
 
-  CSSPlatformTransitions(AnimateFunction animate, RemoveFunction remove);
+  /// Registers an easing curve once; later transitions reference it by id.
+  using DefineEasingFunction =
+      std::function<void(int easingId, int type, const std::vector<float> &pointsX, const std::vector<float> &pointsY)>;
+
+  CSSPlatformTransitions(AnimateFunction animate, RemoveFunction remove, DefineEasingFunction defineEasing);
 
   /// A null `settings` marks the pseudo-selector toggle path, which carries none of
   /// its own and reuses whatever the last config apply stored. A settings-only config
@@ -67,11 +72,30 @@ class CSSPlatformTransitions {
     css::CSSTransitionPropertySettings settings;
   };
 
+  struct EasingKey {
+    std::uint8_t type;
+    std::vector<float> pointsX;
+    std::vector<float> pointsY;
+
+    bool operator==(const EasingKey &other) const = default;
+  };
+
+  struct EasingKeyHash {
+    std::size_t operator()(const EasingKey &key) const;
+  };
+
   const ActiveTransition *activeTransitionFor(Tag viewTag, const std::string &propertyName) const;
 
+  /// Interns the curve, registering it on first sight. Returns nullopt once the
+  /// table is full (an app computing easing points at runtime could otherwise grow
+  /// it forever); such transitions fall back to the loop, which plays any easing.
+  std::optional<int> easingIdFor(const PlatformEasing &easing);
+
   std::unordered_map<Tag, std::unordered_map<std::string, ActiveTransition>> active_;
+  std::unordered_map<EasingKey, int, EasingKeyHash> easingIds_;
   AnimateFunction animate_;
   RemoveFunction remove_;
+  DefineEasingFunction defineEasing_;
 };
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
@@ -87,7 +87,7 @@ class CSSPlatformTransitions {
 
   void retainEasing(int easingId);
 
-  /// The slot stays populated at zero references; it is only reclaimed under pressure.
+  /// The slot stays populated at zero references; another curve only takes it when it needs one.
   void releaseEasing(int easingId);
 
   std::unordered_map<Tag, std::unordered_map<std::string, ActiveTransition>> active_;
@@ -95,8 +95,6 @@ class CSSPlatformTransitions {
   /// Indexed by easing id: the curve occupying the slot, and how many properties route with it.
   std::vector<PlatformEasing> easingKeys_;
   std::vector<int> easingRefs_;
-  /// Slots at zero references, newest first. May name a slot since re-retained, so re-check.
-  std::vector<int> freeEasingIds_;
   AnimateFunction animate_;
   RemoveFunction remove_;
   DefineEasingFunction defineEasing_;

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
@@ -3,11 +3,13 @@
 #include <reanimated/CSS/configs/CSSTransitionConfig.h>
 #include <reanimated/CSS/utils/platform.h>
 #include <reanimated/CSS/utils/reversingShortening.h>
+#include <reanimated/android/CSS/CSSPlatformEasings.h>
 
 #include <react/renderer/core/ReactPrimitives.h>
 
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -16,22 +18,6 @@
 namespace reanimated {
 
 using namespace facebook::react;
-
-/// Carries the curve's own points rather than a sampled table, so a discontinuous
-/// steps() survives at any duration.
-struct PlatformEasing {
-  enum class Type : std::uint8_t { Linear = 0, CubicBezier = 1, Steps = 2, LinearStops = 3 };
-
-  Type type;
-  std::vector<float> pointsX;
-  std::vector<float> pointsY;
-
-  bool operator==(const PlatformEasing &other) const = default;
-};
-
-struct PlatformEasingHash {
-  std::size_t operator()(const PlatformEasing &easing) const;
-};
 
 class CSSPlatformTransitions {
  public:
@@ -48,18 +34,7 @@ class CSSPlatformTransitions {
       bool persistent)>;
   using RemoveFunction = std::function<void(int viewTag, int propertyId)>;
 
-  /// Registers a curve on the platform under an id.
-  using DefineEasingFunction =
-      std::function<void(int easingId, int type, const std::vector<float> &pointsX, const std::vector<float> &pointsY)>;
-
-  /// Drops a curve the platform no longer needs. Ids are never reused, so nothing overwrites it.
-  using UndefineEasingFunction = std::function<void(int easingId)>;
-
-  CSSPlatformTransitions(
-      AnimateFunction animate,
-      RemoveFunction remove,
-      DefineEasingFunction defineEasing,
-      UndefineEasingFunction undefineEasing);
+  CSSPlatformTransitions(AnimateFunction animate, RemoveFunction remove, std::shared_ptr<CSSPlatformEasings> easings);
 
   /// A null `settings` marks the pseudo-selector toggle path, which carries none of
   /// its own and reuses whatever the last config apply stored. A settings-only config
@@ -87,29 +62,11 @@ class CSSPlatformTransitions {
 
   const ActiveTransition *activeTransitionFor(Tag viewTag, const std::string &propertyName) const;
 
-  /// Interns the curve, registering it with the platform on first sight and handing back the id
-  /// the JNI hop carries in place of the points. Always succeeds: ids just keep counting up.
-  int easingIdFor(const PlatformEasing &easing);
-
-  void retainEasing(int easingId);
-
-  /// Drops the curve once no property routes with it, on both sides of the boundary.
-  void releaseEasing(int easingId);
-
-  /// The curve behind an id, and how many routed properties still animate with it.
-  struct InternedEasing {
-    PlatformEasing easing;
-    int refCount;
-  };
-
   std::unordered_map<Tag, std::unordered_map<std::string, ActiveTransition>> active_;
-  std::unordered_map<PlatformEasing, int, PlatformEasingHash> easingIds_;
-  std::unordered_map<int, InternedEasing> internedEasings_;
-  int nextEasingId_{0};
+  /// Shared, so a future platform animation kind interns against the same table.
+  std::shared_ptr<CSSPlatformEasings> easings_;
   AnimateFunction animate_;
   RemoveFunction remove_;
-  DefineEasingFunction defineEasing_;
-  UndefineEasingFunction undefineEasing_;
 };
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
@@ -74,17 +74,28 @@ class CSSPlatformTransitions {
     css::PlatformValue adjustedEnd;
     css::ReversingState reversing;
     css::CSSTransitionPropertySettings settings;
+    /// Keeps the curve's slot alive for as long as this property is routed.
+    int easingId;
   };
 
   const ActiveTransition *activeTransitionFor(Tag viewTag, const std::string &propertyName) const;
 
-  /// Interns the curve, registering it on first sight. Returns nullopt once the table is
-  /// full, which an app computing easing points at runtime could otherwise grow forever;
-  /// those transitions fall back to the loop, which plays any easing.
+  /// Interns the curve, registering it with the platform on first sight. An unused curve stays
+  /// cached so a screen returning to it reuses the flattened interpolator; a full table instead
+  /// reclaims the slot of one nothing routes any more. Returns nullopt only when all
+  /// `kMaxInternedEasings` are simultaneously in use, and that property then runs on the loop.
   std::optional<int> easingIdFor(const PlatformEasing &easing);
+
+  void retainEasing(int easingId);
+
+  /// The slot stays populated at zero references; it is only reclaimed under pressure.
+  void releaseEasing(int easingId);
 
   std::unordered_map<Tag, std::unordered_map<std::string, ActiveTransition>> active_;
   std::unordered_map<PlatformEasing, int, PlatformEasingHash> easingIds_;
+  /// Indexed by easing id: the curve occupying the slot, and how many properties route with it.
+  std::vector<PlatformEasing> easingKeys_;
+  std::vector<int> easingRefs_;
   AnimateFunction animate_;
   RemoveFunction remove_;
   DefineEasingFunction defineEasing_;

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
@@ -52,7 +52,14 @@ class CSSPlatformTransitions {
   using DefineEasingFunction =
       std::function<void(int easingId, int type, const std::vector<float> &pointsX, const std::vector<float> &pointsY)>;
 
-  CSSPlatformTransitions(AnimateFunction animate, RemoveFunction remove, DefineEasingFunction defineEasing);
+  /// Drops a curve the platform no longer needs. Ids are never reused, so nothing overwrites it.
+  using UndefineEasingFunction = std::function<void(int easingId)>;
+
+  CSSPlatformTransitions(
+      AnimateFunction animate,
+      RemoveFunction remove,
+      DefineEasingFunction defineEasing,
+      UndefineEasingFunction undefineEasing);
 
   /// A null `settings` marks the pseudo-selector toggle path, which carries none of
   /// its own and reuses whatever the last config apply stored. A settings-only config
@@ -80,24 +87,29 @@ class CSSPlatformTransitions {
 
   const ActiveTransition *activeTransitionFor(Tag viewTag, const std::string &propertyName) const;
 
-  /// Interns the curve, registering it with the platform on first sight. An unused curve stays
-  /// cached so a screen returning to it reuses the flattened interpolator, and its slot is only
-  /// taken when another curve needs one. Always succeeds: the table has no ceiling.
+  /// Interns the curve, registering it with the platform on first sight and handing back the id
+  /// the JNI hop carries in place of the points. Always succeeds: ids just keep counting up.
   int easingIdFor(const PlatformEasing &easing);
 
   void retainEasing(int easingId);
 
-  /// The slot stays populated at zero references; another curve only takes it when it needs one.
+  /// Drops the curve once no property routes with it, on both sides of the boundary.
   void releaseEasing(int easingId);
+
+  /// The curve behind an id, and how many routed properties still animate with it.
+  struct InternedEasing {
+    PlatformEasing easing;
+    int refCount;
+  };
 
   std::unordered_map<Tag, std::unordered_map<std::string, ActiveTransition>> active_;
   std::unordered_map<PlatformEasing, int, PlatformEasingHash> easingIds_;
-  /// Indexed by easing id: the curve occupying the slot, and how many properties route with it.
-  std::vector<PlatformEasing> easingKeys_;
-  std::vector<int> easingRefs_;
+  std::unordered_map<int, InternedEasing> internedEasings_;
+  int nextEasingId_{0};
   AnimateFunction animate_;
   RemoveFunction remove_;
   DefineEasingFunction defineEasing_;
+  UndefineEasingFunction undefineEasing_;
 };
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
@@ -56,14 +56,14 @@ class CSSPlatformTransitions {
     css::PlatformValue adjustedEnd;
     css::ReversingState reversing;
     css::CSSTransitionPropertySettings settings;
-    /// Keeps the curve's slot alive for as long as this property is routed.
+    /// Holds a reference to the curve for as long as this property is routed.
     int easingId;
   };
 
   const ActiveTransition *activeTransitionFor(Tag viewTag, const std::string &propertyName) const;
 
   std::unordered_map<Tag, std::unordered_map<std::string, ActiveTransition>> active_;
-  /// Shared, so a future platform animation kind interns against the same table.
+  /// Shared so every platform animation kind interns against one table.
   std::shared_ptr<CSSPlatformEasings> easings_;
   AnimateFunction animate_;
   RemoveFunction remove_;

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
@@ -48,11 +48,29 @@ class CSSPlatformTransitions {
       bool persistent)>;
   using RemoveFunction = std::function<void(int viewTag, int propertyId)>;
 
+  /// Carries the curve with the transition, for the rare start that finds no interning slot.
+  /// The platform still plays it; only the marshalling saving is lost.
+  using AnimateWithEasingFunction = std::function<bool(
+      int viewTag,
+      int propertyId,
+      double fromValue,
+      double toValue,
+      double durationMs,
+      double startTimestampMs,
+      int easingType,
+      const std::vector<float> &pointsX,
+      const std::vector<float> &pointsY,
+      bool persistent)>;
+
   /// Registers a curve on the platform under an id.
   using DefineEasingFunction =
       std::function<void(int easingId, int type, const std::vector<float> &pointsX, const std::vector<float> &pointsY)>;
 
-  CSSPlatformTransitions(AnimateFunction animate, RemoveFunction remove, DefineEasingFunction defineEasing);
+  CSSPlatformTransitions(
+      AnimateFunction animate,
+      AnimateWithEasingFunction animateWithEasing,
+      RemoveFunction remove,
+      DefineEasingFunction defineEasing);
 
   /// A null `settings` marks the pseudo-selector toggle path, which carries none of
   /// its own and reuses whatever the last config apply stored. A settings-only config
@@ -74,7 +92,8 @@ class CSSPlatformTransitions {
     css::PlatformValue adjustedEnd;
     css::ReversingState reversing;
     css::CSSTransitionPropertySettings settings;
-    /// Keeps the curve's slot alive for as long as this property is routed.
+    /// Keeps the curve's slot alive for as long as this property is routed, or -1 when the
+    /// table was full and the curve travelled with the start instead of being interned.
     int easingId;
   };
 
@@ -83,7 +102,7 @@ class CSSPlatformTransitions {
   /// Interns the curve, registering it with the platform on first sight. An unused curve stays
   /// cached so a screen returning to it reuses the flattened interpolator; a full table instead
   /// reclaims the slot of one nothing routes any more. Returns nullopt only when all
-  /// `kMaxInternedEasings` are simultaneously in use, and that property then runs on the loop.
+  /// `kMaxInternedEasings` are simultaneously in use, and the curve then travels with the start.
   std::optional<int> easingIdFor(const PlatformEasing &easing);
 
   void retainEasing(int easingId);
@@ -97,6 +116,7 @@ class CSSPlatformTransitions {
   std::vector<PlatformEasing> easingKeys_;
   std::vector<int> easingRefs_;
   AnimateFunction animate_;
+  AnimateWithEasingFunction animateWithEasing_;
   RemoveFunction remove_;
   DefineEasingFunction defineEasing_;
 };

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
@@ -35,9 +35,8 @@ struct PlatformEasingHash {
 
 class CSSPlatformTransitions {
  public:
-  /// False means the property falls back to the loop. An interned `easingId` sends scalars only,
-  /// so the per-transition JNI hop allocates nothing; -1 means the table was full and `easing`
-  /// travels with the start instead, which costs marshalling but still plays on the platform.
+  /// False means the property falls back to the loop. Ids and scalars only, so the
+  /// per-transition JNI hop allocates nothing.
   using AnimateFunction = std::function<bool(
       int viewTag,
       int propertyId,
@@ -46,7 +45,6 @@ class CSSPlatformTransitions {
       double durationMs,
       double startTimestampMs,
       int easingId,
-      const PlatformEasing &easing,
       bool persistent)>;
   using RemoveFunction = std::function<void(int viewTag, int propertyId)>;
 
@@ -76,18 +74,16 @@ class CSSPlatformTransitions {
     css::PlatformValue adjustedEnd;
     css::ReversingState reversing;
     css::CSSTransitionPropertySettings settings;
-    /// Keeps the curve's slot alive for as long as this property is routed, or -1 when the
-    /// table was full and the curve travelled with the start instead of being interned.
+    /// Keeps the curve's slot alive for as long as this property is routed.
     int easingId;
   };
 
   const ActiveTransition *activeTransitionFor(Tag viewTag, const std::string &propertyName) const;
 
   /// Interns the curve, registering it with the platform on first sight. An unused curve stays
-  /// cached so a screen returning to it reuses the flattened interpolator; a full table instead
-  /// reclaims the slot of one nothing routes any more. Returns nullopt only when all
-  /// `kMaxInternedEasings` are simultaneously in use, and the curve then travels with the start.
-  std::optional<int> easingIdFor(const PlatformEasing &easing);
+  /// cached so a screen returning to it reuses the flattened interpolator, and a grown table
+  /// reclaims those slots before adding more. Always succeeds: the table has no ceiling.
+  int easingIdFor(const PlatformEasing &easing);
 
   void retainEasing(int easingId);
 

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
@@ -35,8 +35,9 @@ struct PlatformEasingHash {
 
 class CSSPlatformTransitions {
  public:
-  /// False means the property falls back to the loop. Ids and scalars only, so the
-  /// per-transition JNI hop allocates nothing.
+  /// False means the property falls back to the loop. An interned `easingId` sends scalars only,
+  /// so the per-transition JNI hop allocates nothing; -1 means the table was full and `easing`
+  /// travels with the start instead, which costs marshalling but still plays on the platform.
   using AnimateFunction = std::function<bool(
       int viewTag,
       int propertyId,
@@ -45,32 +46,15 @@ class CSSPlatformTransitions {
       double durationMs,
       double startTimestampMs,
       int easingId,
+      const PlatformEasing &easing,
       bool persistent)>;
   using RemoveFunction = std::function<void(int viewTag, int propertyId)>;
-
-  /// Carries the curve with the transition, for the rare start that finds no interning slot.
-  /// The platform still plays it; only the marshalling saving is lost.
-  using AnimateWithEasingFunction = std::function<bool(
-      int viewTag,
-      int propertyId,
-      double fromValue,
-      double toValue,
-      double durationMs,
-      double startTimestampMs,
-      int easingType,
-      const std::vector<float> &pointsX,
-      const std::vector<float> &pointsY,
-      bool persistent)>;
 
   /// Registers a curve on the platform under an id.
   using DefineEasingFunction =
       std::function<void(int easingId, int type, const std::vector<float> &pointsX, const std::vector<float> &pointsY)>;
 
-  CSSPlatformTransitions(
-      AnimateFunction animate,
-      AnimateWithEasingFunction animateWithEasing,
-      RemoveFunction remove,
-      DefineEasingFunction defineEasing);
+  CSSPlatformTransitions(AnimateFunction animate, RemoveFunction remove, DefineEasingFunction defineEasing);
 
   /// A null `settings` marks the pseudo-selector toggle path, which carries none of
   /// its own and reuses whatever the last config apply stored. A settings-only config
@@ -116,7 +100,6 @@ class CSSPlatformTransitions {
   std::vector<PlatformEasing> easingKeys_;
   std::vector<int> easingRefs_;
   AnimateFunction animate_;
-  AnimateWithEasingFunction animateWithEasing_;
   RemoveFunction remove_;
   DefineEasingFunction defineEasing_;
 };

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
@@ -257,31 +257,7 @@ bool NativeProxy::cssAnimateTransition(
     const double durationMs,
     const double startTimestampMs,
     const int easingId,
-    const bool persistent) {
-  static const auto method =
-      getJniMethod<jboolean(int, int, double, double, double, double, int, jboolean)>("cssAnimateTransition");
-  return method(
-             javaPart_.get(),
-             viewTag,
-             propertyId,
-             fromValue,
-             toValue,
-             durationMs,
-             startTimestampMs,
-             easingId,
-             static_cast<jboolean>(persistent)) != JNI_FALSE;
-}
-
-bool NativeProxy::cssAnimateTransitionWithEasing(
-    const int viewTag,
-    const int propertyId,
-    const double fromValue,
-    const double toValue,
-    const double durationMs,
-    const double startTimestampMs,
-    const int easingType,
-    const std::vector<float> &pointsX,
-    const std::vector<float> &pointsY,
+    const PlatformEasing &easing,
     const bool persistent) {
   static const auto method = getJniMethod<jboolean(
       int,
@@ -291,13 +267,22 @@ bool NativeProxy::cssAnimateTransitionWithEasing(
       double,
       double,
       int,
+      int,
       jni::alias_ref<jni::JArrayFloat>,
       jni::alias_ref<jni::JArrayFloat>,
-      jboolean)>("cssAnimateTransitionWithEasing");
-  auto jPointsX = jni::JArrayFloat::newArray(pointsX.size());
-  jPointsX->setRegion(0, pointsX.size(), pointsX.data());
-  auto jPointsY = jni::JArrayFloat::newArray(pointsY.size());
-  jPointsY->setRegion(0, pointsY.size(), pointsY.data());
+      jboolean)>("cssAnimateTransition");
+
+  // An interned curve already lives on the platform, so only its id crosses and the arrays
+  // stay null; a null reference costs nothing here, unlike allocating one per start.
+  jni::local_ref<jni::JArrayFloat> jPointsX;
+  jni::local_ref<jni::JArrayFloat> jPointsY;
+  if (easingId < 0) {
+    jPointsX = jni::JArrayFloat::newArray(easing.pointsX.size());
+    jPointsX->setRegion(0, easing.pointsX.size(), easing.pointsX.data());
+    jPointsY = jni::JArrayFloat::newArray(easing.pointsY.size());
+    jPointsY->setRegion(0, easing.pointsY.size(), easing.pointsY.data());
+  }
+
   return method(
              javaPart_.get(),
              viewTag,
@@ -306,7 +291,8 @@ bool NativeProxy::cssAnimateTransitionWithEasing(
              toValue,
              durationMs,
              startTimestampMs,
-             easingType,
+             easingId,
+             static_cast<int>(easing.type),
              jPointsX,
              jPointsY,
              static_cast<jboolean>(persistent)) != JNI_FALSE;
@@ -419,7 +405,6 @@ PlatformDepMethodsHolder NativeProxy::getPlatformDependentMethods() {
   // memory.
   auto cssPlatformTransitions = std::make_shared<CSSPlatformTransitions>(
       bindThis(&NativeProxy::cssAnimateTransition),
-      bindThis(&NativeProxy::cssAnimateTransitionWithEasing),
       bindThis(&NativeProxy::cssRemoveTransition),
       bindThis(&NativeProxy::cssDefineEasing));
 

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
@@ -292,6 +292,11 @@ void NativeProxy::cssDefineEasing(
   method(javaPart_.get(), easingId, type, jPointsX, jPointsY);
 }
 
+void NativeProxy::cssUndefineEasing(const int easingId) {
+  static const auto method = getJniMethod<void(int)>("cssUndefineEasing");
+  method(javaPart_.get(), easingId);
+}
+
 void NativeProxy::detachPseudoSelector(Tag tag, PseudoSelector selector) {
   static const auto method = getJniMethod<void(int, int)>("detachPseudoSelector");
   method(javaPart_.get(), static_cast<int>(tag), static_cast<int>(selector));
@@ -380,7 +385,8 @@ PlatformDepMethodsHolder NativeProxy::getPlatformDependentMethods() {
   auto cssPlatformTransitions = std::make_shared<CSSPlatformTransitions>(
       bindThis(&NativeProxy::cssAnimateTransition),
       bindThis(&NativeProxy::cssRemoveTransition),
-      bindThis(&NativeProxy::cssDefineEasing));
+      bindThis(&NativeProxy::cssDefineEasing),
+      bindThis(&NativeProxy::cssUndefineEasing));
 
   auto cssCanRouteProperty = css::CSSCanRoutePropertyFunction(&css::canRouteCSSProperty);
 

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
@@ -382,11 +382,12 @@ PlatformDepMethodsHolder NativeProxy::getPlatformDependentMethods() {
   // Owned by the two callbacks below rather than by NativeProxy: this runs from
   // the constructor's member-initializer list, where a member would still be raw
   // memory.
+  auto cssPlatformEasings = std::make_shared<CSSPlatformEasings>(
+      bindThis(&NativeProxy::cssDefineEasing), bindThis(&NativeProxy::cssUndefineEasing));
   auto cssPlatformTransitions = std::make_shared<CSSPlatformTransitions>(
       bindThis(&NativeProxy::cssAnimateTransition),
       bindThis(&NativeProxy::cssRemoveTransition),
-      bindThis(&NativeProxy::cssDefineEasing),
-      bindThis(&NativeProxy::cssUndefineEasing));
+      std::move(cssPlatformEasings));
 
   auto cssCanRouteProperty = css::CSSCanRoutePropertyFunction(&css::canRouteCSSProperty);
 

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
@@ -257,32 +257,9 @@ bool NativeProxy::cssAnimateTransition(
     const double durationMs,
     const double startTimestampMs,
     const int easingId,
-    const PlatformEasing &easing,
     const bool persistent) {
-  static const auto method = getJniMethod<jboolean(
-      int,
-      int,
-      double,
-      double,
-      double,
-      double,
-      int,
-      int,
-      jni::alias_ref<jni::JArrayFloat>,
-      jni::alias_ref<jni::JArrayFloat>,
-      jboolean)>("cssAnimateTransition");
-
-  // An interned curve already lives on the platform, so only its id crosses and the arrays
-  // stay null; a null reference costs nothing here, unlike allocating one per start.
-  jni::local_ref<jni::JArrayFloat> jPointsX;
-  jni::local_ref<jni::JArrayFloat> jPointsY;
-  if (easingId < 0) {
-    jPointsX = jni::JArrayFloat::newArray(easing.pointsX.size());
-    jPointsX->setRegion(0, easing.pointsX.size(), easing.pointsX.data());
-    jPointsY = jni::JArrayFloat::newArray(easing.pointsY.size());
-    jPointsY->setRegion(0, easing.pointsY.size(), easing.pointsY.data());
-  }
-
+  static const auto method =
+      getJniMethod<jboolean(int, int, double, double, double, double, int, jboolean)>("cssAnimateTransition");
   return method(
              javaPart_.get(),
              viewTag,
@@ -292,9 +269,6 @@ bool NativeProxy::cssAnimateTransition(
              durationMs,
              startTimestampMs,
              easingId,
-             static_cast<int>(easing.type),
-             jPointsX,
-             jPointsY,
              static_cast<jboolean>(persistent)) != JNI_FALSE;
 }
 

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
@@ -251,45 +251,45 @@ void NativeProxy::attachPseudoSelector(Tag tag, PseudoSelector selector, std::fu
 
 bool NativeProxy::cssAnimateTransition(
     const int viewTag,
-    const std::string &propertyName,
+    const int propertyId,
     const double fromValue,
     const double toValue,
     const double durationMs,
     const double startTimestampMs,
-    const PlatformEasing &easing,
+    const int easingId,
     const bool persistent) {
-  static const auto method = getJniMethod<jboolean(
-      int,
-      jni::alias_ref<jni::JString>,
-      double,
-      double,
-      double,
-      double,
-      int,
-      jni::alias_ref<jni::JArrayFloat>,
-      jni::alias_ref<jni::JArrayFloat>,
-      jboolean)>("cssAnimateTransition");
-  auto jPointsX = jni::JArrayFloat::newArray(easing.pointsX.size());
-  jPointsX->setRegion(0, easing.pointsX.size(), easing.pointsX.data());
-  auto jPointsY = jni::JArrayFloat::newArray(easing.pointsY.size());
-  jPointsY->setRegion(0, easing.pointsY.size(), easing.pointsY.data());
+  static const auto method =
+      getJniMethod<jboolean(int, int, double, double, double, double, int, jboolean)>("cssAnimateTransition");
   return method(
              javaPart_.get(),
              viewTag,
-             jni::make_jstring(propertyName),
+             propertyId,
              fromValue,
              toValue,
              durationMs,
              startTimestampMs,
-             static_cast<int>(easing.type),
-             jPointsX,
-             jPointsY,
+             easingId,
              static_cast<jboolean>(persistent)) != JNI_FALSE;
 }
 
-void NativeProxy::cssRemoveTransition(const int viewTag, const std::string &propertyName) {
-  static const auto method = getJniMethod<void(int, jni::alias_ref<jni::JString>)>("cssRemoveTransition");
-  method(javaPart_.get(), viewTag, jni::make_jstring(propertyName));
+void NativeProxy::cssRemoveTransition(const int viewTag, const int propertyId) {
+  static const auto method = getJniMethod<void(int, int)>("cssRemoveTransition");
+  method(javaPart_.get(), viewTag, propertyId);
+}
+
+void NativeProxy::cssDefineEasing(
+    const int easingId,
+    const int type,
+    const std::vector<float> &pointsX,
+    const std::vector<float> &pointsY) {
+  static const auto method =
+      getJniMethod<void(int, int, jni::alias_ref<jni::JArrayFloat>, jni::alias_ref<jni::JArrayFloat>)>(
+          "cssDefineEasing");
+  auto jPointsX = jni::JArrayFloat::newArray(pointsX.size());
+  jPointsX->setRegion(0, pointsX.size(), pointsX.data());
+  auto jPointsY = jni::JArrayFloat::newArray(pointsY.size());
+  jPointsY->setRegion(0, pointsY.size(), pointsY.data());
+  method(javaPart_.get(), easingId, type, jPointsX, jPointsY);
 }
 
 void NativeProxy::detachPseudoSelector(Tag tag, PseudoSelector selector) {
@@ -378,7 +378,9 @@ PlatformDepMethodsHolder NativeProxy::getPlatformDependentMethods() {
   // the constructor's member-initializer list, where a member would still be raw
   // memory.
   auto cssPlatformTransitions = std::make_shared<CSSPlatformTransitions>(
-      bindThis(&NativeProxy::cssAnimateTransition), bindThis(&NativeProxy::cssRemoveTransition));
+      bindThis(&NativeProxy::cssAnimateTransition),
+      bindThis(&NativeProxy::cssRemoveTransition),
+      bindThis(&NativeProxy::cssDefineEasing));
 
   auto cssCanRouteProperty = css::CSSCanRoutePropertyFunction(&css::canRouteCSSProperty);
 

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
@@ -272,6 +272,46 @@ bool NativeProxy::cssAnimateTransition(
              static_cast<jboolean>(persistent)) != JNI_FALSE;
 }
 
+bool NativeProxy::cssAnimateTransitionWithEasing(
+    const int viewTag,
+    const int propertyId,
+    const double fromValue,
+    const double toValue,
+    const double durationMs,
+    const double startTimestampMs,
+    const int easingType,
+    const std::vector<float> &pointsX,
+    const std::vector<float> &pointsY,
+    const bool persistent) {
+  static const auto method = getJniMethod<jboolean(
+      int,
+      int,
+      double,
+      double,
+      double,
+      double,
+      int,
+      jni::alias_ref<jni::JArrayFloat>,
+      jni::alias_ref<jni::JArrayFloat>,
+      jboolean)>("cssAnimateTransitionWithEasing");
+  auto jPointsX = jni::JArrayFloat::newArray(pointsX.size());
+  jPointsX->setRegion(0, pointsX.size(), pointsX.data());
+  auto jPointsY = jni::JArrayFloat::newArray(pointsY.size());
+  jPointsY->setRegion(0, pointsY.size(), pointsY.data());
+  return method(
+             javaPart_.get(),
+             viewTag,
+             propertyId,
+             fromValue,
+             toValue,
+             durationMs,
+             startTimestampMs,
+             easingType,
+             jPointsX,
+             jPointsY,
+             static_cast<jboolean>(persistent)) != JNI_FALSE;
+}
+
 void NativeProxy::cssRemoveTransition(const int viewTag, const int propertyId) {
   static const auto method = getJniMethod<void(int, int)>("cssRemoveTransition");
   method(javaPart_.get(), viewTag, propertyId);
@@ -379,6 +419,7 @@ PlatformDepMethodsHolder NativeProxy::getPlatformDependentMethods() {
   // memory.
   auto cssPlatformTransitions = std::make_shared<CSSPlatformTransitions>(
       bindThis(&NativeProxy::cssAnimateTransition),
+      bindThis(&NativeProxy::cssAnimateTransitionWithEasing),
       bindThis(&NativeProxy::cssRemoveTransition),
       bindThis(&NativeProxy::cssDefineEasing));
 

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
@@ -82,7 +82,6 @@ class NativeProxy : public jni::HybridClass<NativeProxy>, std::enable_shared_fro
       double durationMs,
       double startTimestampMs,
       int easingId,
-      const PlatformEasing &easing,
       bool persistent);
   void cssRemoveTransition(int viewTag, int propertyId);
   void cssDefineEasing(int easingId, int type, const std::vector<float> &pointsX, const std::vector<float> &pointsY);

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
@@ -76,14 +76,15 @@ class NativeProxy : public jni::HybridClass<NativeProxy>, std::enable_shared_fro
   void detachPseudoSelector(Tag tag, PseudoSelector selector);
   bool cssAnimateTransition(
       int viewTag,
-      const std::string &propertyName,
+      int propertyId,
       double fromValue,
       double toValue,
       double durationMs,
       double startTimestampMs,
-      const PlatformEasing &easing,
+      int easingId,
       bool persistent);
-  void cssRemoveTransition(int viewTag, const std::string &propertyName);
+  void cssRemoveTransition(int viewTag, int propertyId);
+  void cssDefineEasing(int easingId, int type, const std::vector<float> &pointsX, const std::vector<float> &pointsY);
 
   /***
    * Wraps a method of `NativeProxy` in a function object capturing `this`

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
@@ -85,6 +85,7 @@ class NativeProxy : public jni::HybridClass<NativeProxy>, std::enable_shared_fro
       bool persistent);
   void cssRemoveTransition(int viewTag, int propertyId);
   void cssDefineEasing(int easingId, int type, const std::vector<float> &pointsX, const std::vector<float> &pointsY);
+  void cssUndefineEasing(int easingId);
 
   /***
    * Wraps a method of `NativeProxy` in a function object capturing `this`

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
@@ -83,6 +83,17 @@ class NativeProxy : public jni::HybridClass<NativeProxy>, std::enable_shared_fro
       double startTimestampMs,
       int easingId,
       bool persistent);
+  bool cssAnimateTransitionWithEasing(
+      int viewTag,
+      int propertyId,
+      double fromValue,
+      double toValue,
+      double durationMs,
+      double startTimestampMs,
+      int easingType,
+      const std::vector<float> &pointsX,
+      const std::vector<float> &pointsY,
+      bool persistent);
   void cssRemoveTransition(int viewTag, int propertyId);
   void cssDefineEasing(int easingId, int type, const std::vector<float> &pointsX, const std::vector<float> &pointsY);
 

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
@@ -82,17 +82,7 @@ class NativeProxy : public jni::HybridClass<NativeProxy>, std::enable_shared_fro
       double durationMs,
       double startTimestampMs,
       int easingId,
-      bool persistent);
-  bool cssAnimateTransitionWithEasing(
-      int viewTag,
-      int propertyId,
-      double fromValue,
-      double toValue,
-      double durationMs,
-      double startTimestampMs,
-      int easingType,
-      const std::vector<float> &pointsX,
-      const std::vector<float> &pointsY,
+      const PlatformEasing &easing,
       bool persistent);
   void cssRemoveTransition(int viewTag, int propertyId);
   void cssDefineEasing(int easingId, int type, const std::vector<float> &pointsX, const std::vector<float> &pointsY);

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
@@ -281,32 +281,6 @@ open class NativeProxy {
     }
 
     @DoNotStrip
-    fun cssAnimateTransitionWithEasing(
-        viewTag: Int,
-        propertyId: Int,
-        fromValue: Double,
-        toValue: Double,
-        durationMs: Double,
-        startTimestampMs: Double,
-        easingType: Int,
-        easingPointsX: FloatArray,
-        easingPointsY: FloatArray,
-        persistent: Boolean,
-    ): Boolean =
-        cssPlatformTransitionsManager.animateTransitionWithEasing(
-            viewTag,
-            propertyId,
-            fromValue,
-            toValue,
-            durationMs,
-            startTimestampMs,
-            easingType,
-            easingPointsX,
-            easingPointsY,
-            persistent,
-        )
-
-    @DoNotStrip
     fun cssAnimateTransition(
         viewTag: Int,
         propertyId: Int,
@@ -315,6 +289,9 @@ open class NativeProxy {
         durationMs: Double,
         startTimestampMs: Double,
         easingId: Int,
+        easingType: Int,
+        easingPointsX: FloatArray?,
+        easingPointsY: FloatArray?,
         persistent: Boolean,
     ): Boolean =
         cssPlatformTransitionsManager.animateTransition(
@@ -325,6 +302,9 @@ open class NativeProxy {
             durationMs,
             startTimestampMs,
             easingId,
+            easingType,
+            easingPointsX,
+            easingPointsY,
             persistent,
         )
 

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
@@ -281,6 +281,11 @@ open class NativeProxy {
     }
 
     @DoNotStrip
+    fun cssUndefineEasing(easingId: Int) {
+        cssPlatformTransitionsManager.undefineEasing(easingId)
+    }
+
+    @DoNotStrip
     fun cssAnimateTransition(
         viewTag: Int,
         propertyId: Int,

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
@@ -289,9 +289,6 @@ open class NativeProxy {
         durationMs: Double,
         startTimestampMs: Double,
         easingId: Int,
-        easingType: Int,
-        easingPointsX: FloatArray?,
-        easingPointsY: FloatArray?,
         persistent: Boolean,
     ): Boolean =
         cssPlatformTransitionsManager.animateTransition(
@@ -302,9 +299,6 @@ open class NativeProxy {
             durationMs,
             startTimestampMs,
             easingId,
-            easingType,
-            easingPointsX,
-            easingPointsY,
             persistent,
         )
 

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
@@ -281,6 +281,32 @@ open class NativeProxy {
     }
 
     @DoNotStrip
+    fun cssAnimateTransitionWithEasing(
+        viewTag: Int,
+        propertyId: Int,
+        fromValue: Double,
+        toValue: Double,
+        durationMs: Double,
+        startTimestampMs: Double,
+        easingType: Int,
+        easingPointsX: FloatArray,
+        easingPointsY: FloatArray,
+        persistent: Boolean,
+    ): Boolean =
+        cssPlatformTransitionsManager.animateTransitionWithEasing(
+            viewTag,
+            propertyId,
+            fromValue,
+            toValue,
+            durationMs,
+            startTimestampMs,
+            easingType,
+            easingPointsX,
+            easingPointsY,
+            persistent,
+        )
+
+    @DoNotStrip
     fun cssAnimateTransition(
         viewTag: Int,
         propertyId: Int,

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
@@ -256,6 +256,7 @@ open class NativeProxy {
         intBuffer: IntArray,
         doubleBuffer: DoubleArray,
     ) {
+        cssPlatformTransitionsManager.onPropsWrittenSynchronously()
         SynchronousPropsBufferParser.parse(intBuffer, doubleBuffer) { viewTag, props ->
             if (BuildConfig.IS_REACT_NATIVE_86_OR_NEWER) {
                 try {

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
@@ -271,37 +271,43 @@ open class NativeProxy {
     }
 
     @DoNotStrip
+    fun cssDefineEasing(
+        easingId: Int,
+        easingType: Int,
+        easingPointsX: FloatArray,
+        easingPointsY: FloatArray,
+    ) {
+        cssPlatformTransitionsManager.defineEasing(easingId, easingType, easingPointsX, easingPointsY)
+    }
+
+    @DoNotStrip
     fun cssAnimateTransition(
         viewTag: Int,
-        propertyName: String,
+        propertyId: Int,
         fromValue: Double,
         toValue: Double,
         durationMs: Double,
         startTimestampMs: Double,
-        easingType: Int,
-        easingPointsX: FloatArray,
-        easingPointsY: FloatArray,
+        easingId: Int,
         persistent: Boolean,
     ): Boolean =
         cssPlatformTransitionsManager.animateTransition(
             viewTag,
-            propertyName,
+            propertyId,
             fromValue,
             toValue,
             durationMs,
             startTimestampMs,
-            easingType,
-            easingPointsX,
-            easingPointsY,
+            easingId,
             persistent,
         )
 
     @DoNotStrip
     fun cssRemoveTransition(
         viewTag: Int,
-        propertyName: String,
+        propertyId: Int,
     ) {
-        cssPlatformTransitionsManager.removeTransition(viewTag, propertyName)
+        cssPlatformTransitionsManager.removeTransition(viewTag, propertyId)
     }
 
     @DoNotStrip

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
@@ -57,11 +57,17 @@ internal class CSSPlatformTransitionsManager(
     private var invalidated = false
 
     private var nextStartToken = 0L
-    private val interpolators = HashMap<InterpolatorKey, TimeInterpolator>()
+
+    /**
+     * Indexed by the easing id the C++ interner assigned; a define always precedes the
+     * first animate call using its id. Copy-on-append keeps reads lock-free.
+     */
+    @Volatile
+    private var easings = arrayOfNulls<TimeInterpolator>(0)
 
     private data class Key(
         val viewTag: Int,
-        val propertyName: String,
+        val propertyId: Int,
     )
 
     private class RunningTransition(
@@ -90,41 +96,33 @@ internal class CSSPlatformTransitionsManager(
         }
     }
 
-    private data class InterpolatorKey(
-        val type: Int,
-        val pointsX: List<Float>,
-        val pointsY: List<Float>,
-    )
-
     /** Whether the property is accepted; it can still fail later if the View never mounts. */
     fun animateTransition(
         viewTag: Int,
-        propertyName: String,
+        propertyId: Int,
         fromValue: Double,
         toValue: Double,
         durationMs: Double,
         startTimestampMs: Double,
-        easingType: Int,
-        easingPointsX: FloatArray,
-        easingPointsY: FloatArray,
+        easingId: Int,
         persistent: Boolean,
     ): Boolean {
         if (invalidated) return false
-        val writer = cssPropertyWriterFor(propertyName) ?: return false
+        val writer = cssPropertyWriterFor(propertyId) ?: return false
+        val interpolator = easings.getOrNull(easingId) ?: return false
         val context = reactContext.get() ?: return false
         val scale = DurationScale.effectiveScale(context)
         if (scale <= 0f) return false
 
         UiThreadUtil.runOnUiThread {
             if (invalidated) return@runOnUiThread
-            val key = Key(viewTag, propertyName)
+            val key = Key(viewTag, propertyId)
             // A fresh token invalidates any retry still queued for this key.
             val token = ++nextStartToken
             startTokens[key] = token
 
             beginWhenMounted(key, token, startTimestampMs + durationMs) {
                 viewForTag(viewTag)?.also { view ->
-                    val interpolator = interpolatorFor(easingType, easingPointsX, easingPointsY)
                     start(view, key, writer, fromValue, toValue, durationMs, startTimestampMs, interpolator, scale, persistent)
                 } != null
             }
@@ -151,10 +149,10 @@ internal class CSSPlatformTransitionsManager(
 
     fun removeTransition(
         viewTag: Int,
-        propertyName: String,
+        propertyId: Int,
     ) {
         UiThreadUtil.runOnUiThread {
-            val key = Key(viewTag, propertyName)
+            val key = Key(viewTag, propertyId)
             startTokens.remove(key)
             animators.remove(key)?.animator?.cancel()
         }
@@ -251,15 +249,18 @@ internal class CSSPlatformTransitionsManager(
         return animators.isNotEmpty()
     }
 
-    /** PathInterpolator flattens its curve on construction, so cache it. Type is in the key
-     * because families share point lists. */
-    private fun interpolatorFor(
-        type: Int,
-        pointsX: FloatArray,
-        pointsY: FloatArray,
-    ): TimeInterpolator {
-        val key = InterpolatorKey(type, pointsX.toList(), pointsY.toList())
-        return interpolators.getOrPut(key) { CSSEasing.interpolator(type, pointsX, pointsY) }
+    /** PathInterpolator flattens its curve natively on construction, so build once per id. */
+    fun defineEasing(
+        easingId: Int,
+        easingType: Int,
+        easingPointsX: FloatArray,
+        easingPointsY: FloatArray,
+    ) {
+        val interpolator = CSSEasing.interpolator(easingType, easingPointsX, easingPointsY)
+        val current = easings
+        val grown = if (easingId < current.size) current.copyOf() else current.copyOf(easingId + 1)
+        grown[easingId] = interpolator
+        easings = grown
     }
 
     private fun viewForTag(viewTag: Int): View? =

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
@@ -60,9 +60,8 @@ internal class CSSPlatformTransitionsManager(
     private var nextStartToken = 0L
 
     /**
-     * Keyed by the easing id the C++ interner assigned; a define always precedes the first
-     * animate call using its id. The C++ side serialises its callers on a mutex, which is not
-     * a happens-before edge for Java, so the map supplies that ordering itself.
+     * A C++ mutex serialises the callers but is not a happens-before edge for Java, so the
+     * map supplies that ordering itself.
      */
     private val easings = ConcurrentHashMap<Int, TimeInterpolator>()
 
@@ -145,7 +144,6 @@ internal class CSSPlatformTransitionsManager(
             animators.clear()
             running.forEach { it.animator.cancel() }
             reconciler.invalidate()
-            // Whatever a live transition still held, since the map is its only owner.
             easings.clear()
         }
     }
@@ -262,7 +260,6 @@ internal class CSSPlatformTransitionsManager(
         easings[easingId] = CSSEasing.interpolator(easingType, easingPointsX, easingPointsY)
     }
 
-    /** The C++ interner drops a curve once nothing routes with it; ids are never handed out twice. */
     fun undefineEasing(easingId: Int) {
         easings.remove(easingId)
     }

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
@@ -24,10 +24,10 @@ internal class CSSPlatformTransitionsManager(
     private val animators = HashMap<Key, RunningTransition>()
 
     /**
-     * React can overwrite an animated value only on frames where a mount ran, so the
+     * React can overwrite an animated value only on frames where it wrote props, so the
      * pre-draw repair is skipped on all others. Everything here runs on the UI thread.
      */
-    private var mountedSinceLastDraw = true
+    private var reactWroteSinceLastDraw = true
 
     @OptIn(UnstableReactNativeAPI::class)
     private val mountListener =
@@ -37,7 +37,7 @@ internal class CSSPlatformTransitionsManager(
             override fun willMountItems(uiManager: UIManager) = Unit
 
             override fun didMountItems(uiManager: UIManager) {
-                mountedSinceLastDraw = true
+                reactWroteSinceLastDraw = true
             }
 
             override fun didDispatchMountItems(uiManager: UIManager) = Unit
@@ -233,10 +233,15 @@ internal class CSSPlatformTransitionsManager(
         reconciler.track(view)
     }
 
+    /** Synchronous prop writes run their mount item inline, so no listener reports them. */
+    fun onPropsWrittenSynchronously() {
+        reactWroteSinceLastDraw = true
+    }
+
     /** Re-asserts each animator's own value wherever a commit overwrote it. */
     private fun repairClobberedValues(): Boolean {
-        if (!mountedSinceLastDraw) return animators.isNotEmpty()
-        mountedSinceLastDraw = false
+        if (!reactWroteSinceLastDraw) return animators.isNotEmpty()
+        reactWroteSinceLastDraw = false
         animators.values.forEach { running ->
             // target is held weakly, so read the View through it rather than keeping one.
             val view = running.animator.target as? View ?: return@forEach

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
@@ -108,9 +108,39 @@ internal class CSSPlatformTransitionsManager(
         easingId: Int,
         persistent: Boolean,
     ): Boolean {
+        val interpolator = easingFor(easingId) ?: return false
+        return animateWith(viewTag, propertyId, fromValue, toValue, durationMs, startTimestampMs, interpolator, persistent)
+    }
+
+    /** For a start the C++ interner had no slot for: same animation, just an uncached curve. */
+    fun animateTransitionWithEasing(
+        viewTag: Int,
+        propertyId: Int,
+        fromValue: Double,
+        toValue: Double,
+        durationMs: Double,
+        startTimestampMs: Double,
+        easingType: Int,
+        easingPointsX: FloatArray,
+        easingPointsY: FloatArray,
+        persistent: Boolean,
+    ): Boolean {
+        val interpolator = CSSEasing.interpolator(easingType, easingPointsX, easingPointsY)
+        return animateWith(viewTag, propertyId, fromValue, toValue, durationMs, startTimestampMs, interpolator, persistent)
+    }
+
+    private fun animateWith(
+        viewTag: Int,
+        propertyId: Int,
+        fromValue: Double,
+        toValue: Double,
+        durationMs: Double,
+        startTimestampMs: Double,
+        interpolator: TimeInterpolator,
+        persistent: Boolean,
+    ): Boolean {
         if (invalidated) return false
         val writer = cssPropertyWriterFor(propertyId) ?: return false
-        val interpolator = easingFor(easingId) ?: return false
         val context = reactContext.get() ?: return false
         val scale = DurationScale.effectiveScale(context)
         if (scale <= 0f) return false

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
@@ -15,6 +15,7 @@ import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.fabric.FabricUIManager
 import com.facebook.react.uimanager.IllegalViewOperationException
 import java.lang.ref.WeakReference
+import java.util.concurrent.atomic.AtomicReferenceArray
 
 internal class CSSPlatformTransitionsManager(
     private val fabricUIManager: FabricUIManager,
@@ -59,11 +60,11 @@ internal class CSSPlatformTransitionsManager(
     private var nextStartToken = 0L
 
     /**
-     * Indexed by the easing id the C++ interner assigned; a define always precedes the
-     * first animate call using its id. Copy-on-append keeps reads lock-free.
+     * Indexed by the easing id the C++ interner assigned; a define always precedes the first
+     * animate call using its id. The C++ side serialises its callers on a mutex, which is not
+     * a happens-before edge for Java, so each slot publishes itself instead.
      */
-    @Volatile
-    private var easings = arrayOfNulls<TimeInterpolator>(0)
+    private val easings = AtomicReferenceArray<TimeInterpolator>(MAX_INTERNED_EASINGS)
 
     private data class Key(
         val viewTag: Int,
@@ -109,7 +110,7 @@ internal class CSSPlatformTransitionsManager(
     ): Boolean {
         if (invalidated) return false
         val writer = cssPropertyWriterFor(propertyId) ?: return false
-        val interpolator = easings.getOrNull(easingId) ?: return false
+        val interpolator = easingFor(easingId) ?: return false
         val context = reactContext.get() ?: return false
         val scale = DurationScale.effectiveScale(context)
         if (scale <= 0f) return false
@@ -146,7 +147,7 @@ internal class CSSPlatformTransitionsManager(
             reconciler.invalidate()
             // Interpolators outlive every animation that used them, so a flattened curve per
             // easing would otherwise sit here until the manager itself is collected.
-            easings = arrayOfNulls(0)
+            for (easingId in 0 until easings.length()) easings.set(easingId, null)
         }
     }
 
@@ -259,12 +260,11 @@ internal class CSSPlatformTransitionsManager(
         easingPointsX: FloatArray,
         easingPointsY: FloatArray,
     ) {
-        val interpolator = CSSEasing.interpolator(easingType, easingPointsX, easingPointsY)
-        val current = easings
-        val grown = if (easingId < current.size) current.copyOf() else current.copyOf(easingId + 1)
-        grown[easingId] = interpolator
-        easings = grown
+        easings.set(easingId, CSSEasing.interpolator(easingType, easingPointsX, easingPointsY))
     }
+
+    /** Null until its define lands, and for an id past the cap the C++ interner never issues. */
+    private fun easingFor(easingId: Int): TimeInterpolator? = if (easingId in 0 until easings.length()) easings.get(easingId) else null
 
     private fun viewForTag(viewTag: Int): View? =
         try {
@@ -273,4 +273,9 @@ internal class CSSPlatformTransitionsManager(
             // Thrown, not null, when the tag is registered but the View does not exist yet.
             null
         }
+
+    private companion object {
+        /** Must match `kMaxInternedEasings` in CSSPlatformTransitions.cpp. */
+        const val MAX_INTERNED_EASINGS = 256
+    }
 }

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
@@ -15,7 +15,7 @@ import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.fabric.FabricUIManager
 import com.facebook.react.uimanager.IllegalViewOperationException
 import java.lang.ref.WeakReference
-import java.util.concurrent.atomic.AtomicReferenceArray
+import java.util.concurrent.ConcurrentHashMap
 
 internal class CSSPlatformTransitionsManager(
     private val fabricUIManager: FabricUIManager,
@@ -60,11 +60,11 @@ internal class CSSPlatformTransitionsManager(
     private var nextStartToken = 0L
 
     /**
-     * Indexed by the easing id the C++ interner assigned; a define always precedes the first
+     * Keyed by the easing id the C++ interner assigned; a define always precedes the first
      * animate call using its id. The C++ side serialises its callers on a mutex, which is not
-     * a happens-before edge for Java, so each slot publishes itself instead.
+     * a happens-before edge for Java, so the map supplies that ordering itself.
      */
-    private val easings = AtomicReferenceArray<TimeInterpolator>(MAX_INTERNED_EASINGS)
+    private val easings = ConcurrentHashMap<Int, TimeInterpolator>()
 
     private data class Key(
         val viewTag: Int,
@@ -106,14 +106,11 @@ internal class CSSPlatformTransitionsManager(
         durationMs: Double,
         startTimestampMs: Double,
         easingId: Int,
-        easingType: Int,
-        easingPointsX: FloatArray?,
-        easingPointsY: FloatArray?,
         persistent: Boolean,
     ): Boolean {
         if (invalidated) return false
         val writer = cssPropertyWriterFor(propertyId) ?: return false
-        val interpolator = interpolatorFor(easingId, easingType, easingPointsX, easingPointsY) ?: return false
+        val interpolator = easings[easingId] ?: return false
         val context = reactContext.get() ?: return false
         val scale = DurationScale.effectiveScale(context)
         if (scale <= 0f) return false
@@ -150,7 +147,7 @@ internal class CSSPlatformTransitionsManager(
             reconciler.invalidate()
             // Interpolators outlive every animation that used them, so a flattened curve per
             // easing would otherwise sit here until the manager itself is collected.
-            for (easingId in 0 until easings.length()) easings.set(easingId, null)
+            easings.clear()
         }
     }
 
@@ -263,22 +260,7 @@ internal class CSSPlatformTransitionsManager(
         easingPointsX: FloatArray,
         easingPointsY: FloatArray,
     ) {
-        easings.set(easingId, CSSEasing.interpolator(easingType, easingPointsX, easingPointsY))
-    }
-
-    /**
-     * An id means the interner registered the curve; -1 means its table was full and the points
-     * came along with the start, so this one is built fresh and not cached.
-     */
-    private fun interpolatorFor(
-        easingId: Int,
-        easingType: Int,
-        easingPointsX: FloatArray?,
-        easingPointsY: FloatArray?,
-    ): TimeInterpolator? {
-        if (easingId in 0 until easings.length()) return easings.get(easingId)
-        if (easingPointsX == null || easingPointsY == null) return null
-        return CSSEasing.interpolator(easingType, easingPointsX, easingPointsY)
+        easings[easingId] = CSSEasing.interpolator(easingType, easingPointsX, easingPointsY)
     }
 
     private fun viewForTag(viewTag: Int): View? =
@@ -288,9 +270,4 @@ internal class CSSPlatformTransitionsManager(
             // Thrown, not null, when the tag is registered but the View does not exist yet.
             null
         }
-
-    private companion object {
-        /** Must match `kMaxInternedEasings` in CSSPlatformTransitions.cpp. */
-        const val MAX_INTERNED_EASINGS = 256
-    }
 }

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
@@ -8,7 +8,10 @@ import android.util.FloatProperty
 import android.view.Choreographer
 import android.view.View
 import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.UIManager
+import com.facebook.react.bridge.UIManagerListener
 import com.facebook.react.bridge.UiThreadUtil
+import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.fabric.FabricUIManager
 import com.facebook.react.uimanager.IllegalViewOperationException
 import java.lang.ref.WeakReference
@@ -19,6 +22,34 @@ internal class CSSPlatformTransitionsManager(
     private val animationTimestamp: () -> Long,
 ) {
     private val animators = HashMap<Key, RunningTransition>()
+
+    /**
+     * React can overwrite an animated value only on frames where a mount ran, so the
+     * pre-draw repair is skipped on all others. Everything here runs on the UI thread.
+     */
+    private var mountedSinceLastDraw = true
+
+    @OptIn(UnstableReactNativeAPI::class)
+    private val mountListener =
+        object : UIManagerListener {
+            override fun willDispatchViewUpdates(uiManager: UIManager) = Unit
+
+            override fun willMountItems(uiManager: UIManager) = Unit
+
+            override fun didMountItems(uiManager: UIManager) {
+                mountedSinceLastDraw = true
+            }
+
+            override fun didDispatchMountItems(uiManager: UIManager) = Unit
+
+            override fun didScheduleMountItems(uiManager: UIManager) = Unit
+        }
+
+    init {
+        @OptIn(UnstableReactNativeAPI::class)
+        fabricUIManager.addUIManagerEventListener(mountListener)
+    }
+
     private val reconciler = CSSPlatformTransitionReconciler(::repairClobberedValues)
     private val startTokens = HashMap<Key, Long>()
 
@@ -106,6 +137,8 @@ internal class CSSPlatformTransitionsManager(
         // Set before posting: a start already queued would otherwise register a new
         // animator and listener behind the cleanup.
         invalidated = true
+        @OptIn(UnstableReactNativeAPI::class)
+        fabricUIManager.removeUIManagerEventListener(mountListener)
         UiThreadUtil.runOnUiThread {
             startTokens.clear()
             // Snapshot first: cancel() runs onAnimationEnd, which reads the map.
@@ -202,6 +235,8 @@ internal class CSSPlatformTransitionsManager(
 
     /** Re-asserts each animator's own value wherever a commit overwrote it. */
     private fun repairClobberedValues(): Boolean {
+        if (!mountedSinceLastDraw) return animators.isNotEmpty()
+        mountedSinceLastDraw = false
         animators.values.forEach { running ->
             // target is held weakly, so read the View through it rather than keeping one.
             val view = running.animator.target as? View ?: return@forEach

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
@@ -106,41 +106,14 @@ internal class CSSPlatformTransitionsManager(
         durationMs: Double,
         startTimestampMs: Double,
         easingId: Int,
-        persistent: Boolean,
-    ): Boolean {
-        val interpolator = easingFor(easingId) ?: return false
-        return animateWith(viewTag, propertyId, fromValue, toValue, durationMs, startTimestampMs, interpolator, persistent)
-    }
-
-    /** For a start the C++ interner had no slot for: same animation, just an uncached curve. */
-    fun animateTransitionWithEasing(
-        viewTag: Int,
-        propertyId: Int,
-        fromValue: Double,
-        toValue: Double,
-        durationMs: Double,
-        startTimestampMs: Double,
         easingType: Int,
-        easingPointsX: FloatArray,
-        easingPointsY: FloatArray,
-        persistent: Boolean,
-    ): Boolean {
-        val interpolator = CSSEasing.interpolator(easingType, easingPointsX, easingPointsY)
-        return animateWith(viewTag, propertyId, fromValue, toValue, durationMs, startTimestampMs, interpolator, persistent)
-    }
-
-    private fun animateWith(
-        viewTag: Int,
-        propertyId: Int,
-        fromValue: Double,
-        toValue: Double,
-        durationMs: Double,
-        startTimestampMs: Double,
-        interpolator: TimeInterpolator,
+        easingPointsX: FloatArray?,
+        easingPointsY: FloatArray?,
         persistent: Boolean,
     ): Boolean {
         if (invalidated) return false
         val writer = cssPropertyWriterFor(propertyId) ?: return false
+        val interpolator = interpolatorFor(easingId, easingType, easingPointsX, easingPointsY) ?: return false
         val context = reactContext.get() ?: return false
         val scale = DurationScale.effectiveScale(context)
         if (scale <= 0f) return false
@@ -293,8 +266,20 @@ internal class CSSPlatformTransitionsManager(
         easings.set(easingId, CSSEasing.interpolator(easingType, easingPointsX, easingPointsY))
     }
 
-    /** Null until its define lands, and for an id past the cap the C++ interner never issues. */
-    private fun easingFor(easingId: Int): TimeInterpolator? = if (easingId in 0 until easings.length()) easings.get(easingId) else null
+    /**
+     * An id means the interner registered the curve; -1 means its table was full and the points
+     * came along with the start, so this one is built fresh and not cached.
+     */
+    private fun interpolatorFor(
+        easingId: Int,
+        easingType: Int,
+        easingPointsX: FloatArray?,
+        easingPointsY: FloatArray?,
+    ): TimeInterpolator? {
+        if (easingId in 0 until easings.length()) return easings.get(easingId)
+        if (easingPointsX == null || easingPointsY == null) return null
+        return CSSEasing.interpolator(easingType, easingPointsX, easingPointsY)
+    }
 
     private fun viewForTag(viewTag: Int): View? =
         try {

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
@@ -145,8 +145,7 @@ internal class CSSPlatformTransitionsManager(
             animators.clear()
             running.forEach { it.animator.cancel() }
             reconciler.invalidate()
-            // Interpolators outlive every animation that used them, so a flattened curve per
-            // easing would otherwise sit here until the manager itself is collected.
+            // Whatever a live transition still held, since the map is its only owner.
             easings.clear()
         }
     }

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
@@ -144,6 +144,9 @@ internal class CSSPlatformTransitionsManager(
             animators.clear()
             running.forEach { it.animator.cancel() }
             reconciler.invalidate()
+            // Interpolators outlive every animation that used them, so a flattened curve per
+            // easing would otherwise sit here until the manager itself is collected.
+            easings = arrayOfNulls(0)
         }
     }
 

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
@@ -263,6 +263,11 @@ internal class CSSPlatformTransitionsManager(
         easings[easingId] = CSSEasing.interpolator(easingType, easingPointsX, easingPointsY)
     }
 
+    /** The C++ interner drops a curve once nothing routes with it; ids are never handed out twice. */
+    fun undefineEasing(easingId: Int) {
+        easings.remove(easingId)
+    }
+
     private fun viewForTag(viewTag: Int): View? =
         try {
             fabricUIManager.resolveView(viewTag)

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPropertyWriter.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPropertyWriter.kt
@@ -3,10 +3,15 @@ package com.swmansion.reanimated.css
 import android.util.FloatProperty
 import android.view.View
 
-/** The View property React Native itself writes, so a commit can overwrite a running animation. */
-internal fun cssPropertyWriterFor(propertyName: String): FloatProperty<View>? =
-    when (propertyName) {
-        "opacity" -> AlphaProperty
+/**
+ * The View property React Native itself writes, so a commit can overwrite a running
+ * animation, which the pre-draw reconciliation repairs.
+ *
+ * Ids must match `platformPropertyId` in CSSPlatformTransitions.cpp.
+ */
+internal fun cssPropertyWriterFor(propertyId: Int): FloatProperty<View>? =
+    when (propertyId) {
+        0 -> AlphaProperty
         else -> null
     }
 

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPropertyWriter.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPropertyWriter.kt
@@ -4,9 +4,7 @@ import android.util.FloatProperty
 import android.view.View
 
 /**
- * The View property React Native itself writes, so a commit can overwrite a running
- * animation, which the pre-draw reconciliation repairs.
- *
+ * The View property React Native itself writes, so a commit can overwrite a running animation.
  * Ids must match `platformPropertyId` in CSSPlatformTransitions.cpp.
  */
 internal fun cssPropertyWriterFor(propertyId: Int): FloatProperty<View>? =


### PR DESCRIPTION
Each easing is defined once under an integer id and properties are routed by id as well, so starting a transition passes only scalars across JNI. Previously every start re-crossed the boundary with the property name string and the easing curve points.

