### PR TITLE
fix: observe Modal windows created before the first pseudo selector registration

### DIFF
--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/pseudoSelectors/PseudoSelectorManager.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/pseudoSelectors/PseudoSelectorManager.kt
@@ -174,7 +174,6 @@ class PseudoSelectorManager(
             }
     }
 
-
     private fun attachPressSelector(
         view: View,
         key: String,

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/pseudoSelectors/PseudoSelectorManager.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/pseudoSelectors/PseudoSelectorManager.kt
@@ -42,7 +42,13 @@ class PseudoSelectorManager(
         // Dialog windows announce their creation only to listeners that already exist, so the
         // bridge must be listening before the first Modal can open. Installing it on the first
         // pseudo registration is too late for a registration that happens inside that Modal.
-        UiThreadUtil.runOnUiThread { ensureExtraWindowBridge() }
+        UiThreadUtil.runOnUiThread {
+            if (BuildConfig.IS_REACT_NATIVE_86_OR_NEWER) {
+                reactContext.get()?.let { context ->
+                    extraWindowBridge = ExtraWindowObserverBridge(context, hover).also { it.install() }
+                }
+            }
+        }
     }
 
     private val pendingAttaches = LinkedHashMap<String, PendingAttach>()
@@ -168,13 +174,6 @@ class PseudoSelectorManager(
             }
     }
 
-    private fun ensureExtraWindowBridge() {
-        if (!BuildConfig.IS_REACT_NATIVE_86_OR_NEWER || extraWindowBridge != null) {
-            return
-        }
-        val context = reactContext.get() ?: return
-        extraWindowBridge = ExtraWindowObserverBridge(context, hover).also { it.install() }
-    }
 
     private fun attachPressSelector(
         view: View,

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/pseudoSelectors/PseudoSelectorManager.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/pseudoSelectors/PseudoSelectorManager.kt
@@ -38,6 +38,13 @@ class PseudoSelectorManager(
     private val hover = TouchHoverCoordinator(::onWindowPressTouch)
     private var extraWindowBridge: ExtraWindowObserverBridge? = null
 
+    init {
+        // Dialog windows announce their creation only to listeners that already exist, so the
+        // bridge must be listening before the first Modal can open. Installing it on the first
+        // pseudo registration is too late for a registration that happens inside that Modal.
+        UiThreadUtil.runOnUiThread { ensureExtraWindowBridge() }
+    }
+
     private val pendingAttaches = LinkedHashMap<String, PendingAttach>()
     private var mountListenerRegistered = false
 
@@ -154,7 +161,6 @@ class PseudoSelectorManager(
         val host = findTouchHost(view)
         acquireTouchListener(host)
         hover.register(view, host, callback)
-        ensureExtraWindowBridge()
         detachActions[key] =
             Runnable {
                 hover.unregister(view, host)
@@ -180,7 +186,6 @@ class PseudoSelectorManager(
         callbacks[view] = callback
         acquireTouchListener(host)
         hover.retainWindowObserver(view)
-        ensureExtraWindowBridge()
         detachActions[key] =
             Runnable {
                 callbacks.remove(view)


### PR DESCRIPTION
## Summary

React Native announces a `Modal`'s `Dialog` window only at `show()`, and `addExtraWindowEventListener` does not replay windows that already exist. Installing the bridge on the first pseudo selector registration therefore missed any `Modal` opened earlier, leaving its selectors on the per-view fallback, where two things break:

- a blank tap does not clear a committed touch `:hover`,
- starting a scroll on a hovered view clears the hover as soon as the `ScrollView` intercepts.

## Fix

Install the bridge when `PseudoSelectorManager` is constructed, before any `Modal` can open. Still gated to RN 0.86+ and idempotent. It can no longer be gated on having a registration, so from RN 0.86 on every `Modal` gets its `Window.Callback` wrapped whether or not the app uses pseudo selectors; the wrapper delegates straight through and the coordinator does nothing while no view is registered.

## Recordings

Same injected input on both builds, main (left) vs fix (right).

Blank tap inside the modal:

https://github.com/user-attachments/assets/f2ed6970-4384-44cb-8638-782ed5edba36

Scroll starting on the hovered view:

https://github.com/user-attachments/assets/9aa53702-b374-4101-8922-18e1f07e05d6
