### PR TITLE
refactor(Worklets): operate on variant values in Synchronizable

### DIFF
--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/JSIWorkletsModuleProxy.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/JSIWorkletsModuleProxy.cpp
@@ -22,7 +22,9 @@
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <utility>
+#include <variant>
 #include <vector>
 
 using namespace facebook;
@@ -167,6 +169,19 @@ inline std::shared_ptr<AsyncQueue> extractAsyncQueue(jsi::Runtime &rt, const jsi
   auto asyncQueue = std::dynamic_pointer_cast<AsyncQueue>(nativeState);
 
   return asyncQueue;
+}
+
+inline jsi::Value synchronizableValueToJSValue(jsi::Runtime &rt, const SynchronizableValue &value) {
+  return std::visit(
+      [&rt](const auto &alternative) -> jsi::Value {
+        using TAlternative = std::decay_t<decltype(alternative)>;
+        if constexpr (std::is_same_v<TAlternative, std::shared_ptr<Serializable>>) {
+          return alternative->toJSValue(rt);
+        } else {
+          return jsi::Value(alternative);
+        }
+      },
+      value);
 }
 
 inline void registerCustomSerializable(
@@ -606,12 +621,14 @@ jsi::Object JSIWorkletsModuleProxy::toOptimizedObject(jsi::Runtime &rt) const {
 
   jsi_utils::addMethod<1>(
       rt, obj, "synchronizableGetDirty", [](jsi::Runtime &rt, const jsi::Value &, const jsi::Value(&args)[1]) {
-        return Synchronizable::extractSynchronizableOrThrow(rt, at<0>(args))->getDirty()->toJSValue(rt);
+        return synchronizableValueToJSValue(
+            rt, Synchronizable::extractSynchronizableOrThrow(rt, at<0>(args))->getDirty());
       });
 
   jsi_utils::addMethod<1>(
       rt, obj, "synchronizableGetBlocking", [](jsi::Runtime &rt, const jsi::Value &, const jsi::Value(&args)[1]) {
-        return Synchronizable::extractSynchronizableOrThrow(rt, at<0>(args))->getBlocking()->toJSValue(rt);
+        return synchronizableValueToJSValue(
+            rt, Synchronizable::extractSynchronizableOrThrow(rt, at<0>(args))->getBlocking());
       });
 
   jsi_utils::addMethod<2>(

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Synchronizable.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Synchronizable.h
@@ -7,8 +7,12 @@
 
 #include <memory>
 #include <utility>
+#include <variant>
 
 namespace worklets {
+
+using SynchronizableValue = std::variant<std::shared_ptr<Serializable>, double, bool>;
+using SynchronizableFixedValue = std::variant<double, bool>;
 
 class Synchronizable : public SynchronizableAccess,
                        public Serializable,
@@ -30,19 +34,21 @@ class Synchronizable : public SynchronizableAccess,
   /**
    * Can run concurrently with getDirty, setDirty, getBlocking, setBlocking.
    */
-  virtual std::shared_ptr<Serializable> getDirty() = 0;
+  virtual SynchronizableValue getDirty() = 0;
 
   /**
    * Can run concurrently with getDirty, getBlocking.
    * Can't run concurrently with setDirty, setBlocking.
    */
-  virtual std::shared_ptr<Serializable> getBlocking() = 0;
+  virtual SynchronizableValue getBlocking() = 0;
 
   /**
    * Can run concurrently with getDirty.
    * Can't run concurrently with getBlocking, setDirty, setBlocking.
    */
   virtual void setBlocking(const std::shared_ptr<Serializable> &value) = 0;
+
+  virtual void setBlocking(const SynchronizableFixedValue &value) = 0;
 
   facebook::jsi::Value toJSValue(facebook::jsi::Runtime &rt) final {
     auto synchronizableUnpacker = rt.global().getProperty(rt, "__synchronizableUnpacker");

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/SynchronizableDynamic.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/SynchronizableDynamic.cpp
@@ -2,14 +2,15 @@
 
 #include <atomic>
 #include <memory>
+#include <stdexcept>
 
 namespace worklets {
 
-std::shared_ptr<Serializable> SynchronizableDynamic::getDirty() {
+SynchronizableValue SynchronizableDynamic::getDirty() {
   return std::atomic_load(&value_);
 }
 
-std::shared_ptr<Serializable> SynchronizableDynamic::getBlocking() {
+SynchronizableValue SynchronizableDynamic::getBlocking() {
   getBlockingBefore();
   auto value = std::atomic_load(&value_);
   getBlockingAfter();
@@ -20,6 +21,10 @@ void SynchronizableDynamic::setBlocking(const std::shared_ptr<Serializable> &val
   setBlockingBefore();
   std::atomic_store(&value_, value);
   setBlockingAfter();
+}
+
+void SynchronizableDynamic::setBlocking(const SynchronizableFixedValue &) {
+  throw std::runtime_error("[Worklets] Dynamic-type Synchronizable operates on Serializables, not plain values.");
 }
 
 } // namespace worklets

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/SynchronizableDynamic.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/SynchronizableDynamic.h
@@ -10,11 +10,13 @@ class SynchronizableDynamic final : public Synchronizable {
  public:
   explicit SynchronizableDynamic(const std::shared_ptr<Serializable> &value) : value_(value) {}
 
-  std::shared_ptr<Serializable> getDirty() override;
+  SynchronizableValue getDirty() override;
 
-  std::shared_ptr<Serializable> getBlocking() override;
+  SynchronizableValue getBlocking() override;
 
   void setBlocking(const std::shared_ptr<Serializable> &value) override;
+
+  void setBlocking(const SynchronizableFixedValue &value) override;
 
  private:
   std::shared_ptr<Serializable> value_;


### PR DESCRIPTION
> [!NOTE]
> **This PR description is AI-generated.**

## Summary

Depends on #10288.

A Synchronizable holding a number or a boolean doesn't need serialization at all, but the C++ interface can only speak `Serializable`. I changed the interface to operate on `std::variant` instead, so a later PR can add a subclass that stores primitives natively.

Getters return `SynchronizableValue`, which holds a `Serializable`, a `double` or a `bool`. Setters take the payload they accept - `setBlocking` has an overload for each, and `SynchronizableDynamic` throws from the plain value one. Nothing needs a `jsi::Runtime` anymore, so the conversion moved to `JSIWorkletsModuleProxy`. There are no behavior changes.

## Test plan

Existing `memory/synchronizable.test` runtime tests cover the refactor.
