### PR TITLE
chore(CSS): share one helper for the jsi array check

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/transforms/TransformMatrix2D.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/transforms/TransformMatrix2D.cpp
@@ -1,4 +1,5 @@
 #include <reanimated/CSS/common/transforms/TransformMatrix2D.h>
+#include <reanimated/CSS/utils/jsiShapes.h>
 
 #include <cmath>
 
@@ -70,16 +71,11 @@ TransformMatrix2D::TransformMatrix2D(const folly::dynamic &array)
 }
 
 bool TransformMatrix2D::canConstruct(jsi::Runtime &rt, const jsi::Value &value) {
-  if (!value.isObject()) {
+  if (!isJSIArray(rt, value)) {
     return false;
   }
 
-  const auto &obj = value.asObject(rt);
-  if (!obj.isArray(rt)) {
-    return false;
-  }
-
-  const auto &array = obj.asArray(rt);
+  const auto array = value.asObject(rt).asArray(rt);
   const auto size = array.size(rt);
 
   // Check if it's a 3x3 matrix (9 elements)

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/transforms/TransformMatrix2D.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/transforms/TransformMatrix2D.cpp
@@ -71,12 +71,12 @@ TransformMatrix2D::TransformMatrix2D(const folly::dynamic &array)
 }
 
 bool TransformMatrix2D::canConstruct(jsi::Runtime &rt, const jsi::Value &value) {
-  if (!isJSIArray(rt, value)) {
+  const auto array = asJSIArray(rt, value);
+  if (!array) {
     return false;
   }
 
-  const auto array = value.asObject(rt).asArray(rt);
-  const auto size = array.size(rt);
+  const auto size = array->size(rt);
 
   // Check if it's a 3x3 matrix (9 elements)
   if (size == 9) {
@@ -91,9 +91,9 @@ bool TransformMatrix2D::canConstruct(jsi::Runtime &rt, const jsi::Value &value) 
     // [x, x, 0, x]
     // [0, 0, 1, 0]
     // [x, x, 0, x]
-    return array.getValueAtIndex(rt, 2).asNumber() == 0.0 && array.getValueAtIndex(rt, 6).asNumber() == 0.0 &&
-        array.getValueAtIndex(rt, 10).asNumber() == 1.0 && array.getValueAtIndex(rt, 11).asNumber() == 0.0 &&
-        array.getValueAtIndex(rt, 14).asNumber() == 0.0 && array.getValueAtIndex(rt, 15).asNumber() == 1.0;
+    return array->getValueAtIndex(rt, 2).asNumber() == 0.0 && array->getValueAtIndex(rt, 6).asNumber() == 0.0 &&
+        array->getValueAtIndex(rt, 10).asNumber() == 1.0 && array->getValueAtIndex(rt, 11).asNumber() == 0.0 &&
+        array->getValueAtIndex(rt, 14).asNumber() == 0.0 && array->getValueAtIndex(rt, 15).asNumber() == 1.0;
   }
 
   return false;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSDiscreteArray.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSDiscreteArray.cpp
@@ -1,4 +1,5 @@
 #include <reanimated/CSS/common/values/CSSDiscreteArray.h>
+#include <reanimated/CSS/utils/jsiShapes.h>
 
 #include <string>
 #include <vector>
@@ -33,7 +34,7 @@ CSSDiscreteArray<TValue>::CSSDiscreteArray(const folly::dynamic &array) {
 template <CSSValueDerived TValue>
 bool CSSDiscreteArray<TValue>::canConstruct(jsi::Runtime &rt, const jsi::Value &jsiValue) {
   // TODO - maybe add better validation
-  return jsiValue.isObject() && jsiValue.asObject(rt).isArray(rt);
+  return isJSIArray(rt, jsiValue);
 }
 
 template <CSSValueDerived TValue>

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/PropertyInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/PropertyInterpolator.cpp
@@ -1,4 +1,5 @@
 #include <reanimated/CSS/interpolation/PropertyInterpolator.h>
+#include <reanimated/CSS/utils/jsiShapes.h>
 #include <reanimated/Compat/WorkletsApi.h>
 
 #include <memory>
@@ -37,7 +38,7 @@ std::string PropertyInterpolator::getPropertyPathString() const {
 std::vector<std::pair<double, jsi::Value>> PropertyInterpolator::parseJSIKeyframes(
     jsi::Runtime &rt,
     const jsi::Value &keyframes) const {
-  if (!keyframes.isObject() || !keyframes.asObject(rt).isArray(rt)) {
+  if (!isJSIArray(rt, keyframes)) {
     throw std::invalid_argument(
         "[Reanimated] Received invalid keyframes object for property: " + getPropertyPathString() +
         ".\n\nExpected an array of objects with 'offset' and 'value' properties, got: " +

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/CSSLengthVector.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/CSSLengthVector.cpp
@@ -1,6 +1,7 @@
 #include <reanimated/CSS/svg/values/CSSLengthArray.h>
 #include <reanimated/CSS/svg/values/CSSLengthVector.h>
 #include <reanimated/CSS/svg/values/SVGStrokeDashArray.h>
+#include <reanimated/CSS/utils/jsiShapes.h>
 
 #include <algorithm>
 #include <sstream>
@@ -33,7 +34,7 @@ CSSLengthVector<Derived>::CSSLengthVector(const folly::dynamic &value) {
 
 template <typename Derived>
 bool CSSLengthVector<Derived>::canConstruct(jsi::Runtime &rt, const jsi::Value &jsiValue) {
-  if (!jsiValue.isObject() || !jsiValue.asObject(rt).isArray(rt)) {
+  if (!isJSIArray(rt, jsiValue)) {
     return false;
   }
   const auto array = jsiValue.asObject(rt).asArray(rt);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/SVGStops.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/SVGStops.cpp
@@ -1,5 +1,6 @@
 #include <reanimated/CSS/svg/values/SVGBrush.h>
 #include <reanimated/CSS/svg/values/SVGStops.h>
+#include <reanimated/CSS/utils/jsiShapes.h>
 
 #include <algorithm>
 #include <cstddef>
@@ -34,16 +35,11 @@ SVGStops::SVGStops(const folly::dynamic &value) {
 }
 
 bool SVGStops::canConstruct(jsi::Runtime &rt, const jsi::Value &jsiValue) {
-  if (!jsiValue.isObject()) {
+  if (!isJSIArray(rt, jsiValue)) {
     return false;
   }
 
-  auto obj = jsiValue.asObject(rt);
-  if (!obj.isArray(rt)) {
-    return false;
-  }
-
-  auto array = obj.asArray(rt);
+  auto array = jsiValue.asObject(rt).asArray(rt);
   size_t length = array.size(rt);
 
   if (length == 0) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/SVGStops.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/SVGStops.cpp
@@ -35,12 +35,12 @@ SVGStops::SVGStops(const folly::dynamic &value) {
 }
 
 bool SVGStops::canConstruct(jsi::Runtime &rt, const jsi::Value &jsiValue) {
-  if (!isJSIArray(rt, jsiValue)) {
+  const auto array = asJSIArray(rt, jsiValue);
+  if (!array) {
     return false;
   }
 
-  auto array = jsiValue.asObject(rt).asArray(rt);
-  size_t length = array.size(rt);
+  const size_t length = array->size(rt);
 
   if (length == 0) {
     return true;
@@ -51,8 +51,8 @@ bool SVGStops::canConstruct(jsi::Runtime &rt, const jsi::Value &jsiValue) {
     return false;
   }
 
-  auto firstOffset = array.getValueAtIndex(rt, 0);
-  auto firstBrush = array.getValueAtIndex(rt, 1);
+  auto firstOffset = array->getValueAtIndex(rt, 0);
+  auto firstBrush = array->getValueAtIndex(rt, 1);
 
   return firstOffset.isNumber() && SVGBrush::canConstruct(rt, firstBrush);
 }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/jsiShapes.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/jsiShapes.h
@@ -2,6 +2,9 @@
 
 #include <jsi/jsi.h>
 
+#include <optional>
+#include <utility>
+
 namespace reanimated::css {
 
 using namespace facebook;
@@ -10,6 +13,22 @@ using namespace facebook;
 /// takes two hops, and skipping the first one asserts on a non-object.
 inline bool isJSIArray(jsi::Runtime &rt, const jsi::Value &value) {
   return value.isObject() && value.getObject(rt).isArray(rt);
+}
+
+/// The array behind the value, or nullopt when it is not one. Use this rather
+/// than isJSIArray() followed by a conversion, which walks the value twice -
+/// here the object is converted once and moved into the result.
+inline std::optional<jsi::Array> asJSIArray(jsi::Runtime &rt, const jsi::Value &value) {
+  if (!value.isObject()) {
+    return std::nullopt;
+  }
+
+  auto object = value.getObject(rt);
+  if (!object.isArray(rt)) {
+    return std::nullopt;
+  }
+
+  return std::move(object).getArray(rt);
 }
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/jsiShapes.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/jsiShapes.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <jsi/jsi.h>
+
+namespace reanimated::css {
+
+using namespace facebook;
+
+/// jsi has no Value::isArray, since an array is an object there - the check
+/// takes two hops, and skipping the first one asserts on a non-object.
+inline bool isJSIArray(jsi::Runtime &rt, const jsi::Value &value) {
+  return value.isObject() && value.getObject(rt).isArray(rt);
+}
+
+} // namespace reanimated::css


### PR DESCRIPTION
In jsi an array is an object, so "is this value an array" takes two hops, and doing only the second one asserts on a non-object. The CSS layer spelled that out in five places, in three different shapes - two as `isObject() && asObject(rt).isArray(rt)`, one as the negation, and two split across an early return and a held intermediate object.

Two helpers now cover both needs. `isJSIArray(rt, value)` answers the question for the three callers that only want a bool. `asJSIArray(rt, value)` returns `std::optional<jsi::Array>` for the two that go on to read the array, converting the object once and moving it into the result rather than checking and then converting again.

Behaviour is unchanged at every site: each already guarded `isObject()` first, so the helpers can use `getObject` rather than the throwing `asObject`, and the one caller that throws on a non-array keeps its own throw. The two array-reading sites end up with one handle clone each instead of two.

The `folly::dynamic` counterparts are deliberately left alone - there `isArray()` is already a single call, and `isObject()` is false for arrays, so the same trap does not exist.

## Testing

All 104 reanimated C++ translation units compile. No behaviour change, so nothing user-facing to verify.
