### PR TITLE
fix(CSS): handle PlatformColor and DynamicColorIOS values

### DIFF
--- a/packages/react-native-reanimated/CHANGELOG.md
+++ b/packages/react-native-reanimated/CHANGELOG.md
@@ -15,5 +15,6 @@
 - Fix crash when a CSS animation or transition runs between two keyword values on a property that also accepts relative lengths, such as `width` going from `auto` to `auto`. ([#10281](https://github.com/software-mansion/react-native-reanimated/pull/10281) by [@MatiPl01](https://github.com/MatiPl01))
 - Fix Android flashes at the start of entering animations in experimental Layout Animations Proxy by temporarily setting opacity 0 at the start of an insert mutation ([#10198](https://github.com/software-mansion/react-native-reanimated/pull/10198) by [@pawicao](https://github.com/pawicao))
 - Fix layout animations getting out of sync across many simultaneously animated views ([#10317](https://github.com/software-mansion/react-native-reanimated/pull/10317) by [@pawicao](https://github.com/pawicao))
+- Fix crash when a CSS animation or transition uses a `PlatformColor` or `DynamicColorIOS` value. ([#10282](https://github.com/software-mansion/react-native-reanimated/pull/10282) by [@MatiPl01](https://github.com/MatiPl01))
 
 ### 💡 Others

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/InterpolatorRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/InterpolatorRegistry.cpp
@@ -127,7 +127,7 @@ const InterpolatorFactoriesRecord STYLE_INTERPOLATORS = {
     {"direction", value<CSSKeyword>("inherit")},
 
     // Shadow (iOS)
-    {"shadowColor", value<CSSPlatformColor, CSSColor>(BLACK)},
+    {"shadowColor", value<CSSColor, CSSPlatformColor>(BLACK)},
     {"shadowOffset", record({{"width", value<CSSDouble>(0)}, {"height", value<CSSDouble>(0)}})},
     {"shadowRadius", value<CSSDouble>(0)},
     {"shadowOpacity", value<CSSDouble>(1)},
@@ -170,33 +170,33 @@ const InterpolatorFactoriesRecord STYLE_INTERPOLATORS = {
 
     // View
     {"backfaceVisibility", value<CSSKeyword>("visible")},
-    {"backgroundColor", value<CSSPlatformColor, CSSColor>(TRANSPARENT)},
-    {"borderBlockColor", value<CSSPlatformColor, CSSColor>(BLACK)},
-    {"borderBlockEndColor", value<CSSPlatformColor, CSSColor>(BLACK)},
-    {"borderBlockStartColor", value<CSSPlatformColor, CSSColor>(BLACK)},
-    {"borderBottomColor", value<CSSPlatformColor, CSSColor>(BLACK)},
+    {"backgroundColor", value<CSSColor, CSSPlatformColor>(TRANSPARENT)},
+    {"borderBlockColor", value<CSSColor, CSSPlatformColor>(BLACK)},
+    {"borderBlockEndColor", value<CSSColor, CSSPlatformColor>(BLACK)},
+    {"borderBlockStartColor", value<CSSColor, CSSPlatformColor>(BLACK)},
+    {"borderBottomColor", value<CSSColor, CSSPlatformColor>(BLACK)},
     {"borderBottomEndRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
     {"borderBottomLeftRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
     {"borderBottomRightRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
     {"borderBottomStartRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
-    {"borderColor", value<CSSPlatformColor, CSSColor>(BLACK)},
+    {"borderColor", value<CSSColor, CSSPlatformColor>(BLACK)},
     {"borderCurve", value<CSSKeyword>("circular")},
-    {"borderEndColor", value<CSSPlatformColor, CSSColor>(BLACK)},
+    {"borderEndColor", value<CSSColor, CSSPlatformColor>(BLACK)},
     {"borderEndEndRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
     {"borderEndStartRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
-    {"borderLeftColor", value<CSSPlatformColor, CSSColor>(BLACK)},
+    {"borderLeftColor", value<CSSColor, CSSPlatformColor>(BLACK)},
     {"borderRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
-    {"borderRightColor", value<CSSPlatformColor, CSSColor>(BLACK)},
-    {"borderStartColor", value<CSSPlatformColor, CSSColor>(BLACK)},
+    {"borderRightColor", value<CSSColor, CSSPlatformColor>(BLACK)},
+    {"borderStartColor", value<CSSColor, CSSPlatformColor>(BLACK)},
     {"borderStartEndRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
     {"borderStartStartRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
     {"borderStyle", value<CSSKeyword>("solid")},
-    {"borderTopColor", value<CSSPlatformColor, CSSColor>(BLACK)},
+    {"borderTopColor", value<CSSColor, CSSPlatformColor>(BLACK)},
     {"borderTopEndRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
     {"borderTopLeftRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
     {"borderTopRightRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
     {"borderTopStartRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
-    {"outlineColor", value<CSSPlatformColor, CSSColor>(BLACK)},
+    {"outlineColor", value<CSSColor, CSSPlatformColor>(BLACK)},
     {"outlineOffset", value<CSSDouble>(0)},
     {"outlineStyle", value<CSSKeyword>("solid")},
     {"outlineWidth", value<CSSDouble>(0)},
@@ -209,7 +209,7 @@ const InterpolatorFactoriesRecord STYLE_INTERPOLATORS = {
     {"mixBlendMode", value<CSSKeyword>("normal")},
 
     // Text
-    {"color", value<CSSPlatformColor, CSSColor>(BLACK)},
+    {"color", value<CSSColor, CSSPlatformColor>(BLACK)},
     {"fontFamily", value<CSSKeyword>("inherit")},
     {"fontSize", value<CSSDouble>(14)},
     {"fontStyle", value<CSSKeyword>("normal")},
@@ -218,7 +218,7 @@ const InterpolatorFactoriesRecord STYLE_INTERPOLATORS = {
     {"lineHeight", value<CSSDouble>(14)}, // TODO - should inherit from fontSize
     {"textAlign", value<CSSKeyword>("auto")},
     {"textDecorationLine", value<CSSKeyword>("none")},
-    {"textShadowColor", value<CSSPlatformColor, CSSColor>(BLACK)},
+    {"textShadowColor", value<CSSColor, CSSPlatformColor>(BLACK)},
     {"textShadowOffset", record({{"width", value<CSSDouble>(0)}, {"height", value<CSSDouble>(0)}})},
     {"textShadowRadius", value<CSSDouble>(0)},
     {"textTransform", value<CSSKeyword>("none")},
@@ -226,7 +226,7 @@ const InterpolatorFactoriesRecord STYLE_INTERPOLATORS = {
 
     // Text (iOS)
     {"fontVariant", value<CSSDiscreteArray<CSSKeyword>>(std::vector<CSSKeyword>{})},
-    {"textDecorationColor", value<CSSPlatformColor, CSSColor>(BLACK)},
+    {"textDecorationColor", value<CSSColor, CSSPlatformColor>(BLACK)},
     {"textDecorationStyle", value<CSSKeyword>("solid")},
     {"writingDirection", value<CSSKeyword>("auto")},
 
@@ -237,8 +237,8 @@ const InterpolatorFactoriesRecord STYLE_INTERPOLATORS = {
 
     // Image
     {"resizeMode", value<CSSKeyword>("cover")},
-    {"overlayColor", value<CSSPlatformColor, CSSColor>(BLACK)},
-    {"tintColor", value<CSSPlatformColor, CSSColor>(BLACK)},
+    {"overlayColor", value<CSSColor, CSSPlatformColor>(BLACK)},
+    {"tintColor", value<CSSColor, CSSPlatformColor>(BLACK)},
 };
 
 // =================

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/InterpolatorRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/InterpolatorRegistry.cpp
@@ -8,6 +8,7 @@
 #include <reanimated/CSS/common/values/CSSKeyword.h>
 #include <reanimated/CSS/common/values/CSSLength.h>
 #include <reanimated/CSS/common/values/CSSNumber.h>
+#include <reanimated/CSS/common/values/CSSPlatformColor.h>
 #include <reanimated/CSS/common/values/CSSValue.h>
 
 #include <reanimated/CSS/common/transforms/TransformMatrix2D.h>
@@ -126,7 +127,7 @@ const InterpolatorFactoriesRecord STYLE_INTERPOLATORS = {
     {"direction", value<CSSKeyword>("inherit")},
 
     // Shadow (iOS)
-    {"shadowColor", value<CSSColor>(BLACK)},
+    {"shadowColor", value<CSSPlatformColor, CSSColor>(BLACK)},
     {"shadowOffset", record({{"width", value<CSSDouble>(0)}, {"height", value<CSSDouble>(0)}})},
     {"shadowRadius", value<CSSDouble>(0)},
     {"shadowOpacity", value<CSSDouble>(1)},
@@ -169,33 +170,33 @@ const InterpolatorFactoriesRecord STYLE_INTERPOLATORS = {
 
     // View
     {"backfaceVisibility", value<CSSKeyword>("visible")},
-    {"backgroundColor", value<CSSColor>(TRANSPARENT)},
-    {"borderBlockColor", value<CSSColor>(BLACK)},
-    {"borderBlockEndColor", value<CSSColor>(BLACK)},
-    {"borderBlockStartColor", value<CSSColor>(BLACK)},
-    {"borderBottomColor", value<CSSColor>(BLACK)},
+    {"backgroundColor", value<CSSPlatformColor, CSSColor>(TRANSPARENT)},
+    {"borderBlockColor", value<CSSPlatformColor, CSSColor>(BLACK)},
+    {"borderBlockEndColor", value<CSSPlatformColor, CSSColor>(BLACK)},
+    {"borderBlockStartColor", value<CSSPlatformColor, CSSColor>(BLACK)},
+    {"borderBottomColor", value<CSSPlatformColor, CSSColor>(BLACK)},
     {"borderBottomEndRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
     {"borderBottomLeftRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
     {"borderBottomRightRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
     {"borderBottomStartRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
-    {"borderColor", value<CSSColor>(BLACK)},
+    {"borderColor", value<CSSPlatformColor, CSSColor>(BLACK)},
     {"borderCurve", value<CSSKeyword>("circular")},
-    {"borderEndColor", value<CSSColor>(BLACK)},
+    {"borderEndColor", value<CSSPlatformColor, CSSColor>(BLACK)},
     {"borderEndEndRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
     {"borderEndStartRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
-    {"borderLeftColor", value<CSSColor>(BLACK)},
+    {"borderLeftColor", value<CSSPlatformColor, CSSColor>(BLACK)},
     {"borderRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
-    {"borderRightColor", value<CSSColor>(BLACK)},
-    {"borderStartColor", value<CSSColor>(BLACK)},
+    {"borderRightColor", value<CSSPlatformColor, CSSColor>(BLACK)},
+    {"borderStartColor", value<CSSPlatformColor, CSSColor>(BLACK)},
     {"borderStartEndRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
     {"borderStartStartRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
     {"borderStyle", value<CSSKeyword>("solid")},
-    {"borderTopColor", value<CSSColor>(BLACK)},
+    {"borderTopColor", value<CSSPlatformColor, CSSColor>(BLACK)},
     {"borderTopEndRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
     {"borderTopLeftRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
     {"borderTopRightRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
     {"borderTopStartRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
-    {"outlineColor", value<CSSColor>(BLACK)},
+    {"outlineColor", value<CSSPlatformColor, CSSColor>(BLACK)},
     {"outlineOffset", value<CSSDouble>(0)},
     {"outlineStyle", value<CSSKeyword>("solid")},
     {"outlineWidth", value<CSSDouble>(0)},
@@ -208,7 +209,7 @@ const InterpolatorFactoriesRecord STYLE_INTERPOLATORS = {
     {"mixBlendMode", value<CSSKeyword>("normal")},
 
     // Text
-    {"color", value<CSSColor>(BLACK)},
+    {"color", value<CSSPlatformColor, CSSColor>(BLACK)},
     {"fontFamily", value<CSSKeyword>("inherit")},
     {"fontSize", value<CSSDouble>(14)},
     {"fontStyle", value<CSSKeyword>("normal")},
@@ -217,7 +218,7 @@ const InterpolatorFactoriesRecord STYLE_INTERPOLATORS = {
     {"lineHeight", value<CSSDouble>(14)}, // TODO - should inherit from fontSize
     {"textAlign", value<CSSKeyword>("auto")},
     {"textDecorationLine", value<CSSKeyword>("none")},
-    {"textShadowColor", value<CSSColor>(BLACK)},
+    {"textShadowColor", value<CSSPlatformColor, CSSColor>(BLACK)},
     {"textShadowOffset", record({{"width", value<CSSDouble>(0)}, {"height", value<CSSDouble>(0)}})},
     {"textShadowRadius", value<CSSDouble>(0)},
     {"textTransform", value<CSSKeyword>("none")},
@@ -225,7 +226,7 @@ const InterpolatorFactoriesRecord STYLE_INTERPOLATORS = {
 
     // Text (iOS)
     {"fontVariant", value<CSSDiscreteArray<CSSKeyword>>(std::vector<CSSKeyword>{})},
-    {"textDecorationColor", value<CSSColor>(BLACK)},
+    {"textDecorationColor", value<CSSPlatformColor, CSSColor>(BLACK)},
     {"textDecorationStyle", value<CSSKeyword>("solid")},
     {"writingDirection", value<CSSKeyword>("auto")},
 
@@ -236,8 +237,8 @@ const InterpolatorFactoriesRecord STYLE_INTERPOLATORS = {
 
     // Image
     {"resizeMode", value<CSSKeyword>("cover")},
-    {"overlayColor", value<CSSColor>(BLACK)},
-    {"tintColor", value<CSSColor>(BLACK)},
+    {"overlayColor", value<CSSPlatformColor, CSSColor>(BLACK)},
+    {"tintColor", value<CSSPlatformColor, CSSColor>(BLACK)},
 };
 
 // =================

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSPlatformColor.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSPlatformColor.cpp
@@ -1,0 +1,58 @@
+#include <reanimated/CSS/common/values/CSSPlatformColor.h>
+#include <reanimated/CSS/utils/platformColor.h>
+
+#include <folly/json.h>
+#include <jsi/JSIDynamic.h>
+
+#include <utility>
+
+namespace reanimated::css {
+
+CSSPlatformColor::CSSPlatformColor(const folly::dynamic &value)
+    : payload(std::make_shared<const folly::dynamic>(value)) {}
+
+CSSPlatformColor::CSSPlatformColor(jsi::Runtime &rt, const jsi::Value &jsiValue)
+    : CSSPlatformColor(jsi::dynamicFromValue(rt, jsiValue)) {}
+
+bool CSSPlatformColor::canConstruct(jsi::Runtime &rt, const jsi::Value &jsiValue) {
+  return isPlatformColorPayload(rt, jsiValue);
+}
+
+bool CSSPlatformColor::canConstruct(const folly::dynamic &value) {
+  return isPlatformColorPayload(value);
+}
+
+folly::dynamic CSSPlatformColor::toDynamic() const {
+  return payload ? *payload : folly::dynamic();
+}
+
+std::string CSSPlatformColor::toString() const {
+  return payload ? folly::toJson(*payload) : "";
+}
+
+CSSPlatformColor CSSPlatformColor::interpolate(
+    const double /*progress*/,
+    const CSSPlatformColor & /*to*/,
+    const ValueInterpolationContext & /*context*/) const {
+  // Resolving a payload against the view is not implemented yet, so there are
+  // no channels to blend.
+  throw std::runtime_error("[Reanimated] Animating the platform color " + toString() + " is not supported yet");
+}
+
+bool CSSPlatformColor::operator==(const CSSPlatformColor &other) const {
+  if (!payload || !other.payload) {
+    return payload == other.payload;
+  }
+  return *payload == *other.payload;
+}
+
+#ifndef NDEBUG
+
+std::ostream &operator<<(std::ostream &os, const CSSPlatformColor &color) {
+  os << "CSSPlatformColor(" << color.toString() << ")";
+  return os;
+}
+
+#endif // NDEBUG
+
+} // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSPlatformColor.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSPlatformColor.cpp
@@ -31,9 +31,10 @@ std::string CSSPlatformColor::toString() const {
 }
 
 bool CSSPlatformColor::canInterpolateTo(const CSSPlatformColor & /*to*/) const {
-  // Blending needs the payload resolved against the animated view, which isn't
-  // implemented yet, so the variant switches over instead - the same thing it
-  // does for a platform color paired with a plain one.
+  // TODO: a platform color carries no channels to blend, since the payload is
+  // only resolved once React Native applies it to a view. Two of them switch
+  // over at the fallback threshold today; they should blend like any other
+  // color once a resolved value is reachable from here.
   return false;
 }
 
@@ -41,6 +42,8 @@ CSSPlatformColor CSSPlatformColor::interpolate(
     const double progress,
     const CSSPlatformColor &to,
     const ValueInterpolationContext &context) const {
+  // Unreachable while canInterpolateTo() is false, and deliberately the same
+  // switch the variant would have applied, so behaviour holds either way.
   return progress < context.fallbackInterpolateThreshold ? *this : to;
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSPlatformColor.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSPlatformColor.cpp
@@ -30,13 +30,18 @@ std::string CSSPlatformColor::toString() const {
   return payload ? folly::toJson(*payload) : "";
 }
 
+bool CSSPlatformColor::canInterpolateTo(const CSSPlatformColor & /*to*/) const {
+  // Blending needs the payload resolved against the animated view, which isn't
+  // implemented yet, so the variant switches over instead - the same thing it
+  // does for a platform color paired with a plain one.
+  return false;
+}
+
 CSSPlatformColor CSSPlatformColor::interpolate(
-    const double /*progress*/,
-    const CSSPlatformColor & /*to*/,
-    const ValueInterpolationContext & /*context*/) const {
-  // Resolving a payload against the view is not implemented yet, so there are
-  // no channels to blend.
-  throw std::runtime_error("[Reanimated] Animating the platform color " + toString() + " is not supported yet");
+    const double progress,
+    const CSSPlatformColor &to,
+    const ValueInterpolationContext &context) const {
+  return progress < context.fallbackInterpolateThreshold ? *this : to;
 }
 
 bool CSSPlatformColor::operator==(const CSSPlatformColor &other) const {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSPlatformColor.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSPlatformColor.h
@@ -25,6 +25,7 @@ struct CSSPlatformColor : public CSSResolvableValue<CSSPlatformColor, ValueInter
   folly::dynamic toDynamic() const override;
   std::string toString() const override;
 
+  bool canInterpolateTo(const CSSPlatformColor &to) const override;
   CSSPlatformColor interpolate(double progress, const CSSPlatformColor &to, const ValueInterpolationContext &context)
       const override;
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSPlatformColor.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSPlatformColor.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <reanimated/CSS/common/values/CSSColor.h>
+#include <reanimated/CSS/common/values/CSSValue.h>
+
+#include <memory>
+#include <string>
+
+namespace reanimated::css {
+
+/// A PlatformColor or DynamicColorIOS payload, kept unresolved so toDynamic()
+/// hands it back to RN, which resolves it against the surface's own theme.
+/// Resolving one here needs the animated view, since keyframes are shared by
+/// every view using an animation.
+struct CSSPlatformColor : public CSSResolvableValue<CSSPlatformColor, ValueInterpolationContext> {
+  std::shared_ptr<const folly::dynamic> payload;
+
+  CSSPlatformColor() = default;
+  explicit CSSPlatformColor(const folly::dynamic &value);
+  explicit CSSPlatformColor(jsi::Runtime &rt, const jsi::Value &jsiValue);
+
+  static bool canConstruct(jsi::Runtime &rt, const jsi::Value &jsiValue);
+  static bool canConstruct(const folly::dynamic &value);
+
+  folly::dynamic toDynamic() const override;
+  std::string toString() const override;
+
+  CSSPlatformColor interpolate(double progress, const CSSPlatformColor &to, const ValueInterpolationContext &context)
+      const override;
+
+  bool operator==(const CSSPlatformColor &other) const;
+
+#ifndef NDEBUG
+  friend std::ostream &operator<<(std::ostream &os, const CSSPlatformColor &color);
+#endif // NDEBUG
+};
+
+} // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSPlatformColor.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSPlatformColor.h
@@ -10,8 +10,11 @@ namespace reanimated::css {
 
 /// A PlatformColor or DynamicColorIOS payload, kept unresolved so toDynamic()
 /// hands it back to RN, which resolves it against the surface's own theme.
-/// Resolving one here needs the animated view, since keyframes are shared by
-/// every view using an animation.
+///
+/// TODO: nothing resolves a payload yet, so this is resolvable in name only. It
+/// is declared that way because blending needs the payload turned into channels
+/// for the view being animated, and keyframes are shared by every view using an
+/// animation - so the value cannot be resolved once and cached on the keyframe.
 struct CSSPlatformColor : public CSSResolvableValue<CSSPlatformColor, ValueInterpolationContext> {
   std::shared_ptr<const folly::dynamic> payload;
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSValue.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSValue.h
@@ -115,6 +115,11 @@ using InterpolationContextFor = typename InterpolationContext<TCSSValues...>::Ty
 template <typename TCSSValue, typename TContext>
 concept InterpolatesWith = !Resolvable<TCSSValue> || std::is_same_v<typename TCSSValue::ContextType, TContext>;
 
+/// Unlike InterpolatesWith, this demands the value actually resolve, and with
+/// this exact context.
+template <typename TCSSValue, typename TContext>
+concept ResolvesWith = Resolvable<TCSSValue> && std::is_same_v<typename TCSSValue::ContextType, TContext>;
+
 // Checks if a type is a discrete value
 template <typename TCSSValue>
 concept Discrete = requires {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSValueVariant.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSValueVariant.cpp
@@ -139,7 +139,6 @@ template class CSSValueVariant<CSSIndex>;
 template class CSSValueVariant<CSSKeyword>;
 template class CSSValueVariant<CSSAngle>;
 template class CSSValueVariant<CSSBoolean>;
-template class CSSValueVariant<CSSColor>;
 template class CSSValueVariant<CSSColor, CSSPlatformColor>;
 template class CSSValueVariant<CSSDisplay>;
 template class CSSValueVariant<CSSBoxShadow>;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSValueVariant.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSValueVariant.cpp
@@ -5,6 +5,7 @@
 #include <reanimated/CSS/common/values/CSSKeyword.h>
 #include <reanimated/CSS/common/values/CSSLength.h>
 #include <reanimated/CSS/common/values/CSSNumber.h>
+#include <reanimated/CSS/common/values/CSSPlatformColor.h>
 #include <reanimated/CSS/common/values/CSSValueVariant.h>
 #include <reanimated/CSS/common/values/complex/CSSBoxShadow.h>
 #include <reanimated/CSS/svg/values/CSSLengthArray.h>
@@ -139,6 +140,7 @@ template class CSSValueVariant<CSSKeyword>;
 template class CSSValueVariant<CSSAngle>;
 template class CSSValueVariant<CSSBoolean>;
 template class CSSValueVariant<CSSColor>;
+template class CSSValueVariant<CSSPlatformColor, CSSColor>;
 template class CSSValueVariant<CSSDisplay>;
 template class CSSValueVariant<CSSBoxShadow>;
 template class CSSValueVariant<CSSDiscreteArray<CSSKeyword>>;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSValueVariant.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSValueVariant.cpp
@@ -140,7 +140,7 @@ template class CSSValueVariant<CSSKeyword>;
 template class CSSValueVariant<CSSAngle>;
 template class CSSValueVariant<CSSBoolean>;
 template class CSSValueVariant<CSSColor>;
-template class CSSValueVariant<CSSPlatformColor, CSSColor>;
+template class CSSValueVariant<CSSColor, CSSPlatformColor>;
 template class CSSValueVariant<CSSDisplay>;
 template class CSSValueVariant<CSSBoxShadow>;
 template class CSSValueVariant<CSSDiscreteArray<CSSKeyword>>;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/InterpolatorFactory.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/InterpolatorFactory.h
@@ -126,7 +126,8 @@ auto value(const auto &defaultValue, RelativeValueInterpolatorConfig config) -> 
     (std::is_constructible_v<AllowedTypes, decltype(defaultValue)> || ...),
     std::shared_ptr<PropertyInterpolatorFactory>> {
   static_assert(
-      (InterpolatesWith<AllowedTypes, RelativeValueInterpolationContext> && ...) && (Resolvable<AllowedTypes> || ...),
+      (InterpolatesWith<AllowedTypes, RelativeValueInterpolationContext> && ...) &&
+          (ResolvesWith<AllowedTypes, RelativeValueInterpolationContext> || ...),
       "This overload is for value types that resolve against a relative property (e.g. CSSLength). Types that "
       "resolve against something else, or that need no resolution at all, use the value(defaultValue) overload.");
   // Create a concrete CSSValue from the defaultValue

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/InterpolatorFactory.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/InterpolatorFactory.h
@@ -10,7 +10,7 @@
 #include <reanimated/CSS/interpolation/transforms/TransformOperation.h>
 #include <reanimated/CSS/interpolation/transforms/TransformOperationInterpolator.h>
 #include <reanimated/CSS/interpolation/transforms/TransformsStyleInterpolator.h>
-#include <reanimated/CSS/interpolation/values/ResolvableValueInterpolator.h>
+#include <reanimated/CSS/interpolation/values/RelativeValueInterpolator.h>
 #include <reanimated/CSS/interpolation/values/SimpleValueInterpolator.h>
 
 #include <memory>
@@ -50,10 +50,10 @@ class SimpleValueInterpolatorFactory : public PropertyInterpolatorFactory {
 };
 
 template <typename... AllowedTypes>
-class ResolvableValueInterpolatorFactory : public PropertyInterpolatorFactory {
+class RelativeValueInterpolatorFactory : public PropertyInterpolatorFactory {
  public:
   template <typename TValue>
-  explicit ResolvableValueInterpolatorFactory(const TValue &defaultValue, ResolvableValueInterpolatorConfig config)
+  explicit RelativeValueInterpolatorFactory(const TValue &defaultValue, RelativeValueInterpolatorConfig config)
       : PropertyInterpolatorFactory(), defaultValue_(defaultValue), config_(std::move(config)) {}
 
   const CSSValue &getDefaultValue() const override {
@@ -63,13 +63,13 @@ class ResolvableValueInterpolatorFactory : public PropertyInterpolatorFactory {
   std::shared_ptr<PropertyInterpolator> create(
       const PropertyPath &propertyPath,
       const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) const override {
-    return std::make_shared<ResolvableValueInterpolator<AllowedTypes...>>(
+    return std::make_shared<RelativeValueInterpolator<AllowedTypes...>>(
         propertyPath, defaultValue_, viewStylesRepository, config_);
   }
 
  private:
   const CSSValueVariant<AllowedTypes...> defaultValue_;
-  ResolvableValueInterpolatorConfig config_;
+  RelativeValueInterpolatorConfig config_;
 };
 
 /**
@@ -114,25 +114,24 @@ auto value(const auto &defaultValue) -> std::enable_if_t<
     std::shared_ptr<PropertyInterpolatorFactory>> {
   static_assert(
       (InterpolatesWith<AllowedTypes, ValueInterpolationContext> && ...),
-      "Value types resolving against a relative property (e.g. CSSLength) need "
-      "a ResolvableValueInterpolatorConfig — use the value(defaultValue, "
-      "{RelativeTo::..., \"...\"}) overload instead");
+      "Value types that resolve against a relative property (e.g. CSSLength) need a "
+      "RelativeValueInterpolatorConfig - use the value(defaultValue, {RelativeTo::..., \"...\"}) overload instead");
   // Create a concrete CSSValue from the defaultValue
   auto cssValue = createCSSValue<AllowedTypes...>(defaultValue);
   return std::make_shared<SimpleValueInterpolatorFactory<AllowedTypes...>>(std::move(cssValue));
 }
 
 template <typename... AllowedTypes>
-auto value(const auto &defaultValue, ResolvableValueInterpolatorConfig config) -> std::enable_if_t<
+auto value(const auto &defaultValue, RelativeValueInterpolatorConfig config) -> std::enable_if_t<
     (std::is_constructible_v<AllowedTypes, decltype(defaultValue)> || ...),
     std::shared_ptr<PropertyInterpolatorFactory>> {
   static_assert(
-      (Resolvable<AllowedTypes> || ...),
-      "None of the value types are resolvable — use the value(defaultValue) "
-      "overload without ResolvableValueInterpolatorConfig instead");
+      (InterpolatesWith<AllowedTypes, RelativeValueInterpolationContext> && ...) && (Resolvable<AllowedTypes> || ...),
+      "This overload is for value types that resolve against a relative property (e.g. CSSLength). Types that "
+      "resolve against something else, or that need no resolution at all, use the value(defaultValue) overload.");
   // Create a concrete CSSValue from the defaultValue
   auto cssValue = createCSSValue<AllowedTypes...>(defaultValue);
-  return std::make_shared<ResolvableValueInterpolatorFactory<AllowedTypes...>>(std::move(cssValue), std::move(config));
+  return std::make_shared<RelativeValueInterpolatorFactory<AllowedTypes...>>(std::move(cssValue), std::move(config));
 }
 
 /**
@@ -146,7 +145,7 @@ auto transformOp(const auto &defaultValue) -> std::enable_if_t<
 }
 
 template <typename TOperation>
-auto transformOp(const auto &defaultValue, ResolvableValueInterpolatorConfig config) -> std::enable_if_t<
+auto transformOp(const auto &defaultValue, RelativeValueInterpolatorConfig config) -> std::enable_if_t<
     std::is_base_of_v<TransformOperation, TOperation> && std::is_constructible_v<TOperation, decltype(defaultValue)> &&
         ResolvableOp<TOperation>,
     std::shared_ptr<StyleOperationInterpolator>> {
@@ -165,7 +164,7 @@ auto filterOp(const auto &defaultValue) -> std::enable_if_t<
 }
 
 template <typename TOperation>
-auto filterOp(const auto &defaultValue, ResolvableValueInterpolatorConfig config) -> std::enable_if_t<
+auto filterOp(const auto &defaultValue, RelativeValueInterpolatorConfig config) -> std::enable_if_t<
     std::is_base_of_v<FilterOperation, TOperation> && std::is_constructible_v<TOperation, decltype(defaultValue)> &&
         ResolvableOp<TOperation>,
     std::shared_ptr<StyleOperationInterpolator>> {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/InterpolatorFactory.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/InterpolatorFactory.h
@@ -113,9 +113,9 @@ auto value(const auto &defaultValue) -> std::enable_if_t<
     (std::is_constructible_v<AllowedTypes, decltype(defaultValue)> || ...),
     std::shared_ptr<PropertyInterpolatorFactory>> {
   static_assert(
-      !(Resolvable<AllowedTypes> || ...),
-      "Resolvable value types (e.g. CSSLength) require a "
-      "ResolvableValueInterpolatorConfig — use the value(defaultValue, "
+      (InterpolatesWith<AllowedTypes, ValueInterpolationContext> && ...),
+      "Value types resolving against a relative property (e.g. CSSLength) need "
+      "a ResolvableValueInterpolatorConfig — use the value(defaultValue, "
       "{RelativeTo::..., \"...\"}) overload instead");
   // Create a concrete CSSValue from the defaultValue
   auto cssValue = createCSSValue<AllowedTypes...>(defaultValue);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/configs.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/configs.h
@@ -7,14 +7,14 @@
 
 namespace reanimated::css {
 
-struct ResolvableValueInterpolatorConfig {
+struct RelativeValueInterpolatorConfig {
   RelativeTo relativeTo;
   std::string relativeProperty;
 
-  ResolvableValueInterpolatorConfig(RelativeTo relativeTo, std::string relativeProperty)
+  RelativeValueInterpolatorConfig(RelativeTo relativeTo, std::string relativeProperty)
       : relativeTo(relativeTo), relativeProperty(std::move(relativeProperty)) {}
 
-  ResolvableValueInterpolatorConfig() = default;
+  RelativeValueInterpolatorConfig() = default;
 };
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformOperationInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformOperationInterpolator.cpp
@@ -152,7 +152,7 @@ template TransformMatrix3D TransformOperationInterpolator<MatrixOperation>::inte
 template <ResolvableOp TOperation>
 TransformOperationInterpolator<TOperation>::TransformOperationInterpolator(
     const std::shared_ptr<TOperation> &defaultOperation,
-    ResolvableValueInterpolatorConfig config)
+    RelativeValueInterpolatorConfig config)
     : StyleOperationInterpolator(defaultOperation), config_(std::move(config)) {}
 
 template <ResolvableOp TOperation>

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformOperationInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformOperationInterpolator.h
@@ -64,7 +64,7 @@ class TransformOperationInterpolator<TOperation> : public StyleOperationInterpol
  public:
   TransformOperationInterpolator(
       const std::shared_ptr<TOperation> &defaultOperation,
-      ResolvableValueInterpolatorConfig config);
+      RelativeValueInterpolatorConfig config);
 
   std::unique_ptr<StyleOperation> interpolate(
       double progress,
@@ -77,7 +77,7 @@ class TransformOperationInterpolator<TOperation> : public StyleOperationInterpol
       const StyleOperationsInterpolationContext &context) const override;
 
  protected:
-  const ResolvableValueInterpolatorConfig config_;
+  const RelativeValueInterpolatorConfig config_;
 
   RelativeValueInterpolationContext getRelativeValueContext(const StyleOperationsInterpolationContext &context) const;
 };

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/RelativeValueInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/RelativeValueInterpolator.cpp
@@ -1,4 +1,4 @@
-#include <reanimated/CSS/interpolation/values/ResolvableValueInterpolator.h>
+#include <reanimated/CSS/interpolation/values/RelativeValueInterpolator.h>
 
 #include <folly/dynamic.h>
 #include <jsi/jsi.h>
@@ -15,16 +15,16 @@
 namespace reanimated::css {
 
 template <typename... AllowedTypes>
-ResolvableValueInterpolator<AllowedTypes...>::ResolvableValueInterpolator(
+RelativeValueInterpolator<AllowedTypes...>::RelativeValueInterpolator(
     const PropertyPath &propertyPath,
     const ValueType &defaultStyleValue,
     const std::shared_ptr<ViewStylesRepository> &viewStylesRepository,
-    const ResolvableValueInterpolatorConfig &config)
+    const RelativeValueInterpolatorConfig &config)
     : SimpleValueInterpolator<AllowedTypes...>(propertyPath, defaultStyleValue, viewStylesRepository),
       config_(config) {}
 
 template <typename... AllowedTypes>
-folly::dynamic ResolvableValueInterpolator<AllowedTypes...>::interpolateValue(
+folly::dynamic RelativeValueInterpolator<AllowedTypes...>::interpolateValue(
     double progress,
     const std::shared_ptr<CSSValue> &fromValue,
     const std::shared_ptr<CSSValue> &toValue,
@@ -44,9 +44,9 @@ folly::dynamic ResolvableValueInterpolator<AllowedTypes...>::interpolateValue(
       .toDynamic();
 }
 
-template class ResolvableValueInterpolator<CSSLength>;
-template class ResolvableValueInterpolator<CSSLength, CSSKeyword>;
-template class ResolvableValueInterpolator<CSSLengthArray>;
-template class ResolvableValueInterpolator<SVGStrokeDashArray, CSSKeyword>;
+template class RelativeValueInterpolator<CSSLength>;
+template class RelativeValueInterpolator<CSSLength, CSSKeyword>;
+template class RelativeValueInterpolator<CSSLengthArray>;
+template class RelativeValueInterpolator<SVGStrokeDashArray, CSSKeyword>;
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/RelativeValueInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/RelativeValueInterpolator.h
@@ -15,19 +15,19 @@ namespace reanimated::css {
  * can occur.
  */
 template <typename... AllowedTypes>
-class ResolvableValueInterpolator final : public SimpleValueInterpolator<AllowedTypes...> {
+class RelativeValueInterpolator final : public SimpleValueInterpolator<AllowedTypes...> {
   static_assert(
       (... && std::is_base_of<CSSValue, AllowedTypes>::value),
-      "[Reanimated] ResolvableValueInterpolator: All interpolated types must inherit from CSSValue");
+      "[Reanimated] RelativeValueInterpolator: All interpolated types must inherit from CSSValue");
 
  public:
   using ValueType = typename SimpleValueInterpolator<AllowedTypes...>::ValueType;
 
-  explicit ResolvableValueInterpolator(
+  explicit RelativeValueInterpolator(
       const PropertyPath &propertyPath,
       const ValueType &defaultStyleValue,
       const std::shared_ptr<ViewStylesRepository> &viewStylesRepository,
-      const ResolvableValueInterpolatorConfig &config);
+      const RelativeValueInterpolatorConfig &config);
 
  protected:
   folly::dynamic interpolateValue(
@@ -37,7 +37,7 @@ class ResolvableValueInterpolator final : public SimpleValueInterpolator<Allowed
       const ValueInterpolationContext &context) const override;
 
  private:
-  const ResolvableValueInterpolatorConfig &config_;
+  const RelativeValueInterpolatorConfig &config_;
 };
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/SimpleValueInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/SimpleValueInterpolator.cpp
@@ -68,7 +68,7 @@ template class SimpleValueInterpolator<CSSInteger>;
 template class SimpleValueInterpolator<CSSIndex>;
 template class SimpleValueInterpolator<CSSAngle>;
 template class SimpleValueInterpolator<CSSColor>;
-template class SimpleValueInterpolator<CSSPlatformColor, CSSColor>;
+template class SimpleValueInterpolator<CSSColor, CSSPlatformColor>;
 template class SimpleValueInterpolator<CSSBoolean>;
 template class SimpleValueInterpolator<CSSDisplay>;
 template class SimpleValueInterpolator<CSSKeyword>;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/SimpleValueInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/SimpleValueInterpolator.cpp
@@ -67,7 +67,6 @@ template class SimpleValueInterpolator<CSSDouble, CSSKeyword>;
 template class SimpleValueInterpolator<CSSInteger>;
 template class SimpleValueInterpolator<CSSIndex>;
 template class SimpleValueInterpolator<CSSAngle>;
-template class SimpleValueInterpolator<CSSColor>;
 template class SimpleValueInterpolator<CSSColor, CSSPlatformColor>;
 template class SimpleValueInterpolator<CSSBoolean>;
 template class SimpleValueInterpolator<CSSDisplay>;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/SimpleValueInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/SimpleValueInterpolator.cpp
@@ -10,6 +10,7 @@
 #include <reanimated/CSS/common/values/CSSKeyword.h>
 #include <reanimated/CSS/common/values/CSSLength.h>
 #include <reanimated/CSS/common/values/CSSNumber.h>
+#include <reanimated/CSS/common/values/CSSPlatformColor.h>
 #include <reanimated/CSS/common/values/complex/CSSBoxShadow.h>
 #include <reanimated/CSS/svg/values/CSSLengthArray.h>
 #include <reanimated/CSS/svg/values/SVGBrush.h>
@@ -67,6 +68,7 @@ template class SimpleValueInterpolator<CSSInteger>;
 template class SimpleValueInterpolator<CSSIndex>;
 template class SimpleValueInterpolator<CSSAngle>;
 template class SimpleValueInterpolator<CSSColor>;
+template class SimpleValueInterpolator<CSSPlatformColor, CSSColor>;
 template class SimpleValueInterpolator<CSSBoolean>;
 template class SimpleValueInterpolator<CSSDisplay>;
 template class SimpleValueInterpolator<CSSKeyword>;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/SimpleValueInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/SimpleValueInterpolator.cpp
@@ -52,7 +52,7 @@ folly::dynamic SimpleValueInterpolator<AllowedTypes...>::interpolateValue(
     const auto &to = std::static_pointer_cast<ValueType>(toValue);
     return from->interpolate(progress, *to, context).toDynamic();
   } else {
-    // Only instantiated as ResolvableValueInterpolator's base, which overrides
+    // Only instantiated as RelativeValueInterpolator's base, which overrides
     // this and can build the context these values ask for.
     throw std::runtime_error(
         "[Reanimated] Cannot interpolate " + fromValue->toString() + " to " + toValue->toString() +

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/platformColor.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/platformColor.cpp
@@ -1,0 +1,50 @@
+#include <reanimated/CSS/utils/platformColor.h>
+
+namespace reanimated::css {
+
+namespace {
+
+bool isArrayProperty(const folly::dynamic &value, const char *name) {
+  const auto *property = value.get_ptr(name);
+  return property != nullptr && property->isArray();
+}
+
+bool isArrayProperty(jsi::Runtime &rt, const jsi::Object &object, const char *name) {
+  const auto property = object.getProperty(rt, name);
+  return property.isObject() && property.getObject(rt).isArray(rt);
+}
+
+} // namespace
+
+bool isPlatformColorPayload(const folly::dynamic &value) {
+  if (!value.isObject()) {
+    return false;
+  }
+
+  if (isArrayProperty(value, "semantic") || isArrayProperty(value, "resource_paths")) {
+    return true;
+  }
+
+  const auto *dynamicColor = value.get_ptr("dynamic");
+  return dynamicColor != nullptr && dynamicColor->isObject();
+}
+
+bool isPlatformColorPayload(jsi::Runtime &rt, const jsi::Value &value) {
+  if (!value.isObject()) {
+    return false;
+  }
+
+  const auto object = value.getObject(rt);
+  if (object.isArray(rt) || object.isFunction(rt)) {
+    return false;
+  }
+
+  if (isArrayProperty(rt, object, "semantic") || isArrayProperty(rt, object, "resource_paths")) {
+    return true;
+  }
+
+  const auto dynamicColor = object.getProperty(rt, "dynamic");
+  return dynamicColor.isObject() && !dynamicColor.getObject(rt).isArray(rt);
+}
+
+} // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/platformColor.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/platformColor.cpp
@@ -4,6 +4,15 @@ namespace reanimated::css {
 
 namespace {
 
+bool isPlainObject(jsi::Runtime &rt, const jsi::Value &value) {
+  if (!value.isObject()) {
+    return false;
+  }
+
+  const auto object = value.getObject(rt);
+  return !object.isArray(rt) && !object.isFunction(rt);
+}
+
 bool isArrayProperty(const folly::dynamic &value, const char *name) {
   const auto *property = value.get_ptr(name);
   return property != nullptr && property->isArray();
@@ -30,21 +39,16 @@ bool isPlatformColorPayload(const folly::dynamic &value) {
 }
 
 bool isPlatformColorPayload(jsi::Runtime &rt, const jsi::Value &value) {
-  if (!value.isObject()) {
+  if (!isPlainObject(rt, value)) {
     return false;
   }
 
   const auto object = value.getObject(rt);
-  if (object.isArray(rt) || object.isFunction(rt)) {
-    return false;
-  }
-
   if (isArrayProperty(rt, object, "semantic") || isArrayProperty(rt, object, "resource_paths")) {
     return true;
   }
 
-  const auto dynamicColor = object.getProperty(rt, "dynamic");
-  return dynamicColor.isObject() && !dynamicColor.getObject(rt).isArray(rt);
+  return isPlainObject(rt, object.getProperty(rt, "dynamic"));
 }
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/platformColor.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/platformColor.h
@@ -8,8 +8,8 @@
 namespace reanimated::css {
 
 /// Matches the payload shapes RN emits for PlatformColor and DynamicColorIOS.
-/// CSSPlatformColor is tried before CSSColor, so a loose match here would
-/// swallow ordinary colors.
+/// Keep it strict: any other object should still fail to construct rather than
+/// be taken for a platform color and handed back to RN unresolved.
 bool isPlatformColorPayload(const folly::dynamic &value);
 bool isPlatformColorPayload(jsi::Runtime &rt, const jsi::Value &value);
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/platformColor.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/platformColor.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <reanimated/CSS/common/definitions.h>
+
+#include <folly/dynamic.h>
+#include <jsi/jsi.h>
+
+namespace reanimated::css {
+
+/// Matches the payload shapes RN emits for PlatformColor and DynamicColorIOS.
+/// CSSPlatformColor is tried before CSSColor, so a loose match here would
+/// swallow ordinary colors.
+bool isPlatformColorPayload(const folly::dynamic &value);
+bool isPlatformColorPayload(jsi::Runtime &rt, const jsi::Value &value);
+
+} // namespace reanimated::css


### PR DESCRIPTION
First PR of a series adding `PlatformColor` support to CSS animations. It puts the skeleton in place - the value type and the shared-code changes the layer needs to carry one - without resolving anything yet. Resolution and blending follow in #10305.

`PlatformColor` and `DynamicColorIOS` payloads are objects, but `CSSColor` accepts only numbers and bools, so a color property carrying one killed the app with `No compatible type found for construction`.

They now parse into `CSSPlatformColor`, which keeps the payload and hands it back from `toDynamic()` for React Native to resolve against the surface's theme, exactly as for a static style. Color properties accept either alternative, `value<CSSColor, CSSPlatformColor>`.

Turning a payload into channels needs the animated view, which is not implemented here, so a platform color reports that it cannot interpolate and the variant switches over instead. Nothing throws.

Shared code moves to make room for it. `CSSPlatformColor` is the first value type that resolves without being relative to a view property, a distinction the two `value()` overloads did not draw before, so `ResolvableValueInterpolator`, its config and its factory become `Relative*` to match what they actually carry, and the overload guards now separate "resolves against a relative property" from "resolves at all".

## Testing

iOS and Android build, jest and static checks pass. On the simulator: plain color ramps unchanged, static `PlatformColor` renders, and both platform-to-platform and platform-to-plain switch over with the app alive.
