### PR TITLE
docs: add privacy policy link in footer

### DIFF
--- a/docs/docs-reanimated/src/components/FooterBackground/styles.module.css
+++ b/docs/docs-reanimated/src/components/FooterBackground/styles.module.css
@@ -79,42 +79,49 @@
 
 .starsContainer {
   position: relative;
-  margin-top: 106px;
+  margin-top: 122px;
 }
 
 [class*='footerLanding'] {
-  margin-top: -106px;
+  margin-top: -122px;
 }
 
 @media (max-width: 996px) {
   .starsContainer {
-    position: relative;
-    margin-top: 120px;
+    margin-top: 138px;
   }
 
   [class*='footerLanding'] {
-    margin-top: -120px;
+    margin-top: -138px;
   }
 }
 
-@media (max-width: 700px) {
+@media (max-width: 916px) {
   .starsContainer {
-    position: relative;
-    margin-top: 146px;
+    margin-top: 164px;
   }
 
   [class*='footerLanding'] {
-    margin-top: -146px;
+    margin-top: -164px;
   }
 }
 
-@media (max-width: 375px) {
+@media (max-width: 505px) {
   .starsContainer {
-    position: relative;
-    margin-top: 172px;
+    margin-top: 189px;
   }
 
   [class*='footerLanding'] {
-    margin-top: -172px;
+    margin-top: -189px;
+  }
+}
+
+@media (max-width: 344px) {
+  .starsContainer {
+    margin-top: 215px;
+  }
+
+  [class*='footerLanding'] {
+    margin-top: -215px;
   }
 }

--- a/docs/docs-reanimated/src/css/overrides.css
+++ b/docs/docs-reanimated/src/css/overrides.css
@@ -168,6 +168,41 @@ button[class*='DocSearch-Button'] {
   word-break: normal;
 }
 
+footer.footer {
+  --ifm-footer-padding-vertical: 40px;
+}
+
+@media (max-width: 996px) {
+  footer.footer {
+    --ifm-footer-padding-vertical: 30px;
+  }
+}
+
+@media (max-width: 768px) {
+  footer.footer {
+    --ifm-footer-padding-vertical: 30px;
+  }
+}
+
+footer .footer__bottom [class*='footer__copyright'] {
+  justify-content: center;
+  padding-bottom: var(--swm-footer-copyright-padding-bottom);
+}
+
+footer .footer__bottom [class*='footer__copyright'] p {
+  text-align: center;
+}
+
+@media (max-width: 996px) {
+  footer .footer__bottom [class*='footer__copyright'] {
+    align-items: center;
+  }
+}
+
+footer .footer__bottom [class*='footer__copyright'] p a[data-privacy-policy] {
+  text-decoration: none;
+}
+
 /* Tabs nested inside details: bump label contrast against the purple details background. */
 details .tabs__item {
   color: var(--swm-details-color) !important;

--- a/docs/docs-reanimated/src/theme/Footer/index.js
+++ b/docs/docs-reanimated/src/theme/Footer/index.js
@@ -14,7 +14,7 @@ export default function Footer(props) {
     const link = document.createElement('a');
     link.href = PRIVACY_POLICY_URL;
     link.target = '_blank';
-    link.rel = 'noopener noreferrer';
+    link.rel = 'noopener';
     link.dataset.privacyPolicy = '';
     link.textContent = 'Privacy Policy';
     paragraph.appendChild(link);

--- a/docs/docs-reanimated/src/theme/Footer/index.js
+++ b/docs/docs-reanimated/src/theme/Footer/index.js
@@ -1,3 +1,25 @@
-import { Footer } from '@swmansion/t-rex-ui';
+import React, { useEffect } from 'react';
+import { Footer as TRexFooter } from '@swmansion/t-rex-ui';
 
-export default Footer;
+const PRIVACY_POLICY_URL = 'https://swmansion.com/privacy/policy/';
+
+export default function Footer(props) {
+  useEffect(() => {
+    const paragraph = document.querySelector('footer .footer__copyright p');
+    if (!paragraph || paragraph.querySelector('[data-privacy-policy]')) {
+      return;
+    }
+
+    paragraph.appendChild(document.createTextNode(' Read about our '));
+    const link = document.createElement('a');
+    link.href = PRIVACY_POLICY_URL;
+    link.target = '_blank';
+    link.rel = 'noopener noreferrer';
+    link.dataset.privacyPolicy = '';
+    link.textContent = 'Privacy Policy';
+    paragraph.appendChild(link);
+    paragraph.appendChild(document.createTextNode('.'));
+  }, []);
+
+  return <TRexFooter {...props} />;
+}

--- a/docs/docs-worklets/src/css/overrides.css
+++ b/docs/docs-worklets/src/css/overrides.css
@@ -140,13 +140,6 @@ button[class*='DocSearch-Button'] {
   background-color: transparent;
 }
 
-.footer .footer__copyright {
-  justify-content: center;
-  flex-direction: column-reverse;
-  gap: 60px;
-  margin-bottom: 28px;
-}
-
 .navbar .navbar__title {
   margin-left: 0;
   display: flex;
@@ -168,17 +161,43 @@ button[class*='DocSearch-Button'] {
   .navbar .navbar__title {
     display: none;
   }
-
-  .footer .footer__copyright {
-    gap: 30px;
-    margin-bottom: 0;
-    align-items: center;
-    p {
-      text-align: center;
-    }
-  }
 }
 
 [class*='headerWithBadges'] {
   align-items: baseline;
+}
+
+footer.footer {
+  --ifm-footer-padding-vertical: 40px;
+}
+
+@media (max-width: 996px) {
+  footer.footer {
+    --ifm-footer-padding-vertical: 30px;
+  }
+}
+
+@media (max-width: 768px) {
+  footer.footer {
+    --ifm-footer-padding-vertical: 30px;
+  }
+}
+
+footer .footer__bottom [class*='footer__copyright'] {
+  justify-content: center;
+  padding-bottom: var(--swm-footer-copyright-padding-bottom);
+}
+
+footer .footer__bottom [class*='footer__copyright'] p {
+  text-align: center;
+}
+
+@media (max-width: 996px) {
+  footer .footer__bottom [class*='footer__copyright'] {
+    align-items: center;
+  }
+}
+
+footer .footer__bottom [class*='footer__copyright'] p a[data-privacy-policy] {
+  text-decoration: none;
 }

--- a/docs/docs-worklets/src/theme/Footer/index.js
+++ b/docs/docs-worklets/src/theme/Footer/index.js
@@ -1,0 +1,25 @@
+import React, { useEffect } from 'react';
+import { Footer as TRexFooter } from '@swmansion/t-rex-ui';
+
+const PRIVACY_POLICY_URL = 'https://swmansion.com/privacy/policy/';
+
+export default function Footer(props) {
+  useEffect(() => {
+    const paragraph = document.querySelector('footer .footer__copyright p');
+    if (!paragraph || paragraph.querySelector('[data-privacy-policy]')) {
+      return;
+    }
+
+    paragraph.appendChild(document.createTextNode(' Read about our '));
+    const link = document.createElement('a');
+    link.href = PRIVACY_POLICY_URL;
+    link.target = '_blank';
+    link.rel = 'noopener';
+    link.dataset.privacyPolicy = '';
+    link.textContent = 'Privacy Policy';
+    paragraph.appendChild(link);
+    paragraph.appendChild(document.createTextNode('.'));
+  }, []);
+
+  return <TRexFooter {...props} />;
+}


### PR DESCRIPTION
## Summary

* Adds a Privacy Policy link in the docs site footer
* Centers footer copyright content
* Fixes footer bottom padding and landing footer spacing across breakpoints

## Test Plan

- [ ] Confirm the footer shows the Privacy Policy link and opens `https://swmansion.com/privacy/policy/` in a new tab
- [ ] Check copyright text is centered on desktop and mobile
- [ ] Verify footer padding looks correct at common widths (desktop, tablet, phone)
- [ ] On the landing page, confirm footer/background spacing still lines up after the layout tweaks

<img width="1607" height="788" alt="image" src="https://github.com/user-attachments/assets/4fcb4aa2-3116-4abe-9a14-3df28269b936" />
