### PR TITLE
feat(Worklets): fixed-type Synchronizable

### DIFF
--- a/apps/common-app/runtime-tests/worklets/tests/memory/synchronizable.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/memory/synchronizable.test.tsx
@@ -1,122 +1,38 @@
 import {
-  isSynchronizable,
   createSynchronizable,
-  scheduleOnUI,
+  type FixedSynchronizable,
+  isSynchronizable,
+  runOnRuntimeSync,
   runOnUISync,
   scheduleOnRN,
-  createWorkletRuntime,
   scheduleOnRuntime,
+  scheduleOnUI,
   type Synchronizable,
-  runOnRuntimeSync,
+  type SynchronizableConfig,
   type WorkletRuntime,
 } from 'react-native-worklets';
+
 import {
   describe,
   expect,
+  getWorkletRuntimeFromPool,
   notify,
   test,
   waitForNotification,
 } from '../../../ReJest/RuntimeTestsApi';
 
 const NOTIFICATION = 'NOTIFICATION';
-const workletRuntime = createWorkletRuntime({ name: 'test' });
+const workletRuntime = getWorkletRuntimeFromPool('test');
 
-describe('Test Synchronizable creation and serialization', () => {
-  test('createSynchronizable returns Synchronizable', () => {
-    const synchronizable = createSynchronizable(0);
+type SynchronizableVariant = {
+  variantName: string;
+  config?: SynchronizableConfig;
+};
 
-    expect(isSynchronizable(synchronizable)).toBe(true);
-  });
-
-  test('Synchronizable serializes correctly from RN Runtime to UI Runtime', () => {
-    const synchronizable = createSynchronizable(0);
-    const value = runOnUISync(() => {
-      return synchronizable.getBlocking();
-    });
-
-    expect(value).toBe(0);
-  });
-
-  test('Synchronizable serializes correctly from RN Runtime to BG Runtime', async () => {
-    const synchronizable = createSynchronizable(42);
-
-    let readValue = 0;
-    const onJSCallback = (value: number) => {
-      readValue = value;
-      notify(NOTIFICATION);
-    };
-
-    // Act
-    scheduleOnRuntime(workletRuntime, () => {
-      'worklet';
-      const value = synchronizable.getBlocking();
-      scheduleOnRN(onJSCallback, value);
-    });
-    await waitForNotification(NOTIFICATION);
-
-    // Assert
-    expect(readValue).toBe(42);
-  });
-
-  test('Synchronizable serializes correctly from UI Runtime to RN runtime', () => {
-    const synchronizable = createSynchronizable(0);
-    const synchronizableCopy = runOnUISync(() => {
-      return synchronizable;
-    });
-
-    const value = synchronizableCopy.getBlocking();
-    expect(value).toBe(0);
-  });
-
-  test('Synchronizable serializes correctly from BG Runtime to RN Runtime', async () => {
-    const synchronizable = createSynchronizable(42);
-    let synchronizableCopy: Synchronizable<number>;
-
-    const onJSCallback = (value: Synchronizable<number>) => {
-      synchronizableCopy = value;
-      notify(NOTIFICATION);
-    };
-
-    // Act
-    scheduleOnRuntime(workletRuntime, () => {
-      'worklet';
-      scheduleOnRN(onJSCallback, synchronizable);
-    });
-    await waitForNotification(NOTIFICATION);
-
-    const value = synchronizableCopy!.getBlocking();
-    expect(value).toBe(42);
-  });
-
-  // TODO: This test doesn't work because nested `scheduleOnRN` isn't copied properly.
-  // It will be fixed when BundleMode™ becomes the standard.
-  // test('Synchronizable serializes correctly from UI Runtime to BG Runtime', async () => {
-  //   const synchronizable = createSynchronizable(42);
-  //   let readValue = 0;
-
-  //   const onJSCallback = (value: number) => {
-  //     readValue = value;
-  //     notify(NOTIFICATION);
-  //   };
-
-  //   // Act
-  //   const runtime = createWorkletRuntime({
-  //     name: 'test',
-  //   });
-  //   scheduleOnUI(() => {
-  //     scheduleOnRuntime(runtime, () => {
-  //       'worklet';
-  //       const value = synchronizable.getBlocking();
-  //       console.log(scheduleOnRN);
-  //       scheduleOnRN(onJSCallback)(value);
-  //     })();
-  //   })();
-
-  //   await waitForNotify(NOTIFICATION);
-
-  //   expect(readValue).toBe(42);
-  // });
-});
+const VARIANTS: SynchronizableVariant[] = [
+  { variantName: 'dynamic' },
+  { variantName: 'fixed', config: { fixedType: true } },
+];
 
 const initialValue = 0;
 
@@ -160,14 +76,14 @@ function imperativeLockGetSet(synchronizable: Synchronizable<number>) {
 }
 
 function dispatch(
-  workletRuntime: WorkletRuntime,
+  runtime: WorkletRuntime,
+  synchronizable: Synchronizable<number>,
   method: (synchronizable: Synchronizable<number>) => number,
   callbackRN: (value: number) => void,
   callbackUI: (value: number) => void,
   callbackBG: (value: number) => void
 ) {
-  const synchronizable = createSynchronizable(initialValue);
-  scheduleOnRuntime(workletRuntime, () => {
+  scheduleOnRuntime(runtime, () => {
     'worklet';
     const value = method(synchronizable);
     scheduleOnRN(callbackBG, value);
@@ -185,191 +101,197 @@ function dispatch(
   });
 }
 
-describe('Test Synchronizable access', () => {
-  test('dirty reading yields intermediate values', async () => {
-    let valueRN = 0;
-    let valueUI = 0;
-    let valueBG = 0;
+async function runDispatched(
+  config: SynchronizableConfig | undefined,
+  method: (synchronizable: Synchronizable<number>) => number
+) {
+  const values = { valueRN: 0, valueUI: 0, valueBG: 0 };
 
-    function setValueRN(value: number) {
-      valueRN = value;
-      if (valueRN > 0 && valueUI > 0 && valueBG > 0) {
-        notify(NOTIFICATION);
-      }
+  const maybeNotify = () => {
+    if (values.valueRN > 0 && values.valueUI > 0 && values.valueBG > 0) {
+      notify(NOTIFICATION);
     }
+  };
+  const setValueRN = (value: number) => {
+    values.valueRN = value;
+    maybeNotify();
+  };
+  const setValueUI = (value: number) => {
+    values.valueUI = value;
+    maybeNotify();
+  };
+  const setValueBG = (value: number) => {
+    values.valueBG = value;
+    maybeNotify();
+  };
 
-    function setValueUI(value: number) {
-      valueUI = value;
-      if (valueRN > 0 && valueUI > 0 && valueBG > 0) {
-        notify(NOTIFICATION);
-      }
-    }
+  dispatch(
+    workletRuntime,
+    createSynchronizable(initialValue, config),
+    method,
+    setValueRN,
+    setValueUI,
+    setValueBG
+  );
 
-    function setValueBG(value: number) {
-      valueBG = value;
-      if (valueRN > 0 && valueUI > 0 && valueBG > 0) {
-        notify(NOTIFICATION);
-      }
-    }
+  await waitForNotification(NOTIFICATION);
 
-    dispatch(
-      workletRuntime,
-      getDirtySetBlocking,
-      setValueRN,
-      setValueUI,
-      setValueBG
-    );
+  return values;
+}
 
-    await waitForNotification(NOTIFICATION);
+for (const { variantName, config } of VARIANTS) {
+  describe(`Test Synchronizable creation and serialization (${variantName})`, () => {
+    test('createSynchronizable returns Synchronizable', () => {
+      const synchronizable = createSynchronizable(0, config);
 
-    expect(valueRN).toBeWithinRange(initialValue + 1, targetValue * 3 - 1);
-    expect(valueUI).toBeWithinRange(initialValue + 1, targetValue * 3 - 1);
-    expect(valueBG).toBeWithinRange(initialValue + 1, targetValue * 3 - 1);
-  });
-
-  test('blocking reading yields intermediate values', async () => {
-    let valueRN = 0;
-    let valueUI = 0;
-    let valueBG = 0;
-
-    function setValueRN(value: number) {
-      valueRN = value;
-      if (valueRN > 0 && valueUI > 0 && valueBG > 0) {
-        notify(NOTIFICATION);
-      }
-    }
-
-    function setValueUI(value: number) {
-      valueUI = value;
-      if (valueRN > 0 && valueUI > 0 && valueBG > 0) {
-        notify(NOTIFICATION);
-      }
-    }
-
-    function setValueBG(value: number) {
-      valueBG = value;
-      if (valueRN > 0 && valueUI > 0 && valueBG > 0) {
-        notify(NOTIFICATION);
-      }
-    }
-
-    dispatch(
-      workletRuntime,
-      getBlockingSetBlocking,
-      setValueRN,
-      setValueUI,
-      setValueBG
-    );
-
-    await waitForNotification(NOTIFICATION);
-
-    expect(valueRN).toBeWithinRange(initialValue + 1, targetValue * 3 - 1);
-    expect(valueUI).toBeWithinRange(initialValue + 1, targetValue * 3 - 1);
-    expect(valueBG).toBeWithinRange(initialValue + 1, targetValue * 3 - 1);
-  });
-
-  test('transaction reading is atomic', async () => {
-    let valueRN = 0;
-    let valueUI = 0;
-    let valueBG = 0;
-
-    function setValueRN(value: number) {
-      valueRN = value;
-      if (valueRN > 0 && valueUI > 0 && valueBG > 0) {
-        notify(NOTIFICATION);
-      }
-    }
-
-    function setValueUI(value: number) {
-      valueUI = value;
-      if (valueRN > 0 && valueUI > 0 && valueBG > 0) {
-        notify(NOTIFICATION);
-      }
-    }
-
-    function setValueBG(value: number) {
-      valueBG = value;
-      if (valueRN > 0 && valueUI > 0 && valueBG > 0) {
-        notify(NOTIFICATION);
-      }
-    }
-
-    dispatch(
-      workletRuntime,
-      transactionGetSet,
-      setValueRN,
-      setValueUI,
-      setValueBG
-    );
-
-    await waitForNotification(NOTIFICATION);
-
-    expect(Math.max(valueRN, valueUI, valueBG)).toBe(targetValue * 3);
-  });
-
-  test('imperative locking reading is atomic', async () => {
-    let valueRN = 0;
-    let valueUI = 0;
-    let valueBG = 0;
-
-    function setValueRN(value: number) {
-      valueRN = value;
-      if (valueRN > 0 && valueUI > 0 && valueBG > 0) {
-        notify(NOTIFICATION);
-      }
-    }
-
-    function setValueUI(value: number) {
-      valueUI = value;
-      if (valueRN > 0 && valueUI > 0 && valueBG > 0) {
-        notify(NOTIFICATION);
-      }
-    }
-
-    function setValueBG(value: number) {
-      valueBG = value;
-      if (valueRN > 0 && valueUI > 0 && valueBG > 0) {
-        notify(NOTIFICATION);
-      }
-    }
-
-    dispatch(
-      workletRuntime,
-      imperativeLockGetSet,
-      setValueRN,
-      setValueUI,
-      setValueBG
-    );
-
-    await waitForNotification(NOTIFICATION);
-
-    expect(Math.max(valueRN, valueUI, valueBG)).toBe(targetValue * 3);
-  });
-});
-
-describe('Test Synchronizable serialization', () => {
-  test('Synchronizable accepts primitives', () => {
-    const synchronizable = createSynchronizable(0);
-
-    // RN Runtime
-    synchronizable.setBlocking(1);
-    expect(synchronizable.getBlocking()).toBe(1);
-
-    // UI Runtime
-    runOnUISync(() => {
-      'worklet';
-      synchronizable.setBlocking(2);
+      expect(isSynchronizable(synchronizable)).toBe(true);
     });
-    expect(synchronizable.getBlocking()).toBe(2);
 
-    // Worker Runtime
-    runOnRuntimeSync(workletRuntime, () => {
-      'worklet';
-      synchronizable.setBlocking(3);
+    test('Synchronizable serializes correctly from RN Runtime to UI Runtime', () => {
+      const synchronizable = createSynchronizable(0, config);
+      const value = runOnUISync(() => {
+        return synchronizable.getBlocking();
+      });
+
+      expect(value).toBe(0);
     });
-    expect(synchronizable.getBlocking()).toBe(3);
+
+    test('Synchronizable serializes correctly from RN Runtime to BG Runtime', async () => {
+      const synchronizable = createSynchronizable(42, config);
+
+      let readValue = 0;
+      const onJSCallback = (value: number) => {
+        readValue = value;
+        notify(NOTIFICATION);
+      };
+
+      // Act
+      scheduleOnRuntime(workletRuntime, () => {
+        'worklet';
+        const value = synchronizable.getBlocking();
+        scheduleOnRN(onJSCallback, value);
+      });
+      await waitForNotification(NOTIFICATION);
+
+      // Assert
+      expect(readValue).toBe(42);
+    });
+
+    test('Synchronizable serializes correctly from UI Runtime to RN runtime', () => {
+      const synchronizable = createSynchronizable(0, config);
+      const synchronizableCopy = runOnUISync(() => {
+        return synchronizable;
+      });
+
+      const value = synchronizableCopy.getBlocking();
+      expect(value).toBe(0);
+    });
+
+    test('Synchronizable serializes correctly from BG Runtime to RN Runtime', async () => {
+      const synchronizable = createSynchronizable(42, config);
+      let synchronizableCopy: Synchronizable<number>;
+
+      const onJSCallback = (value: Synchronizable<number>) => {
+        synchronizableCopy = value;
+        notify(NOTIFICATION);
+      };
+
+      // Act
+      scheduleOnRuntime(workletRuntime, () => {
+        'worklet';
+        scheduleOnRN(onJSCallback, synchronizable);
+      });
+      await waitForNotification(NOTIFICATION);
+
+      const value = synchronizableCopy!.getBlocking();
+      expect(value).toBe(42);
+    });
+
+    // TODO: There is no test for serialization from UI Runtime to BG Runtime
+    // because nested `scheduleOnRN` isn't copied properly.
+    // It will be fixed when BundleMode™ becomes the standard.
   });
 
+  describe(`Test Synchronizable access (${variantName})`, () => {
+    // The three runtimes can complete their loops without overlapping,
+    // keeping every update.
+    const intermediateUpperBound = targetValue * 3;
+
+    test('dirty reading yields intermediate values', async () => {
+      const { valueRN, valueUI, valueBG } = await runDispatched(
+        config,
+        getDirtySetBlocking
+      );
+
+      expect(valueRN).toBeWithinRange(initialValue + 1, intermediateUpperBound);
+      expect(valueUI).toBeWithinRange(initialValue + 1, intermediateUpperBound);
+      expect(valueBG).toBeWithinRange(initialValue + 1, intermediateUpperBound);
+    });
+
+    test('blocking reading yields intermediate values', async () => {
+      const { valueRN, valueUI, valueBG } = await runDispatched(
+        config,
+        getBlockingSetBlocking
+      );
+
+      expect(valueRN).toBeWithinRange(initialValue + 1, intermediateUpperBound);
+      expect(valueUI).toBeWithinRange(initialValue + 1, intermediateUpperBound);
+      expect(valueBG).toBeWithinRange(initialValue + 1, intermediateUpperBound);
+    });
+
+    test('transaction reading is atomic', async () => {
+      const { valueRN, valueUI, valueBG } = await runDispatched(
+        config,
+        transactionGetSet
+      );
+
+      expect(Math.max(valueRN, valueUI, valueBG)).toBe(targetValue * 3);
+    });
+
+    test('imperative locking reading is atomic', async () => {
+      const { valueRN, valueUI, valueBG } = await runDispatched(
+        config,
+        imperativeLockGetSet
+      );
+
+      expect(Math.max(valueRN, valueUI, valueBG)).toBe(targetValue * 3);
+    });
+  });
+
+  describe(`Test Synchronizable serialization (${variantName})`, () => {
+    test('Synchronizable accepts primitives', () => {
+      const synchronizable = createSynchronizable(0, config);
+
+      // RN Runtime
+      synchronizable.setBlocking(1);
+      expect(synchronizable.getBlocking()).toBe(1);
+
+      // UI Runtime
+      runOnUISync(() => {
+        'worklet';
+        synchronizable.setBlocking(2);
+      });
+      expect(synchronizable.getBlocking()).toBe(2);
+
+      // Worker Runtime
+      runOnRuntimeSync(workletRuntime, () => {
+        'worklet';
+        synchronizable.setBlocking(3);
+      });
+      expect(synchronizable.getBlocking()).toBe(3);
+    });
+
+    test('functional setBlocking updates the value', () => {
+      const synchronizable = createSynchronizable(1, config);
+
+      synchronizable.setBlocking((prev) => prev + 41);
+
+      expect(synchronizable.getBlocking()).toBe(42);
+    });
+  });
+}
+
+describe('Test dynamic Synchronizable serialization', () => {
   test('Synchronizable accepts objects', () => {
     const synchronizable = createSynchronizable({ a: 0 });
 
@@ -391,4 +313,263 @@ describe('Test Synchronizable serialization', () => {
     });
     expect(synchronizable.getBlocking().a).toBe(3);
   });
+
+  test('dynamic Synchronizable has no setDirty', () => {
+    const synchronizable = createSynchronizable(0);
+
+    expect('setDirty' in synchronizable).toBe(false);
+  });
+});
+
+describe('Test fixed-type Synchronizable creation', () => {
+  test('createSynchronizable with fixedType returns FixedSynchronizable', () => {
+    const synchronizable = createSynchronizable(0, { fixedType: true });
+
+    expect(isSynchronizable(synchronizable)).toBe(true);
+    expect(typeof synchronizable.setDirty).toBe('function');
+  });
+
+  test('fixed number keeps its initial value', () => {
+    const synchronizable = createSynchronizable(42, { fixedType: true });
+
+    expect(synchronizable.getDirty()).toBe(42);
+    expect(synchronizable.getBlocking()).toBe(42);
+  });
+
+  test('fixed boolean keeps its type', () => {
+    const synchronizable = createSynchronizable(true, { fixedType: true });
+
+    expect(typeof synchronizable.getDirty()).toBe('boolean');
+    expect(typeof synchronizable.getBlocking()).toBe('boolean');
+    expect(synchronizable.getDirty()).toBe(true);
+
+    synchronizable.setDirty(false);
+    expect(typeof synchronizable.getDirty()).toBe('boolean');
+    expect(synchronizable.getDirty()).toBe(false);
+  });
+
+  test('fixedType with an unsupported initial value throws in dev', async () => {
+    await expect(() => {
+      createSynchronizable('string' as unknown as number, {
+        fixedType: true,
+      });
+    }).toThrow(
+      '[Worklets] `fixedType` requires a number or boolean initial value.'
+    );
+  });
+});
+
+describe('Test fixed-type Synchronizable writes', () => {
+  test('setDirty is visible through getDirty and getBlocking', () => {
+    const synchronizable = createSynchronizable(0, { fixedType: true });
+
+    synchronizable.setDirty(1);
+
+    expect(synchronizable.getDirty()).toBe(1);
+    expect(synchronizable.getBlocking()).toBe(1);
+  });
+
+  test('setBlocking is visible through getDirty', () => {
+    const synchronizable = createSynchronizable(0, { fixedType: true });
+
+    synchronizable.setBlocking(2);
+
+    expect(synchronizable.getDirty()).toBe(2);
+  });
+});
+
+describe('Test fixed-type Synchronizable serialization', () => {
+  test('fixed Synchronizable works across RN, UI and Worker Runtimes', () => {
+    const synchronizable = createSynchronizable(0, { fixedType: true });
+
+    synchronizable.setDirty(1);
+    expect(synchronizable.getBlocking()).toBe(1);
+
+    runOnUISync(() => {
+      'worklet';
+      synchronizable.setDirty(2);
+    });
+    expect(synchronizable.getBlocking()).toBe(2);
+
+    runOnRuntimeSync(workletRuntime, () => {
+      'worklet';
+      synchronizable.setBlocking(3);
+    });
+    expect(synchronizable.getDirty()).toBe(3);
+  });
+
+  test('fixed boolean Synchronizable works across RN, UI and Worker Runtimes', async () => {
+    const synchronizable = createSynchronizable(false, { fixedType: true });
+
+    runOnUISync(() => {
+      'worklet';
+      synchronizable.setDirty(true);
+    });
+    expect(typeof synchronizable.getBlocking()).toBe('boolean');
+    expect(synchronizable.getBlocking()).toBe(true);
+
+    let readValue: boolean | undefined;
+    const onJSCallback = (value: boolean) => {
+      readValue = value;
+      notify(NOTIFICATION);
+    };
+
+    scheduleOnRuntime(workletRuntime, () => {
+      'worklet';
+      const value = synchronizable.getDirty();
+      synchronizable.setBlocking(false);
+      scheduleOnRN(onJSCallback, value);
+    });
+    await waitForNotification(NOTIFICATION);
+
+    expect(readValue).toBe(true);
+    expect(typeof synchronizable.getDirty()).toBe('boolean');
+    expect(synchronizable.getDirty()).toBe(false);
+  });
+
+  test('fixed Synchronizable keeps setDirty after RN to UI to RN roundtrip', () => {
+    const synchronizable = createSynchronizable(7, { fixedType: true });
+    const synchronizableCopy = runOnUISync(() => {
+      'worklet';
+      return synchronizable;
+    });
+
+    expect(typeof synchronizableCopy.setDirty).toBe('function');
+    synchronizableCopy.setDirty(8);
+    expect(synchronizable.getDirty()).toBe(8);
+  });
+
+  test('fixed Synchronizable keeps setDirty after BG to RN hop', async () => {
+    const synchronizable = createSynchronizable(42, { fixedType: true });
+    let synchronizableCopy: FixedSynchronizable<number>;
+
+    const onJSCallback = (value: FixedSynchronizable<number>) => {
+      synchronizableCopy = value;
+      notify(NOTIFICATION);
+    };
+
+    scheduleOnRuntime(workletRuntime, () => {
+      'worklet';
+      synchronizable.setDirty(43);
+      scheduleOnRN(onJSCallback, synchronizable);
+    });
+    await waitForNotification(NOTIFICATION);
+
+    expect(typeof synchronizableCopy!.setDirty).toBe('function');
+    expect(synchronizableCopy!.getBlocking()).toBe(43);
+  });
+});
+
+describe('Test fixed-type Synchronizable access', () => {
+  test('concurrent setDirty never yields torn values', async () => {
+    const synchronizable = createSynchronizable(0, { fixedType: true });
+    const evenValue = 2;
+    const oddValue = 3;
+
+    let done = false;
+    const onBGDone = () => {
+      done = true;
+    };
+
+    scheduleOnRuntime(workletRuntime, () => {
+      'worklet';
+      for (let i = 0; i < targetValue; i++) {
+        synchronizable.setDirty(oddValue);
+      }
+      scheduleOnRN(onBGDone);
+    });
+
+    scheduleOnUI(() => {
+      'worklet';
+      for (let i = 0; i < targetValue; i++) {
+        synchronizable.setDirty(evenValue);
+      }
+    });
+
+    while (!done) {
+      const observed = synchronizable.getDirty();
+      expect(
+        observed === 0 || observed === evenValue || observed === oddValue
+      ).toBe(true);
+      await new Promise((resolve) => {
+        setTimeout(resolve, 1);
+      });
+    }
+
+    const final = synchronizable.getDirty();
+    expect(final === evenValue || final === oddValue).toBe(true);
+  });
+
+  test('setDirty waits for a foreign lock', async () => {
+    const LOCK_HOLDER_DONE = 'LOCK_HOLDER_DONE';
+    const DIRTY_WRITER_DONE = 'DIRTY_WRITER_DONE';
+    const holdDurationMs = 200;
+
+    const synchronizable = createSynchronizable(0, { fixedType: true });
+    const lockTaken = createSynchronizable(false, { fixedType: true });
+
+    let lockHolderResult = { firstRead: -1, secondRead: -1, unlockedAt: -1 };
+    let dirtyWriterReturnedAt = -1;
+
+    const onLockHolderDone = (result: typeof lockHolderResult) => {
+      lockHolderResult = result;
+      notify(LOCK_HOLDER_DONE);
+    };
+    const onDirtyWriterDone = (returnedAt: number) => {
+      dirtyWriterReturnedAt = returnedAt;
+      notify(DIRTY_WRITER_DONE);
+    };
+
+    scheduleOnRuntime(workletRuntime, () => {
+      'worklet';
+      synchronizable.lock();
+      lockTaken.setDirty(true);
+      const firstRead = synchronizable.getBlocking();
+      const start = Date.now();
+      let now = start;
+      while (now - start < holdDurationMs) {
+        now = Date.now();
+      }
+      const secondRead = synchronizable.getBlocking();
+      synchronizable.unlock();
+      const unlockedAt = Date.now();
+      scheduleOnRN(onLockHolderDone, { firstRead, secondRead, unlockedAt });
+    });
+
+    scheduleOnUI(() => {
+      'worklet';
+      let taken = lockTaken.getDirty();
+      while (!taken) {
+        taken = lockTaken.getDirty();
+      }
+      synchronizable.setDirty(42);
+      const returnedAt = Date.now();
+      scheduleOnRN(onDirtyWriterDone, returnedAt);
+    });
+
+    await waitForNotification(LOCK_HOLDER_DONE);
+    await waitForNotification(DIRTY_WRITER_DONE);
+
+    expect(lockHolderResult.firstRead).toBe(0);
+    expect(lockHolderResult.secondRead).toBe(0);
+    expect(dirtyWriterReturnedAt >= lockHolderResult.unlockedAt).toBe(true);
+    expect(synchronizable.getBlocking()).toBe(42);
+  });
+});
+
+describe('Test Synchronizable error handling', () => {
+  for (const { variantName, config } of VARIANTS) {
+    test(`a throwing setter function releases the lock (${variantName})`, async () => {
+      const synchronizable = createSynchronizable(initialValue, config);
+
+      await expect(() => {
+        synchronizable.setBlocking(() => {
+          throw new Error('setter failure');
+        });
+      }).toThrow('setter failure');
+
+      synchronizable.setBlocking(1);
+      expect(synchronizable.getBlocking()).toBe(1);
+    });
+  }
 });

--- a/apps/common-app/runtime-tests/worklets/tests/runtimes/loggingFromWorkletRuntime.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/runtimes/loggingFromWorkletRuntime.test.tsx
@@ -46,6 +46,7 @@ type TestCase = {
 const hostObject = createWorkletRuntime({ name: 'HO' });
 const shareable = createShareable(UIRuntimeId, 42);
 const synchronizable = createSynchronizable(42);
+const synchronizableFixed = createSynchronizable(42, { fixedType: true });
 
 const testCases: Record<string, TestCase> = {
   number: {
@@ -322,6 +323,14 @@ const testCases: Record<string, TestCase> = {
     factory: () => {
       'worklet';
       return synchronizable;
+    },
+  },
+  synchronizableFixed: {
+    expected:
+      '{ __serializableRef: true,\n  __synchronizableRef: true,\n  getDirty: [Function],\n  getBlocking: [Function],\n  setBlocking: [Function],\n  lock: [Function],\n  unlock: [Function],\n  setDirty: [Function] }',
+    factory: () => {
+      'worklet';
+      return synchronizableFixed;
     },
   },
 };

--- a/apps/common-app/src/apps/reanimated/examples/SynchronizableExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/SynchronizableExample.tsx
@@ -1,72 +1,99 @@
 import React from 'react';
 import { Button, StyleSheet, Text, View } from 'react-native';
+import type {
+  FixedSynchronizable,
+  Synchronizable,
+} from 'react-native-worklets';
 import {
   createSynchronizable,
-  scheduleOnRN,
-  scheduleOnUI,
   createWorkletRuntime,
+  scheduleOnRN,
   scheduleOnRuntime,
+  scheduleOnUI,
 } from 'react-native-worklets';
 
 const initialValue = 0;
 
 const targetValue = 200000;
 
+type VariantKey = 'dynamic' | 'fixed';
+
+type RuntimeKey = 'RN' | 'UI' | 'BG';
+
+type BenchmarkResult = { value: number; durationMS: number };
+
+type Results = Record<VariantKey, Record<RuntimeKey, BenchmarkResult>>;
+
+const emptyResult: BenchmarkResult = {
+  value: initialValue,
+  durationMS: 0,
+};
+
+const emptyResults: Results = {
+  dynamic: { RN: emptyResult, UI: emptyResult, BG: emptyResult },
+  fixed: { RN: emptyResult, UI: emptyResult, BG: emptyResult },
+};
+
 export default function SynchronizablePerformanceExample() {
-  const [valueRN, setValueRN] = React.useState(initialValue);
-  const [durationRNMS, setDurationRNMS] = React.useState(0);
-  const [valueUI, setValueUI] = React.useState(initialValue);
-  const [durationUIMS, setDurationUIMS] = React.useState(0);
-  const [valueBG, setValueBG] = React.useState(initialValue);
-  const [durationBGMS, setDurationBGMS] = React.useState(0);
+  const [results, setResults] = React.useState<Results>(emptyResults);
+  const [selectedVariant, setSelectedVariant] =
+    React.useState<VariantKey>('dynamic');
   const [runningRuntimes, setRunningRuntimes] = React.useState(0);
 
-  const synchronizable = createSynchronizable(initialValue);
+  const fixedSynchronizable: FixedSynchronizable<number> =
+    createSynchronizable(initialValue, { fixedType: true });
+
+  const synchronizables: Record<VariantKey, Synchronizable<number>> = {
+    dynamic: createSynchronizable(initialValue),
+    fixed: fixedSynchronizable,
+  };
 
   const runtime = createWorkletRuntime({ name: 'SynchronizableExample' });
 
-  function setUIValueRemote(value: number, durationMS: number) {
-    setValueUI(value);
-    setDurationUIMS(durationMS);
-  }
-
-  function setBGValueRemote(value: number, durationMS: number) {
-    setValueBG(value);
-    setDurationBGMS(durationMS);
+  function setResult(
+    variant: VariantKey,
+    runtimeKey: RuntimeKey,
+    value: number,
+    durationMS: number
+  ) {
+    setResults((prev) => ({
+      ...prev,
+      [variant]: { ...prev[variant], [runtimeKey]: { value, durationMS } },
+    }));
   }
 
   const decrementRuntimes = () => setRunningRuntimes((prev) => prev - 1);
 
-  function setValueAndDuration(value: number, durationMS: number) {
+  function setValueAndDuration(
+    variant: VariantKey,
+    value: number,
+    durationMS: number
+  ) {
     'worklet';
     if (!globalThis._WORKLET) {
-      setValueRN(value);
-      setDurationRNMS(durationMS);
+      setResult(variant, 'RN', value, durationMS);
       decrementRuntimes();
       return;
     }
 
-    if ((globalThis as Record<string, unknown>)._LABEL === 'UI') {
-      scheduleOnRN(setUIValueRemote, value, durationMS);
-    } else {
-      scheduleOnRN(setBGValueRemote, value, durationMS);
-    }
+    const runtimeKey =
+      (globalThis as Record<string, unknown>)._LABEL === 'UI' ? 'UI' : 'BG';
+    scheduleOnRN(setResult, variant, runtimeKey, value, durationMS);
 
     scheduleOnRN(decrementRuntimes);
   }
 
-  function resetState() {
+  function resetVariant(variant: VariantKey) {
     setRunningRuntimes(0);
-    setValueRN(initialValue);
-    setDurationRNMS(0);
-    setValueUI(initialValue);
-    setDurationUIMS(0);
-    setValueBG(initialValue);
-    setDurationBGMS(0);
+    setResults((prev) => ({
+      ...prev,
+      [variant]: { RN: emptyResult, UI: emptyResult, BG: emptyResult },
+    }));
   }
 
-  function getDirtySetBlocking() {
+  function getDirtySetBlocking(variant: VariantKey) {
     'worklet';
+    const synchronizable = synchronizables[variant];
     const start = performance.now();
     for (let i = 0; i < targetValue; i++) {
       const value = synchronizable.getDirty();
@@ -74,11 +101,12 @@ export default function SynchronizablePerformanceExample() {
     }
     const end = performance.now();
     const durationMS = end - start;
-    setValueAndDuration(synchronizable.getBlocking(), durationMS);
+    setValueAndDuration(variant, synchronizable.getBlocking(), durationMS);
   }
 
-  function getBlockingSetBlocking() {
+  function getBlockingSetBlocking(variant: VariantKey) {
     'worklet';
+    const synchronizable = synchronizables[variant];
     const start = performance.now();
     for (let i = 0; i < targetValue; i++) {
       const value = synchronizable.getBlocking();
@@ -86,22 +114,36 @@ export default function SynchronizablePerformanceExample() {
     }
     const end = performance.now();
     const durationMS = end - start;
-    setValueAndDuration(synchronizable.getBlocking(), durationMS);
+    setValueAndDuration(variant, synchronizable.getBlocking(), durationMS);
   }
 
-  function setBlockingSetBlockingTransaction() {
+  function setBlockingSetBlockingTransaction(variant: VariantKey) {
     'worklet';
+    const synchronizable = synchronizables[variant];
     const start = performance.now();
     for (let i = 0; i < targetValue; i++) {
       synchronizable.setBlocking((prev) => prev + 1);
     }
     const end = performance.now();
     const durationMS = end - start;
-    setValueAndDuration(synchronizable.getBlocking(), durationMS);
+    setValueAndDuration(variant, synchronizable.getBlocking(), durationMS);
   }
 
-  function imperativeLocking() {
+  function getDirtySetDirty(variant: VariantKey) {
     'worklet';
+    const start = performance.now();
+    for (let i = 0; i < targetValue; i++) {
+      const value = fixedSynchronizable.getDirty();
+      fixedSynchronizable.setDirty(value + 1);
+    }
+    const end = performance.now();
+    const durationMS = end - start;
+    setValueAndDuration(variant, fixedSynchronizable.getBlocking(), durationMS);
+  }
+
+  function imperativeLocking(variant: VariantKey) {
+    'worklet';
+    const synchronizable = synchronizables[variant];
     const start = performance.now();
     for (let i = 0; i < targetValue; i++) {
       synchronizable.lock();
@@ -111,13 +153,26 @@ export default function SynchronizablePerformanceExample() {
     }
     const end = performance.now();
     const durationMS = end - start;
-    setValueAndDuration(synchronizable.getBlocking(), durationMS);
+    setValueAndDuration(variant, synchronizable.getBlocking(), durationMS);
+  }
+
+  function runBenchmark(benchmark: (variant: VariantKey) => void) {
+    const variant = selectedVariant;
+    resetVariant(variant);
+    setRunningRuntimes(3);
+
+    setTimeout(() => {
+      scheduleOnUI(benchmark, variant);
+      scheduleOnRuntime(runtime, benchmark, variant);
+      queueMicrotask(() => benchmark(variant));
+    }, 50);
   }
 
   return (
     <View style={styles.container}>
       <View style={styles.table}>
         <View style={styles.leftColumn}>
+          <Text style={styles.columnHeader}>Variant:</Text>
           <Text>Initial value:</Text>
           <Text>Target value:</Text>
           <Text>Value read when RN finished:</Text>
@@ -127,70 +182,52 @@ export default function SynchronizablePerformanceExample() {
           <Text>Duration on UI:</Text>
           <Text>Duration on BG:</Text>
         </View>
-        <View style={styles.rightColumn}>
-          <Text>{initialValue}</Text>
-          <Text>{targetValue * 3}</Text>
-          <Text>{valueRN}</Text>
-          <Text>{valueUI}</Text>
-          <Text>{valueBG}</Text>
-          <Text>{(durationRNMS / 1000).toFixed(2)}s</Text>
-          <Text>{(durationUIMS / 1000).toFixed(2)}s</Text>
-          <Text>{(durationBGMS / 1000).toFixed(2)}s</Text>
-        </View>
+        {(['dynamic', 'fixed'] as VariantKey[]).map((variant) => (
+          <View key={variant} style={styles.rightColumn}>
+            <Text style={styles.columnHeader}>
+              {variant === selectedVariant ? `[${variant}]` : variant}
+            </Text>
+            <Text>{initialValue}</Text>
+            <Text>{targetValue * 3}</Text>
+            <Text>{results[variant].RN.value}</Text>
+            <Text>{results[variant].UI.value}</Text>
+            <Text>{results[variant].BG.value}</Text>
+            <Text>{(results[variant].RN.durationMS / 1000).toFixed(2)}s</Text>
+            <Text>{(results[variant].UI.durationMS / 1000).toFixed(2)}s</Text>
+            <Text>{(results[variant].BG.durationMS / 1000).toFixed(2)}s</Text>
+          </View>
+        ))}
       </View>
       <View style={{ opacity: runningRuntimes >= 1 ? 1 : 0 }}>
         <Text>Please wait...</Text>
       </View>
       <Button
-        onPress={() => {
-          resetState();
-          setRunningRuntimes(3);
-
-          setTimeout(() => {
-            scheduleOnUI(getDirtySetBlocking);
-            scheduleOnRuntime(runtime, getDirtySetBlocking);
-            queueMicrotask(getDirtySetBlocking);
-          }, 50);
-        }}
+        onPress={() =>
+          setSelectedVariant((prev) =>
+            prev === 'dynamic' ? 'fixed' : 'dynamic'
+          )
+        }
+        title={`Selected variant: ${selectedVariant}`}
+      />
+      <Button
+        onPress={() => runBenchmark(getDirtySetBlocking)}
         title=".getDirty() & .setBlocking() on two threads"
       />
       <Button
-        onPress={() => {
-          resetState();
-          setRunningRuntimes(3);
-
-          setTimeout(() => {
-            scheduleOnRuntime(runtime, getBlockingSetBlocking);
-            scheduleOnUI(getBlockingSetBlocking);
-            queueMicrotask(getBlockingSetBlocking);
-          }, 50);
-        }}
+        onPress={() => runBenchmark(getBlockingSetBlocking)}
         title=".getBlocking() & .setBlocking() on two threads"
       />
       <Button
-        onPress={() => {
-          resetState();
-          setRunningRuntimes(3);
-
-          setTimeout(() => {
-            scheduleOnUI(setBlockingSetBlockingTransaction);
-            scheduleOnRuntime(runtime, setBlockingSetBlockingTransaction);
-            queueMicrotask(setBlockingSetBlockingTransaction);
-          }, 50);
-        }}
+        onPress={() => runBenchmark(setBlockingSetBlockingTransaction)}
         title=".setBlocking() with setter on two threads - transaction"
       />
       <Button
-        onPress={() => {
-          resetState();
-          setRunningRuntimes(3);
-
-          setTimeout(() => {
-            scheduleOnUI(imperativeLocking);
-            scheduleOnRuntime(runtime, imperativeLocking);
-            queueMicrotask(imperativeLocking);
-          }, 50);
-        }}
+        disabled={selectedVariant !== 'fixed'}
+        onPress={() => runBenchmark(getDirtySetDirty)}
+        title=".getDirty() & .setDirty() on two threads - fixed only"
+      />
+      <Button
+        onPress={() => runBenchmark(imperativeLocking)}
         title="Imperative locking"
       />
     </View>
@@ -221,5 +258,8 @@ const styles = StyleSheet.create({
     flexDirection: 'column',
     alignItems: 'flex-end',
     gap: 10,
+  },
+  columnHeader: {
+    fontWeight: 'bold',
   },
 });

--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/JSIWorkletsModuleProxy.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/JSIWorkletsModuleProxy.cpp
@@ -9,6 +9,7 @@
 #include <worklets/SharedItems/Shareable.h>
 #include <worklets/SharedItems/Synchronizable.h>
 #include <worklets/SharedItems/SynchronizableDynamic.h>
+#include <worklets/SharedItems/SynchronizableFixed.h>
 #include <worklets/Tools/FeatureFlags.h>
 #include <worklets/Tools/JSLogger.h>
 #include <worklets/Tools/WorkletsJSIUtils.h>
@@ -182,6 +183,16 @@ inline jsi::Value synchronizableValueToJSValue(jsi::Runtime &rt, const Synchroni
         }
       },
       value);
+}
+
+inline SynchronizableFixedValue jsValueToSynchronizableFixedValue(const jsi::Value &value) {
+  if (value.isBool()) {
+    return value.getBool();
+  }
+  if (value.isNumber()) {
+    return value.getNumber();
+  }
+  throw std::runtime_error("[Worklets] Expected a number or boolean for a fixed-type Synchronizable.");
 }
 
 inline void registerCustomSerializable(
@@ -612,11 +623,15 @@ jsi::Object JSIWorkletsModuleProxy::toOptimizedObject(jsi::Runtime &rt) const {
             /* value */ at<1>(args).asBool());
       });
 
-  jsi_utils::addMethod<1>(
-      rt, obj, "createSynchronizable", [](jsi::Runtime &rt, const jsi::Value &, const jsi::Value(&args)[1]) {
-        auto initial = extractSerializableOrThrow(rt, at<0>(args), "[Worklets] Value must be a Serializable.");
-        auto synchronizable = std::make_shared<SynchronizableDynamic>(initial);
-        return SerializableJSRef::newNativeStateObject(rt, synchronizable);
+  jsi_utils::addMethod<2>(
+      rt, obj, "createSynchronizable", [](jsi::Runtime &rt, const jsi::Value &, const jsi::Value(&args)[2]) {
+        if (at<1>(args).getBool()) {
+          return SerializableJSRef::newNativeStateObject(
+              rt, SynchronizableFixed::make(jsValueToSynchronizableFixedValue(at<0>(args))));
+        } else {
+          auto initial = extractSerializableOrThrow(rt, at<0>(args), "[Worklets] Value must be a Serializable.");
+          return SerializableJSRef::newNativeStateObject(rt, std::make_shared<SynchronizableDynamic>(initial));
+        }
       });
 
   jsi_utils::addMethod<1>(
@@ -634,8 +649,19 @@ jsi::Object JSIWorkletsModuleProxy::toOptimizedObject(jsi::Runtime &rt) const {
   jsi_utils::addMethod<2>(
       rt, obj, "synchronizableSetBlocking", [](jsi::Runtime &rt, const jsi::Value &, const jsi::Value(&args)[2]) {
         auto synchronizable = Synchronizable::extractSynchronizableOrThrow(rt, at<0>(args));
-        auto newValue = extractSerializableOrThrow(rt, at<1>(args), "[Worklets] Value must be a Serializable.");
-        synchronizable->setBlocking(newValue);
+        const auto &newValue = at<1>(args);
+        if (synchronizable->isFixed()) {
+          synchronizable->setBlocking(jsValueToSynchronizableFixedValue(newValue));
+        } else {
+          synchronizable->setBlocking(
+              extractSerializableOrThrow(rt, newValue, "[Worklets] Value must be a Serializable."));
+        }
+      });
+
+  jsi_utils::addMethod<2>(
+      rt, obj, "synchronizableSetDirty", [](jsi::Runtime &rt, const jsi::Value &, const jsi::Value(&args)[2]) {
+        Synchronizable::extractSynchronizableOrThrow(rt, at<0>(args))
+            ->setDirty(jsValueToSynchronizableFixedValue(at<1>(args)));
       });
 
   jsi_utils::addMethod<1>(

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Synchronizable.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Synchronizable.h
@@ -31,6 +31,10 @@ class Synchronizable : public SynchronizableAccess,
     return synchronizable;
   }
 
+  bool isFixed() const {
+    return isFixed_;
+  }
+
   /**
    * Can run concurrently with getDirty, setDirty, getBlocking, setBlocking.
    */
@@ -60,13 +64,17 @@ class Synchronizable : public SynchronizableAccess,
     auto synchronizableUnpacker = rt.global().getProperty(rt, "__synchronizableUnpacker");
     react_native_assert(synchronizableUnpacker.isObject() && "synchronizableUnpacker not found");
     auto ref = SerializableJSRef::newNativeStateObject(rt, this->shared_from_this());
-    return synchronizableUnpacker.getObject(rt).getFunction(rt).call(rt, std::move(ref));
+    return synchronizableUnpacker.getObject(rt).getFunction(rt).call(
+        rt, std::move(ref), facebook::jsi::Value(isFixed()));
   }
 
   ~Synchronizable() override = default;
 
  protected:
-  Synchronizable() : Serializable(ValueType::SynchronizableType) {}
+  explicit Synchronizable(bool isFixed) : Serializable(ValueType::SynchronizableType), isFixed_(isFixed) {}
+
+ private:
+  const bool isFixed_;
 };
 
 } // namespace worklets

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/SynchronizableAccess.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/SynchronizableAccess.cpp
@@ -6,7 +6,7 @@ namespace worklets {
 void SynchronizableAccess::getBlockingBefore() {
   std::unique_lock<std::mutex> lock(accessLock_);
   queue_.wait(lock, [this]() {
-    return !blockingWriter_ /* && dirtyWriters_ == 0 */ && (!imperativelyLocked_ || imperativeOwner_ == pthread_self());
+    return !blockingWriter_ && dirtyWriters_ == 0 && (!imperativelyLocked_ || imperativeOwner_ == pthread_self());
   });
   blockingReaders_++;
 }
@@ -19,31 +19,26 @@ void SynchronizableAccess::getBlockingAfter() {
   }
 }
 
-// TODO: Shared pointer members (unless they're atomic) can't be assigned
-// in a non thread-safe manner, therefore `setDirty` has little sense now.
-// void SynchronizableAccess::setDirtyBefore() {
-//   std::unique_lock<std::mutex> lock(accessLock_);
-//   queue_.wait(lock, [this]() {
-//     return !blockingWriter_ && blockingReaders_ == 0 &&
-//         (!imperativelyLocked_ || imperativeOwner_ == pthread_self());
-//   });
-//   dirtyWriters_++;
-// }
+void SynchronizableAccess::setDirtyBefore() {
+  std::unique_lock<std::mutex> lock(accessLock_);
+  queue_.wait(lock, [this]() {
+    return !blockingWriter_ && blockingReaders_ == 0 && (!imperativelyLocked_ || imperativeOwner_ == pthread_self());
+  });
+  dirtyWriters_++;
+}
 
-// TODO: Shared pointer members (unless they're atomic) can't be assigned
-// in a non thread-safe manner, therefore `setDirty` has little sense now.
-// void SynchronizableAccess::setDirtyAfter() {
-//   std::unique_lock<std::mutex> lock(accessLock_);
-//   dirtyWriters_--;
-//   if (dirtyWriters_ == 0) {
-//     queue_.notify_all();
-//   }
-// }
+void SynchronizableAccess::setDirtyAfter() {
+  std::unique_lock<std::mutex> lock(accessLock_);
+  dirtyWriters_--;
+  if (dirtyWriters_ == 0) {
+    queue_.notify_all();
+  }
+}
 
 void SynchronizableAccess::setBlockingBefore() {
   std::unique_lock<std::mutex> lock(accessLock_);
   queue_.wait(lock, [this]() {
-    return !blockingWriter_ && blockingReaders_ == 0 /* && dirtyWriters_ == 0 */ &&
+    return !blockingWriter_ && blockingReaders_ == 0 && dirtyWriters_ == 0 &&
         (!imperativelyLocked_ || imperativeOwner_ == pthread_self());
   });
   blockingWriter_ = true;
@@ -58,7 +53,7 @@ void SynchronizableAccess::setBlockingAfter() {
 void SynchronizableAccess::lock() {
   std::unique_lock<std::mutex> lock(accessLock_);
   queue_.wait(lock, [this]() {
-    return !blockingWriter_ && blockingReaders_ == 0 /* && dirtyWriters_ == 0 */ &&
+    return !blockingWriter_ && blockingReaders_ == 0 && dirtyWriters_ == 0 &&
         (!imperativelyLocked_ || imperativeOwner_ == pthread_self());
   });
   imperativelyLocked_ = true;

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/SynchronizableAccess.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/SynchronizableAccess.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <pthread.h>
+
 #include <condition_variable>
 #include <mutex>
 
@@ -23,22 +25,19 @@ class SynchronizableAccess {
   void getBlockingBefore();
   void getBlockingAfter();
 
-  // TODO: Shared pointer members (unless they're atomic) can't be assigned
-  // in a non thread-safe manner, therefore `setDirty` has little sense now.
-  // void setDirtyBefore();
-  // void setDirtyAfter();
+  void setDirtyBefore();
+  void setDirtyAfter();
 
   void setBlockingBefore();
   void setBlockingAfter();
 
  private:
   int blockingReaders_{0};
-  // int dirtyWriters_{0};
+  int dirtyWriters_{0};
   bool blockingWriter_{false};
   bool imperativelyLocked_{false};
   pthread_t imperativeOwner_{};
   std::mutex accessLock_;
-  std::recursive_mutex imperativeLock_;
   std::condition_variable queue_;
 };
 

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/SynchronizableDynamic.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/SynchronizableDynamic.h
@@ -8,7 +8,7 @@ namespace worklets {
 
 class SynchronizableDynamic final : public Synchronizable {
  public:
-  explicit SynchronizableDynamic(const std::shared_ptr<Serializable> &value) : value_(value) {}
+  explicit SynchronizableDynamic(const std::shared_ptr<Serializable> &value) : Synchronizable(false), value_(value) {}
 
   SynchronizableValue getDirty() override;
 

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/SynchronizableFixed.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/SynchronizableFixed.cpp
@@ -1,0 +1,65 @@
+#include <react/debug/react_native_assert.h>
+#include <worklets/SharedItems/SynchronizableFixed.h>
+
+#include <memory>
+#include <stdexcept>
+#include <type_traits>
+#include <variant>
+
+namespace worklets {
+
+std::shared_ptr<SynchronizableFixed> SynchronizableFixed::make(const SynchronizableFixedValue &initialValue) {
+  return std::visit(
+      [](const auto &alternative) { return std::make_shared<SynchronizableFixed>(alternative); }, initialValue);
+}
+
+SynchronizableValue SynchronizableFixed::getDirty() {
+  return load();
+}
+
+SynchronizableValue SynchronizableFixed::getBlocking() {
+  getBlockingBefore();
+  auto value = load();
+  getBlockingAfter();
+  return value;
+}
+
+void SynchronizableFixed::setDirty(const SynchronizableFixedValue &value) {
+  setDirtyBefore();
+  store(value);
+  setDirtyAfter();
+}
+
+void SynchronizableFixed::setBlocking(const std::shared_ptr<Serializable> &) {
+  throw std::runtime_error("[Worklets] Fixed-type Synchronizable operates on plain values, not Serializables.");
+}
+
+void SynchronizableFixed::setBlocking(const SynchronizableFixedValue &value) {
+  setBlockingBefore();
+  store(value);
+  setBlockingAfter();
+}
+
+void SynchronizableFixed::store(const SynchronizableFixedValue &value) {
+  std::visit(
+      [](auto &atomic, const auto &alternative) {
+        using TAtomic = std::decay_t<decltype(atomic)>;
+        using TAlternative = std::decay_t<decltype(alternative)>;
+        if constexpr (std::is_same_v<TAtomic, std::atomic<TAlternative>>) {
+          atomic.store(alternative, std::memory_order_relaxed);
+        } else if constexpr (std::is_same_v<TAtomic, std::atomic<double>>) {
+          react_native_assert(false && "[Worklets] Expected a number for a fixed-type Synchronizable.");
+        } else {
+          react_native_assert(false && "[Worklets] Expected a boolean for a fixed-type Synchronizable.");
+        }
+      },
+      value_,
+      value);
+}
+
+SynchronizableValue SynchronizableFixed::load() const {
+  return std::visit(
+      [](const auto &atomic) { return SynchronizableValue(atomic.load(std::memory_order_relaxed)); }, value_);
+}
+
+} // namespace worklets

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/SynchronizableFixed.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/SynchronizableFixed.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <worklets/SharedItems/Synchronizable.h>
+
+#include <atomic>
+#include <memory>
+#include <type_traits>
+#include <variant>
+
+namespace worklets {
+
+class SynchronizableFixed final : public Synchronizable {
+ public:
+  explicit SynchronizableFixed(double value)
+      : Synchronizable(true), value_(std::in_place_type<std::atomic<double>>, value) {}
+
+  explicit SynchronizableFixed(bool value)
+      : Synchronizable(true), value_(std::in_place_type<std::atomic<bool>>, value) {}
+
+  template <
+      typename TInteger,
+      typename = std::enable_if_t<std::is_integral_v<TInteger> && !std::is_same_v<TInteger, bool>>>
+  explicit SynchronizableFixed(TInteger value) = delete;
+
+  static std::shared_ptr<SynchronizableFixed> make(const SynchronizableFixedValue &initialValue);
+
+  SynchronizableValue getDirty() override;
+
+  SynchronizableValue getBlocking() override;
+
+  void setDirty(const SynchronizableFixedValue &value) override;
+
+  void setBlocking(const std::shared_ptr<Serializable> &value) override;
+
+  void setBlocking(const SynchronizableFixedValue &value) override;
+
+ private:
+  void store(const SynchronizableFixedValue &value);
+  SynchronizableValue load() const;
+
+  std::variant<std::atomic<double>, std::atomic<bool>> value_;
+};
+
+static_assert(std::atomic<double>::is_always_lock_free);
+static_assert(std::atomic<bool>::is_always_lock_free);
+
+} // namespace worklets

--- a/packages/react-native-worklets/src/WorkletsModule/NativeWorklets.native.ts
+++ b/packages/react-native-worklets/src/WorkletsModule/NativeWorklets.native.ts
@@ -343,8 +343,11 @@ See https://docs.swmansion.com/react-native-worklets/docs/guides/troubleshooting
     );
   }
 
-  createSynchronizable<TValue>(value: TValue): SynchronizableRef<TValue> {
-    return this.#workletsModuleProxy.createSynchronizable(value);
+  createSynchronizable<TValue>(
+    value: SerializableRef<TValue> | TValue,
+    isFixed: boolean
+  ): SynchronizableRef<TValue> {
+    return this.#workletsModuleProxy.createSynchronizable(value, isFixed);
   }
 
   synchronizableGetDirty<TValue>(
@@ -363,9 +366,19 @@ See https://docs.swmansion.com/react-native-worklets/docs/guides/troubleshooting
 
   synchronizableSetBlocking<TValue>(
     synchronizableRef: SynchronizableRef<TValue>,
-    value: SerializableRef<TValue>
+    value: SerializableRef<TValue> | TValue
   ) {
     return this.#workletsModuleProxy.synchronizableSetBlocking(
+      synchronizableRef,
+      value
+    );
+  }
+
+  synchronizableSetDirty<TValue extends number | boolean>(
+    synchronizableRef: SynchronizableRef<TValue>,
+    value: TValue
+  ): void {
+    return this.#workletsModuleProxy.synchronizableSetDirty(
       synchronizableRef,
       value
     );

--- a/packages/react-native-worklets/src/WorkletsModule/workletsModuleProxy.ts
+++ b/packages/react-native-worklets/src/WorkletsModule/workletsModuleProxy.ts
@@ -197,7 +197,10 @@ export interface WorkletsModuleProxy {
 
   reportFatalErrorOnJS(message: string, stack: string, name: string): void;
 
-  createSynchronizable<TValue>(value: TValue): SynchronizableRef<TValue>;
+  createSynchronizable<TValue>(
+    value: SerializableRef<TValue> | TValue,
+    isFixed: boolean
+  ): SynchronizableRef<TValue>;
 
   synchronizableGetDirty<TValue>(
     synchronizableRef: SynchronizableRef<TValue>
@@ -209,7 +212,12 @@ export interface WorkletsModuleProxy {
 
   synchronizableSetBlocking<TValue>(
     synchronizableRef: SynchronizableRef<TValue>,
-    value: SerializableRef<TValue>
+    value: SerializableRef<TValue> | TValue
+  ): void;
+
+  synchronizableSetDirty<TValue extends number | boolean>(
+    synchronizableRef: SynchronizableRef<TValue>,
+    value: TValue
   ): void;
 
   synchronizableLock<TValue>(

--- a/packages/react-native-worklets/src/index.ts
+++ b/packages/react-native-worklets/src/index.ts
@@ -37,6 +37,7 @@ export { serializableMappingCache } from './memory/serializableMappingCache';
 export { createShareable } from './memory/shareable';
 export { createSynchronizable } from './memory/synchronizable';
 export type {
+  FixedSynchronizable,
   RegistrationData,
   SerializableRef,
   Shareable,
@@ -50,6 +51,7 @@ export type {
   ShareableHostMeta,
   ShareableHostProps,
   Synchronizable,
+  SynchronizableConfig,
   SynchronizableRef,
 } from './memory/types';
 export {

--- a/packages/react-native-worklets/src/memory/synchronizable.native.ts
+++ b/packages/react-native-worklets/src/memory/synchronizable.native.ts
@@ -2,16 +2,50 @@
 
 import { WorkletsModule } from '../WorkletsModule/NativeWorklets';
 import { createSerializable } from './serializable';
-import type { Synchronizable } from './types';
+import type {
+  FixedSynchronizable,
+  Synchronizable,
+  SynchronizableConfig,
+} from './types';
+
+export function createSynchronizable<TValue extends number | boolean>(
+  initialValue: TValue,
+  config: SynchronizableConfig & { fixedType: true }
+): FixedSynchronizable<TValue extends boolean ? boolean : number>;
+
+export function createSynchronizable<TValue extends number | boolean>(
+  initialValue: TValue,
+  config: SynchronizableConfig
+): Synchronizable<TValue> | FixedSynchronizable<TValue>;
 
 export function createSynchronizable<TValue = unknown>(
-  initialValue: TValue
+  initialValue: TValue,
+  config?: SynchronizableConfig
+): Synchronizable<TValue>;
+
+export function createSynchronizable<TValue = unknown>(
+  initialValue: TValue,
+  config?: SynchronizableConfig
 ): Synchronizable<TValue> {
+  const isFixed = !!config?.fixedType;
+
+  if (
+    __DEV__ &&
+    isFixed &&
+    !(typeof initialValue === 'number' || typeof initialValue === 'boolean')
+  ) {
+    throw new Error(
+      '[Worklets] `fixedType` requires a number or boolean initial value.'
+    );
+  }
+
   const synchronizableRef = WorkletsModule.createSynchronizable(
-    createSerializable(initialValue)
+    isFixed ? initialValue : createSerializable(initialValue),
+    isFixed
   );
 
   return globalThis.__synchronizableUnpacker(
-    synchronizableRef
+    synchronizableRef,
+    isFixed
   ) as unknown as Synchronizable<TValue>;
 }

--- a/packages/react-native-worklets/src/memory/synchronizable.ts
+++ b/packages/react-native-worklets/src/memory/synchronizable.ts
@@ -1,9 +1,29 @@
 'use strict';
 
-import type { Synchronizable } from './types';
+import type {
+  FixedSynchronizable,
+  Synchronizable,
+  SynchronizableConfig,
+} from './types';
+
+export function createSynchronizable<TValue extends number | boolean>(
+  initialValue: TValue,
+  config: SynchronizableConfig & { fixedType: true }
+): FixedSynchronizable<TValue extends boolean ? boolean : number>;
+
+export function createSynchronizable<TValue extends number | boolean>(
+  initialValue: TValue,
+  config: SynchronizableConfig
+): Synchronizable<TValue> | FixedSynchronizable<TValue>;
 
 export function createSynchronizable<TValue = unknown>(
-  _value: TValue
+  initialValue: TValue,
+  config?: SynchronizableConfig
+): Synchronizable<TValue>;
+
+export function createSynchronizable<TValue = unknown>(
+  _initialValue: TValue,
+  _config?: SynchronizableConfig
 ): Synchronizable<TValue> {
   throw new Error('[Worklets] `createSynchronizable` is not supported on web.');
 }

--- a/packages/react-native-worklets/src/memory/synchronizableUnpacker.native.ts
+++ b/packages/react-native-worklets/src/memory/synchronizableUnpacker.native.ts
@@ -3,7 +3,11 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 'use strict';
 
-import { type Synchronizable, type SynchronizableRef } from './types';
+import {
+  type FixedSynchronizable,
+  type Synchronizable,
+  type SynchronizableRef,
+} from './types';
 
 export function installSynchronizableUnpacker() {
   'worklet';
@@ -15,7 +19,8 @@ export function installSynchronizableUnpacker() {
       : (value: unknown) => globalThis.__serializer(value);
 
   function synchronizableUnpacker<TValue>(
-    synchronizableRef: SynchronizableRef<TValue>
+    synchronizableRef: SynchronizableRef<TValue>,
+    isFixed: boolean
   ): Synchronizable<TValue> {
     const synchronizable =
       synchronizableRef as unknown as Synchronizable<TValue>;
@@ -28,23 +33,32 @@ export function installSynchronizableUnpacker() {
     synchronizable.getBlocking = () => {
       return proxy.synchronizableGetBlocking(synchronizable);
     };
+    const setBlockingValue = (newValue: TValue) => {
+      proxy.synchronizableSetBlocking(
+        synchronizable,
+        isFixed ? newValue : serializer(newValue)
+      );
+    };
     synchronizable.setBlocking = (
       valueOrFunction: TValue | ((prev: TValue) => TValue)
     ) => {
-      let newValue: TValue;
       if (typeof valueOrFunction === 'function') {
         const func = valueOrFunction as (prev: TValue) => TValue;
         synchronizable.lock();
-        const prev = synchronizable.getBlocking();
-        newValue = func(prev);
-
-        proxy.synchronizableSetBlocking(synchronizable, serializer(newValue));
-
-        synchronizable.unlock();
+        if (__DEV__) {
+          try {
+            const prev = synchronizable.getBlocking();
+            setBlockingValue(func(prev));
+          } finally {
+            synchronizable.unlock();
+          }
+        } else {
+          const prev = synchronizable.getBlocking();
+          setBlockingValue(func(prev));
+          synchronizable.unlock();
+        }
       } else {
-        const value = valueOrFunction;
-        newValue = value;
-        proxy.synchronizableSetBlocking(synchronizable, serializer(newValue));
+        setBlockingValue(valueOrFunction);
       }
     };
     synchronizable.lock = () => {
@@ -53,6 +67,16 @@ export function installSynchronizableUnpacker() {
     synchronizable.unlock = () => {
       proxy.synchronizableUnlock(synchronizable);
     };
+    if (isFixed) {
+      (
+        synchronizable as unknown as FixedSynchronizable<number | boolean>
+      ).setDirty = (value: number | boolean) => {
+        proxy.synchronizableSetDirty(
+          synchronizable as unknown as SynchronizableRef<number | boolean>,
+          value
+        );
+      };
+    }
 
     return synchronizable;
   }
@@ -61,5 +85,6 @@ export function installSynchronizableUnpacker() {
 }
 
 export type SynchronizableUnpacker = <TValue>(
-  synchronizableRef: SynchronizableRef<TValue>
+  synchronizableRef: SynchronizableRef<TValue>,
+  isFixed: boolean
 ) => Synchronizable<TValue>;

--- a/packages/react-native-worklets/src/memory/types.ts
+++ b/packages/react-native-worklets/src/memory/types.ts
@@ -36,6 +36,15 @@ export type Synchronizable<TValue = unknown> = SerializableRef<TValue> &
     unlock(): void;
   };
 
+export type FixedSynchronizable<TValue extends number | boolean> =
+  Synchronizable<TValue> & {
+  setDirty(value: TValue): void;
+};
+
+export type SynchronizableConfig = {
+  fixedType?: boolean;
+};
+
 /**
  * Registration data for
  * [registerCustomSerializable](https://docs.swmansion.com/react-native-worklets/docs/memory/registerCustomSerializable)

--- a/packages/react-native-worklets/src/mock.ts
+++ b/packages/react-native-worklets/src/mock.ts
@@ -44,7 +44,33 @@ const WorkletAPI = {
       setSync: set,
     };
   },
-  createSynchronizable: ID,
+  createSynchronizable: <TValue>(
+    initialValue: TValue,
+    config?: { fixedType?: boolean }
+  ) => {
+    let value = initialValue;
+    const synchronizable = {
+      __synchronizableRef: true,
+      getDirty: () => value,
+      getBlocking: () => value,
+      setBlocking: (newValue: TValue | ((prev: TValue) => TValue)) => {
+        value =
+          typeof newValue === 'function'
+            ? (newValue as (prev: TValue) => TValue)(value)
+            : newValue;
+      },
+      lock: NOOP,
+      unlock: NOOP,
+    };
+    if (config?.fixedType) {
+      Object.assign(synchronizable, {
+        setDirty: (newValue: TValue) => {
+          value = newValue;
+        },
+      });
+    }
+    return synchronizable;
+  },
   createWorkletRuntime: NOOP_FACTORY,
   executeOnUIRuntimeSync: ID,
   getDynamicFeatureFlag: () => false,


### PR DESCRIPTION
> [!NOTE]
> **This PR description is AI-generated.**

## Summary

Depends on #10290.

Every Synchronizable access used to go through `worklets::Serializable`, which allocates a `SerializableScalar` and a JSI ref object per write even when the value is just a number. I added an opt-in fast path: `createSynchronizable(value, { fixedType: true })` creates a `SynchronizableFixed` that stores its number or boolean value directly in native memory as a `std::variant<std::atomic<double>, std::atomic<bool>>`, with the value type inferred from the initial value and locked forever. The shared JS unpacker receives an `isFixed` flag from `toJSValue`, so fixed instances skip serialization in both directions.

Since the payload is a single lock-free atomic, I could finally implement `setDirty` - a non-exclusive write that accepts a plain value. It waits for blocking accesses and transactions, but runs concurrently with other `setDirty` calls, so a concurrent dirty write can be lost. Reanimated's migration to the fixed-type Synchronizable is split out to a follow-up PR.

I merged the Synchronizable runtime tests into a dynamic/fixed matrix and extended the performance example with a variant selector.

## Test plan

- Runtime tests: `memory/synchronizable.test` runs every shared behavior for both variants, plus fixed-only coverage (`setDirty`, boolean type preservation, torn-value check).
- `SynchronizablePerformanceExample` compares dynamic and fixed durations side by side.


