### PR TITLE
feat(Worklets): add setDirty to the Synchronizable interface

### DIFF
--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Synchronizable.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Synchronizable.h
@@ -43,6 +43,12 @@ class Synchronizable : public SynchronizableAccess,
   virtual SynchronizableValue getBlocking() = 0;
 
   /**
+   * Can run concurrently with getDirty, setDirty.
+   * Can't run concurrently with getBlocking, setBlocking.
+   */
+  virtual void setDirty(const SynchronizableFixedValue &value) = 0;
+
+  /**
    * Can run concurrently with getDirty.
    * Can't run concurrently with getBlocking, setDirty, setBlocking.
    */

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/SynchronizableDynamic.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/SynchronizableDynamic.cpp
@@ -17,6 +17,11 @@ SynchronizableValue SynchronizableDynamic::getBlocking() {
   return value;
 }
 
+void SynchronizableDynamic::setDirty(const SynchronizableFixedValue &) {
+  throw std::runtime_error(
+      "[Worklets] Cannot invoke setDirty on a dynamic-type Synchronizable. Use setBlocking instead.");
+}
+
 void SynchronizableDynamic::setBlocking(const std::shared_ptr<Serializable> &value) {
   setBlockingBefore();
   std::atomic_store(&value_, value);

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/SynchronizableDynamic.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/SynchronizableDynamic.h
@@ -14,6 +14,8 @@ class SynchronizableDynamic final : public Synchronizable {
 
   SynchronizableValue getBlocking() override;
 
+  void setDirty(const SynchronizableFixedValue &value) override;
+
   void setBlocking(const std::shared_ptr<Serializable> &value) override;
 
   void setBlocking(const SynchronizableFixedValue &value) override;


### PR DESCRIPTION
> [!NOTE]
> **This PR description is AI-generated.**

## Summary

Depends on #10289.

I added `setDirty` to the `Synchronizable` interface. It's a non-exclusive write that accepts a plain value, and only a fixed-type Synchronizable can implement it, so `SynchronizableDynamic` throws.

This lands separately to keep the fixed-type implementation PR to the subclass itself. Nothing calls the method yet - it isn't exposed to JavaScript until the fixed-type Synchronizable arrives.

## Test plan

n/a - the only implementation throws.
