### PR TITLE
chore: Correct the past-end priming comment

### DIFF
--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
@@ -258,8 +258,8 @@ internal class CSSPlatformTransitionsManager(
         val elapsedMs = animationTimestamp().toDouble() - command.startTimestampMs
 
         // ObjectAnimator writes nothing until its first frame, so the view would show the
-        // already-committed target for the whole delay. A start that is already past its end
-        // has no delay left to cover, so priming it would only be a wasted write.
+        // already-committed target for the whole delay. A start past its end skips the prime:
+        // it would flash the stale start value for one frame over the correct target.
         if (elapsedMs < durationMs) writer.setValue(view, startValue)
 
         val animator = ObjectAnimator.ofFloat(view, writer, startValue, command.toValue.toFloat())


### PR DESCRIPTION
The comment on the priming guard called the skipped write merely wasted. The real reason is visible: ObjectAnimator writes nothing until its first frame, so priming a start that is already past its end would flash the stale start value for one frame over the committed target.