### PR TITLE
chore: prefix the CSS lifecycle callbacks with onCSS

### DIFF
--- a/apps/common-app/src/apps/css/examples/animations/screens/miscellaneous/AnimationCallbacks.tsx
+++ b/apps/common-app/src/apps/css/examples/animations/screens/miscellaneous/AnimationCallbacks.tsx
@@ -118,13 +118,13 @@ export default function AnimationCallbacks() {
                   styles.box,
                   animation,
                   {
-                    onAnimationCancel: ({ elapsedTime }) =>
+                    onCSSAnimationCancel: ({ elapsedTime }) =>
                       log('cancel', elapsedTime),
-                    onAnimationEnd: ({ elapsedTime }) =>
+                    onCSSAnimationEnd: ({ elapsedTime }) =>
                       log('end', elapsedTime),
-                    onAnimationIteration: ({ elapsedTime }) =>
+                    onCSSAnimationIteration: ({ elapsedTime }) =>
                       log('iteration', elapsedTime),
-                    onAnimationStart: ({ elapsedTime }) =>
+                    onCSSAnimationStart: ({ elapsedTime }) =>
                       log('start', elapsedTime),
                   },
                 ]}

--- a/packages/react-native-reanimated/src/css/native/events/__tests__/mask.test.ts
+++ b/packages/react-native-reanimated/src/css/native/events/__tests__/mask.test.ts
@@ -10,7 +10,7 @@ describe('getAnimationEventMaskFromProps', () => {
   test('combines the bits of every present prop', () => {
     expect(
       getAnimationEventMaskFromProps(
-        new Set(['onAnimationStart', 'onAnimationCancel'] as const)
+        new Set(['onCSSAnimationStart', 'onCSSAnimationCancel'] as const)
       )
     ).toBe(CSS_EVENT_MASK.animationStart | CSS_EVENT_MASK.animationCancel);
   });

--- a/packages/react-native-reanimated/src/css/native/events/mask.ts
+++ b/packages/react-native-reanimated/src/css/native/events/mask.ts
@@ -7,17 +7,17 @@ import type { CSSAnimationEventType, CSSTransitionEventType } from './types';
 import { CSS_EVENT_MASK } from './types';
 
 export const ANIMATION_CALLBACK_PROP_BY_EVENT_TYPE = {
-  animationStart: 'onAnimationStart',
-  animationEnd: 'onAnimationEnd',
-  animationIteration: 'onAnimationIteration',
-  animationCancel: 'onAnimationCancel',
+  animationStart: 'onCSSAnimationStart',
+  animationEnd: 'onCSSAnimationEnd',
+  animationIteration: 'onCSSAnimationIteration',
+  animationCancel: 'onCSSAnimationCancel',
 } as const satisfies Record<CSSAnimationEventType, CSSAnimationCallbackProp>;
 
 export const TRANSITION_CALLBACK_PROP_BY_EVENT_TYPE = {
-  transitionRun: 'onTransitionRun',
-  transitionStart: 'onTransitionStart',
-  transitionEnd: 'onTransitionEnd',
-  transitionCancel: 'onTransitionCancel',
+  transitionRun: 'onCSSTransitionRun',
+  transitionStart: 'onCSSTransitionStart',
+  transitionEnd: 'onCSSTransitionEnd',
+  transitionCancel: 'onCSSTransitionCancel',
 } as const satisfies Record<CSSTransitionEventType, CSSTransitionCallbackProp>;
 
 /** Inverse of a prop table, so each pairing is written down only once. */

--- a/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSCallbacksManager.test.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSCallbacksManager.test.ts
@@ -26,8 +26,8 @@ describe('CSSCallbacksManager', () => {
 
   describe('masks', () => {
     test('each kind reflects its own callbacks', () => {
-      manager.syncAnimationCallbacks({ onAnimationEnd: jest.fn() });
-      manager.syncTransitionCallbacks({ onTransitionStart: jest.fn() });
+      manager.syncAnimationCallbacks({ onCSSAnimationEnd: jest.fn() });
+      manager.syncTransitionCallbacks({ onCSSTransitionStart: jest.fn() });
 
       expect(manager.getAnimationEventMask()).toBe(CSS_EVENT_MASK.animationEnd);
       expect(manager.getTransitionEventMask()).toBe(
@@ -37,17 +37,17 @@ describe('CSSCallbacksManager', () => {
 
     test('drops the bit of a removed callback', () => {
       manager.syncAnimationCallbacks({
-        onAnimationEnd: jest.fn(),
-        onAnimationStart: jest.fn(),
+        onCSSAnimationEnd: jest.fn(),
+        onCSSAnimationStart: jest.fn(),
       });
-      manager.syncAnimationCallbacks({ onAnimationEnd: jest.fn() });
+      manager.syncAnimationCallbacks({ onCSSAnimationEnd: jest.fn() });
 
       expect(manager.getAnimationEventMask()).toBe(CSS_EVENT_MASK.animationEnd);
     });
 
     test('are empty again after detach', () => {
-      manager.syncAnimationCallbacks({ onAnimationEnd: jest.fn() });
-      manager.syncTransitionCallbacks({ onTransitionEnd: jest.fn() });
+      manager.syncAnimationCallbacks({ onCSSAnimationEnd: jest.fn() });
+      manager.syncTransitionCallbacks({ onCSSTransitionEnd: jest.fn() });
       manager.detach();
 
       expect(manager.getAnimationEventMask()).toBe(0);
@@ -57,28 +57,28 @@ describe('CSSCallbacksManager', () => {
 
   describe('event delivery', () => {
     test('maps the native payload to the public animation event', () => {
-      const onAnimationEnd = jest.fn();
-      manager.syncAnimationCallbacks({ onAnimationEnd });
+      const onCSSAnimationEnd = jest.fn();
+      manager.syncAnimationCallbacks({ onCSSAnimationEnd });
 
       cssCallbacksRegistry.dispatch([
         event('animationEnd', { name: 'pulse', elapsedTime: 1.5 }),
       ]);
 
-      expect(onAnimationEnd).toHaveBeenCalledWith({
+      expect(onCSSAnimationEnd).toHaveBeenCalledWith({
         animationName: 'pulse',
         elapsedTime: 1.5,
       });
     });
 
     test('maps the native payload to the public transition event', () => {
-      const onTransitionEnd = jest.fn();
-      manager.syncTransitionCallbacks({ onTransitionEnd });
+      const onCSSTransitionEnd = jest.fn();
+      manager.syncTransitionCallbacks({ onCSSTransitionEnd });
 
       cssCallbacksRegistry.dispatch([
         event('transitionEnd', { name: 'opacity', elapsedTime: 0.3 }),
       ]);
 
-      expect(onTransitionEnd).toHaveBeenCalledWith({
+      expect(onCSSTransitionEnd).toHaveBeenCalledWith({
         propertyName: 'opacity',
         elapsedTime: 0.3,
       });
@@ -86,10 +86,10 @@ describe('CSSCallbacksManager', () => {
 
     test('routes every animation event type to its own callback', () => {
       const callbacks = {
-        onAnimationStart: jest.fn(),
-        onAnimationEnd: jest.fn(),
-        onAnimationIteration: jest.fn(),
-        onAnimationCancel: jest.fn(),
+        onCSSAnimationStart: jest.fn(),
+        onCSSAnimationEnd: jest.fn(),
+        onCSSAnimationIteration: jest.fn(),
+        onCSSAnimationCancel: jest.fn(),
       };
       manager.syncAnimationCallbacks(callbacks);
 
@@ -100,18 +100,18 @@ describe('CSSCallbacksManager', () => {
         event('animationCancel'),
       ]);
 
-      expect(callbacks.onAnimationStart).toHaveBeenCalledTimes(1);
-      expect(callbacks.onAnimationEnd).toHaveBeenCalledTimes(1);
-      expect(callbacks.onAnimationIteration).toHaveBeenCalledTimes(1);
-      expect(callbacks.onAnimationCancel).toHaveBeenCalledTimes(1);
+      expect(callbacks.onCSSAnimationStart).toHaveBeenCalledTimes(1);
+      expect(callbacks.onCSSAnimationEnd).toHaveBeenCalledTimes(1);
+      expect(callbacks.onCSSAnimationIteration).toHaveBeenCalledTimes(1);
+      expect(callbacks.onCSSAnimationCancel).toHaveBeenCalledTimes(1);
     });
 
     test('routes every transition event type to its own callback', () => {
       const callbacks = {
-        onTransitionRun: jest.fn(),
-        onTransitionStart: jest.fn(),
-        onTransitionEnd: jest.fn(),
-        onTransitionCancel: jest.fn(),
+        onCSSTransitionRun: jest.fn(),
+        onCSSTransitionStart: jest.fn(),
+        onCSSTransitionEnd: jest.fn(),
+        onCSSTransitionCancel: jest.fn(),
       };
       manager.syncTransitionCallbacks(callbacks);
 
@@ -122,26 +122,26 @@ describe('CSSCallbacksManager', () => {
         event('transitionCancel'),
       ]);
 
-      expect(callbacks.onTransitionRun).toHaveBeenCalledTimes(1);
-      expect(callbacks.onTransitionStart).toHaveBeenCalledTimes(1);
-      expect(callbacks.onTransitionEnd).toHaveBeenCalledTimes(1);
-      expect(callbacks.onTransitionCancel).toHaveBeenCalledTimes(1);
+      expect(callbacks.onCSSTransitionRun).toHaveBeenCalledTimes(1);
+      expect(callbacks.onCSSTransitionStart).toHaveBeenCalledTimes(1);
+      expect(callbacks.onCSSTransitionEnd).toHaveBeenCalledTimes(1);
+      expect(callbacks.onCSSTransitionCancel).toHaveBeenCalledTimes(1);
     });
 
     test('a transition event does not reach animation callbacks', () => {
-      const onAnimationEnd = jest.fn();
-      manager.syncAnimationCallbacks({ onAnimationEnd });
+      const onCSSAnimationEnd = jest.fn();
+      manager.syncAnimationCallbacks({ onCSSAnimationEnd });
 
       cssCallbacksRegistry.dispatch([event('transitionEnd')]);
 
-      expect(onAnimationEnd).not.toHaveBeenCalled();
+      expect(onCSSAnimationEnd).not.toHaveBeenCalled();
     });
 
     test('invokes the callback from the latest sync', () => {
       const first = jest.fn();
       const second = jest.fn();
-      manager.syncAnimationCallbacks({ onAnimationEnd: first });
-      manager.syncAnimationCallbacks({ onAnimationEnd: second });
+      manager.syncAnimationCallbacks({ onCSSAnimationEnd: first });
+      manager.syncAnimationCallbacks({ onCSSAnimationEnd: second });
 
       cssCallbacksRegistry.dispatch([event('animationEnd')]);
 
@@ -150,67 +150,67 @@ describe('CSSCallbacksManager', () => {
     });
 
     test('stops delivering once the callback is removed', () => {
-      const onAnimationEnd = jest.fn();
-      manager.syncAnimationCallbacks({ onAnimationEnd });
+      const onCSSAnimationEnd = jest.fn();
+      manager.syncAnimationCallbacks({ onCSSAnimationEnd });
       manager.syncAnimationCallbacks({});
 
       cssCallbacksRegistry.dispatch([event('animationEnd')]);
 
-      expect(onAnimationEnd).not.toHaveBeenCalled();
+      expect(onCSSAnimationEnd).not.toHaveBeenCalled();
     });
 
     test('stops delivering after detach and resumes after a new sync', () => {
-      const onAnimationEnd = jest.fn();
-      manager.syncAnimationCallbacks({ onAnimationEnd });
+      const onCSSAnimationEnd = jest.fn();
+      manager.syncAnimationCallbacks({ onCSSAnimationEnd });
       manager.detach();
 
       cssCallbacksRegistry.dispatch([event('animationEnd')]);
-      expect(onAnimationEnd).not.toHaveBeenCalled();
+      expect(onCSSAnimationEnd).not.toHaveBeenCalled();
 
-      manager.syncAnimationCallbacks({ onAnimationEnd });
+      manager.syncAnimationCallbacks({ onCSSAnimationEnd });
       cssCallbacksRegistry.dispatch([event('animationEnd')]);
-      expect(onAnimationEnd).toHaveBeenCalledTimes(1);
+      expect(onCSSAnimationEnd).toHaveBeenCalledTimes(1);
     });
   });
 
   describe('registration', () => {
     test('adding a second callback does not duplicate delivery', () => {
-      const onAnimationStart = jest.fn();
+      const onCSSAnimationStart = jest.fn();
 
-      manager.syncAnimationCallbacks({ onAnimationStart });
+      manager.syncAnimationCallbacks({ onCSSAnimationStart });
       manager.syncAnimationCallbacks({
-        onAnimationStart,
-        onAnimationEnd: jest.fn(),
+        onCSSAnimationStart,
+        onCSSAnimationEnd: jest.fn(),
       });
 
       cssCallbacksRegistry.dispatch([event('animationStart')]);
 
-      expect(onAnimationStart).toHaveBeenCalledTimes(1);
+      expect(onCSSAnimationStart).toHaveBeenCalledTimes(1);
     });
 
     test('stays registered while either kind still has callbacks', () => {
-      const onTransitionEnd = jest.fn();
-      manager.syncAnimationCallbacks({ onAnimationEnd: jest.fn() });
-      manager.syncTransitionCallbacks({ onTransitionEnd });
+      const onCSSTransitionEnd = jest.fn();
+      manager.syncAnimationCallbacks({ onCSSAnimationEnd: jest.fn() });
+      manager.syncTransitionCallbacks({ onCSSTransitionEnd });
 
       manager.syncAnimationCallbacks({});
       cssCallbacksRegistry.dispatch([event('transitionEnd')]);
 
-      expect(onTransitionEnd).toHaveBeenCalledTimes(1);
+      expect(onCSSTransitionEnd).toHaveBeenCalledTimes(1);
     });
 
     test('does not register a view that has no tag yet', () => {
       const registerSpy = jest.spyOn(cssCallbacksRegistry, 'register');
       const tagless = new CSSCallbacksManager(-1);
 
-      const onAnimationEnd = jest.fn();
-      tagless.syncAnimationCallbacks({ onAnimationEnd });
+      const onCSSAnimationEnd = jest.fn();
+      tagless.syncAnimationCallbacks({ onCSSAnimationEnd });
 
       expect(registerSpy).not.toHaveBeenCalled();
       expect(tagless.getAnimationEventMask()).toBe(CSS_EVENT_MASK.animationEnd);
 
       cssCallbacksRegistry.dispatch([event('animationEnd', { tag: -1 })]);
-      expect(onAnimationEnd).not.toHaveBeenCalled();
+      expect(onCSSAnimationEnd).not.toHaveBeenCalled();
 
       registerSpy.mockRestore();
     });
@@ -220,8 +220,8 @@ describe('CSSCallbacksManager', () => {
       const inner = jest.fn();
       const otherManager = new CSSCallbacksManager(VIEW_TAG);
 
-      manager.syncAnimationCallbacks({ onAnimationEnd: outer });
-      otherManager.syncAnimationCallbacks({ onAnimationEnd: inner });
+      manager.syncAnimationCallbacks({ onCSSAnimationEnd: outer });
+      otherManager.syncAnimationCallbacks({ onCSSAnimationEnd: inner });
       manager.detach();
 
       cssCallbacksRegistry.dispatch([event('animationEnd')]);

--- a/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSManager.test.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSManager.test.ts
@@ -94,71 +94,71 @@ describe('CSSManager', () => {
     });
 
     test('delivers a native event to the provided callback', () => {
-      const onAnimationEnd = jest.fn();
-      manager.update({ ...ANIMATION, onAnimationEnd });
+      const onCSSAnimationEnd = jest.fn();
+      manager.update({ ...ANIMATION, onCSSAnimationEnd });
 
       cssCallbacksRegistry.dispatch([event('animationEnd')]);
 
-      expect(onAnimationEnd).toHaveBeenCalledWith({
+      expect(onCSSAnimationEnd).toHaveBeenCalledWith({
         animationName: 'fadeIn',
         elapsedTime: 2,
       });
     });
 
     test('starts delivering when a callback appears after the first update', () => {
-      const onAnimationEnd = jest.fn();
+      const onCSSAnimationEnd = jest.fn();
       manager.update(ANIMATION);
-      manager.update({ ...ANIMATION, onAnimationEnd });
+      manager.update({ ...ANIMATION, onCSSAnimationEnd });
 
       cssCallbacksRegistry.dispatch([event('animationEnd')]);
 
-      expect(onAnimationEnd).toHaveBeenCalledWith({
+      expect(onCSSAnimationEnd).toHaveBeenCalledWith({
         animationName: 'fadeIn',
         elapsedTime: 2,
       });
     });
 
     test('keeps delivering events while the animation detaches', () => {
-      const onAnimationCancel = jest.fn();
-      manager.update({ ...ANIMATION, onAnimationCancel });
-      manager.update({ onAnimationCancel });
+      const onCSSAnimationCancel = jest.fn();
+      manager.update({ ...ANIMATION, onCSSAnimationCancel });
+      manager.update({ onCSSAnimationCancel });
 
       cssCallbacksRegistry.dispatch([event('animationCancel')]);
 
-      expect(onAnimationCancel).toHaveBeenCalledTimes(1);
+      expect(onCSSAnimationCancel).toHaveBeenCalledTimes(1);
     });
 
     test('drops a cancel emitted for an animation removed together with its callbacks', () => {
-      const onAnimationCancel = jest.fn();
-      manager.update({ ...ANIMATION, onAnimationCancel });
+      const onCSSAnimationCancel = jest.fn();
+      manager.update({ ...ANIMATION, onCSSAnimationCancel });
       // The animation and its callbacks go away in the same update, so the
       // native side may still emit a cancel using the mask it had before.
       manager.update({});
 
       cssCallbacksRegistry.dispatch([event('animationCancel')]);
 
-      expect(onAnimationCancel).not.toHaveBeenCalled();
+      expect(onCSSAnimationCancel).not.toHaveBeenCalled();
     });
 
     test('delivers the cancel the engine emits while the view unmounts', () => {
-      const onAnimationCancel = jest.fn();
-      manager.update({ ...ANIMATION, onAnimationCancel });
+      const onCSSAnimationCancel = jest.fn();
+      manager.update({ ...ANIMATION, onCSSAnimationCancel });
       // The engine emits the cancel during cleanup, but its batch is dispatched
       // after cleanup has already returned.
       manager.unmountCleanup();
 
       cssCallbacksRegistry.dispatch([event('animationCancel')]);
 
-      expect(onAnimationCancel).toHaveBeenCalledTimes(1);
+      expect(onCSSAnimationCancel).toHaveBeenCalledTimes(1);
     });
 
     test('delivers a transition event to the provided callback', () => {
-      const onTransitionEnd = jest.fn();
+      const onCSSTransitionEnd = jest.fn();
       manager.update({
         opacity: 0,
         transitionProperty: 'opacity',
         transitionDuration: '300ms',
-        onTransitionEnd,
+        onCSSTransitionEnd,
       });
 
       cssCallbacksRegistry.dispatch([
@@ -170,7 +170,7 @@ describe('CSSManager', () => {
         },
       ]);
 
-      expect(onTransitionEnd).toHaveBeenCalledWith({
+      expect(onCSSTransitionEnd).toHaveBeenCalledWith({
         propertyName: 'opacity',
         elapsedTime: 0.3,
       });

--- a/packages/react-native-reanimated/src/css/types/animation.ts
+++ b/packages/react-native-reanimated/src/css/types/animation.ts
@@ -52,13 +52,13 @@ export type CSSAnimationCallback = (event: CSSAnimationEvent) => void;
 
 export type CSSAnimationCallbacks = {
   /** Fired when the animation starts, after any `animationDelay`. */
-  onAnimationStart?: CSSAnimationCallback;
+  onCSSAnimationStart?: CSSAnimationCallback;
   /** Fired when the animation completes. */
-  onAnimationEnd?: CSSAnimationCallback;
+  onCSSAnimationEnd?: CSSAnimationCallback;
   /** Fired at the end of each iteration except the last. */
-  onAnimationIteration?: CSSAnimationCallback;
+  onCSSAnimationIteration?: CSSAnimationCallback;
   /** Fired when the animation is interrupted before completing. */
-  onAnimationCancel?: CSSAnimationCallback;
+  onCSSAnimationCancel?: CSSAnimationCallback;
 };
 
 export type CSSAnimationCallbackProp = keyof CSSAnimationCallbacks;

--- a/packages/react-native-reanimated/src/css/types/transition.ts
+++ b/packages/react-native-reanimated/src/css/types/transition.ts
@@ -35,13 +35,13 @@ export type CSSTransitionCallback = (event: CSSTransitionEvent) => void;
 
 export type CSSTransitionCallbacks = {
   /** Fired when the transition is triggered, before any `transitionDelay`. */
-  onTransitionRun?: CSSTransitionCallback;
+  onCSSTransitionRun?: CSSTransitionCallback;
   /** Fired after `transitionDelay`, when the property starts animating. */
-  onTransitionStart?: CSSTransitionCallback;
+  onCSSTransitionStart?: CSSTransitionCallback;
   /** Fired when the transition completes. */
-  onTransitionEnd?: CSSTransitionCallback;
+  onCSSTransitionEnd?: CSSTransitionCallback;
   /** Fired when the transition is interrupted before completing. */
-  onTransitionCancel?: CSSTransitionCallback;
+  onCSSTransitionCancel?: CSSTransitionCallback;
 };
 
 export type CSSTransitionCallbackProp = keyof CSSTransitionCallbacks;

--- a/packages/react-native-reanimated/src/css/utils/__tests__/props.test.ts
+++ b/packages/react-native-reanimated/src/css/utils/__tests__/props.test.ts
@@ -556,24 +556,27 @@ describe(filterCSSAndStyleProperties, () => {
     });
 
     test('extracts callback props and keeps them out of the style object', () => {
-      const onTransitionEnd = jest.fn();
-      const onTransitionRun = jest.fn();
+      const onCSSTransitionEnd = jest.fn();
+      const onCSSTransitionRun = jest.fn();
       const style: CSSStyle = {
         width: 100,
         transitionProperty: 'opacity',
         transitionDuration: 100,
-        onTransitionRun,
-        onTransitionEnd,
+        onCSSTransitionRun,
+        onCSSTransitionEnd,
       };
 
       const [, transitionConfig, , , transitionCallbacks, filteredStyle] =
         filterCSSAndStyleProperties(style);
 
-      expect(transitionCallbacks).toEqual({ onTransitionRun, onTransitionEnd });
+      expect(transitionCallbacks).toEqual({
+        onCSSTransitionRun,
+        onCSSTransitionEnd,
+      });
       // Callbacks must not leak into the plain style nor the transition config.
       expect(filteredStyle).toEqual({ width: 100 });
-      expect(transitionConfig).not.toHaveProperty('onTransitionRun');
-      expect(transitionConfig).not.toHaveProperty('onTransitionEnd');
+      expect(transitionConfig).not.toHaveProperty('onCSSTransitionRun');
+      expect(transitionConfig).not.toHaveProperty('onCSSTransitionEnd');
     });
   });
 
@@ -590,9 +593,11 @@ describe(filterCSSAndStyleProperties, () => {
       });
 
       test('warns when transition callbacks are used without any transition props', () => {
-        filterCSSAndStyleProperties({ onTransitionEnd: jest.fn() } as CSSStyle);
+        filterCSSAndStyleProperties({
+          onCSSTransitionEnd: jest.fn(),
+        } as CSSStyle);
         expect(console.warn).toHaveBeenCalledWith(
-          expect.stringContaining('onTransitionEnd')
+          expect.stringContaining('onCSSTransitionEnd')
         );
       });
 
@@ -600,7 +605,7 @@ describe(filterCSSAndStyleProperties, () => {
         filterCSSAndStyleProperties({
           transitionProperty: 'opacity',
           transitionDuration: 100,
-          onTransitionEnd: jest.fn(),
+          onCSSTransitionEnd: jest.fn(),
         } as CSSStyle);
         expect(console.warn).not.toHaveBeenCalled();
       });
@@ -608,7 +613,7 @@ describe(filterCSSAndStyleProperties, () => {
       test('does not warn when only the transition shorthand is provided', () => {
         filterCSSAndStyleProperties({
           transition: 'opacity 2s',
-          onTransitionEnd: jest.fn(),
+          onCSSTransitionEnd: jest.fn(),
         } as CSSStyle);
         expect(console.warn).not.toHaveBeenCalled();
       });
@@ -620,7 +625,9 @@ describe(filterCSSAndStyleProperties, () => {
       });
 
       test('skips validation entirely - never warns, even without transition props', () => {
-        filterCSSAndStyleProperties({ onTransitionEnd: jest.fn() } as CSSStyle);
+        filterCSSAndStyleProperties({
+          onCSSTransitionEnd: jest.fn(),
+        } as CSSStyle);
         expect(console.warn).not.toHaveBeenCalled();
       });
     });
@@ -646,8 +653,8 @@ describe(filterCSSAndStyleProperties, () => {
     });
 
     test('extracts callback props and keeps them out of the style object', () => {
-      const onAnimationStart = jest.fn();
-      const onAnimationEnd = jest.fn();
+      const onCSSAnimationStart = jest.fn();
+      const onCSSAnimationEnd = jest.fn();
       const style: CSSStyle = {
         width: 100,
         animationName: css.keyframes({
@@ -655,18 +662,21 @@ describe(filterCSSAndStyleProperties, () => {
           to: { opacity: 1 },
         }),
         animationDuration: 100,
-        onAnimationStart,
-        onAnimationEnd,
+        onCSSAnimationStart,
+        onCSSAnimationEnd,
       };
 
       const [animationConfig, , , animationCallbacks, , filteredStyle] =
         filterCSSAndStyleProperties(style);
 
-      expect(animationCallbacks).toEqual({ onAnimationStart, onAnimationEnd });
+      expect(animationCallbacks).toEqual({
+        onCSSAnimationStart,
+        onCSSAnimationEnd,
+      });
       // Callbacks must not leak into the plain style nor the animation config.
       expect(filteredStyle).toEqual({ width: 100 });
-      expect(animationConfig).not.toHaveProperty('onAnimationStart');
-      expect(animationConfig).not.toHaveProperty('onAnimationEnd');
+      expect(animationConfig).not.toHaveProperty('onCSSAnimationStart');
+      expect(animationConfig).not.toHaveProperty('onCSSAnimationEnd');
     });
   });
 
@@ -683,9 +693,11 @@ describe(filterCSSAndStyleProperties, () => {
       });
 
       test('warns when animation callbacks are used without any animation props', () => {
-        filterCSSAndStyleProperties({ onAnimationEnd: jest.fn() } as CSSStyle);
+        filterCSSAndStyleProperties({
+          onCSSAnimationEnd: jest.fn(),
+        } as CSSStyle);
         expect(console.warn).toHaveBeenCalledWith(
-          expect.stringContaining('onAnimationEnd')
+          expect.stringContaining('onCSSAnimationEnd')
         );
       });
 
@@ -696,7 +708,7 @@ describe(filterCSSAndStyleProperties, () => {
             to: { opacity: 1 },
           }),
           animationDuration: 100,
-          onAnimationEnd: jest.fn(),
+          onCSSAnimationEnd: jest.fn(),
         } as CSSStyle);
         expect(console.warn).not.toHaveBeenCalled();
       });
@@ -705,7 +717,7 @@ describe(filterCSSAndStyleProperties, () => {
         filterCSSAndStyleProperties({
           animationName: { from: { opacity: 0 }, to: { opacity: 1 } },
           animationDuration: 100,
-          onAnimationEnd: jest.fn(),
+          onCSSAnimationEnd: jest.fn(),
         } as CSSStyle);
         expect(console.warn).not.toHaveBeenCalled();
       });
@@ -716,10 +728,10 @@ describe(filterCSSAndStyleProperties, () => {
         filterCSSAndStyleProperties({
           animationName: {},
           animationDuration: 100,
-          onAnimationEnd: jest.fn(),
+          onCSSAnimationEnd: jest.fn(),
         } as CSSStyle);
         expect(console.warn).toHaveBeenCalledWith(
-          expect.stringContaining('onAnimationEnd')
+          expect.stringContaining('onCSSAnimationEnd')
         );
       });
     });
@@ -730,7 +742,9 @@ describe(filterCSSAndStyleProperties, () => {
       });
 
       test('skips validation entirely - never warns, even without animation props', () => {
-        filterCSSAndStyleProperties({ onAnimationEnd: jest.fn() } as CSSStyle);
+        filterCSSAndStyleProperties({
+          onCSSAnimationEnd: jest.fn(),
+        } as CSSStyle);
         expect(console.warn).not.toHaveBeenCalled();
       });
     });

--- a/packages/react-native-reanimated/src/css/utils/guards.ts
+++ b/packages/react-native-reanimated/src/css/utils/guards.ts
@@ -60,10 +60,10 @@ export const isTransitionCallbackProp = (
   key: string
 ): key is CSSTransitionCallbackProp => {
   switch (key) {
-    case 'onTransitionRun':
-    case 'onTransitionStart':
-    case 'onTransitionEnd':
-    case 'onTransitionCancel':
+    case 'onCSSTransitionRun':
+    case 'onCSSTransitionStart':
+    case 'onCSSTransitionEnd':
+    case 'onCSSTransitionCancel':
       return true;
     default:
       return false;
@@ -74,10 +74,10 @@ export const isAnimationCallbackProp = (
   key: string
 ): key is CSSAnimationCallbackProp => {
   switch (key) {
-    case 'onAnimationStart':
-    case 'onAnimationEnd':
-    case 'onAnimationIteration':
-    case 'onAnimationCancel':
+    case 'onCSSAnimationStart':
+    case 'onCSSAnimationEnd':
+    case 'onCSSAnimationIteration':
+    case 'onCSSAnimationCancel':
       return true;
     default:
       return false;

--- a/packages/react-native-reanimated/src/css/web/managers/CSSAnimationsManager.ts
+++ b/packages/react-native-reanimated/src/css/web/managers/CSSAnimationsManager.ts
@@ -25,10 +25,10 @@ import { maybeAddSuffixes, parseTimingFunction } from '../utils';
 import { CSSCallbackListeners } from './CSSCallbackListeners';
 
 const ANIMATION_EVENT_NAME: Record<CSSAnimationCallbackProp, string> = {
-  onAnimationStart: 'animationstart',
-  onAnimationEnd: 'animationend',
-  onAnimationIteration: 'animationiteration',
-  onAnimationCancel: 'animationcancel',
+  onCSSAnimationStart: 'animationstart',
+  onCSSAnimationEnd: 'animationend',
+  onCSSAnimationIteration: 'animationiteration',
+  onCSSAnimationCancel: 'animationcancel',
 };
 
 const isCSSKeyframesRuleImpl = (

--- a/packages/react-native-reanimated/src/css/web/managers/CSSTransitionsManager.ts
+++ b/packages/react-native-reanimated/src/css/web/managers/CSSTransitionsManager.ts
@@ -13,10 +13,10 @@ import { maybeAddSuffixes, parseTimingFunction } from '../utils';
 import { CSSCallbackListeners } from './CSSCallbackListeners';
 
 const TRANSITION_EVENT_NAME: Record<CSSTransitionCallbackProp, string> = {
-  onTransitionRun: 'transitionrun',
-  onTransitionStart: 'transitionstart',
-  onTransitionEnd: 'transitionend',
-  onTransitionCancel: 'transitioncancel',
+  onCSSTransitionRun: 'transitionrun',
+  onCSSTransitionStart: 'transitionstart',
+  onCSSTransitionEnd: 'transitionend',
+  onCSSTransitionCancel: 'transitioncancel',
 };
 
 export default class CSSTransitionsManager implements ICSSTransitionsManager {

--- a/packages/react-native-reanimated/src/css/web/managers/__tests__/CSSAnimationsManager.web.test.ts
+++ b/packages/react-native-reanimated/src/css/web/managers/__tests__/CSSAnimationsManager.web.test.ts
@@ -183,7 +183,7 @@ describe('CSSAnimationsManager (web)', () => {
       const addSpy = jest.spyOn(element, 'addEventListener');
       const removeSpy = jest.spyOn(element, 'removeEventListener');
 
-      manager.update(animation(), { onAnimationEnd: jest.fn() });
+      manager.update(animation(), { onCSSAnimationEnd: jest.fn() });
       expect(addSpy).toHaveBeenCalledWith('animationend', expect.any(Function));
 
       // Removing the callback on the next update must detach the exact same
@@ -196,10 +196,10 @@ describe('CSSAnimationsManager (web)', () => {
       const addSpy = jest.spyOn(element, 'addEventListener');
 
       manager.update(animation(), {
-        onAnimationStart: jest.fn(),
-        onAnimationEnd: jest.fn(),
-        onAnimationIteration: jest.fn(),
-        onAnimationCancel: jest.fn(),
+        onCSSAnimationStart: jest.fn(),
+        onCSSAnimationEnd: jest.fn(),
+        onCSSAnimationIteration: jest.fn(),
+        onCSSAnimationCancel: jest.fn(),
       });
 
       for (const eventName of [
@@ -213,14 +213,14 @@ describe('CSSAnimationsManager (web)', () => {
     });
 
     test('forwards the animationName and elapsedTime when the event fires', () => {
-      const onAnimationEnd = jest.fn();
-      manager.update(animation(), { onAnimationEnd });
+      const onCSSAnimationEnd = jest.fn();
+      manager.update(animation(), { onCSSAnimationEnd });
 
       element.dispatchEvent(
         animationEvent('animationend', 'my-animation', 0.3)
       );
 
-      expect(onAnimationEnd).toHaveBeenCalledWith({
+      expect(onCSSAnimationEnd).toHaveBeenCalledWith({
         animationName: 'my-animation',
         elapsedTime: 0.3,
       });
@@ -229,13 +229,13 @@ describe('CSSAnimationsManager (web)', () => {
     test('ignores events that bubble up from descendant nodes', () => {
       const child = document.createElement('div');
       element.appendChild(child);
-      const onAnimationEnd = jest.fn();
-      manager.update(animation(), { onAnimationEnd });
+      const onCSSAnimationEnd = jest.fn();
+      manager.update(animation(), { onCSSAnimationEnd });
 
       // The event bubbles from the child to the element's listener.
       child.dispatchEvent(animationEvent('animationend', 'my-animation', 0.1));
 
-      expect(onAnimationEnd).not.toHaveBeenCalled();
+      expect(onCSSAnimationEnd).not.toHaveBeenCalled();
     });
 
     test('uses the latest callback without re-subscribing on re-render', () => {
@@ -243,8 +243,8 @@ describe('CSSAnimationsManager (web)', () => {
       const first = jest.fn();
       const second = jest.fn();
 
-      manager.update(animation(), { onAnimationEnd: first });
-      manager.update(animation(), { onAnimationEnd: second });
+      manager.update(animation(), { onCSSAnimationEnd: first });
+      manager.update(animation(), { onCSSAnimationEnd: second });
 
       const endSubscriptions = addSpy.mock.calls.filter(
         ([eventName]) => eventName === 'animationend'
@@ -263,8 +263,8 @@ describe('CSSAnimationsManager (web)', () => {
       const removeSpy = jest.spyOn(element, 'removeEventListener');
 
       manager.update(animation(), {
-        onAnimationStart: jest.fn(),
-        onAnimationEnd: jest.fn(),
+        onCSSAnimationStart: jest.fn(),
+        onCSSAnimationEnd: jest.fn(),
       });
       manager.unmountCleanup();
 

--- a/packages/react-native-reanimated/src/css/web/managers/__tests__/CSSTransitionsManager.web.test.ts
+++ b/packages/react-native-reanimated/src/css/web/managers/__tests__/CSSTransitionsManager.web.test.ts
@@ -87,7 +87,7 @@ describe('CSSTransitionsManager (web)', () => {
       const addSpy = jest.spyOn(element, 'addEventListener');
       const removeSpy = jest.spyOn(element, 'removeEventListener');
 
-      manager.update(transition(), { onTransitionEnd: jest.fn() });
+      manager.update(transition(), { onCSSTransitionEnd: jest.fn() });
       expect(addSpy).toHaveBeenCalledWith(
         'transitionend',
         expect.any(Function)
@@ -103,10 +103,10 @@ describe('CSSTransitionsManager (web)', () => {
       const addSpy = jest.spyOn(element, 'addEventListener');
 
       manager.update(transition(), {
-        onTransitionRun: jest.fn(),
-        onTransitionStart: jest.fn(),
-        onTransitionEnd: jest.fn(),
-        onTransitionCancel: jest.fn(),
+        onCSSTransitionRun: jest.fn(),
+        onCSSTransitionStart: jest.fn(),
+        onCSSTransitionEnd: jest.fn(),
+        onCSSTransitionCancel: jest.fn(),
       });
 
       for (const eventName of [
@@ -120,14 +120,14 @@ describe('CSSTransitionsManager (web)', () => {
     });
 
     test('forwards a camelCased propertyName and elapsedTime when the event fires', () => {
-      const onTransitionEnd = jest.fn();
-      manager.update(transition(), { onTransitionEnd });
+      const onCSSTransitionEnd = jest.fn();
+      manager.update(transition(), { onCSSTransitionEnd });
 
       element.dispatchEvent(
         transitionEvent('transitionend', 'background-color', 0.3)
       );
 
-      expect(onTransitionEnd).toHaveBeenCalledWith({
+      expect(onCSSTransitionEnd).toHaveBeenCalledWith({
         propertyName: 'backgroundColor',
         elapsedTime: 0.3,
       });
@@ -136,13 +136,13 @@ describe('CSSTransitionsManager (web)', () => {
     test('ignores events that bubble up from descendant nodes', () => {
       const child = document.createElement('div');
       element.appendChild(child);
-      const onTransitionEnd = jest.fn();
-      manager.update(transition(), { onTransitionEnd });
+      const onCSSTransitionEnd = jest.fn();
+      manager.update(transition(), { onCSSTransitionEnd });
 
       // The event bubbles from the child to the element's listener.
       child.dispatchEvent(transitionEvent('transitionend', 'opacity', 0.1));
 
-      expect(onTransitionEnd).not.toHaveBeenCalled();
+      expect(onCSSTransitionEnd).not.toHaveBeenCalled();
     });
 
     test('uses the latest callback without re-subscribing on re-render', () => {
@@ -150,8 +150,8 @@ describe('CSSTransitionsManager (web)', () => {
       const first = jest.fn();
       const second = jest.fn();
 
-      manager.update(transition(), { onTransitionEnd: first });
-      manager.update(transition(), { onTransitionEnd: second });
+      manager.update(transition(), { onCSSTransitionEnd: first });
+      manager.update(transition(), { onCSSTransitionEnd: second });
 
       const endSubscriptions = addSpy.mock.calls.filter(
         ([eventName]) => eventName === 'transitionend'
@@ -168,8 +168,8 @@ describe('CSSTransitionsManager (web)', () => {
       const removeSpy = jest.spyOn(element, 'removeEventListener');
 
       manager.update(transition(), {
-        onTransitionStart: jest.fn(),
-        onTransitionEnd: jest.fn(),
+        onCSSTransitionStart: jest.fn(),
+        onCSSTransitionEnd: jest.fn(),
       });
       manager.unmountCleanup();
 


### PR DESCRIPTION
Renames the eight CSS lifecycle callbacks: `onAnimationStart` becomes `onCSSAnimationStart`, `onTransitionRun` becomes `onCSSTransitionRun`, and so on.