### PR TITLE
feat: report the lifecycle milestones a transition crosses

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSLoopTransition.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSLoopTransition.cpp
@@ -62,10 +62,11 @@ folly::dynamic CSSLoopTransition::run(
 
 void CSSLoopTransition::updateSettings(
     const PropertiesSettingsMap &changedPropertiesSettings,
-    const std::vector<std::string> &removedProperties) {
+    const std::vector<std::string> &removedProperties,
+    const double timestamp) {
 
   // Remove interpolators and progress providers for no longer transitioned props
-  removeProperties(removedProperties);
+  removeProperties(removedProperties, timestamp);
 
   // Update the settings saved in progress provider
   progressProvider_.setPropertySettings(changedPropertiesSettings);
@@ -93,7 +94,7 @@ void CSSLoopTransition::handleChangedProperties(
     const auto allowDiscrete = progressProvider_.getPropertySettings(propertyName).allowDiscrete;
 
     if (!allowDiscrete && isDiscreteProperty(propertyName, componentName_)) {
-      removeProperty(propertyName);
+      removeProperty(propertyName, timestamp);
       continue;
     }
 
@@ -125,7 +126,7 @@ void CSSLoopTransition::handleChangedProperties(
     const auto allowDiscrete = progressProvider_.getPropertySettings(propertyName).allowDiscrete;
 
     if (!allowDiscrete && isDiscreteProperty(propertyName, componentName_)) {
-      removeProperty(propertyName);
+      removeProperty(propertyName, timestamp);
       continue;
     }
 
@@ -143,14 +144,14 @@ void CSSLoopTransition::handleChangedProperties(
   }
 }
 
-void CSSLoopTransition::removeProperties(const std::vector<std::string> &propertyNames) {
+void CSSLoopTransition::removeProperties(const std::vector<std::string> &propertyNames, const double timestamp) {
   styleInterpolator_.removeProperties(propertyNames);
-  progressProvider_.removeProperties(propertyNames);
+  progressProvider_.removeProperties(propertyNames, timestamp);
 }
 
-void CSSLoopTransition::removeProperty(const std::string &propertyName) {
+void CSSLoopTransition::removeProperty(const std::string &propertyName, const double timestamp) {
   styleInterpolator_.removeProperty(propertyName);
-  progressProvider_.removeProperty(propertyName);
+  progressProvider_.removeProperty(propertyName, timestamp);
 }
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSLoopTransition.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSLoopTransition.h
@@ -42,11 +42,12 @@ class CSSLoopTransition : public OperationsLoop::LoopOperation, public std::enab
       double timestamp);
   void updateSettings(
       const PropertiesSettingsMap &changedPropertiesSettings,
-      const std::vector<std::string> &removedProperties);
+      const std::vector<std::string> &removedProperties,
+      double timestamp);
 
   folly::dynamic computeCurrentStyle(const std::shared_ptr<const ShadowNode> &shadowNode);
 
-  void removeProperties(const std::vector<std::string> &propertyNames);
+  void removeProperties(const std::vector<std::string> &propertyNames, double timestamp);
 
  private:
   const Tag viewTag_;
@@ -66,7 +67,7 @@ class CSSLoopTransition : public OperationsLoop::LoopOperation, public std::enab
       const PropertyValueDynamicDiffsMap &propertiesDiffs,
       const folly::dynamic &lastUpdateValue,
       double timestamp);
-  void removeProperty(const std::string &propertyName);
+  void removeProperty(const std::string &propertyName, double timestamp);
 };
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.cpp
@@ -44,7 +44,7 @@ folly::dynamic CSSTransition::run(jsi::Runtime &rt, CSSTransitionConfig &&config
   }
 
   auto &loopTransition = ensureLoopTransition();
-  loopTransition.updateSettings(loopConfig.changedPropertiesSettings, loopConfig.removedProperties);
+  loopTransition.updateSettings(loopConfig.changedPropertiesSettings, loopConfig.removedProperties, timestamp);
 
   // Settings-only configs reconfigure without running.
   if (!loopConfig.hasValueUpdates()) {
@@ -90,7 +90,7 @@ void CSSTransition::cancel() {
   platformTransitionProxy_->cancelAll(getViewTag(), routing_.platform);
 }
 
-void CSSTransition::removeProperties(const std::vector<std::string> &propertyNames) {
+void CSSTransition::removeProperties(const std::vector<std::string> &propertyNames, const double timestamp) {
   TransitionProperties platformProperties;
   for (const auto &propertyName : propertyNames) {
     if (routing_.platform.erase(propertyName) > 0) {
@@ -103,7 +103,7 @@ void CSSTransition::removeProperties(const std::vector<std::string> &propertyNam
     platformTransitionProxy_->cancelAll(getViewTag(), platformProperties);
   }
   if (loopTransition_) {
-    loopTransition_->removeProperties(propertyNames);
+    loopTransition_->removeProperties(propertyNames, timestamp);
   }
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.h
@@ -55,7 +55,7 @@ class CSSTransition {
   void cancel();
   /// Drops the properties from the transition, so neither the loop nor a native animation keeps
   /// writing them once their value has been evicted from the updates registry.
-  void removeProperties(const std::vector<std::string> &propertyNames);
+  void removeProperties(const std::vector<std::string> &propertyNames, double timestamp);
 
   void setPseudoLockedProperties(TransitionProperties properties);
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
@@ -54,8 +54,6 @@ ReversingState TransitionPropertyProgressProvider::getReversingState() const {
 
 void TransitionPropertyProgressProvider::onMilestone(RunLifecycle::Reporter reporter) {
   lifecycle_.onMilestone(std::move(reporter));
-  // Reports the stage already reached, so a provider observed right at
-  // creation reports Created. Stages crossed earlier are not replayed.
   lifecycle_.reachPosition(computeStage());
 }
 
@@ -71,7 +69,6 @@ void TransitionPropertyProgressProvider::update(const double timestamp) {
 
 RunStage TransitionPropertyProgressProvider::computeStage() const {
   switch (getState()) {
-    // Pending means created but still waiting out its delay.
     case TransitionProgressState::Pending:
       return RunStage::Created;
     case TransitionProgressState::Running:
@@ -198,8 +195,6 @@ void TransitionProgressProvider::runProgressProvider(
       provider = createReversingShorteningProgressProvider(timestamp, settings, *progressProvider);
     }
 
-    // Taking over a still-running property interrupts it; aborting an ended
-    // one is a no-op, so it is not cancelled retroactively.
     progressProvider->abort(timestamp);
   }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
@@ -87,7 +87,8 @@ double TransitionPropertyProgressProvider::elapsedTimeAt(const MilestoneTime tim
       return duration_;
     case MilestoneTime::ActiveTime:
       return std::max(0.0, cancelTimestamp_ - (creationTimestamp_ + delay_));
-    case MilestoneTime::IterationBoundary:
+    case MilestoneTime::IterationStart:
+    case MilestoneTime::IterationEnd:
       // A transition has no iterations, so it never reaches a boundary.
       return 0;
   }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
@@ -81,17 +81,13 @@ RunStage TransitionPropertyProgressProvider::computeStage() const {
 
 double TransitionPropertyProgressProvider::elapsedTimeAt(const RunMilestone milestone) const {
   switch (milestone) {
-    case RunMilestone::Created:
-    case RunMilestone::Started:
-      return 0;
     case RunMilestone::Ended:
       return duration_;
     case RunMilestone::Aborted:
       return std::max(0.0, cancelTimestamp_ - (creationTimestamp_ + delay_));
-    case RunMilestone::Repeated:
+    default:
       return 0;
   }
-  return 0;
 }
 
 TransitionProgressState TransitionPropertyProgressProvider::getState() const {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
@@ -213,18 +213,20 @@ void TransitionProgressProvider::runProgressProvider(
   observeProperty(propertyName, *provider);
 }
 
-void TransitionProgressProvider::removeProperties(const std::vector<std::string> &propertyNames) {
+void TransitionProgressProvider::removeProperties(
+    const std::vector<std::string> &propertyNames,
+    const double timestamp) {
   for (const auto &propertyName : propertyNames) {
-    removeProperty(propertyName);
+    removeProperty(propertyName, timestamp);
   }
 }
 
-void TransitionProgressProvider::removeProperty(const std::string &propertyName) {
+void TransitionProgressProvider::removeProperty(const std::string &propertyName, const double timestamp) {
   const auto it = propertyProgressProviders_.find(propertyName);
   if (it == propertyProgressProviders_.end()) {
     return;
   }
-  it->second->abort(lastTimestamp_);
+  it->second->abort(timestamp);
   propertyProgressProviders_.erase(it);
 }
 
@@ -245,7 +247,6 @@ void TransitionProgressProvider::discardFinishedProgressProviders() {
 }
 
 void TransitionProgressProvider::update(const double timestamp) {
-  lastTimestamp_ = timestamp;
   removedProperties_.clear();
 
   for (const auto &[propertyName, propertyProgressProvider] : propertyProgressProviders_) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
@@ -58,6 +58,10 @@ void TransitionPropertyProgressProvider::setMilestoneReporter(RunLifecycle::Repo
 }
 
 void TransitionPropertyProgressProvider::abort(const double timestamp) {
+  // A cancel can arrive at a timestamp the provider has not been ticked to, and
+  // the run still owes the milestones it crossed in between. Advancing first
+  // also lets a run that has since finished report its end instead of a cancel.
+  update(timestamp);
   cancelTimestamp_ = timestamp;
   lifecycle_.abort();
 }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
@@ -54,7 +54,7 @@ ReversingState TransitionPropertyProgressProvider::getReversingState() const {
 
 void TransitionPropertyProgressProvider::setMilestoneReporter(RunLifecycle::Reporter reporter) {
   lifecycle_.setMilestoneReporter(std::move(reporter));
-  lifecycle_.reachPosition(computeStage());
+  lifecycle_.reachPhase(computePhase());
 }
 
 void TransitionPropertyProgressProvider::abort(const double timestamp) {
@@ -64,36 +64,36 @@ void TransitionPropertyProgressProvider::abort(const double timestamp) {
 
 void TransitionPropertyProgressProvider::update(const double timestamp) {
   TimeProgressProvider::update(timestamp);
-  lifecycle_.reachPosition(computeStage());
+  lifecycle_.reachPhase(computePhase());
 }
 
-RunStage TransitionPropertyProgressProvider::computeStage() const {
+RunPhase TransitionPropertyProgressProvider::computePhase() const {
   switch (getState()) {
     case TransitionProgressState::Pending:
-      return RunStage::Created;
+      return RunPhase::Before;
     case TransitionProgressState::Running:
-      return RunStage::Started;
+      return RunPhase::Active;
     case TransitionProgressState::Idle:
-      return RunStage::Ended;
+      return RunPhase::After;
   }
-  return RunStage::None;
+  return RunPhase::Idle;
 }
 
-double TransitionPropertyProgressProvider::elapsedTimeAt(const RunMilestone milestone) const {
-  switch (milestone) {
-    case RunMilestone::Created:
-    case RunMilestone::Started:
-      return startElapsedTime();
-    case RunMilestone::Ended:
+double TransitionPropertyProgressProvider::elapsedTimeAt(const MilestoneTime time) const {
+  switch (time) {
+    case MilestoneTime::IntervalStart:
+      return intervalStart();
+    case MilestoneTime::IntervalEnd:
       return duration_;
-    case RunMilestone::Aborted:
+    case MilestoneTime::ActiveTime:
       return std::max(0.0, cancelTimestamp_ - (creationTimestamp_ + delay_));
-    default:
+    case MilestoneTime::IterationBoundary:
+      // A transition has no iterations, so it never reaches a boundary.
       return 0;
   }
 }
 
-double TransitionPropertyProgressProvider::startElapsedTime() const {
+double TransitionPropertyProgressProvider::intervalStart() const {
   // A negative delay starts the transition partway through, and the web reports
   // that offset capped to the duration.
   return std::min(std::max(0.0, -delay_), duration_);
@@ -176,9 +176,10 @@ void TransitionProgressProvider::observeProperty(
   }
 
   // The lambda lives inside the provider, so capturing it by reference is safe.
-  provider.setMilestoneReporter([this, propertyName, &provider](const RunMilestone milestone) {
-    reporter_(milestone, propertyName, provider.elapsedTimeAt(milestone));
-  });
+  provider.setMilestoneReporter(
+      [this, propertyName, &provider](const RunMilestone milestone, const MilestoneTime time) {
+        reporter_(milestone, propertyName, provider.elapsedTimeAt(time));
+      });
 }
 
 void TransitionProgressProvider::runProgressProvider(

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
@@ -219,6 +219,12 @@ void TransitionProgressProvider::removeProperty(const std::string &propertyName)
   propertyProgressProviders_.erase(it);
 }
 
+void TransitionProgressProvider::abort(const double timestamp) {
+  for (const auto &[_, provider] : propertyProgressProviders_) {
+    provider->abort(timestamp);
+  }
+}
+
 void TransitionProgressProvider::discardFinishedProgressProviders() {
   for (auto it = propertyProgressProviders_.begin(); it != propertyProgressProviders_.end();) {
     if (it->second->getState() == TransitionProgressState::Idle) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
@@ -2,6 +2,7 @@
 
 #include <reanimated/CSS/utils/reversingShortening.h>
 
+#include <algorithm>
 #include <limits>
 #include <memory>
 #include <string>
@@ -49,6 +50,51 @@ double TransitionPropertyProgressProvider::getRemainingDelay(const double timest
 
 ReversingState TransitionPropertyProgressProvider::getReversingState() const {
   return {reversingShorteningFactor_, creationTimestamp_ + delay_, duration_, delay_, easing_};
+}
+
+void TransitionPropertyProgressProvider::onMilestone(RunLifecycle::Reporter reporter) {
+  lifecycle_.onMilestone(std::move(reporter));
+  // Reports the stage already reached, so a provider observed right at
+  // creation reports Created. Stages crossed earlier are not replayed.
+  lifecycle_.reachPosition(computeStage());
+}
+
+void TransitionPropertyProgressProvider::abort(const double timestamp) {
+  cancelTimestamp_ = timestamp;
+  lifecycle_.abort();
+}
+
+void TransitionPropertyProgressProvider::update(const double timestamp) {
+  TimeProgressProvider::update(timestamp);
+  lifecycle_.reachPosition(computeStage());
+}
+
+RunStage TransitionPropertyProgressProvider::computeStage() const {
+  switch (getState()) {
+    // Pending means created but still waiting out its delay.
+    case TransitionProgressState::Pending:
+      return RunStage::Created;
+    case TransitionProgressState::Running:
+      return RunStage::Started;
+    case TransitionProgressState::Idle:
+      return RunStage::Ended;
+  }
+  return RunStage::None;
+}
+
+double TransitionPropertyProgressProvider::elapsedTimeAt(const RunMilestone milestone) const {
+  switch (milestone) {
+    case RunMilestone::Created:
+    case RunMilestone::Started:
+      return 0;
+    case RunMilestone::Ended:
+      return duration_;
+    case RunMilestone::Aborted:
+      return std::max(0.0, cancelTimestamp_ - (creationTimestamp_ + delay_));
+    case RunMilestone::Repeated:
+      return 0;
+  }
+  return 0;
 }
 
 TransitionProgressState TransitionPropertyProgressProvider::getState() const {
@@ -111,6 +157,28 @@ std::unordered_set<std::string> TransitionProgressProvider::getRemovedProperties
   return removedProperties_;
 }
 
+void TransitionProgressProvider::onMilestone(MilestoneReporter reporter) {
+  reporter_ = std::move(reporter);
+
+  for (const auto &[propertyName, propertyProgressProvider] : propertyProgressProviders_) {
+    observeProperty(propertyName, *propertyProgressProvider);
+  }
+}
+
+void TransitionProgressProvider::observeProperty(
+    const std::string &propertyName,
+    TransitionPropertyProgressProvider &provider) {
+  if (!reporter_) {
+    provider.onMilestone(nullptr);
+    return;
+  }
+
+  // The lambda lives inside the provider, so capturing it by reference is safe.
+  provider.onMilestone([this, propertyName, &provider](const RunMilestone milestone) {
+    reporter_(milestone, propertyName, provider.elapsedTimeAt(milestone));
+  });
+}
+
 void TransitionProgressProvider::runProgressProvider(
     const std::string &propertyName,
     const bool isReversed,
@@ -119,6 +187,7 @@ void TransitionProgressProvider::runProgressProvider(
   const auto settings = getPropertySettings(propertyName);
 
   const auto providerIt = propertyProgressProviders_.find(propertyName);
+  std::shared_ptr<TransitionPropertyProgressProvider> provider;
 
   if (providerIt != propertyProgressProviders_.end()) {
     const auto &progressProvider = providerIt->second;
@@ -126,27 +195,37 @@ void TransitionProgressProvider::runProgressProvider(
 
     if (isReversed && progressProvider->getState() != TransitionProgressState::Idle) {
       // Create reversing shortening progress provider for interrupted reversing transition
-      propertyProgressProviders_.insert_or_assign(
-          propertyName, createReversingShorteningProgressProvider(timestamp, settings, *progressProvider));
-      return;
+      provider = createReversingShorteningProgressProvider(timestamp, settings, *progressProvider);
     }
+
+    // Taking over a still-running property interrupts it; aborting an ended
+    // one is a no-op, so it is not cancelled retroactively.
+    progressProvider->abort(timestamp);
   }
 
-  // Create progress provider with the new settings
-  propertyProgressProviders_.insert_or_assign(
-      propertyName,
-      std::make_shared<TransitionPropertyProgressProvider>(
-          timestamp, settings.duration, settings.delay, settings.easingConfig));
+  if (!provider) {
+    // Create progress provider with the new settings
+    provider = std::make_shared<TransitionPropertyProgressProvider>(
+        timestamp, settings.duration, settings.delay, settings.easingConfig);
+  }
+
+  propertyProgressProviders_.insert_or_assign(propertyName, provider);
+  observeProperty(propertyName, *provider);
 }
 
 void TransitionProgressProvider::removeProperties(const std::vector<std::string> &propertyNames) {
   for (const auto &propertyName : propertyNames) {
-    propertyProgressProviders_.erase(propertyName);
+    removeProperty(propertyName);
   }
 }
 
 void TransitionProgressProvider::removeProperty(const std::string &propertyName) {
-  propertyProgressProviders_.erase(propertyName);
+  const auto it = propertyProgressProviders_.find(propertyName);
+  if (it == propertyProgressProviders_.end()) {
+    return;
+  }
+  it->second->abort(lastTimestamp_);
+  propertyProgressProviders_.erase(it);
 }
 
 void TransitionProgressProvider::discardFinishedProgressProviders() {
@@ -160,6 +239,7 @@ void TransitionProgressProvider::discardFinishedProgressProviders() {
 }
 
 void TransitionProgressProvider::update(const double timestamp) {
+  lastTimestamp_ = timestamp;
   removedProperties_.clear();
 
   for (const auto &[propertyName, propertyProgressProvider] : propertyProgressProviders_) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
@@ -52,8 +52,8 @@ ReversingState TransitionPropertyProgressProvider::getReversingState() const {
   return {reversingShorteningFactor_, creationTimestamp_ + delay_, duration_, delay_, easing_};
 }
 
-void TransitionPropertyProgressProvider::onMilestone(RunLifecycle::Reporter reporter) {
-  lifecycle_.onMilestone(std::move(reporter));
+void TransitionPropertyProgressProvider::setMilestoneReporter(RunLifecycle::Reporter reporter) {
+  lifecycle_.setMilestoneReporter(std::move(reporter));
   lifecycle_.reachPosition(computeStage());
 }
 
@@ -150,7 +150,7 @@ std::unordered_set<std::string> TransitionProgressProvider::getRemovedProperties
   return removedProperties_;
 }
 
-void TransitionProgressProvider::onMilestone(MilestoneReporter reporter) {
+void TransitionProgressProvider::setMilestoneReporter(MilestoneReporter reporter) {
   reporter_ = std::move(reporter);
 
   for (const auto &[propertyName, propertyProgressProvider] : propertyProgressProviders_) {
@@ -162,12 +162,12 @@ void TransitionProgressProvider::observeProperty(
     const std::string &propertyName,
     TransitionPropertyProgressProvider &provider) {
   if (!reporter_) {
-    provider.onMilestone(nullptr);
+    provider.setMilestoneReporter(nullptr);
     return;
   }
 
   // The lambda lives inside the provider, so capturing it by reference is safe.
-  provider.onMilestone([this, propertyName, &provider](const RunMilestone milestone) {
+  provider.setMilestoneReporter([this, propertyName, &provider](const RunMilestone milestone) {
     reporter_(milestone, propertyName, provider.elapsedTimeAt(milestone));
   });
 }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
@@ -81,6 +81,9 @@ RunStage TransitionPropertyProgressProvider::computeStage() const {
 
 double TransitionPropertyProgressProvider::elapsedTimeAt(const RunMilestone milestone) const {
   switch (milestone) {
+    case RunMilestone::Created:
+    case RunMilestone::Started:
+      return startElapsedTime();
     case RunMilestone::Ended:
       return duration_;
     case RunMilestone::Aborted:
@@ -88,6 +91,12 @@ double TransitionPropertyProgressProvider::elapsedTimeAt(const RunMilestone mile
     default:
       return 0;
   }
+}
+
+double TransitionPropertyProgressProvider::startElapsedTime() const {
+  // A negative delay starts the transition partway through, and the web reports
+  // that offset capped to the duration.
+  return std::min(std::max(0.0, -delay_), duration_);
 }
 
 TransitionProgressState TransitionPropertyProgressProvider::getState() const {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.h
@@ -52,6 +52,7 @@ class TransitionPropertyProgressProvider final : public KeyframeProgressProvider
   // The lifecycle reports an abort without a timestamp, so abort() leaves one here.
   double cancelTimestamp_ = 0;
 
+  double startElapsedTime() const;
   double getElapsedTime(double timestamp) const;
   RunStage computeStage() const;
 };

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.h
@@ -2,6 +2,7 @@
 
 #include <reanimated/CSS/configs/CSSTransitionConfig.h>
 #include <reanimated/CSS/progress/KeyframeProgressProvider.h>
+#include <reanimated/CSS/progress/RunLifecycle.h>
 #include <reanimated/CSS/progress/TimeProgressProvider.h>
 #include <reanimated/CSS/utils/props.h>
 #include <reanimated/CSS/utils/reversingShortening.h>
@@ -32,6 +33,13 @@ class TransitionPropertyProgressProvider final : public KeyframeProgressProvider
   ReversingState getReversingState() const;
   TransitionProgressState getState() const;
 
+  /// Time the property has run by the given milestone, in milliseconds.
+  double elapsedTimeAt(RunMilestone milestone) const;
+
+  void onMilestone(RunLifecycle::Reporter reporter);
+  void abort(double timestamp);
+  void update(double timestamp) override;
+
  protected:
   std::optional<double> calculateRawProgress(double timestamp) override;
 
@@ -40,7 +48,12 @@ class TransitionPropertyProgressProvider final : public KeyframeProgressProvider
   EasingFunction easingFunction_;
   double reversingShorteningFactor_ = 1;
 
+  RunLifecycle lifecycle_;
+  // The lifecycle reports an abort without a timestamp, so abort() leaves one here.
+  double cancelTimestamp_ = 0;
+
   double getElapsedTime(double timestamp) const;
+  RunStage computeStage() const;
 };
 
 using TransitionPropertyProgressProviders =
@@ -48,10 +61,15 @@ using TransitionPropertyProgressProviders =
 
 class TransitionProgressProvider final {
  public:
+  /// Reports a milestone of one property, with the time elapsed by then.
+  using MilestoneReporter = std::function<void(RunMilestone, const std::string &property, double elapsedTime)>;
+
   TransitionProgressState getState() const;
   double getMinDelay(double timestamp) const;
   TransitionPropertyProgressProviders getPropertyProgressProviders() const;
   std::unordered_set<std::string> getRemovedProperties() const;
+
+  void onMilestone(MilestoneReporter reporter);
 
   void runProgressProvider(const std::string &propertyName, bool isReversed, double timestamp);
   void removeProperties(const std::vector<std::string> &propertyNames);
@@ -63,6 +81,11 @@ class TransitionProgressProvider final {
 
  private:
   TransitionPropertyProgressProviders propertyProgressProviders_;
+  MilestoneReporter reporter_;
+  // removeProperty() reports a cancel, which needs a timestamp its caller does not supply.
+  double lastTimestamp_ = 0;
+
+  void observeProperty(const std::string &propertyName, TransitionPropertyProgressProvider &provider);
 
   // TO DO: currently never cleaned by design - if the property has already been transitioned in the past, we might want
   // to reuse the config (run without settings in the config).

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.h
@@ -36,7 +36,7 @@ class TransitionPropertyProgressProvider final : public KeyframeProgressProvider
   /// Time the property has run by the given milestone, in milliseconds.
   double elapsedTimeAt(RunMilestone milestone) const;
 
-  void onMilestone(RunLifecycle::Reporter reporter);
+  void setMilestoneReporter(RunLifecycle::Reporter reporter);
   void abort(double timestamp);
   void update(double timestamp) override;
 
@@ -69,7 +69,7 @@ class TransitionProgressProvider final {
   TransitionPropertyProgressProviders getPropertyProgressProviders() const;
   std::unordered_set<std::string> getRemovedProperties() const;
 
-  void onMilestone(MilestoneReporter reporter);
+  void setMilestoneReporter(MilestoneReporter reporter);
 
   void runProgressProvider(const std::string &propertyName, bool isReversed, double timestamp);
   void removeProperties(const std::vector<std::string> &propertyNames);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.h
@@ -72,6 +72,7 @@ class TransitionProgressProvider final {
   void setMilestoneReporter(MilestoneReporter reporter);
 
   void runProgressProvider(const std::string &propertyName, bool isReversed, double timestamp);
+  void abort(double timestamp);
   void removeProperties(const std::vector<std::string> &propertyNames);
   void removeProperty(const std::string &propertyName);
   void discardFinishedProgressProviders();

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.h
@@ -34,7 +34,7 @@ class TransitionPropertyProgressProvider final : public KeyframeProgressProvider
   TransitionProgressState getState() const;
 
   /// Time the property has run by the given milestone, in milliseconds.
-  double elapsedTimeAt(RunMilestone milestone) const;
+  double elapsedTimeAt(MilestoneTime time) const;
 
   void setMilestoneReporter(RunLifecycle::Reporter reporter);
   void abort(double timestamp);
@@ -52,9 +52,9 @@ class TransitionPropertyProgressProvider final : public KeyframeProgressProvider
   // The lifecycle reports an abort without a timestamp, so abort() leaves one here.
   double cancelTimestamp_ = 0;
 
-  double startElapsedTime() const;
+  double intervalStart() const;
   double getElapsedTime(double timestamp) const;
-  RunStage computeStage() const;
+  RunPhase computePhase() const;
 };
 
 using TransitionPropertyProgressProviders =

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.h
@@ -74,8 +74,8 @@ class TransitionProgressProvider final {
 
   void runProgressProvider(const std::string &propertyName, bool isReversed, double timestamp);
   void abort(double timestamp);
-  void removeProperties(const std::vector<std::string> &propertyNames);
-  void removeProperty(const std::string &propertyName);
+  void removeProperties(const std::vector<std::string> &propertyNames, double timestamp);
+  void removeProperty(const std::string &propertyName, double timestamp);
   void discardFinishedProgressProviders();
   void update(double timestamp);
   void setPropertySettings(const PropertiesSettingsMap &changedPropertiesSettings);
@@ -84,8 +84,6 @@ class TransitionProgressProvider final {
  private:
   TransitionPropertyProgressProviders propertyProgressProviders_;
   MilestoneReporter reporter_;
-  // removeProperty() reports a cancel, which needs a timestamp its caller does not supply.
-  double lastTimestamp_ = 0;
 
   void observeProperty(const std::string &propertyName, TransitionPropertyProgressProvider &provider);
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSTransitionsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSTransitionsRegistry.cpp
@@ -98,7 +98,7 @@ void CSSTransitionsRegistry::reconcilePseudoStyledProperties(
   if (!evictedProperties.empty()) {
     // An in-flight transition would otherwise re-emit the evicted value on its next tick and
     // pin the property again.
-    transition->removeProperties(evictedProperties);
+    transition->removeProperties(evictedProperties, loop_->resolveTimestamp());
     setInUpdatesRegistry(transition->getShadowNodeFamily(), updates);
   }
   if (!corrections.empty()) {


### PR DESCRIPTION
Reports the milestones each transitioning property crosses, so the CSS engine can turn them into transition events. Nothing consumes them yet.

Transitions run per property, so the lifecycle lives on the property progress provider and every milestone is tagged with the property name. The run lifecycle is reused unchanged: Created maps to transitionrun, Started to transitionstart, Ended to transitionend and an abort to transitioncancel; a transition never repeats.

Which time a milestone carries follows the phase change that produced it, per [css-transitions-2](https://drafts.csswg.org/css-transitions-2/#event-dispatch). A cancel advances the property to its own timestamp first, so a removal landing after the transition finished reports the end rather than a cancel.