### PR TITLE
feat(CSS): resolve and blend platform colors on iOS

### DIFF
--- a/apps/common-app/eslint.config.mjs
+++ b/apps/common-app/eslint.config.mjs
@@ -82,7 +82,11 @@ export default config(
       'lines-around-comment': ['error'],
       'new-cap': [
         'error',
-        { capIsNewExceptionPattern: '^Gesture\\.', newIsCap: true },
+        {
+          capIsNewExceptionPattern: '^Gesture\\.',
+          capIsNewExceptions: ['PlatformColor'],
+          newIsCap: true,
+        },
       ],
       'new-parens': ['off'],
       'no-async-promise-executor': ['error'],

--- a/apps/common-app/src/apps/css/examples/animations/routes/index.ts
+++ b/apps/common-app/src/apps/css/examples/animations/routes/index.ts
@@ -70,6 +70,10 @@ const routes = {
         Component: miscellaneous.MultipleAnimations,
         name: 'Multiple Animations',
       },
+      PlatformColors: {
+        Component: miscellaneous.PlatformColors,
+        name: 'Platform Colors',
+      },
       UpdatingAnimationSettings: {
         Component: miscellaneous.UpdatingAnimationSettings,
         name: 'Updating Animation Settings',

--- a/apps/common-app/src/apps/css/examples/animations/screens/miscellaneous/PlatformColors.tsx
+++ b/apps/common-app/src/apps/css/examples/animations/screens/miscellaneous/PlatformColors.tsx
@@ -3,17 +3,30 @@ import Animated, { css } from 'react-native-reanimated';
 
 import { ScrollScreen, Section, Stagger } from '@/apps/css/components';
 import { radius, sizes } from '@/theme';
-import { IS_IOS } from '@/utils';
+import { IS_IOS, IS_WEB } from '@/utils';
 
-const blue = IS_IOS
-  ? PlatformColor('systemBlue')
-  : PlatformColor('?attr/colorPrimary');
-const red = IS_IOS
-  ? PlatformColor('systemRed')
-  : PlatformColor('?attr/colorError');
-const label = IS_IOS
-  ? PlatformColor('labelColor')
-  : PlatformColor('?attr/colorOnBackground');
+// react-native-web has no PlatformColor, so web falls back to literals.
+const blue = IS_WEB
+  ? '#0a84ff'
+  : IS_IOS
+    ? PlatformColor('systemBlue')
+    : PlatformColor('?attr/colorPrimary');
+const red = IS_WEB
+  ? '#ff453a'
+  : IS_IOS
+    ? PlatformColor('systemRed')
+    : PlatformColor('?attr/colorError');
+const label = IS_WEB
+  ? '#000000'
+  : IS_IOS
+    ? PlatformColor('labelColor')
+    : PlatformColor('?attr/colorOnBackground');
+
+const NOTE = IS_WEB
+  ? ' PlatformColor does not exist on web, so this screen shows literal fallbacks.'
+  : IS_IOS
+    ? ''
+    : ' Resolution is iOS-only so far, so on this platform the color steps between the endpoints instead.';
 
 const bothPlatform = css.keyframes({
   from: { backgroundColor: blue },
@@ -41,16 +54,12 @@ const animation = css.create({
   },
 });
 
-const RESOLVED_NOTE = IS_IOS
-  ? ''
-  : ' Resolution is iOS-only so far, so here the color steps between the endpoints instead of blending.';
-
 export default function PlatformColors() {
   return (
     <ScrollScreen>
       <Stagger>
         <Section
-          description={`Both endpoints are platform colors, so the blend follows the current appearance - toggle dark mode while it runs and the colors re-resolve.${RESOLVED_NOTE}`}
+          description={`Both endpoints are platform colors, blended against the current appearance.${NOTE}`}
           title="Between two platform colors">
           <Animated.View
             style={[animation.box, { animationName: bothPlatform }]}
@@ -58,16 +67,24 @@ export default function PlatformColors() {
         </Section>
 
         <Section
-          description="A literal color blends with a platform color the same way."
-          title="Mixed with a literal">
+          title="Mixed with a literal"
+          description={
+            IS_IOS
+              ? 'A literal color blends with a platform color the same way.'
+              : 'A literal color paired with a platform color follows the same rules.'
+          }>
           <Animated.View
             style={[animation.box, { animationName: mixedWithLiteral }]}
           />
         </Section>
 
         <Section
-          description="Theme-aware endpoints, such as the label color, pick up their dark variants mid-animation."
-          title="Theme-aware endpoints">
+          title="Theme-aware endpoints"
+          description={
+            IS_IOS
+              ? 'Theme-aware endpoints, such as the label color, pick up their dark variants mid-animation - toggle dark mode while it runs.'
+              : 'Theme-aware endpoints, such as the label color, render their current theme variants.'
+          }>
           <Animated.View
             style={[animation.box, { animationName: themeAware }]}
           />

--- a/apps/common-app/src/apps/css/examples/animations/screens/miscellaneous/PlatformColors.tsx
+++ b/apps/common-app/src/apps/css/examples/animations/screens/miscellaneous/PlatformColors.tsx
@@ -1,0 +1,78 @@
+import { PlatformColor } from 'react-native';
+import Animated, { css } from 'react-native-reanimated';
+
+import { ScrollScreen, Section, Stagger } from '@/apps/css/components';
+import { radius, sizes } from '@/theme';
+import { IS_IOS } from '@/utils';
+
+const blue = IS_IOS
+  ? PlatformColor('systemBlue')
+  : PlatformColor('?attr/colorPrimary');
+const red = IS_IOS
+  ? PlatformColor('systemRed')
+  : PlatformColor('?attr/colorError');
+const label = IS_IOS
+  ? PlatformColor('labelColor')
+  : PlatformColor('?attr/colorOnBackground');
+
+const bothPlatform = css.keyframes({
+  from: { backgroundColor: blue },
+  to: { backgroundColor: red },
+});
+
+const mixedWithLiteral = css.keyframes({
+  from: { backgroundColor: '#2ecc71' },
+  to: { backgroundColor: red },
+});
+
+const themeAware = css.keyframes({
+  from: { backgroundColor: label },
+  to: { backgroundColor: blue },
+});
+
+const animation = css.create({
+  box: {
+    animationDirection: 'alternate',
+    animationDuration: '2s',
+    animationIterationCount: 'infinite',
+    borderRadius: radius.sm,
+    height: sizes.lg,
+    width: sizes.xxxl,
+  },
+});
+
+const RESOLVED_NOTE = IS_IOS
+  ? ''
+  : ' Resolution is iOS-only so far, so here the color steps between the endpoints instead of blending.';
+
+export default function PlatformColors() {
+  return (
+    <ScrollScreen>
+      <Stagger>
+        <Section
+          description={`Both endpoints are platform colors, so the blend follows the current appearance - toggle dark mode while it runs and the colors re-resolve.${RESOLVED_NOTE}`}
+          title="Between two platform colors">
+          <Animated.View
+            style={[animation.box, { animationName: bothPlatform }]}
+          />
+        </Section>
+
+        <Section
+          description="A literal color blends with a platform color the same way."
+          title="Mixed with a literal">
+          <Animated.View
+            style={[animation.box, { animationName: mixedWithLiteral }]}
+          />
+        </Section>
+
+        <Section
+          description="Theme-aware endpoints, such as the label color, pick up their dark variants mid-animation."
+          title="Theme-aware endpoints">
+          <Animated.View
+            style={[animation.box, { animationName: themeAware }]}
+          />
+        </Section>
+      </Stagger>
+    </ScrollScreen>
+  );
+}

--- a/apps/common-app/src/apps/css/examples/animations/screens/miscellaneous/PlatformColors.tsx
+++ b/apps/common-app/src/apps/css/examples/animations/screens/miscellaneous/PlatformColors.tsx
@@ -22,11 +22,11 @@ const label = IS_WEB
     ? PlatformColor('labelColor')
     : PlatformColor('?attr/colorOnBackground');
 
-const NOTE = IS_WEB
-  ? ' PlatformColor does not exist on web, so this screen shows literal fallbacks.'
+const FIRST_SECTION_DESCRIPTION = IS_WEB
+  ? 'PlatformColor does not exist on web, so this screen animates literal fallbacks instead.'
   : IS_IOS
-    ? ''
-    : ' Resolution is iOS-only so far, so on this platform the color steps between the endpoints instead.';
+    ? 'Both endpoints are platform colors, blended against the current appearance - toggle dark mode while it runs.'
+    : 'Both endpoints are platform colors. Resolution is iOS-only so far, so on this platform the color steps between them instead of blending.';
 
 const bothPlatform = css.keyframes({
   from: { backgroundColor: blue },
@@ -59,7 +59,7 @@ export default function PlatformColors() {
     <ScrollScreen>
       <Stagger>
         <Section
-          description={`Both endpoints are platform colors, blended against the current appearance.${NOTE}`}
+          description={FIRST_SECTION_DESCRIPTION}
           title="Between two platform colors">
           <Animated.View
             style={[animation.box, { animationName: bothPlatform }]}

--- a/apps/common-app/src/apps/css/examples/animations/screens/miscellaneous/index.ts
+++ b/apps/common-app/src/apps/css/examples/animations/screens/miscellaneous/index.ts
@@ -2,6 +2,7 @@ import AnimationCallbacks from './AnimationCallbacks';
 import ChangingAnimation from './ChangingAnimation';
 import KeyframeTimingFunctions from './KeyframeTimingFunctions';
 import MultipleAnimations from './MultipleAnimations';
+import PlatformColors from './PlatformColors';
 import UpdatingAnimationSettings from './UpdatingAnimationSettings';
 
 export default {
@@ -9,5 +10,6 @@ export default {
   ChangingAnimation,
   KeyframeTimingFunctions,
   MultipleAnimations,
+  PlatformColors,
   UpdatingAnimationSettings,
 };

--- a/packages/react-native-reanimated/CHANGELOG.md
+++ b/packages/react-native-reanimated/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🎉 New features
 
+- Animate `PlatformColor` and `DynamicColorIOS` values in CSS animations and transitions on iOS. ([#10305](https://github.com/software-mansion/react-native-reanimated/pull/10305) by [@MatiPl01](https://github.com/MatiPl01))
+
 ### 🐛 Bug fixes
 
 - Fix `EXC_BAD_ACCESS` crash in `-[REANodesManager performOperations]` when called before the `_performOperations` block is registered on iOS. ([#10229](https://github.com/software-mansion/react-native-reanimated/pull/10229) by [@tomekzaw](https://github.com/tomekzaw))

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSPlatformColor.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSPlatformColor.cpp
@@ -23,41 +23,37 @@ bool CSSPlatformColor::canConstruct(const folly::dynamic &value) {
 }
 
 folly::dynamic CSSPlatformColor::toDynamic() const {
-  if (blended) {
-    return blended->toDynamic();
-  }
   return payload ? *payload : folly::dynamic();
 }
 
 std::string CSSPlatformColor::toString() const {
-  if (blended) {
-    return blended->toString();
-  }
   return payload ? folly::toJson(*payload) : "";
+}
+
+std::optional<CSSColor> CSSPlatformColor::resolve(const ValueInterpolationContext &context) const {
+  if (!payload) {
+    return std::nullopt;
+  }
+
+  const auto channels = resolvePlatformColor(*payload, context.node);
+  if (!channels) {
+    return std::nullopt;
+  }
+  // A transparent-typed result keeps the counterpart's hue when fading, the
+  // same way a literal 'transparent' endpoint does.
+  return (*channels)[3] == 0 ? CSSColor(CSSColorType::Transparent) : CSSColor(*channels);
 }
 
 CSSPlatformColor CSSPlatformColor::interpolate(
     const double progress,
     const CSSPlatformColor &to,
     const ValueInterpolationContext &context) const {
-  // Both endpoints hold payloads here: a blended value only exists mid-flight
-  // and never becomes an endpoint. Resolution is memoized, so past the first
-  // frame this is a lookup, not a platform call.
-  const auto fromChannels = payload ? resolvePlatformColor(*payload, context.node) : std::nullopt;
-  const auto toChannels = to.payload ? resolvePlatformColor(*to.payload, context.node) : std::nullopt;
-  if (!fromChannels || !toChannels) {
-    return progress < context.fallbackInterpolateThreshold ? *this : to;
-  }
-
-  CSSPlatformColor result = progress < 0.5 ? *this : to;
-  result.blended = CSSColor(*fromChannels).interpolate(progress, CSSColor(*toChannels));
-  return result;
+  // Reached only when resolve() failed for both endpoints - with no channels to
+  // blend, the value switches over like any other incompatible pair.
+  return progress < context.fallbackInterpolateThreshold ? *this : to;
 }
 
 bool CSSPlatformColor::operator==(const CSSPlatformColor &other) const {
-  if (blended != other.blended) {
-    return false;
-  }
   if (!payload || !other.payload) {
     return payload == other.payload;
   }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSPlatformColor.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSPlatformColor.cpp
@@ -23,31 +23,41 @@ bool CSSPlatformColor::canConstruct(const folly::dynamic &value) {
 }
 
 folly::dynamic CSSPlatformColor::toDynamic() const {
+  if (blended) {
+    return blended->toDynamic();
+  }
   return payload ? *payload : folly::dynamic();
 }
 
 std::string CSSPlatformColor::toString() const {
+  if (blended) {
+    return blended->toString();
+  }
   return payload ? folly::toJson(*payload) : "";
-}
-
-bool CSSPlatformColor::canInterpolateTo(const CSSPlatformColor & /*to*/) const {
-  // TODO: a platform color carries no channels to blend, since the payload is
-  // only resolved once React Native applies it to a view. Two of them switch
-  // over at the fallback threshold today; they should blend like any other
-  // color once a resolved value is reachable from here.
-  return false;
 }
 
 CSSPlatformColor CSSPlatformColor::interpolate(
     const double progress,
     const CSSPlatformColor &to,
     const ValueInterpolationContext &context) const {
-  // Unreachable while canInterpolateTo() is false, and deliberately the same
-  // switch the variant would have applied, so behaviour holds either way.
-  return progress < context.fallbackInterpolateThreshold ? *this : to;
+  // Both endpoints hold payloads here: a blended value only exists mid-flight
+  // and never becomes an endpoint. Resolution is memoized, so past the first
+  // frame this is a lookup, not a platform call.
+  const auto fromChannels = payload ? resolvePlatformColor(*payload, context.node) : std::nullopt;
+  const auto toChannels = to.payload ? resolvePlatformColor(*to.payload, context.node) : std::nullopt;
+  if (!fromChannels || !toChannels) {
+    return progress < context.fallbackInterpolateThreshold ? *this : to;
+  }
+
+  CSSPlatformColor result = progress < 0.5 ? *this : to;
+  result.blended = CSSColor(*fromChannels).interpolate(progress, CSSColor(*toChannels));
+  return result;
 }
 
 bool CSSPlatformColor::operator==(const CSSPlatformColor &other) const {
+  if (blended != other.blended) {
+    return false;
+  }
   if (!payload || !other.payload) {
     return payload == other.payload;
   }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSPlatformColor.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSPlatformColor.h
@@ -9,14 +9,13 @@
 
 namespace reanimated::css {
 
-/// A PlatformColor or DynamicColorIOS payload. It stays unresolved at rest, so
-/// toDynamic() hands it back to RN, which resolves it against the surface's own
-/// theme. Only interpolation resolves it into channels - per frame, against the
-/// animated view, since keyframes are shared by every view using an animation -
-/// and a mid-flight blend is carried here as a plain color.
+/// A PlatformColor or DynamicColorIOS payload, kept unresolved so toDynamic()
+/// hands it back to RN, which resolves it against the surface's own theme.
+/// Interpolation resolves it per frame through resolve() instead - keyframes
+/// are shared by every view using an animation, so a resolution cannot be
+/// stored here.
 struct CSSPlatformColor : public CSSResolvableValue<CSSPlatformColor, ValueInterpolationContext> {
   std::shared_ptr<const folly::dynamic> payload;
-  std::optional<CSSColor> blended;
 
   CSSPlatformColor() = default;
   explicit CSSPlatformColor(const folly::dynamic &value);
@@ -27,6 +26,11 @@ struct CSSPlatformColor : public CSSResolvableValue<CSSPlatformColor, ValueInter
 
   folly::dynamic toDynamic() const override;
   std::string toString() const override;
+
+  /// The payload as a plain color, or nullopt where no platform resolver
+  /// exists. CSSValueVariant calls this before interpolating, so the blend
+  /// itself always happens between two plain colors.
+  std::optional<CSSColor> resolve(const ValueInterpolationContext &context) const;
 
   CSSPlatformColor interpolate(double progress, const CSSPlatformColor &to, const ValueInterpolationContext &context)
       const override;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSPlatformColor.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSPlatformColor.h
@@ -4,19 +4,19 @@
 #include <reanimated/CSS/common/values/CSSValue.h>
 
 #include <memory>
+#include <optional>
 #include <string>
 
 namespace reanimated::css {
 
-/// A PlatformColor or DynamicColorIOS payload, kept unresolved so toDynamic()
-/// hands it back to RN, which resolves it against the surface's own theme.
-///
-/// TODO: nothing resolves a payload yet, so this is resolvable in name only. It
-/// is declared that way because blending needs the payload turned into channels
-/// for the view being animated, and keyframes are shared by every view using an
-/// animation - so the value cannot be resolved once and cached on the keyframe.
+/// A PlatformColor or DynamicColorIOS payload. It stays unresolved at rest, so
+/// toDynamic() hands it back to RN, which resolves it against the surface's own
+/// theme. Only interpolation resolves it into channels - per frame, against the
+/// animated view, since keyframes are shared by every view using an animation -
+/// and a mid-flight blend is carried here as a plain color.
 struct CSSPlatformColor : public CSSResolvableValue<CSSPlatformColor, ValueInterpolationContext> {
   std::shared_ptr<const folly::dynamic> payload;
+  std::optional<CSSColor> blended;
 
   CSSPlatformColor() = default;
   explicit CSSPlatformColor(const folly::dynamic &value);
@@ -28,7 +28,6 @@ struct CSSPlatformColor : public CSSResolvableValue<CSSPlatformColor, ValueInter
   folly::dynamic toDynamic() const override;
   std::string toString() const override;
 
-  bool canInterpolateTo(const CSSPlatformColor &to) const override;
   CSSPlatformColor interpolate(double progress, const CSSPlatformColor &to, const ValueInterpolationContext &context)
       const override;
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSValueVariant.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSValueVariant.cpp
@@ -102,7 +102,15 @@ CSSValueVariant<AllowedTypes...> CSSValueVariant<AllowedTypes...>::interpolate(
     const CSSValueVariant &to,
     const InterpolationContextFor<AllowedTypes...> &context) const {
   if constexpr ((ResolvesToAlternative<AllowedTypes, ContextType, AllowedTypes...> || ...)) {
-    return resolved(context).interpolateResolved(progress, to.resolved(context), context);
+    const auto resolvedFrom = resolved(context);
+    const auto resolvedTo = to.resolved(context);
+    // Blend only when both sides ended up on the same alternative. When just one
+    // of them resolved, switching the originals over keeps the unresolved
+    // payload intact for RN to resolve against the view.
+    if (resolvedFrom.storage_.index() != resolvedTo.storage_.index()) {
+      return fallbackInterpolate(progress, to, context.fallbackInterpolateThreshold);
+    }
+    return resolvedFrom.interpolateResolved(progress, resolvedTo, context);
   } else {
     return interpolateResolved(progress, to, context);
   }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSValueVariant.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSValueVariant.cpp
@@ -101,6 +101,33 @@ CSSValueVariant<AllowedTypes...> CSSValueVariant<AllowedTypes...>::interpolate(
     const double progress,
     const CSSValueVariant &to,
     const InterpolationContextFor<AllowedTypes...> &context) const {
+  if constexpr ((ResolvesToAlternative<AllowedTypes, ContextType, AllowedTypes...> || ...)) {
+    return resolved(context).interpolateResolved(progress, to.resolved(context), context);
+  } else {
+    return interpolateResolved(progress, to, context);
+  }
+}
+
+template <CSSValueDerived... AllowedTypes>
+CSSValueVariant<AllowedTypes...> CSSValueVariant<AllowedTypes...>::resolved(const ContextType &context) const {
+  return std::visit(
+      [&](const auto &value) -> CSSValueVariant {
+        using TCSSValue = std::remove_cvref_t<decltype(value)>;
+        if constexpr (ResolvesToAlternative<TCSSValue, ContextType, AllowedTypes...>) {
+          if (auto resolvedValue = value.resolve(context)) {
+            return CSSValueVariant(std::variant<AllowedTypes...>(std::move(*resolvedValue)));
+          }
+        }
+        return *this;
+      },
+      storage_);
+}
+
+template <CSSValueDerived... AllowedTypes>
+CSSValueVariant<AllowedTypes...> CSSValueVariant<AllowedTypes...>::interpolateResolved(
+    const double progress,
+    const CSSValueVariant &to,
+    const ContextType &context) const {
   if (storage_.index() != to.storage_.index()) {
     return fallbackInterpolate(progress, to, context.fallbackInterpolateThreshold);
   }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSValueVariant.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSValueVariant.h
@@ -4,6 +4,7 @@
 
 #include <folly/json.h>
 
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
@@ -45,6 +46,14 @@ template <typename TCSSValue>
 concept DynamicConstructibleCSSValue = requires(const folly::dynamic &value) {
   { TCSSValue::canConstruct(value) } -> std::same_as<bool>;
   { TCSSValue(value) } -> std::same_as<TCSSValue>;
+}; // NOLINT(readability/braces)
+
+// Checks whether a type resolves into one of the variant's alternatives (e.g.
+// CSSPlatformColor into CSSColor). Selecting on the return type keeps CSSLength
+// out: its resolve() yields a bare double, not an alternative.
+template <typename TCSSValue, typename TContext, typename... TAlternatives>
+concept ResolvesToAlternative = requires(const TCSSValue &value, const TContext &context) {
+  requires(std::is_same_v<decltype(value.resolve(context)), std::optional<TAlternatives>> || ...);
 }; // NOLINT(readability/braces)
 
 /**
@@ -98,7 +107,17 @@ class CSSValueVariant final : public CSSValue {
       const InterpolationContextFor<AllowedTypes...> &context) const;
 
  private:
+  using ContextType = InterpolationContextFor<AllowedTypes...>;
+
   std::variant<AllowedTypes...> storage_;
+
+  /// A copy with any ResolvesToAlternative value replaced by its resolution, so
+  /// e.g. a platform color can blend with a plain one. Unresolvable values stay
+  /// as they are and take the fallback path below.
+  CSSValueVariant resolved(const ContextType &context) const;
+
+  CSSValueVariant interpolateResolved(const double progress, const CSSValueVariant &to, const ContextType &context)
+      const;
 
   CSSValueVariant
   fallbackInterpolate(const double progress, const CSSValueVariant &to, double fallbackInterpolateThreshold) const;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/platformColor.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/platformColor.cpp
@@ -1,22 +1,17 @@
 #include <reanimated/CSS/utils/platformColor.h>
 
 #include <folly/json.h>
+#include <glog/logging.h>
 
 #include <mutex>
 #include <string>
 #include <unordered_map>
 
-#ifndef NDEBUG
-#ifdef ANDROID
-#include <android/log.h>
-#else
-#include <iostream>
-#endif // ANDROID
-#endif // NDEBUG
-
 namespace reanimated::css {
 
 namespace {
+
+constexpr size_t maxCachedResolutions = 256;
 
 bool isPlainObject(jsi::Runtime &rt, const jsi::Value &value) {
   if (!value.isObject()) {
@@ -45,6 +40,8 @@ cacheKey(const folly::dynamic &value, const facebook::react::SurfaceId surfaceId
 
   for (const auto *name : {"semantic", "resource_paths"}) {
     if (const auto *names = value.get_ptr(name)) {
+      key += '\x1f';
+      key += name;
       for (const auto &entry : *names) {
         key += '\x1f' + (entry.isString() ? entry.getString() : "?");
       }
@@ -61,19 +58,12 @@ cacheKey(const folly::dynamic &value, const facebook::react::SurfaceId surfaceId
   return key;
 }
 
-/// Once per process: where no implementation exists every payload fails, and
-/// this runs on every interpolated frame.
 void warnUnresolvable([[maybe_unused]] const folly::dynamic &value) {
 #ifndef NDEBUG
   static std::once_flag warned;
   std::call_once(warned, [&value] {
-    const auto message = "[Reanimated] Cannot resolve the platform color " + folly::toJson(value) +
-        " while animating it, so the animation steps between its endpoints.";
-#ifdef ANDROID
-    __android_log_print(ANDROID_LOG_WARN, "Reanimated", "%s", message.c_str());
-#else
-    std::cerr << message << std::endl;
-#endif // ANDROID
+    LOG(WARNING) << "[Reanimated] Cannot resolve the platform color " << folly::toJson(value)
+                 << " while animating it, so the animation steps between its endpoints.";
   });
 #endif // NDEBUG
 }
@@ -109,7 +99,8 @@ bool isPlatformColorPayload(jsi::Runtime &rt, const jsi::Value &value) {
 std::optional<ColorChannels> resolvePlatformColor(
     const folly::dynamic &value,
     const std::shared_ptr<const facebook::react::ShadowNode> &node) {
-  if (node == nullptr) {
+  if (node == nullptr || !detail::canResolvePlatformColors()) {
+    warnUnresolvable(value);
     return std::nullopt;
   }
 
@@ -117,9 +108,8 @@ std::optional<ColorChannels> resolvePlatformColor(
   static std::unordered_map<std::string, ColorChannels> cache;
   static uint64_t cachedGeneration = 0;
 
-  const auto surfaceId = node->getSurfaceId();
   const auto generation = detail::appearanceGeneration();
-  const auto key = cacheKey(value, surfaceId, generation);
+  const auto key = cacheKey(value, node->getSurfaceId(), generation);
   {
     std::lock_guard<std::mutex> lock(mutex);
     if (generation != cachedGeneration) {
@@ -132,7 +122,7 @@ std::optional<ColorChannels> resolvePlatformColor(
     }
   }
 
-  const auto channels = detail::resolvePlatformColorForNode(value, node);
+  const auto channels = detail::resolvePlatformColorUncached(value, node);
   if (!channels) {
     warnUnresolvable(value);
     return std::nullopt;
@@ -140,6 +130,10 @@ std::optional<ColorChannels> resolvePlatformColor(
 
   std::lock_guard<std::mutex> lock(mutex);
   if (generation == cachedGeneration) {
+    // The key space is app-supplied, so cap it instead of trusting it.
+    if (cache.size() >= maxCachedResolutions) {
+      cache.clear();
+    }
     cache.emplace(key, *channels);
   }
   return channels;
@@ -149,9 +143,11 @@ std::optional<ColorChannels> resolvePlatformColor(
 
 namespace detail {
 
-/// Resolution is Apple-only so far - everything else keeps the discrete switch
-/// and the one-time warning above.
-std::optional<ColorChannels> resolvePlatformColorForNode(
+bool canResolvePlatformColors() {
+  return false;
+}
+
+std::optional<ColorChannels> resolvePlatformColorUncached(
     const folly::dynamic & /*value*/,
     const std::shared_ptr<const facebook::react::ShadowNode> & /*node*/) {
   return std::nullopt;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/platformColor.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/platformColor.cpp
@@ -1,5 +1,19 @@
 #include <reanimated/CSS/utils/platformColor.h>
 
+#include <folly/json.h>
+
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+#ifndef NDEBUG
+#ifdef ANDROID
+#include <android/log.h>
+#else
+#include <iostream>
+#endif // ANDROID
+#endif // NDEBUG
+
 namespace reanimated::css {
 
 namespace {
@@ -21,6 +35,47 @@ bool isArrayProperty(const folly::dynamic &value, const char *name) {
 bool isArrayProperty(jsi::Runtime &rt, const jsi::Object &object, const char *name) {
   const auto property = object.getProperty(rt, name);
   return property.isObject() && property.getObject(rt).isArray(rt);
+}
+
+/// Built by hand because folly::toJson iterates keys in unspecified order, so
+/// its output is not a stable key.
+std::string
+cacheKey(const folly::dynamic &value, const facebook::react::SurfaceId surfaceId, const uint64_t generation) {
+  std::string key = std::to_string(generation) + '\x1f' + std::to_string(surfaceId);
+
+  for (const auto *name : {"semantic", "resource_paths"}) {
+    if (const auto *names = value.get_ptr(name)) {
+      for (const auto &entry : *names) {
+        key += '\x1f' + (entry.isString() ? entry.getString() : "?");
+      }
+      return key;
+    }
+  }
+
+  if (const auto *dynamicColor = value.get_ptr("dynamic")) {
+    for (const auto *field : {"light", "dark", "highContrastLight", "highContrastDark"}) {
+      const auto *channel = dynamicColor->get_ptr(field);
+      key += '\x1f' + (channel != nullptr && channel->isNumber() ? std::to_string(channel->asInt()) : "-");
+    }
+  }
+  return key;
+}
+
+/// Once per process: where no implementation exists every payload fails, and
+/// this runs on every interpolated frame.
+void warnUnresolvable([[maybe_unused]] const folly::dynamic &value) {
+#ifndef NDEBUG
+  static std::once_flag warned;
+  std::call_once(warned, [&value] {
+    const auto message = "[Reanimated] Cannot resolve the platform color " + folly::toJson(value) +
+        " while animating it, so the animation steps between its endpoints.";
+#ifdef ANDROID
+    __android_log_print(ANDROID_LOG_WARN, "Reanimated", "%s", message.c_str());
+#else
+    std::cerr << message << std::endl;
+#endif // ANDROID
+  });
+#endif // NDEBUG
 }
 
 } // namespace
@@ -50,5 +105,64 @@ bool isPlatformColorPayload(jsi::Runtime &rt, const jsi::Value &value) {
 
   return isPlainObject(rt, object.getProperty(rt, "dynamic"));
 }
+
+std::optional<ColorChannels> resolvePlatformColor(
+    const folly::dynamic &value,
+    const std::shared_ptr<const facebook::react::ShadowNode> &node) {
+  if (node == nullptr) {
+    return std::nullopt;
+  }
+
+  static std::mutex mutex;
+  static std::unordered_map<std::string, ColorChannels> cache;
+  static uint64_t cachedGeneration = 0;
+
+  const auto surfaceId = node->getSurfaceId();
+  const auto generation = detail::appearanceGeneration();
+  const auto key = cacheKey(value, surfaceId, generation);
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    if (generation != cachedGeneration) {
+      cache.clear();
+      cachedGeneration = generation;
+    }
+    const auto cached = cache.find(key);
+    if (cached != cache.end()) {
+      return cached->second;
+    }
+  }
+
+  const auto channels = detail::resolvePlatformColorForNode(value, node);
+  if (!channels) {
+    warnUnresolvable(value);
+    return std::nullopt;
+  }
+
+  std::lock_guard<std::mutex> lock(mutex);
+  if (generation == cachedGeneration) {
+    cache.emplace(key, *channels);
+  }
+  return channels;
+}
+
+#if !defined(__APPLE__)
+
+namespace detail {
+
+/// Resolution is Apple-only so far - everything else keeps the discrete switch
+/// and the one-time warning above.
+std::optional<ColorChannels> resolvePlatformColorForNode(
+    const folly::dynamic & /*value*/,
+    const std::shared_ptr<const facebook::react::ShadowNode> & /*node*/) {
+  return std::nullopt;
+}
+
+uint64_t appearanceGeneration() {
+  return 0;
+}
+
+} // namespace detail
+
+#endif // !defined(__APPLE__)
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/platformColor.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/platformColor.h
@@ -19,22 +19,23 @@ bool isPlatformColorPayload(jsi::Runtime &rt, const jsi::Value &value);
 
 namespace detail {
 
+/// False where no resolver exists, so callers skip the memoization entirely.
+bool canResolvePlatformColors();
+
 /// Raw per-platform resolution, called only on a cache miss. Apple ignores the
-/// surface: a window with its own overrideUserInterfaceStyle is not honoured.
-std::optional<ColorChannels> resolvePlatformColorForNode(
+/// node: a window with its own overrideUserInterfaceStyle is not honoured.
+std::optional<ColorChannels> resolvePlatformColorUncached(
     const folly::dynamic &value,
     const std::shared_ptr<const facebook::react::ShadowNode> &node);
 
-/// Bumped whenever previously resolved colors stop being valid. Apple tracks
-/// appearance changes; Android has no equivalent signal, so a theme change
-/// there is only picked up when the surface is recreated.
+/// Bumped whenever previously resolved colors stop being valid. Constant where
+/// canResolvePlatformColors() is false.
 uint64_t appearanceGeneration();
 
 } // namespace detail
 
 /// Memoized per (payload, surface, appearance): an animated color resolves on
-/// every interpolated frame. Returns nullopt, and warns once, when the platform
-/// cannot resolve the payload.
+/// every interpolated frame.
 std::optional<ColorChannels> resolvePlatformColor(
     const folly::dynamic &value,
     const std::shared_ptr<const facebook::react::ShadowNode> &node);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/platformColor.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/platformColor.h
@@ -4,6 +4,10 @@
 
 #include <folly/dynamic.h>
 #include <jsi/jsi.h>
+#include <react/renderer/core/ShadowNode.h>
+
+#include <memory>
+#include <optional>
 
 namespace reanimated::css {
 
@@ -12,5 +16,27 @@ namespace reanimated::css {
 /// be taken for a platform color and handed back to RN unresolved.
 bool isPlatformColorPayload(const folly::dynamic &value);
 bool isPlatformColorPayload(jsi::Runtime &rt, const jsi::Value &value);
+
+namespace detail {
+
+/// Raw per-platform resolution, called only on a cache miss. Apple ignores the
+/// surface: a window with its own overrideUserInterfaceStyle is not honoured.
+std::optional<ColorChannels> resolvePlatformColorForNode(
+    const folly::dynamic &value,
+    const std::shared_ptr<const facebook::react::ShadowNode> &node);
+
+/// Bumped whenever previously resolved colors stop being valid. Apple tracks
+/// appearance changes; Android has no equivalent signal, so a theme change
+/// there is only picked up when the surface is recreated.
+uint64_t appearanceGeneration();
+
+} // namespace detail
+
+/// Memoized per (payload, surface, appearance): an animated color resolves on
+/// every interpolated frame. Returns nullopt, and warns once, when the platform
+/// cannot resolve the payload.
+std::optional<ColorChannels> resolvePlatformColor(
+    const folly::dynamic &value,
+    const std::shared_ptr<const facebook::react::ShadowNode> &node);
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformColor.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformColor.mm
@@ -5,6 +5,7 @@
 #if !TARGET_OS_OSX
 
 #import <React/RCTConstants.h>
+#import <React/RCTUtils.h>
 #import <UIKit/UIKit.h>
 #import <react/renderer/graphics/HostPlatformColor.h>
 #import <react/renderer/graphics/RCTPlatformColorUtils.h>
@@ -22,29 +23,30 @@ namespace detail {
 
 namespace {
 
-std::mutex &traitsMutex()
-{
-  static std::mutex mutex;
-  return mutex;
-}
-
+std::mutex traitsMutex;
 UITraitCollection *storedTraits = nil;
+id<NSObject> traitsObserver = nil;
 std::atomic<uint64_t> appearanceCounter{0};
 
-/// The notification also fires for orientation and font-size changes, hence the
-/// explicit color-appearance check.
-void observeAppearanceChanges()
+/// Seeds from the key window, whose traits honour overrideUserInterfaceStyle,
+/// then follows RN's appearance notification. The notification also fires for
+/// orientation changes, hence the explicit color-appearance check.
+void watchAppearance()
 {
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-    [NSNotificationCenter.defaultCenter
+    RCTUnsafeExecuteOnMainQueueSync(^{
+      std::lock_guard<std::mutex> lock(traitsMutex);
+      storedTraits = RCTKeyWindow().traitCollection;
+    });
+    traitsObserver = [NSNotificationCenter.defaultCenter
         addObserverForName:RCTUserInterfaceStyleDidChangeNotification
                     object:nil
                      queue:NSOperationQueue.mainQueue
                 usingBlock:^(NSNotification *notification) {
                   UITraitCollection *next =
                       notification.userInfo[RCTUserInterfaceStyleDidChangeNotificationTraitCollectionKey];
-                  std::lock_guard<std::mutex> lock(traitsMutex());
+                  std::lock_guard<std::mutex> lock(traitsMutex);
 
                   if (next == nil ||
                       (storedTraits != nil &&
@@ -57,13 +59,13 @@ void observeAppearanceChanges()
   });
 }
 
-int32_t colorField(const folly::dynamic &value, const char *name, const int32_t fallback)
+int32_t colorField(const folly::dynamic &value, const char *name)
 {
   const auto *field = value.get_ptr(name);
-  return field != nullptr && field->isNumber() ? static_cast<int32_t>(field->asInt()) : fallback;
+  return field != nullptr && field->isNumber() ? static_cast<int32_t>(field->asInt()) : 0;
 }
 
-UIColor *unresolvedColor(const folly::dynamic &value)
+UIColor *payloadUIColor(const folly::dynamic &value)
 {
   if (const auto *semantic = value.get_ptr("semantic")) {
     std::vector<std::string> names;
@@ -81,38 +83,38 @@ UIColor *unresolvedColor(const folly::dynamic &value)
     return nil;
   }
 
-  const auto light = colorField(*dynamicColor, "light", 0);
-  // Color(const DynamicColor &) yields a nil UIColor when a side is missing.
-  const auto dark = colorField(*dynamicColor, "dark", light);
+  // Missing sides stay 0 (transparent), matching how RN renders the same
+  // payload when it is not animated.
   return RCTPlatformColorFromColor(facebook::react::Color(facebook::react::DynamicColor{
-      .lightColor = light,
-      .darkColor = dark,
-      .highContrastLightColor = colorField(*dynamicColor, "highContrastLight", light),
-      .highContrastDarkColor = colorField(*dynamicColor, "highContrastDark", dark)}));
+      .lightColor = colorField(*dynamicColor, "light"),
+      .darkColor = colorField(*dynamicColor, "dark"),
+      .highContrastLightColor = colorField(*dynamicColor, "highContrastLight"),
+      .highContrastDarkColor = colorField(*dynamicColor, "highContrastDark")}));
 }
 
 } // namespace
 
-std::optional<ColorChannels> resolvePlatformColorForNode(
+bool canResolvePlatformColors()
+{
+  return true;
+}
+
+std::optional<ColorChannels> resolvePlatformColorUncached(
     const folly::dynamic &value,
     const std::shared_ptr<const facebook::react::ShadowNode> & /*node*/)
 {
-  observeAppearanceChanges();
+  watchAppearance();
 
-  UIColor *color = unresolvedColor(value);
+  UIColor *color = payloadUIColor(value);
   if (color == nil) {
     return std::nullopt;
   }
 
   UITraitCollection *traits = nil;
   {
-    std::lock_guard<std::mutex> lock(traitsMutex());
-    if (storedTraits == nil) {
-      storedTraits = UITraitCollection.currentTraitCollection;
-    }
+    std::lock_guard<std::mutex> lock(traitsMutex);
     traits = storedTraits;
   }
-
   UIColor *resolved = traits != nil ? [color resolvedColorWithTraitCollection:traits] : color;
 
   CGFloat red = 0, green = 0, blue = 0, alpha = 0;
@@ -128,7 +130,7 @@ std::optional<ColorChannels> resolvePlatformColorForNode(
 
 uint64_t appearanceGeneration()
 {
-  observeAppearanceChanges();
+  watchAppearance();
   return appearanceCounter.load();
 }
 
@@ -142,7 +144,12 @@ namespace reanimated::css {
 
 namespace detail {
 
-std::optional<ColorChannels> resolvePlatformColorForNode(
+bool canResolvePlatformColors()
+{
+  return false;
+}
+
+std::optional<ColorChannels> resolvePlatformColorUncached(
     const folly::dynamic & /*value*/,
     const std::shared_ptr<const facebook::react::ShadowNode> & /*node*/)
 {

--- a/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformColor.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformColor.mm
@@ -1,0 +1,161 @@
+#import <reanimated/CSS/utils/platformColor.h>
+
+#import <TargetConditionals.h>
+
+#if !TARGET_OS_OSX
+
+#import <React/RCTConstants.h>
+#import <UIKit/UIKit.h>
+#import <react/renderer/graphics/HostPlatformColor.h>
+#import <react/renderer/graphics/RCTPlatformColorUtils.h>
+
+#import <algorithm>
+#import <atomic>
+#import <cmath>
+#import <mutex>
+#import <string>
+#import <vector>
+
+namespace reanimated::css {
+
+namespace detail {
+
+namespace {
+
+std::mutex &traitsMutex()
+{
+  static std::mutex mutex;
+  return mutex;
+}
+
+UITraitCollection *storedTraits = nil;
+std::atomic<uint64_t> appearanceCounter{0};
+
+/// The notification also fires for orientation and font-size changes, hence the
+/// explicit color-appearance check.
+void observeAppearanceChanges()
+{
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    [NSNotificationCenter.defaultCenter
+        addObserverForName:RCTUserInterfaceStyleDidChangeNotification
+                    object:nil
+                     queue:NSOperationQueue.mainQueue
+                usingBlock:^(NSNotification *notification) {
+                  UITraitCollection *next =
+                      notification.userInfo[RCTUserInterfaceStyleDidChangeNotificationTraitCollectionKey];
+                  std::lock_guard<std::mutex> lock(traitsMutex());
+
+                  if (next == nil ||
+                      (storedTraits != nil &&
+                       ![next hasDifferentColorAppearanceComparedToTraitCollection:storedTraits])) {
+                    return;
+                  }
+                  storedTraits = next;
+                  ++appearanceCounter;
+                }];
+  });
+}
+
+int32_t colorField(const folly::dynamic &value, const char *name, const int32_t fallback)
+{
+  const auto *field = value.get_ptr(name);
+  return field != nullptr && field->isNumber() ? static_cast<int32_t>(field->asInt()) : fallback;
+}
+
+UIColor *unresolvedColor(const folly::dynamic &value)
+{
+  if (const auto *semantic = value.get_ptr("semantic")) {
+    std::vector<std::string> names;
+    names.reserve(semantic->size());
+    for (const auto &name : *semantic) {
+      if (name.isString()) {
+        names.push_back(name.getString());
+      }
+    }
+    return names.empty() ? nil : RCTPlatformColorFromSemanticItems(names);
+  }
+
+  const auto *dynamicColor = value.get_ptr("dynamic");
+  if (dynamicColor == nullptr) {
+    return nil;
+  }
+
+  const auto light = colorField(*dynamicColor, "light", 0);
+  // Color(const DynamicColor &) yields a nil UIColor when a side is missing.
+  const auto dark = colorField(*dynamicColor, "dark", light);
+  return RCTPlatformColorFromColor(facebook::react::Color(facebook::react::DynamicColor{
+      .lightColor = light,
+      .darkColor = dark,
+      .highContrastLightColor = colorField(*dynamicColor, "highContrastLight", light),
+      .highContrastDarkColor = colorField(*dynamicColor, "highContrastDark", dark)}));
+}
+
+} // namespace
+
+std::optional<ColorChannels> resolvePlatformColorForNode(
+    const folly::dynamic &value,
+    const std::shared_ptr<const facebook::react::ShadowNode> & /*node*/)
+{
+  observeAppearanceChanges();
+
+  UIColor *color = unresolvedColor(value);
+  if (color == nil) {
+    return std::nullopt;
+  }
+
+  UITraitCollection *traits = nil;
+  {
+    std::lock_guard<std::mutex> lock(traitsMutex());
+    if (storedTraits == nil) {
+      storedTraits = UITraitCollection.currentTraitCollection;
+    }
+    traits = storedTraits;
+  }
+
+  UIColor *resolved = traits != nil ? [color resolvedColorWithTraitCollection:traits] : color;
+
+  CGFloat red = 0, green = 0, blue = 0, alpha = 0;
+  if (![resolved getRed:&red green:&green blue:&blue alpha:&alpha]) {
+    return std::nullopt;
+  }
+
+  const auto channel = [](const CGFloat component) {
+    return static_cast<uint8_t>(std::lround(std::clamp<CGFloat>(component, 0.0, 1.0) * 255.0));
+  };
+  return ColorChannels{channel(red), channel(green), channel(blue), channel(alpha)};
+}
+
+uint64_t appearanceGeneration()
+{
+  observeAppearanceChanges();
+  return appearanceCounter.load();
+}
+
+} // namespace detail
+
+} // namespace reanimated::css
+
+#else
+
+namespace reanimated::css {
+
+namespace detail {
+
+std::optional<ColorChannels> resolvePlatformColorForNode(
+    const folly::dynamic & /*value*/,
+    const std::shared_ptr<const facebook::react::ShadowNode> & /*node*/)
+{
+  return std::nullopt;
+}
+
+uint64_t appearanceGeneration()
+{
+  return 0;
+}
+
+} // namespace detail
+
+} // namespace reanimated::css
+
+#endif // !TARGET_OS_OSX


### PR DESCRIPTION
Makes `PlatformColor` and `DynamicColorIOS` values actually animate in CSS animations and transitions on iOS. #10282 taught the CSS layer to parse them and switch over; this resolves them into channels and blends.

`CSSPlatformColor` gains `resolve()`, and `CSSValueVariant` resolves any alternative whose resolution is another alternative before interpolating, so a payload comes back as a plain `CSSColor` and blends with anything a color can - including a literal on the other side, or the default when a keyframe omits one endpoint. Selection is on the resolve return type, which keeps `CSSLength` on its relative path. At progress 0 and 1 the raw payload still goes to React Native, so settled values keep re-resolving on theme changes.

Resolution runs through RN's own platform color utilities, memoized per payload, surface and appearance generation - a bounded cache invalidated by RN's appearance notification, so past the first frame a resolve is a lookup, with no per-frame UIKit calls. The first resolution seeds from the key window's traits, which honour `overrideUserInterfaceStyle`. Platforms without a resolver skip all of it and keep the discrete switch from #10282, with a one-time dev warning.

## Testing

- iOS build, all C++ TUs, clang-tidy on the changed files, jest and static checks.
- On the simulator, `backgroundColor`: platform-to-platform, literal-to-platform and single-endpoint keyframes all blend; a platform-to-platform transition animates and settles correctly.
- Dark-mode flip mid-animation: a running `labelColor` ramp re-resolves from black to white, and a settled transition picks up the dark variant through RN.
