### PR TITLE
feat(Worklets): add setDirty to the Synchronizable interface

### DIFF
--- a/packages/react-native-worklets/CHANGELOG.md
+++ b/packages/react-native-worklets/CHANGELOG.md
@@ -21,3 +21,4 @@
 
 - Split `Synchronizable` into an interface and a `SynchronizableDynamic` implementation. ([#10293](https://github.com/software-mansion/react-native-reanimated/pull/10293) by [@tjzel](https://github.com/tjzel))
 - Make the C++ `Synchronizable` interface operate on `std::variant` values instead of Serializables. ([#10294](https://github.com/software-mansion/react-native-reanimated/pull/10294) by [@tjzel](https://github.com/tjzel))
+- Add `setDirty` to the C++ `Synchronizable` interface. ([#10295](https://github.com/software-mansion/react-native-reanimated/pull/10295) by [@tjzel](https://github.com/tjzel))

--- a/packages/react-native-worklets/CHANGELOG.md
+++ b/packages/react-native-worklets/CHANGELOG.md
@@ -20,3 +20,4 @@
 \[general] - bump Worklets version to 0.13.0
 
 - Split `Synchronizable` into an interface and a `SynchronizableDynamic` implementation. ([#10293](https://github.com/software-mansion/react-native-reanimated/pull/10293) by [@tjzel](https://github.com/tjzel))
+- Make the C++ `Synchronizable` interface operate on `std::variant` values instead of Serializables. ([#10294](https://github.com/software-mansion/react-native-reanimated/pull/10294) by [@tjzel](https://github.com/tjzel))

--- a/packages/react-native-worklets/CHANGELOG.md
+++ b/packages/react-native-worklets/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### 🛠 Breaking changes
 
 - Change the C++ `Synchronizable` interface to operate on `std::variant` values. Getters return a `Serializable`, a `double` or a `bool`, and `setBlocking` takes either a `Serializable` or a plain value. ([#10294](https://github.com/software-mansion/react-native-reanimated/pull/10294) by [@tjzel](https://github.com/tjzel))
-- Add `setDirty` to the C++ `Synchronizable` interface. It's pure virtual, so C++ implementations of the interface have to provide it. `SynchronizableDynamic` throws from it - write a dynamic Synchronizable with `setBlocking` and a `Serializable` value. ([#10295](https://github.com/software-mansion/react-native-reanimated/pull/10295) by [@tjzel](https://github.com/tjzel))
+- Add virtual `setDirty` to the C++ `Synchronizable` interface. `SynchronizableDynamic` throws from it. ([#10295](https://github.com/software-mansion/react-native-reanimated/pull/10295) by [@tjzel](https://github.com/tjzel))
 
 ### 🎉 New features
 

--- a/packages/react-native-worklets/CHANGELOG.md
+++ b/packages/react-native-worklets/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🛠 Breaking changes
 
+- Change the C++ `Synchronizable` interface to operate on `std::variant` values. Getters return a `Serializable`, a `double` or a `bool`, and `setBlocking` takes either a `Serializable` or a plain value. ([#10294](https://github.com/software-mansion/react-native-reanimated/pull/10294) by [@tjzel](https://github.com/tjzel))
+
 ### 🎉 New features
 
 \[General] Per-runtime caching for RetainingSerializable
@@ -20,4 +22,3 @@
 \[general] - bump Worklets version to 0.13.0
 
 - Split `Synchronizable` into an interface and a `SynchronizableDynamic` implementation. ([#10293](https://github.com/software-mansion/react-native-reanimated/pull/10293) by [@tjzel](https://github.com/tjzel))
-- Make the C++ `Synchronizable` interface operate on `std::variant` values instead of Serializables. ([#10294](https://github.com/software-mansion/react-native-reanimated/pull/10294) by [@tjzel](https://github.com/tjzel))

--- a/packages/react-native-worklets/CHANGELOG.md
+++ b/packages/react-native-worklets/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🛠 Breaking changes
 
 - Change the C++ `Synchronizable` interface to operate on `std::variant` values. Getters return a `Serializable`, a `double` or a `bool`, and `setBlocking` takes either a `Serializable` or a plain value. ([#10294](https://github.com/software-mansion/react-native-reanimated/pull/10294) by [@tjzel](https://github.com/tjzel))
+- Add `setDirty` to the C++ `Synchronizable` interface. It's pure virtual, so C++ implementations of the interface have to provide it. `SynchronizableDynamic` throws from it - write a dynamic Synchronizable with `setBlocking` and a `Serializable` value. ([#10295](https://github.com/software-mansion/react-native-reanimated/pull/10295) by [@tjzel](https://github.com/tjzel))
 
 ### 🎉 New features
 

--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/JSIWorkletsModuleProxy.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/JSIWorkletsModuleProxy.cpp
@@ -22,7 +22,9 @@
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <utility>
+#include <variant>
 #include <vector>
 
 using namespace facebook;
@@ -167,6 +169,19 @@ inline std::shared_ptr<AsyncQueue> extractAsyncQueue(jsi::Runtime &rt, const jsi
   auto asyncQueue = std::dynamic_pointer_cast<AsyncQueue>(nativeState);
 
   return asyncQueue;
+}
+
+inline jsi::Value synchronizableValueToJSValue(jsi::Runtime &rt, const SynchronizableValue &value) {
+  return std::visit(
+      [&rt](const auto &alternative) -> jsi::Value {
+        using TAlternative = std::decay_t<decltype(alternative)>;
+        if constexpr (std::is_same_v<TAlternative, std::shared_ptr<Serializable>>) {
+          return alternative->toJSValue(rt);
+        } else {
+          return jsi::Value(alternative);
+        }
+      },
+      value);
 }
 
 inline void registerCustomSerializable(
@@ -606,12 +621,14 @@ jsi::Object JSIWorkletsModuleProxy::toOptimizedObject(jsi::Runtime &rt) const {
 
   jsi_utils::addMethod<1>(
       rt, obj, "synchronizableGetDirty", [](jsi::Runtime &rt, const jsi::Value &, const jsi::Value(&args)[1]) {
-        return Synchronizable::extractSynchronizableOrThrow(rt, at<0>(args))->getDirty()->toJSValue(rt);
+        return synchronizableValueToJSValue(
+            rt, Synchronizable::extractSynchronizableOrThrow(rt, at<0>(args))->getDirty());
       });
 
   jsi_utils::addMethod<1>(
       rt, obj, "synchronizableGetBlocking", [](jsi::Runtime &rt, const jsi::Value &, const jsi::Value(&args)[1]) {
-        return Synchronizable::extractSynchronizableOrThrow(rt, at<0>(args))->getBlocking()->toJSValue(rt);
+        return synchronizableValueToJSValue(
+            rt, Synchronizable::extractSynchronizableOrThrow(rt, at<0>(args))->getBlocking());
       });
 
   jsi_utils::addMethod<2>(

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Synchronizable.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Synchronizable.h
@@ -43,6 +43,12 @@ class Synchronizable : public SynchronizableAccess,
   virtual SynchronizableValue getBlocking() = 0;
 
   /**
+   * Can run concurrently with getDirty, setDirty.
+   * Can't run concurrently with getBlocking, setBlocking.
+   */
+  virtual void setDirty(const SynchronizableFixedValue &value) = 0;
+
+  /**
    * Can run concurrently with getDirty.
    * Can't run concurrently with getBlocking, setDirty, setBlocking.
    */

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Synchronizable.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Synchronizable.h
@@ -7,8 +7,12 @@
 
 #include <memory>
 #include <utility>
+#include <variant>
 
 namespace worklets {
+
+using SynchronizableValue = std::variant<std::shared_ptr<Serializable>, double, bool>;
+using SynchronizableFixedValue = std::variant<double, bool>;
 
 class Synchronizable : public SynchronizableAccess,
                        public Serializable,
@@ -30,19 +34,21 @@ class Synchronizable : public SynchronizableAccess,
   /**
    * Can run concurrently with getDirty, setDirty, getBlocking, setBlocking.
    */
-  virtual std::shared_ptr<Serializable> getDirty() = 0;
+  virtual SynchronizableValue getDirty() = 0;
 
   /**
    * Can run concurrently with getDirty, getBlocking.
    * Can't run concurrently with setDirty, setBlocking.
    */
-  virtual std::shared_ptr<Serializable> getBlocking() = 0;
+  virtual SynchronizableValue getBlocking() = 0;
 
   /**
    * Can run concurrently with getDirty.
    * Can't run concurrently with getBlocking, setDirty, setBlocking.
    */
   virtual void setBlocking(const std::shared_ptr<Serializable> &value) = 0;
+
+  virtual void setBlocking(const SynchronizableFixedValue &value) = 0;
 
   facebook::jsi::Value toJSValue(facebook::jsi::Runtime &rt) final {
     auto synchronizableUnpacker = rt.global().getProperty(rt, "__synchronizableUnpacker");

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/SynchronizableDynamic.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/SynchronizableDynamic.cpp
@@ -2,14 +2,15 @@
 
 #include <atomic>
 #include <memory>
+#include <stdexcept>
 
 namespace worklets {
 
-std::shared_ptr<Serializable> SynchronizableDynamic::getDirty() {
+SynchronizableValue SynchronizableDynamic::getDirty() {
   return std::atomic_load(&value_);
 }
 
-std::shared_ptr<Serializable> SynchronizableDynamic::getBlocking() {
+SynchronizableValue SynchronizableDynamic::getBlocking() {
   getBlockingBefore();
   auto value = std::atomic_load(&value_);
   getBlockingAfter();
@@ -20,6 +21,10 @@ void SynchronizableDynamic::setBlocking(const std::shared_ptr<Serializable> &val
   setBlockingBefore();
   std::atomic_store(&value_, value);
   setBlockingAfter();
+}
+
+void SynchronizableDynamic::setBlocking(const SynchronizableFixedValue &) {
+  throw std::runtime_error("[Worklets] Dynamic-type Synchronizable operates on Serializables, not plain values.");
 }
 
 } // namespace worklets

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/SynchronizableDynamic.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/SynchronizableDynamic.cpp
@@ -17,6 +17,11 @@ SynchronizableValue SynchronizableDynamic::getBlocking() {
   return value;
 }
 
+void SynchronizableDynamic::setDirty(const SynchronizableFixedValue &) {
+  throw std::runtime_error(
+      "[Worklets] Cannot invoke setDirty on a dynamic-type Synchronizable. Use setBlocking instead.");
+}
+
 void SynchronizableDynamic::setBlocking(const std::shared_ptr<Serializable> &value) {
   setBlockingBefore();
   std::atomic_store(&value_, value);

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/SynchronizableDynamic.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/SynchronizableDynamic.cpp
@@ -19,7 +19,8 @@ SynchronizableValue SynchronizableDynamic::getBlocking() {
 
 void SynchronizableDynamic::setDirty(const SynchronizableFixedValue &) {
   throw std::runtime_error(
-      "[Worklets] Cannot invoke setDirty on a dynamic-type Synchronizable. Use setBlocking instead.");
+      "[Worklets] Cannot invoke setDirty on a dynamic-type Synchronizable. "
+      "Use setBlocking with a Serializable value instead.");
 }
 
 void SynchronizableDynamic::setBlocking(const std::shared_ptr<Serializable> &value) {

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/SynchronizableDynamic.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/SynchronizableDynamic.h
@@ -14,6 +14,8 @@ class SynchronizableDynamic final : public Synchronizable {
 
   SynchronizableValue getBlocking() override;
 
+  void setDirty(const SynchronizableFixedValue &value) override;
+
   void setBlocking(const std::shared_ptr<Serializable> &value) override;
 
   void setBlocking(const SynchronizableFixedValue &value) override;

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/SynchronizableDynamic.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/SynchronizableDynamic.h
@@ -10,11 +10,13 @@ class SynchronizableDynamic final : public Synchronizable {
  public:
   explicit SynchronizableDynamic(const std::shared_ptr<Serializable> &value) : value_(value) {}
 
-  std::shared_ptr<Serializable> getDirty() override;
+  SynchronizableValue getDirty() override;
 
-  std::shared_ptr<Serializable> getBlocking() override;
+  SynchronizableValue getBlocking() override;
 
   void setBlocking(const std::shared_ptr<Serializable> &value) override;
+
+  void setBlocking(const SynchronizableFixedValue &value) override;
 
  private:
   std::shared_ptr<Serializable> value_;


### PR DESCRIPTION
## Summary

Depends on #10294.

I added `setDirty` to the `Synchronizable` interface. It's a non-exclusive write that accepts a plain value, and only a fixed-type Synchronizable can implement it, so `SynchronizableDynamic` throws.

This lands separately to keep the fixed-type implementation PR to the subclass itself. Nothing calls the method yet.

## Test plan

n/a - the only implementation throws.


