### PR TITLE
docs: fix dead Worklets installation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This repository contains two main packages:
 
 ## Installation
 
-Check out the detailed installation [instructions for Reanimated](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/#installation) and [instructions for Worklets](https://docs.swmansion.com/react-native-worklets/docs/) their dedicated documentation pages.
+Check out the detailed installation [instructions for Reanimated](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/#installation) and [instructions for Worklets](https://docs.swmansion.com/react-native-worklets/docs/fundamentals/getting-started/#installation) on their dedicated documentation pages.
 
 ## Compatibility
 


### PR DESCRIPTION
The Worklets link in the Installation section returns 404:

| Link | Status |
| --- | --- |
| `docs.swmansion.com/react-native-worklets/docs/` | 404 |
| `docs.swmansion.com/react-native-worklets/docs/fundamentals/getting-started/#installation` | 200 |

The replacement mirrors the Reanimated link in the same sentence, which already points at `docs/fundamentals/getting-started/#installation`. I checked the rendered page and the `id="installation"` anchor is present.

While in the sentence I also added the missing preposition — it read "...instructions for Worklets) their dedicated documentation pages" and now reads "...on their dedicated documentation pages". Happy to drop that part if you would rather keep the change to the link alone.

Docs-only, no code changes.