### PR TITLE
fix(Worklets): make Synchronizable value access atomic

### DIFF
--- a/packages/react-native-worklets/CHANGELOG.md
+++ b/packages/react-native-worklets/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - Fix a crash on Android when the React instance is recreated while animations are running - `AnimationFrameQueue` kept delivering frames after `WorkletsModule` was invalidated. ([#10278](https://github.com/software-mansion/react-native-reanimated/pull/10278) by [@shubhamdeol](https://github.com/shubhamdeol))
+- Fix a data race between `getDirty` and `setBlocking` on a Synchronizable - the pointer holding the value is now read and written atomically. ([#10292](https://github.com/software-mansion/react-native-reanimated/pull/10292) by [@tjzel](https://github.com/tjzel))
 
 ### 💡 Others
 

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Synchronizable.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Synchronizable.cpp
@@ -1,18 +1,19 @@
 #include <react/debug/react_native_assert.h>
 #include <worklets/SharedItems/Synchronizable.h>
 
+#include <atomic>
 #include <memory>
 #include <utility>
 
 namespace worklets {
 
 std::shared_ptr<Serializable> Synchronizable::getDirty() {
-  return value_;
+  return std::atomic_load(&value_);
 }
 
 std::shared_ptr<Serializable> Synchronizable::getBlocking() {
   getBlockingBefore();
-  auto value = value_;
+  auto value = std::atomic_load(&value_);
   getBlockingAfter();
   return value;
 }
@@ -27,7 +28,7 @@ std::shared_ptr<Serializable> Synchronizable::getBlocking() {
 
 void Synchronizable::setBlocking(const std::shared_ptr<Serializable> &value) {
   setBlockingBefore();
-  value_ = value;
+  std::atomic_store(&value_, value);
   setBlockingAfter();
 }
 


### PR DESCRIPTION
## Summary

`Synchronizable::getDirty` copies the `shared_ptr` member while `setBlocking` can assign it from another thread. `getDirty` doesn't take the access lock, so those two race on the control block, which is undefined behavior and can corrupt the reference count.

I made both accesses atomic with `std::atomic_load` and `std::atomic_store`. `std::atomic<std::shared_ptr>` isn't available in libc++ yet, so I used the free functions - they are lock based, which is acceptable here because a Synchronizable holding a primitive can use the fixed-type fast path added later in the stack.

## Test plan

Existing `memory/synchronizable.test` runtime tests pass.


