### PR TITLE
feat(Reanimated): migrate mutables to fixed-type Synchronizable

### DIFF
--- a/packages/react-native-reanimated/CHANGELOG.md
+++ b/packages/react-native-reanimated/CHANGELOG.md
@@ -16,3 +16,4 @@
 
 - Add `fontVariationSettings` to the style properties config, so the package type-checks against React Native 0.88 ([#10239](https://github.com/software-mansion/react-native-reanimated/pull/10239) by [@tjzel](https://github.com/tjzel))
 - Add `backgroundPosition`, `backgroundRepeat` and `backgroundSize` to the style properties config, so the package type-checks against React Native 0.88. ([#10354](https://github.com/software-mansion/react-native-reanimated/pull/10354) by [@tjzel](https://github.com/tjzel))
+- Migrate Mutable's dirty flag to Fixed Synchronizable for better performance. ([#10272](https://github.com/software-mansion/react-native-reanimated/pull/10272) by [@tjzel](https://github.com/tjzel))

--- a/packages/react-native-reanimated/src/commonTypes.ts
+++ b/packages/react-native-reanimated/src/commonTypes.ts
@@ -230,10 +230,10 @@ export interface Mutable<Value = unknown> extends SharedValue<Value> {
    */
   _value: Value;
   /**
-   * Defined only on the UI Runtime host mutable. Guest mutables and the web
-   * implementation don't define it.
+   * Defined on the UI Runtime host mutable and as a no-op on web and Guest
+   * mutables.
    */
-  setDirtyFlag?: (dirty: boolean) => void;
+  setDirtyFlag: (dirty: boolean) => void;
 }
 
 export type MapperRawInputs = unknown[];

--- a/packages/react-native-reanimated/src/mutables.native.ts
+++ b/packages/react-native-reanimated/src/mutables.native.ts
@@ -1,6 +1,9 @@
 'use strict';
 
-import type { ShareableGuest, Synchronizable } from 'react-native-worklets';
+import type {
+  FixedSynchronizable,
+  ShareableGuest,
+} from 'react-native-worklets';
 import {
   createShareable,
   createSynchronizable,
@@ -19,7 +22,7 @@ import {
 function mutableGuestDecorator<TValue>(
   initial: TValue,
   mutable: ShareableGuest<TValue> & Mutable<TValue>,
-  dirtyFlag: Synchronizable<boolean>
+  dirtyFlag: FixedSynchronizable<boolean>
 ): ShareableGuest<TValue> & Mutable<TValue> {
   'worklet';
   let latest = initial;
@@ -31,10 +34,10 @@ function mutableGuestDecorator<TValue>(
           latest = mutable.getSync();
         } else {
           checkInvalidReadDuringRender();
-          if (dirtyFlag.getBlocking()) {
+          if (dirtyFlag.getDirty()) {
             const uiValueGetter = (svArg: Mutable<TValue>) =>
               runOnUISync((sv) => {
-                sv.setDirtyFlag?.(false);
+                sv.setDirtyFlag(false);
                 return sv.value;
               }, svArg);
             latest = uiValueGetter(mutable as Mutable<TValue>);
@@ -127,6 +130,13 @@ function mutableGuestDecorator<TValue>(
       configurable: true,
     },
 
+    setDirtyFlag: {
+      value: () => undefined,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    },
+
     _isReanimatedSharedValue: {
       value: true,
       writable: true,
@@ -139,7 +149,7 @@ function mutableGuestDecorator<TValue>(
 }
 
 export function makeMutable<TValue>(initial: TValue): Mutable<TValue> {
-  const dirtyFlag = createSynchronizable(false);
+  const dirtyFlag = createSynchronizable(false, { fixedType: true });
 
   const shareable = createShareable<TValue, Mutable<TValue>, Mutable<TValue>>(
     UIRuntimeId,

--- a/packages/react-native-reanimated/src/mutables.ts
+++ b/packages/react-native-reanimated/src/mutables.ts
@@ -69,6 +69,8 @@ export function makeMutable<TValue>(initial: TValue): Mutable<TValue> {
       listeners.delete(id);
     },
 
+    setDirtyFlag: () => undefined,
+
     _isReanimatedSharedValue: true,
   };
 

--- a/packages/react-native-reanimated/src/mutablesCommon.ts
+++ b/packages/react-native-reanimated/src/mutablesCommon.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import type { ShareableHost, Synchronizable } from 'react-native-worklets';
+import type { FixedSynchronizable, ShareableHost } from 'react-native-worklets';
 
 import { logger } from './common';
 import type { Mutable } from './commonTypes';
@@ -33,7 +33,7 @@ export type Listener<TValue> = (newValue: TValue) => void;
 
 export function mutableHostDecorator<TValue>(
   mutable: ShareableHost<TValue> & Mutable<TValue>,
-  dirtyFlag?: Synchronizable<boolean>
+  dirtyFlag?: FixedSynchronizable<boolean>
 ): ShareableHost<TValue> & Mutable<TValue> {
   'worklet';
   const listeners = new Map<number, Listener<TValue>>();
@@ -41,7 +41,7 @@ export function mutableHostDecorator<TValue>(
   let isDirty = false;
 
   const setDirtyFlag = (dirty: boolean) => {
-    dirtyFlag?.setBlocking(dirty);
+    dirtyFlag?.setDirty(dirty);
     isDirty = dirty;
   };
 


### PR DESCRIPTION
## Summary

Depends on #10261.

I made Mutables use new, more optimized Synchronizable Fixed type for faster accesses of the dirty flag.

## Test plan

Runtime tests for Mutables pass.

