### PR TITLE
fix(CSS): interpolate values with the context they declare

### DIFF
--- a/packages/react-native-reanimated/CHANGELOG.md
+++ b/packages/react-native-reanimated/CHANGELOG.md
@@ -12,5 +12,6 @@
 
 - Fix `EXC_BAD_ACCESS` crash in `-[REANodesManager performOperations]` when called before the `_performOperations` block is registered on iOS. ([#10229](https://github.com/software-mansion/react-native-reanimated/pull/10229) by [@tomekzaw](https://github.com/tomekzaw))
 - Fix missing unmount of ancestors of animated components with exiting animations in experimental Layout Animations Proxy ([#10103](https://github.com/software-mansion/react-native-reanimated/pull/10103) by [@pawicao](https://github.com/pawicao))
+- Fix crash when a CSS animation or transition runs between two keyword values on a property that also accepts relative lengths, such as `width` going from `auto` to `auto`. ([#10281](https://github.com/software-mansion/react-native-reanimated/pull/10281) by [@MatiPl01](https://github.com/MatiPl01))
 
 ### 💡 Others

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSLength.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSLength.cpp
@@ -1,4 +1,5 @@
 #include <reanimated/CSS/common/values/CSSLength.h>
+#include <reanimated/CSS/misc/ViewStylesRepository.h>
 
 #include <string>
 
@@ -69,7 +70,7 @@ std::string CSSLength::toString() const {
 CSSLength CSSLength::interpolate(
     const double progress,
     const CSSLength &to,
-    const ResolvableValueInterpolationContext &context) const {
+    const RelativeValueInterpolationContext &context) const {
   // If both value types are the same, we can interpolate without reading the
   // relative value from the shadow node
   // (also, when one of the values is 0, and the other is relative)
@@ -87,7 +88,7 @@ CSSLength CSSLength::interpolate(
   return CSSLength(resolvedFrom.value() + (resolvedTo.value() - resolvedFrom.value()) * progress);
 }
 
-std::optional<double> CSSLength::resolve(const ResolvableValueInterpolationContext &context) const {
+std::optional<double> CSSLength::resolve(const RelativeValueInterpolationContext &context) const {
   if (!isRelative) {
     return value;
   }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSLength.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSLength.h
@@ -6,7 +6,7 @@
 
 namespace reanimated::css {
 
-struct CSSLength : public CSSResolvableValue<CSSLength, double> {
+struct CSSLength : public CSSResolvableValue<CSSLength, RelativeValueInterpolationContext> {
   double value;
   bool isRelative;
 
@@ -24,9 +24,9 @@ struct CSSLength : public CSSResolvableValue<CSSLength, double> {
 
   folly::dynamic toDynamic() const override;
   std::string toString() const override;
-  CSSLength interpolate(double progress, const CSSLength &to, const ResolvableValueInterpolationContext &context)
+  CSSLength interpolate(double progress, const CSSLength &to, const RelativeValueInterpolationContext &context)
       const override;
-  std::optional<double> resolve(const ResolvableValueInterpolationContext &context) const override;
+  std::optional<double> resolve(const RelativeValueInterpolationContext &context) const;
 
   bool operator==(const CSSLength &other) const;
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSValue.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSValue.h
@@ -1,6 +1,8 @@
 #pragma once
 
-#include <reanimated/CSS/misc/ViewStylesRepository.h>
+#include <reanimated/CSS/common/definitions.h>
+
+#include <react/renderer/core/ShadowNode.h>
 
 #include <memory>
 #include <string>
@@ -11,18 +13,24 @@ namespace reanimated::css {
 
 using namespace facebook;
 
+// Held by reference only, which keeps UIManager and DOM out of every value
+// type's include graph.
+class ViewStylesRepository;
+
 enum class RelativeTo : std::uint8_t {
   Parent,
   Self,
 };
 
 struct ValueInterpolationContext {
-  const std::shared_ptr<const ShadowNode> &node;
+  const std::shared_ptr<const react::ShadowNode> &node;
   const double fallbackInterpolateThreshold;
 };
 
-struct ResolvableValueInterpolationContext {
-  const std::shared_ptr<const ShadowNode> &node;
+/// Interpolating a value that is relative to a view - e.g. a percentage
+/// length against its parent - needs the view's styles as well as the node.
+struct RelativeValueInterpolationContext {
+  const std::shared_ptr<const react::ShadowNode> &node;
   const double fallbackInterpolateThreshold;
   const std::shared_ptr<ViewStylesRepository> &viewStylesRepository;
   const std::string &relativeProperty;
@@ -58,20 +66,17 @@ struct CSSSimpleValue : public CSSValue {
 };
 
 // Base for leaf values that need resolution before interpolation
-template <typename TDerived, typename TResolved = TDerived>
+template <typename TDerived, typename TContext>
 struct CSSResolvableValue : public CSSValue {
   static constexpr bool is_resolvable_value = true;
+  using ContextType = TContext;
 
   bool operator==(const CSSValue &other) const override {
     return typeid(*this) == typeid(other) &&
         *static_cast<const TDerived *>(this) == static_cast<const TDerived &>(other);
   }
 
-  virtual TDerived interpolate(double progress, const TDerived &to, const ResolvableValueInterpolationContext &context)
-      const = 0;
-  virtual std::optional<TResolved> resolve(const ResolvableValueInterpolationContext &context) const {
-    return std::nullopt;
-  }
+  virtual TDerived interpolate(double progress, const TDerived &to, const TContext &context) const = 0;
   virtual bool canInterpolateTo(const TDerived &to) const {
     return true;
   }
@@ -84,6 +89,25 @@ concept Resolvable = requires {
   { TCSSValue::is_resolvable_value } -> std::convertible_to<bool>;
   requires TCSSValue::is_resolvable_value == true;
 };
+
+/// The context needed to interpolate these types together: the resolvable
+/// one's, or the plain context when none of them resolve.
+template <typename... TCSSValues>
+struct InterpolationContext {
+  using Type = ValueInterpolationContext;
+};
+
+template <Resolvable TCSSValue, typename... TRest>
+struct InterpolationContext<TCSSValue, TRest...> {
+  using Type = typename TCSSValue::ContextType;
+};
+
+template <typename... TCSSValues>
+using InterpolationContextFor = typename InterpolationContext<TCSSValues...>::Type;
+
+/// Values that need no context at all satisfy this trivially.
+template <typename TCSSValue, typename TContext>
+concept InterpolatesWith = !Resolvable<TCSSValue> || std::is_same_v<typename TCSSValue::ContextType, TContext>;
 
 // Checks if a type is a discrete value
 template <typename TCSSValue>

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSValue.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSValue.h
@@ -90,11 +90,17 @@ concept Resolvable = requires {
   requires TCSSValue::is_resolvable_value == true;
 };
 
-/// The context needed to interpolate these types together: the resolvable
-/// one's, or the plain context when none of them resolve.
+/// The context needed to interpolate these types together: the one declared by
+/// the resolvable alternative, wherever it sits in the list, or the plain
+/// context when none of them resolve.
 template <typename... TCSSValues>
 struct InterpolationContext {
   using Type = ValueInterpolationContext;
+};
+
+template <typename TCSSValue, typename... TRest>
+struct InterpolationContext<TCSSValue, TRest...> {
+  using Type = typename InterpolationContext<TRest...>::Type;
 };
 
 template <Resolvable TCSSValue, typename... TRest>

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSValueVariant.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSValueVariant.cpp
@@ -99,7 +99,7 @@ template <CSSValueDerived... AllowedTypes>
 CSSValueVariant<AllowedTypes...> CSSValueVariant<AllowedTypes...>::interpolate(
     const double progress,
     const CSSValueVariant &to,
-    const ValueInterpolationContext &context) const {
+    const InterpolationContextFor<AllowedTypes...> &context) const {
   if (storage_.index() != to.storage_.index()) {
     return fallbackInterpolate(progress, to, context.fallbackInterpolateThreshold);
   }
@@ -107,34 +107,12 @@ CSSValueVariant<AllowedTypes...> CSSValueVariant<AllowedTypes...>::interpolate(
   return std::visit(
       [&](const auto &fromValue, const auto &toValue) -> CSSValueVariant {
         REA_IF_SAME_TYPE(fromValue, toValue) {
-          if constexpr (Resolvable<L>) {
-            throw std::runtime_error("[Reanimated] Resolvable value cannot be interpolated as non-resolvable");
-          } else if (fromValue.canInterpolateTo(toValue)) {
-            return CSSValueVariant(fromValue.interpolate(progress, toValue));
-          }
-        }
-        return fallbackInterpolate(progress, to, context.fallbackInterpolateThreshold);
-      },
-      storage_,
-      to.storage_);
-}
-
-template <CSSValueDerived... AllowedTypes>
-CSSValueVariant<AllowedTypes...> CSSValueVariant<AllowedTypes...>::interpolate(
-    const double progress,
-    const CSSValueVariant &to,
-    const ResolvableValueInterpolationContext &context) const {
-  if (storage_.index() != to.storage_.index()) {
-    return fallbackInterpolate(progress, to, context.fallbackInterpolateThreshold);
-  }
-
-  return std::visit(
-      [&](const auto &fromValue, const auto &toValue) -> CSSValueVariant {
-        REA_IF_SAME_TYPE(fromValue, toValue) {
-          if constexpr (!Resolvable<L>) {
-            throw std::runtime_error("[Reanimated] Non-resolvable value cannot be interpolated as resolvable");
-          } else if (fromValue.canInterpolateTo(toValue)) {
-            return CSSValueVariant(fromValue.interpolate(progress, toValue, context));
+          if (fromValue.canInterpolateTo(toValue)) {
+            if constexpr (requires { fromValue.interpolate(progress, toValue, context); }) {
+              return CSSValueVariant(fromValue.interpolate(progress, toValue, context));
+            } else {
+              return CSSValueVariant(fromValue.interpolate(progress, toValue));
+            }
           }
         }
         return fallbackInterpolate(progress, to, context.fallbackInterpolateThreshold);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSValueVariant.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSValueVariant.h
@@ -89,8 +89,8 @@ class CSSValueVariant final : public CSSValue {
 
   static_assert(
       (InterpolatesWith<AllowedTypes, InterpolationContextFor<AllowedTypes...>> && ...),
-      "A resolvable value type must be listed first - the variant takes its interpolation context from the "
-      "first alternative (e.g. <CSSLength, CSSKeyword> rather than <CSSKeyword, CSSLength>).");
+      "Alternatives may be listed in any order, but the resolvable ones must all declare the same interpolation "
+      "context - a variant cannot mix value types that resolve against different things.");
 
   CSSValueVariant interpolate(
       const double progress,

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSValueVariant.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSValueVariant.h
@@ -87,19 +87,15 @@ class CSSValueVariant final : public CSSValue {
   folly::dynamic toDynamic() const override;
   std::string toString() const override;
 
-  /**
-   * Interpolate (non-resolvable)
-   */
-  CSSValueVariant
-  interpolate(const double progress, const CSSValueVariant &to, const ValueInterpolationContext &context) const;
+  static_assert(
+      (InterpolatesWith<AllowedTypes, InterpolationContextFor<AllowedTypes...>> && ...),
+      "A resolvable value type must be listed first - the variant takes its interpolation context from the "
+      "first alternative (e.g. <CSSLength, CSSKeyword> rather than <CSSKeyword, CSSLength>).");
 
-  /**
-   * Interpolate (resolvable)
-   */
   CSSValueVariant interpolate(
       const double progress,
       const CSSValueVariant &to,
-      const ResolvableValueInterpolationContext &context) const;
+      const InterpolationContextFor<AllowedTypes...> &context) const;
 
  private:
   std::variant<AllowedTypes...> storage_;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformOperationInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformOperationInterpolator.cpp
@@ -164,8 +164,7 @@ std::unique_ptr<StyleOperation> TransformOperationInterpolator<TOperation>::inte
   const auto &fromOp = *std::static_pointer_cast<TOperation>(from);
   const auto &toOp = *std::static_pointer_cast<TOperation>(to);
 
-  return std::make_unique<TOperation>(
-      fromOp.value.interpolate(progress, toOp.value, getResolvableValueContext(context)));
+  return std::make_unique<TOperation>(fromOp.value.interpolate(progress, toOp.value, getRelativeValueContext(context)));
 }
 
 template <ResolvableOp TOperation>
@@ -173,7 +172,7 @@ std::shared_ptr<StyleOperation> TransformOperationInterpolator<TOperation>::reso
     const std::shared_ptr<StyleOperation> &operation,
     const StyleOperationsInterpolationContext &context) const {
   const auto &resolvableOp = std::static_pointer_cast<TOperation>(operation);
-  const auto &resolved = resolvableOp->value.resolve(getResolvableValueContext(context));
+  const auto &resolved = resolvableOp->value.resolve(getRelativeValueContext(context));
 
   if (!resolved.has_value()) {
     throw std::invalid_argument(
@@ -185,9 +184,9 @@ std::shared_ptr<StyleOperation> TransformOperationInterpolator<TOperation>::reso
 }
 
 template <ResolvableOp TOperation>
-ResolvableValueInterpolationContext TransformOperationInterpolator<TOperation>::getResolvableValueContext(
+RelativeValueInterpolationContext TransformOperationInterpolator<TOperation>::getRelativeValueContext(
     const StyleOperationsInterpolationContext &context) const {
-  return ResolvableValueInterpolationContext{
+  return RelativeValueInterpolationContext{
       .node = context.node,
       .fallbackInterpolateThreshold = context.fallbackInterpolateThreshold,
       .viewStylesRepository = context.viewStylesRepository,

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformOperationInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformOperationInterpolator.h
@@ -79,8 +79,7 @@ class TransformOperationInterpolator<TOperation> : public StyleOperationInterpol
  protected:
   const ResolvableValueInterpolatorConfig config_;
 
-  ResolvableValueInterpolationContext getResolvableValueContext(
-      const StyleOperationsInterpolationContext &context) const;
+  RelativeValueInterpolationContext getRelativeValueContext(const StyleOperationsInterpolationContext &context) const;
 };
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/ResolvableValueInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/ResolvableValueInterpolator.cpp
@@ -35,11 +35,12 @@ folly::dynamic ResolvableValueInterpolator<AllowedTypes...>::interpolateValue(
       ->interpolate(
           progress,
           *to,
-          {.node = context.node,
-           .fallbackInterpolateThreshold = context.fallbackInterpolateThreshold,
-           .viewStylesRepository = this->viewStylesRepository_,
-           .relativeProperty = config_.relativeProperty,
-           .relativeTo = config_.relativeTo})
+          RelativeValueInterpolationContext{
+              .node = context.node,
+              .fallbackInterpolateThreshold = context.fallbackInterpolateThreshold,
+              .viewStylesRepository = this->viewStylesRepository_,
+              .relativeProperty = config_.relativeProperty,
+              .relativeTo = config_.relativeTo})
       .toDynamic();
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/SimpleValueInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/SimpleValueInterpolator.cpp
@@ -46,9 +46,17 @@ folly::dynamic SimpleValueInterpolator<AllowedTypes...>::interpolateValue(
     const std::shared_ptr<CSSValue> &fromValue,
     const std::shared_ptr<CSSValue> &toValue,
     const ValueInterpolationContext &context) const {
-  const auto &from = std::static_pointer_cast<ValueType>(fromValue);
-  const auto &to = std::static_pointer_cast<ValueType>(toValue);
-  return from->interpolate(progress, *to, context).toDynamic();
+  if constexpr (std::is_same_v<InterpolationContextFor<AllowedTypes...>, ValueInterpolationContext>) {
+    const auto &from = std::static_pointer_cast<ValueType>(fromValue);
+    const auto &to = std::static_pointer_cast<ValueType>(toValue);
+    return from->interpolate(progress, *to, context).toDynamic();
+  } else {
+    // Only instantiated as ResolvableValueInterpolator's base, which overrides
+    // this and can build the context these values ask for.
+    throw std::runtime_error(
+        "[Reanimated] Cannot interpolate " + fromValue->toString() + " to " + toValue->toString() +
+        ": this property is registered with an interpolator that cannot supply the context these values need");
+  }
 }
 
 template class SimpleValueInterpolator<CSSLength>;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/CSSLengthArray.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/CSSLengthArray.cpp
@@ -10,7 +10,7 @@ namespace reanimated::css {
 CSSLengthArray CSSLengthArray::interpolate(
     double progress,
     const CSSLengthArray &to,
-    const ResolvableValueInterpolationContext &context) const {
+    const RelativeValueInterpolationContext &context) const {
   // Treat an empty list as a single zero.
   static const std::vector<CSSLength> fallback{CSSLength(0.0)};
   const auto &fromLengths = values.empty() ? fallback : values;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/CSSLengthArray.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/CSSLengthArray.h
@@ -14,7 +14,7 @@ struct CSSLengthArray : public CSSLengthVector<CSSLengthArray> {
   CSSLengthArray interpolate(
       double progress,
       const CSSLengthArray &to,
-      const ResolvableValueInterpolationContext &context) const override;
+      const RelativeValueInterpolationContext &context) const override;
 
 #ifndef NDEBUG
   friend std::ostream &operator<<(std::ostream &os, const CSSLengthArray &value);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/CSSLengthVector.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/CSSLengthVector.h
@@ -8,7 +8,7 @@
 namespace reanimated::css {
 
 template <typename Derived>
-struct CSSLengthVector : public CSSResolvableValue<Derived> {
+struct CSSLengthVector : public CSSResolvableValue<Derived, RelativeValueInterpolationContext> {
   std::vector<CSSLength> values;
 
   CSSLengthVector() = default;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/SVGStrokeDashArray.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/SVGStrokeDashArray.cpp
@@ -8,7 +8,7 @@ namespace reanimated::css {
 SVGStrokeDashArray SVGStrokeDashArray::interpolate(
     double progress,
     const SVGStrokeDashArray &to,
-    const ResolvableValueInterpolationContext &context) const {
+    const RelativeValueInterpolationContext &context) const {
   std::vector<CSSLength> result;
   auto fromValues = values;
   auto toValues = to.values;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/SVGStrokeDashArray.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/SVGStrokeDashArray.h
@@ -10,7 +10,7 @@ struct SVGStrokeDashArray : public CSSLengthVector<SVGStrokeDashArray> {
   SVGStrokeDashArray interpolate(
       double progress,
       const SVGStrokeDashArray &to,
-      const ResolvableValueInterpolationContext &context) const override;
+      const RelativeValueInterpolationContext &context) const override;
 
   folly::dynamic toDynamic() const override;
 


### PR DESCRIPTION
Fixes an uncaught throw that kills the app when a CSS animation or transition interpolates between two keyword values on a property that also accepts relative lengths:

```jsx
animationName: { from: { width: 'auto' }, to: { width: 'auto' } }  // crashes on main
```

```
libc++abi: terminating due to uncaught exception of type std::runtime_error:
[Reanimated] Non-resolvable value cannot be interpolated as resolvable
```

It hits every property registered with a keyword alternative - `width`, `height`, `top`, `bottom`, `flexBasis`, all `margin*` and `padding*`, and the SVG `cx`, `cy`, `r`, `rx`, `ry`, `strokeDasharray`.

The cause is that values came in exactly two fixed kinds, plain and "resolvable" (which really meant "relative to a view property"), and `CSSValueVariant::interpolate` had one overload per kind, chosen by asking whether *any* alternative was resolvable. A variant holding both kinds, as in `value<CSSLength, CSSKeyword>("auto", {RelativeTo::Parent, "width"})`, always took the resolvable overload - which threw the moment both endpoints turned out to be the plain `CSSKeyword`. Endpoints sitting in *different* alternatives were never affected: both overloads already fell back for those.

Now each value type declares the interpolation context its `interpolate` needs and the variant derives its own from its alternatives, so there is a single overload and nothing left to pick wrong. Alternatives may be listed in any order; the only rule the compiler enforces is that the resolvable ones agree on a context. `ResolvableValueInterpolationContext` becomes `RelativeValueInterpolationContext` to match what it actually carries, and `CSSValue.h` forward-declares `ViewStylesRepository` rather than including it, since it only names the type in a reference now.

Two same-alternative keywords now interpolate as keywords do everywhere else, switching at the midpoint, instead of throwing.

## Test plan

- On device, the snippet above aborts on `main` and animates on this branch.
- CSS examples on iOS and Android still animate as before: pixel and percentage lengths, keyword endpoints, transforms, and SVG `strokeDasharray`.
- Checked the derived context at compile time for a resolvable alternative in first, middle and last position, for no resolvable alternative, and for two resolvable alternatives that disagree.
- Jest and the static checks pass.
