### PR TITLE
fix(worklets): stop AnimationFrameQueue when WorkletsModule is invalidated

### DIFF
--- a/packages/react-native-worklets/CHANGELOG.md
+++ b/packages/react-native-worklets/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix `AnimationFrameQueue` continuing to deliver frames after `WorkletsModule` is invalidated, which aborted the process with `JNI DETECTED ERROR IN APPLICATION: obj == null` on Android when the React instance was recreated while animations were running. ([#10278](https://github.com/software-mansion/react-native-reanimated/pull/10278) by [@shubhamdeol](https://github.com/shubhamdeol))
+- Fix a crash on Android when the React instance is recreated while animations are running - `AnimationFrameQueue` kept delivering frames after `WorkletsModule` was invalidated. ([#10278](https://github.com/software-mansion/react-native-reanimated/pull/10278) by [@shubhamdeol](https://github.com/shubhamdeol))
 
 ### 💡 Others
 

--- a/packages/react-native-worklets/CHANGELOG.md
+++ b/packages/react-native-worklets/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix `AnimationFrameQueue` continuing to deliver frames after `WorkletsModule` is invalidated, which aborted the process with `JNI DETECTED ERROR IN APPLICATION: obj == null` on Android when the React instance was recreated while animations were running. ([#PR_NUMBER](https://github.com/software-mansion/react-native-reanimated/pull/PR_NUMBER) by [@shubhamdeol](https://github.com/shubhamdeol))
+- Fix `AnimationFrameQueue` continuing to deliver frames after `WorkletsModule` is invalidated, which aborted the process with `JNI DETECTED ERROR IN APPLICATION: obj == null` on Android when the React instance was recreated while animations were running. ([#10278](https://github.com/software-mansion/react-native-reanimated/pull/10278) by [@shubhamdeol](https://github.com/shubhamdeol))
 
 ### 💡 Others
 

--- a/packages/react-native-worklets/CHANGELOG.md
+++ b/packages/react-native-worklets/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix `AnimationFrameQueue` continuing to deliver frames after `WorkletsModule` is invalidated, which aborted the process with `JNI DETECTED ERROR IN APPLICATION: obj == null` on Android when the React instance was recreated while animations were running. ([#PR_NUMBER](https://github.com/software-mansion/react-native-reanimated/pull/PR_NUMBER) by [@shubhamdeol](https://github.com/shubhamdeol))
+
 ### 💡 Others
 
 \[general] - bump Worklets version to 0.13.0

--- a/packages/react-native-worklets/android/src/main/java/com/swmansion/worklets/runloop/AnimationFrameQueue.kt
+++ b/packages/react-native-worklets/android/src/main/java/com/swmansion/worklets/runloop/AnimationFrameQueue.kt
@@ -25,6 +25,7 @@ class AnimationFrameQueue(
         }
     private val mCallbackPosted = AtomicBoolean()
     private val mPaused = AtomicBoolean()
+    private val mInvalidated = AtomicBoolean()
     private val mFrameCallbacks = mutableListOf<AnimationFrameCallback>()
 
     fun resume() {
@@ -44,8 +45,30 @@ class AnimationFrameQueue(
         }
     }
 
+    /**
+     * Permanently stops the queue. Called when the owning `WorkletsModule` is invalidated, i.e. when
+     * the React instance is being destroyed.
+     *
+     * Unlike [pause], this cannot be undone by [resume] — after this returns, no further frame is
+     * delivered and no new callback is accepted. Every [AnimationFrameCallback] holds a `HybridData`
+     * handle into native state that module teardown is about to release, so a frame delivered
+     * afterwards would call into a dead native module.
+     */
+    fun invalidate() {
+        // Unsubscribes from the Choreographer and latches mPaused, so scheduleQueueExecution()
+        // cannot post a new callback either.
+        pause()
+        synchronized(mFrameCallbacks) {
+            mInvalidated.set(true)
+            mFrameCallbacks.clear()
+        }
+    }
+
     fun requestAnimationFrame(animationFrameCallback: AnimationFrameCallback) {
         synchronized(mFrameCallbacks) {
+            if (mInvalidated.get()) {
+                return
+            }
             mFrameCallbacks.add(animationFrameCallback)
         }
         scheduleQueueExecution()

--- a/packages/react-native-worklets/android/src/main/java/com/swmansion/worklets/runloop/AnimationFrameQueue.kt
+++ b/packages/react-native-worklets/android/src/main/java/com/swmansion/worklets/runloop/AnimationFrameQueue.kt
@@ -27,6 +27,7 @@ class AnimationFrameQueue(
     private val mPaused = AtomicBoolean()
     private val mInvalidated = AtomicBoolean()
     private val mFrameCallbacks = mutableListOf<AnimationFrameCallback>()
+    private val mDispatchLock = Any()
 
     fun resume() {
         if (mPaused.getAndSet(false)) {
@@ -45,22 +46,13 @@ class AnimationFrameQueue(
         }
     }
 
-    /**
-     * Permanently stops the queue. Called when the owning `WorkletsModule` is invalidated, i.e. when
-     * the React instance is being destroyed.
-     *
-     * Unlike [pause], this cannot be undone by [resume] — after this returns, no further frame is
-     * delivered and no new callback is accepted. Every [AnimationFrameCallback] holds a `HybridData`
-     * handle into native state that module teardown is about to release, so a frame delivered
-     * afterwards would call into a dead native module.
-     */
     fun invalidate() {
-        // Unsubscribes from the Choreographer and latches mPaused, so scheduleQueueExecution()
-        // cannot post a new callback either.
-        pause()
-        synchronized(mFrameCallbacks) {
-            mInvalidated.set(true)
-            mFrameCallbacks.clear()
+        mInvalidated.set(true)
+        removePostedFrameCallback()
+        synchronized(mDispatchLock) {
+            synchronized(mFrameCallbacks) {
+                mFrameCallbacks.clear()
+            }
         }
     }
 
@@ -87,12 +79,24 @@ class AnimationFrameQueue(
 
     private fun scheduleQueueExecution() {
         synchronized(mPaused) {
+            if (mInvalidated.get()) {
+                return
+            }
             if (!mPaused.get() && !mCallbackPosted.getAndSet(true)) {
                 mReactChoreographer.postFrameCallback(
                     ReactChoreographer.CallbackType.NATIVE_ANIMATED_MODULE,
                     mChoreographerCallback,
                 )
             }
+        }
+    }
+
+    private fun removePostedFrameCallback() {
+        if (mCallbackPosted.getAndSet(false)) {
+            mReactChoreographer.removeFrameCallback(
+                ReactChoreographer.CallbackType.NATIVE_ANIMATED_MODULE,
+                mChoreographerCallback,
+            )
         }
     }
 
@@ -106,12 +110,17 @@ class AnimationFrameQueue(
             return
         }
 
-        val frameCallbacks = pullCallbacks()
-        mCallbackPosted.set(false)
+        synchronized(mDispatchLock) {
+            val frameCallbacks = pullCallbacks()
+            mCallbackPosted.set(false)
+            if (mInvalidated.get()) {
+                return
+            }
 
-        lastFrameTimeMs = currentFrameTimeMs
-        for (callback in frameCallbacks) {
-            callback.onAnimationFrame(currentFrameTimeMs)
+            lastFrameTimeMs = currentFrameTimeMs
+            for (callback in frameCallbacks) {
+                callback.onAnimationFrame(currentFrameTimeMs)
+            }
         }
     }
 

--- a/packages/react-native-worklets/android/src/networking/com/swmansion/worklets/WorkletsModule.kt
+++ b/packages/react-native-worklets/android/src/networking/com/swmansion/worklets/WorkletsModule.kt
@@ -171,9 +171,6 @@ class WorkletsModule(
             mInvalidated = true
             reactApplicationContext.removeLifecycleEventListener(this)
         }
-        // Must run before invalidateCpp(). The queued callbacks reach into the native module that
-        // invalidateCpp() tears down, and removing the lifecycle event listener above means
-        // onHostPause() can no longer stop the frame loop for us.
         mAnimationFrameQueue.invalidate()
         if (mHybridData != null && mHybridData!!.isValid) {
             invalidateCpp()

--- a/packages/react-native-worklets/android/src/networking/com/swmansion/worklets/WorkletsModule.kt
+++ b/packages/react-native-worklets/android/src/networking/com/swmansion/worklets/WorkletsModule.kt
@@ -171,6 +171,10 @@ class WorkletsModule(
             mInvalidated = true
             reactApplicationContext.removeLifecycleEventListener(this)
         }
+        // Must run before invalidateCpp(). The queued callbacks reach into the native module that
+        // invalidateCpp() tears down, and removing the lifecycle event listener above means
+        // onHostPause() can no longer stop the frame loop for us.
+        mAnimationFrameQueue.invalidate()
         if (mHybridData != null && mHybridData!!.isValid) {
             invalidateCpp()
         }

--- a/packages/react-native-worklets/android/src/no-networking/com/swmansion/worklets/WorkletsModule.kt
+++ b/packages/react-native-worklets/android/src/no-networking/com/swmansion/worklets/WorkletsModule.kt
@@ -127,9 +127,6 @@ class WorkletsModule(
             mInvalidated = true
             reactApplicationContext.removeLifecycleEventListener(this)
         }
-        // Must run before invalidateCpp(). The queued callbacks reach into the native module that
-        // invalidateCpp() tears down, and removing the lifecycle event listener above means
-        // onHostPause() can no longer stop the frame loop for us.
         mAnimationFrameQueue.invalidate()
         if (mHybridData != null && mHybridData!!.isValid) {
             invalidateCpp()

--- a/packages/react-native-worklets/android/src/no-networking/com/swmansion/worklets/WorkletsModule.kt
+++ b/packages/react-native-worklets/android/src/no-networking/com/swmansion/worklets/WorkletsModule.kt
@@ -127,6 +127,10 @@ class WorkletsModule(
             mInvalidated = true
             reactApplicationContext.removeLifecycleEventListener(this)
         }
+        // Must run before invalidateCpp(). The queued callbacks reach into the native module that
+        // invalidateCpp() tears down, and removing the lifecycle event listener above means
+        // onHostPause() can no longer stop the frame loop for us.
+        mAnimationFrameQueue.invalidate()
         if (mHybridData != null && mHybridData!!.isValid) {
             invalidateCpp()
         }


### PR DESCRIPTION
> [!NOTE]
> This pull request was authored by AI on behalf of @shubhamdeol.

Related: #7659, #9449, #9450.

## Summary

On Android, `WorkletsModule.invalidate()` tore down the C++ side and the UI scheduler but never stopped `mAnimationFrameQueue`, so the frames that followed teardown ran worklet rAF callbacks against native state that had just been released, and aborted the process.

```
Abort message: 'JNI DETECTED ERROR IN APPLICATION: obj == null
    in call to CallLongMethodV
    from void com.swmansion.worklets.runloop.AnimationFrameCallback.onAnimationFrame(double)'
```

I gave `AnimationFrameQueue` a terminal `invalidate()` that drops every queued callback and rejects later `requestAnimationFrame()` calls, and called it from `WorkletsModule.invalidate()` before `invalidateCpp()` in both the `networking` and `no-networking` source sets.

Dropping the queue is not enough on its own, because `invalidate()` runs on the React instance teardown thread rather than the UI thread and can land while the Choreographer is dispatching a batch that `pullCallbacks()` has already copied out, so `executeQueue()` now dispatches under a lock that `invalidate()` also takes.

`invalidate()` does not go through `pause()`, because `pause()` calls into `ReactChoreographer` while holding the `mPaused` monitor and `ReactChoreographer` holds its own monitor across the whole frame dispatch, which would invert the lock order against the UI thread; it removes the posted frame callback with no lock held instead, and `scheduleQueueExecution()` refuses to post once the queue is invalidated.

## Test plan

Reproducing needs a React instance recreated in place, not a cold start, while worklet rAF callbacks are in flight. Render a few always-animating views, then reload:

```tsx
const progress = useSharedValue(0);
useEffect(() => {
  progress.value = withRepeat(
    withTiming(1, { duration: 500, easing: Easing.inOut(Easing.ease) }),
    -1,
    true,
  );
}, []);
const style = useAnimatedStyle(() => ({ opacity: 0.25 + progress.value * 0.75 }));
// then reload: Updates.reloadAsync() / codePush.restartApp() / reactHost.reload()
```

On a physical Moto G84 (Android 15, arm64, release build), the unpatched build aborted within one or two reloads and the patched build survived 23 consecutive reloads. The animations matter: 40 reloads on a static screen never reproduced it.

Those runs covered the first two commits. The teardown-thread synchronisation in 1d908bc has not been re-run on a device.

## Changelog

- [x] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.
