### PR TITLE
fix: support :active on opacity-0 views on iOS

### DIFF
--- a/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REAPseudoSelectorObserver.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REAPseudoSelectorObserver.mm
@@ -50,6 +50,22 @@ static const CGFloat kActivePressMovementThreshold = 10.0;
 #if !TARGET_OS_OSX
 static __weak UITouch *sActivePrimaryTouch;
 static NSInteger sActiveTouchCount;
+
+void REAPseudoPressGateRetain(UITouch *touch)
+{
+  if (sActivePrimaryTouch == nil) {
+    sActivePrimaryTouch = touch;
+  }
+  sActiveTouchCount++;
+}
+
+void REAPseudoPressGateRelease(void)
+{
+  if (--sActiveTouchCount <= 0) {
+    sActiveTouchCount = 0;
+    sActivePrimaryTouch = nil;
+  }
+}
 #endif
 
 - (instancetype)initWithView:(REAUIView *)view

--- a/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REAPseudoSelectorObserver.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REAPseudoSelectorObserver.mm
@@ -430,8 +430,9 @@ static int _focusObserverContext;
 #if !TARGET_OS_TV
   UIWindow *window = view.window;
   if (window != nil) {
-    UIView *bumpedHit = [[REATouchHoverCoordinator sharedCoordinator] hitTestInWindow:window
-                                                                             atPoint:[recognizer locationInView:window]];
+    UIView *bumpedHit =
+        [[REATouchHoverCoordinator sharedCoordinator] hitTestInWindow:window
+                                                              atPoint:[recognizer locationInView:window]];
     if (bumpedHit != nil && [bumpedHit isDescendantOfView:view]) {
       return bumpedHit;
     }

--- a/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REAPseudoSelectorObserver.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REAPseudoSelectorObserver.mm
@@ -105,6 +105,16 @@ static NSInteger sActiveTouchCount;
   recognizer.delegate = self;
   [view addGestureRecognizer:recognizer];
   _gestureRecognizer = recognizer;
+#if !TARGET_OS_OSX && !TARGET_OS_TV
+  // UIKit never delivers touches to views with alpha < ~0.01 (e.g. `opacity: {default: 0, ':active': 1}`),
+  // so the recognizer alone cannot engage them. The coordinator activates exactly those views through
+  // its alpha-bumped hit-test; reachable views stay on the recognizer path.
+  [[REATouchHoverCoordinator sharedCoordinator]
+      registerPressObserver:self
+                       view:view
+                    deepest:_selector == reanimated::PseudoSelector::ActiveDeepest
+                   callback:_callback];
+#endif
 }
 
 - (void)attachHoverToView:(REAUIView *)view
@@ -455,6 +465,9 @@ static int _focusObserverContext;
 #if !TARGET_OS_TV
   if (_selector == reanimated::PseudoSelector::Hover) {
     [[REATouchHoverCoordinator sharedCoordinator] unregisterObserver:self];
+  }
+  if ([self isPressSelector]) {
+    [[REATouchHoverCoordinator sharedCoordinator] unregisterPressObserver:self];
   }
 #endif
 #endif

--- a/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REAPseudoSelectorObserver.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REAPseudoSelectorObserver.mm
@@ -122,9 +122,6 @@ void REAPseudoPressGateRelease(void)
   [view addGestureRecognizer:recognizer];
   _gestureRecognizer = recognizer;
 #if !TARGET_OS_OSX && !TARGET_OS_TV
-  // UIKit never delivers touches to views with alpha < ~0.01 (e.g. `opacity: {default: 0, ':active': 1}`),
-  // so the recognizer alone cannot engage them. The coordinator activates exactly those views through
-  // its alpha-bumped hit-test; reachable views stay on the recognizer path.
   [[REATouchHoverCoordinator sharedCoordinator]
       registerPressObserver:self
                        view:view
@@ -419,9 +416,8 @@ static int _focusObserverContext;
 }
 
 #if !TARGET_OS_OSX
-// UIKit's hit-test cannot see a press-registered descendant with near-zero alpha, so on its own it
-// would report this view as the deepest one and let it claim a press the coordinator is about to
-// give that descendant. Ask the coordinator whether it will act here first.
+// UIKit's hit-test cannot see a near-zero-alpha descendant, so on its own it would report this view
+// as the deepest and let it claim a press the coordinator is about to give that descendant.
 - (BOOL)isOutrankedByRescuedPressAt:(CGPoint)location inView:(REAUIView *)view
 {
 #if !TARGET_OS_TV

--- a/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REAPseudoSelectorObserver.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REAPseudoSelectorObserver.mm
@@ -419,6 +419,27 @@ static int _focusObserverContext;
 }
 
 #if !TARGET_OS_OSX
+// UIKit's own hit-test cannot see a press-registered descendant with near-zero alpha, so asking it
+// which view is deepest would let this view win over a descendant the coordinator is about to
+// engage. Arbitrate over the coordinator's alpha-bumped hit-test instead, and only when it lands
+// inside this view - anything else keeps UIKit's answer.
+- (UIView *)deepestPressCandidateAt:(CGPoint)location
+                             inView:(REAUIView *)view
+                      forRecognizer:(UIGestureRecognizer *)recognizer
+{
+#if !TARGET_OS_TV
+  UIWindow *window = view.window;
+  if (window != nil) {
+    UIView *bumpedHit = [[REATouchHoverCoordinator sharedCoordinator] hitTestInWindow:window
+                                                                             atPoint:[recognizer locationInView:window]];
+    if (bumpedHit != nil && [bumpedHit isDescendantOfView:view]) {
+      return bumpedHit;
+    }
+  }
+#endif
+  return [view hitTest:location withEvent:nil];
+}
+
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
 #else
 - (BOOL)gestureRecognizerShouldBegin:(NSGestureRecognizer *)gestureRecognizer
@@ -433,7 +454,7 @@ static int _focusObserverContext;
   }
   CGPoint location = [gestureRecognizer locationInView:view];
 #if !TARGET_OS_OSX
-  UIView *current = [view hitTest:location withEvent:nil];
+  UIView *current = [self deepestPressCandidateAt:location inView:view forRecognizer:gestureRecognizer];
   while (current && current != view) {
     for (UIGestureRecognizer *gr in current.gestureRecognizers) {
       if ([gr.delegate isKindOfClass:[REAPseudoSelectorObserver class]] &&

--- a/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REAPseudoSelectorObserver.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REAPseudoSelectorObserver.mm
@@ -429,7 +429,9 @@ static int _focusObserverContext;
   if (window == nil) {
     return NO;
   }
-  UIView *rescued = [[REATouchHoverCoordinator sharedCoordinator] rescuedPressViewInWindow:window
+  // sActivePrimaryTouch is the touch this recognizer was just admitted for by -shouldReceiveTouch:.
+  UIView *rescued = [[REATouchHoverCoordinator sharedCoordinator] rescuedPressViewForTouch:sActivePrimaryTouch
+                                                                                  inWindow:window
                                                                                    atPoint:[view convertPoint:location
                                                                                                        toView:window]];
   return rescued != nil && rescued != view && [rescued isDescendantOfView:view];

--- a/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REAPseudoSelectorObserver.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REAPseudoSelectorObserver.mm
@@ -419,26 +419,23 @@ static int _focusObserverContext;
 }
 
 #if !TARGET_OS_OSX
-// UIKit's own hit-test cannot see a press-registered descendant with near-zero alpha, so asking it
-// which view is deepest would let this view win over a descendant the coordinator is about to
-// engage. Arbitrate over the coordinator's alpha-bumped hit-test instead, and only when it lands
-// inside this view - anything else keeps UIKit's answer.
-- (UIView *)deepestPressCandidateAt:(CGPoint)location
-                             inView:(REAUIView *)view
-                      forRecognizer:(UIGestureRecognizer *)recognizer
+// UIKit's hit-test cannot see a press-registered descendant with near-zero alpha, so on its own it
+// would report this view as the deepest one and let it claim a press the coordinator is about to
+// give that descendant. Ask the coordinator whether it will act here first.
+- (BOOL)isOutrankedByRescuedPressAt:(CGPoint)location inView:(REAUIView *)view
 {
 #if !TARGET_OS_TV
   UIWindow *window = view.window;
-  if (window != nil) {
-    UIView *bumpedHit =
-        [[REATouchHoverCoordinator sharedCoordinator] hitTestInWindow:window
-                                                              atPoint:[recognizer locationInView:window]];
-    if (bumpedHit != nil && [bumpedHit isDescendantOfView:view]) {
-      return bumpedHit;
-    }
+  if (window == nil) {
+    return NO;
   }
+  UIView *rescued = [[REATouchHoverCoordinator sharedCoordinator] rescuedPressViewInWindow:window
+                                                                                   atPoint:[view convertPoint:location
+                                                                                                       toView:window]];
+  return rescued != nil && rescued != view && [rescued isDescendantOfView:view];
+#else
+  return NO;
 #endif
-  return [view hitTest:location withEvent:nil];
 }
 
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
@@ -455,7 +452,10 @@ static int _focusObserverContext;
   }
   CGPoint location = [gestureRecognizer locationInView:view];
 #if !TARGET_OS_OSX
-  UIView *current = [self deepestPressCandidateAt:location inView:view forRecognizer:gestureRecognizer];
+  if ([self isOutrankedByRescuedPressAt:location inView:view]) {
+    return NO;
+  }
+  UIView *current = [view hitTest:location withEvent:nil];
   while (current && current != view) {
     for (UIGestureRecognizer *gr in current.gestureRecognizers) {
       if ([gr.delegate isKindOfClass:[REAPseudoSelectorObserver class]] &&

--- a/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REATouchHoverCoordinator.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REATouchHoverCoordinator.h
@@ -10,27 +10,23 @@
 - (void)registerObserver:(id)owner view:(UIView *)view callback:(std::function<void(bool)>)callback;
 - (void)unregisterObserver:(id)owner;
 
-/// Fallback press path for views UIKit's hit-test cannot reach (alpha < ~0.01). The per-view
-/// UILongPressGestureRecognizer never fires for them, so the window observer drives `:active`
-/// through the same alpha-bumped hit-test that touch `:hover` uses. Activates an entry only
-/// when the touch lands on it thanks to the bump, so it never races the recognizer.
+/// Fallback press path for views UIKit's hit-test cannot reach (alpha < ~0.01): their
+/// UILongPressGestureRecognizer never fires, so the window observer drives `:active` instead,
+/// and only for views the alpha bump revealed - never for ones the recognizer can serve.
 - (void)registerPressObserver:(id)owner
                          view:(UIView *)view
                       deepest:(BOOL)deepest
                      callback:(std::function<void(bool)>)callback;
 - (void)unregisterPressObserver:(id)owner;
 
-/// The view this coordinator would drive `:active` for, or nil when it would not act on this touch.
-/// `:active-deepest` recognizers ask before claiming a press: a descendant the coordinator is about
-/// to engage outranks them, exactly as a UIKit-reachable descendant does. Answers nil for windows it
-/// does not observe and for touches it is not driving, so it never suppresses a press nobody rescues.
+/// The view this coordinator would drive `:active` for, or nil when it would not act on this
+/// touch. `:active-deepest` recognizers ask before claiming a press, since a descendant the
+/// coordinator is about to engage outranks them just as a UIKit-reachable one does.
 - (UIView *)rescuedPressViewForTouch:(UITouch *)touch inWindow:(UIWindow *)window atPoint:(CGPoint)point;
 @end
 
-/// One touch drives all presses globally: the recognizers share a gate that admits a single
-/// touch, and the coordinator holds the same gate from the moment a fallback press engages
-/// until the touch sequence ends - dismissing the press by dragging must not let another
-/// finger start one. Defined with the gate state in REAPseudoSelectorObserver.mm.
+/// Single-touch gate shared with the recognizers, held from the moment a fallback press engages
+/// until the touch sequence ends. Defined with its state in REAPseudoSelectorObserver.mm.
 void REAPseudoPressGateRetain(UITouch *touch);
 void REAPseudoPressGateRelease(void);
 

--- a/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REATouchHoverCoordinator.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REATouchHoverCoordinator.h
@@ -20,11 +20,11 @@
                      callback:(std::function<void(bool)>)callback;
 - (void)unregisterPressObserver:(id)owner;
 
-/// The view this coordinator would drive `:active` for at `point`, or nil when it would not act
-/// there. `:active-deepest` recognizers ask this before claiming a press: a descendant the
-/// coordinator is about to engage outranks them, exactly as a UIKit-reachable descendant does.
-/// Answers nil for windows it does not observe, so it never suppresses a press nobody rescues.
-- (UIView *)rescuedPressViewInWindow:(UIWindow *)window atPoint:(CGPoint)point;
+/// The view this coordinator would drive `:active` for, or nil when it would not act on this touch.
+/// `:active-deepest` recognizers ask before claiming a press: a descendant the coordinator is about
+/// to engage outranks them, exactly as a UIKit-reachable descendant does. Answers nil for windows it
+/// does not observe and for touches it is not driving, so it never suppresses a press nobody rescues.
+- (UIView *)rescuedPressViewForTouch:(UITouch *)touch inWindow:(UIWindow *)window atPoint:(CGPoint)point;
 @end
 
 /// One touch drives all presses globally: the recognizers share a gate that admits a single

--- a/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REATouchHoverCoordinator.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REATouchHoverCoordinator.h
@@ -20,10 +20,11 @@
                      callback:(std::function<void(bool)>)callback;
 - (void)unregisterPressObserver:(id)owner;
 
-/// Topmost view at `point`, treating registered near-zero-alpha views as hit-testable. The
-/// `:active-deepest` recognizers arbitrate over this rather than UIKit's own hit-test, so an
-/// invisible press-registered descendant still outranks a visible ancestor.
-- (UIView *)hitTestInWindow:(UIWindow *)window atPoint:(CGPoint)point;
+/// The view this coordinator would drive `:active` for at `point`, or nil when it would not act
+/// there. `:active-deepest` recognizers ask this before claiming a press: a descendant the
+/// coordinator is about to engage outranks them, exactly as a UIKit-reachable descendant does.
+/// Answers nil for windows it does not observe, so it never suppresses a press nobody rescues.
+- (UIView *)rescuedPressViewInWindow:(UIWindow *)window atPoint:(CGPoint)point;
 @end
 
 /// One touch drives all presses globally: the recognizers share a gate that admits a single

--- a/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REATouchHoverCoordinator.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REATouchHoverCoordinator.h
@@ -9,6 +9,16 @@
 + (instancetype)sharedCoordinator;
 - (void)registerObserver:(id)owner view:(UIView *)view callback:(std::function<void(bool)>)callback;
 - (void)unregisterObserver:(id)owner;
+
+/// Fallback press path for views UIKit's hit-test cannot reach (alpha < ~0.01). The per-view
+/// UILongPressGestureRecognizer never fires for them, so the window observer drives `:active`
+/// through the same alpha-bumped hit-test that touch `:hover` uses. Activates an entry only
+/// when the touch lands on it thanks to the bump, so it never races the recognizer.
+- (void)registerPressObserver:(id)owner
+                         view:(UIView *)view
+                      deepest:(BOOL)deepest
+                     callback:(std::function<void(bool)>)callback;
+- (void)unregisterPressObserver:(id)owner;
 @end
 
 #endif

--- a/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REATouchHoverCoordinator.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REATouchHoverCoordinator.h
@@ -21,4 +21,11 @@
 - (void)unregisterPressObserver:(id)owner;
 @end
 
+/// One touch drives all presses globally: the recognizers share a gate that admits a single
+/// touch, and the coordinator holds the same gate while a fallback press is engaged so a
+/// recognizer press cannot start from another finger meanwhile. Defined with the gate state
+/// in REAPseudoSelectorObserver.mm.
+void REAPseudoPressGateRetain(UITouch *touch);
+void REAPseudoPressGateRelease(void);
+
 #endif

--- a/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REATouchHoverCoordinator.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REATouchHoverCoordinator.h
@@ -19,12 +19,17 @@
                       deepest:(BOOL)deepest
                      callback:(std::function<void(bool)>)callback;
 - (void)unregisterPressObserver:(id)owner;
+
+/// Topmost view at `point`, treating registered near-zero-alpha views as hit-testable. The
+/// `:active-deepest` recognizers arbitrate over this rather than UIKit's own hit-test, so an
+/// invisible press-registered descendant still outranks a visible ancestor.
+- (UIView *)hitTestInWindow:(UIWindow *)window atPoint:(CGPoint)point;
 @end
 
 /// One touch drives all presses globally: the recognizers share a gate that admits a single
-/// touch, and the coordinator holds the same gate while a fallback press is engaged so a
-/// recognizer press cannot start from another finger meanwhile. Defined with the gate state
-/// in REAPseudoSelectorObserver.mm.
+/// touch, and the coordinator holds the same gate from the moment a fallback press engages
+/// until the touch sequence ends - dismissing the press by dragging must not let another
+/// finger start one. Defined with the gate state in REAPseudoSelectorObserver.mm.
 void REAPseudoPressGateRetain(UITouch *touch);
 void REAPseudoPressGateRelease(void);
 

--- a/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REATouchHoverCoordinator.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REATouchHoverCoordinator.mm
@@ -4,29 +4,18 @@
 
 #import <UIKit/UIKit.h>
 
-@interface REATouchEntryBase : NSObject {
+/// One registration. Hover entries live in `_entries`, press entries in `_pressEntries`;
+/// `deepest` distinguishes `:active-deepest` from `:active` and is unused for hover.
+@interface REATouchEntry : NSObject {
  @public
   __weak id owner;
   __weak UIView *view;
   std::function<void(bool)> callback;
-  /// Last state delivered to the callback: hover for hover entries, press for press entries.
   BOOL engaged;
-}
-@end
-@implementation REATouchEntryBase
-@end
-
-@interface REATouchHoverEntry : REATouchEntryBase
-@end
-@implementation REATouchHoverEntry
-@end
-
-@interface REATouchPressEntry : REATouchEntryBase {
- @public
   BOOL deepest;
 }
 @end
-@implementation REATouchPressEntry
+@implementation REATouchEntry
 @end
 
 @interface REAHoverTouchObserver : UIGestureRecognizer
@@ -75,8 +64,8 @@
 static const CGFloat kPrimaryTouchTapMovement = 10.0;
 
 @implementation REATouchHoverCoordinator {
-  NSMutableArray<REATouchHoverEntry *> *_entries;
-  NSMutableArray<REATouchPressEntry *> *_pressEntries;
+  NSMutableArray<REATouchEntry *> *_entries;
+  NSMutableArray<REATouchEntry *> *_pressEntries;
   REAHoverTouchObserver *_windowObserver;
   __weak UIWindow *_observedWindow;
   __weak UITouch *_primaryTouch;
@@ -112,7 +101,7 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
 - (void)registerObserver:(id)owner view:(UIView *)view callback:(std::function<void(bool)>)callback
 {
   [self unregisterObserver:owner];
-  REATouchHoverEntry *entry = [REATouchHoverEntry new];
+  REATouchEntry *entry = [REATouchEntry new];
   entry->owner = owner;
   entry->view = view;
   entry->callback = std::move(callback);
@@ -122,8 +111,8 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
 
 - (void)unregisterObserver:(id)owner
 {
-  NSMutableArray<REATouchHoverEntry *> *removed = [NSMutableArray array];
-  for (REATouchHoverEntry *entry in _entries) {
+  NSMutableArray<REATouchEntry *> *removed = [NSMutableArray array];
+  for (REATouchEntry *entry in _entries) {
     if (entry->owner == nil || entry->owner == owner) {
       [self setEntry:entry engaged:NO];
       [removed addObject:entry];
@@ -138,7 +127,7 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
                      callback:(std::function<void(bool)>)callback
 {
   [self unregisterPressObserver:owner];
-  REATouchPressEntry *entry = [REATouchPressEntry new];
+  REATouchEntry *entry = [REATouchEntry new];
   entry->owner = owner;
   entry->view = view;
   entry->callback = std::move(callback);
@@ -149,8 +138,8 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
 
 - (void)unregisterPressObserver:(id)owner
 {
-  NSMutableArray<REATouchPressEntry *> *removed = [NSMutableArray array];
-  for (REATouchPressEntry *entry in _pressEntries) {
+  NSMutableArray<REATouchEntry *> *removed = [NSMutableArray array];
+  for (REATouchEntry *entry in _pressEntries) {
     if (entry->owner == nil || entry->owner == owner) {
       [self setEntry:entry engaged:NO];
       [removed addObject:entry];
@@ -211,7 +200,7 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
   [self endPressSequence];
 }
 
-- (void)purgeEntries:(NSArray<REATouchHoverEntry *> *)batch
+- (void)purgeEntries:(NSArray<REATouchEntry *> *)batch
 {
   if (batch.count == 0) {
     return;
@@ -280,7 +269,7 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
     return;
   }
   UIView *hit = window != nil ? [self hitTestInWindow:window atPoint:[_primaryTouch locationInView:window]] : nil;
-  for (REATouchHoverEntry *entry in _entries) {
+  for (REATouchEntry *entry in _entries) {
     if (entry->engaged && ![self isView:entry->view onBranchOfHitView:hit]) {
       [self setEntry:entry engaged:NO];
     }
@@ -313,7 +302,7 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
   }
   UIView *deepestPressView = [self deepestRescuedPressViewUnder:bumpedHit reachableHit:plainHit];
   BOOL engagedAny = NO;
-  for (REATouchPressEntry *entry in _pressEntries) {
+  for (REATouchEntry *entry in _pressEntries) {
     UIView *view = entry->view;
     if (view == nil || ![self isView:view onBranchOfHitView:bumpedHit] ||
         [self isView:view onBranchOfHitView:plainHit]) {
@@ -333,7 +322,7 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
 
 - (void)deactivateAllPressEntries
 {
-  for (REATouchPressEntry *entry in _pressEntries) {
+  for (REATouchEntry *entry in _pressEntries) {
     [self setEntry:entry engaged:NO];
   }
 }
@@ -351,7 +340,7 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
 
 #pragma mark - State reconciliation
 
-- (void)setEntry:(REATouchEntryBase *)entry engaged:(BOOL)engaged
+- (void)setEntry:(REATouchEntry *)entry engaged:(BOOL)engaged
 {
   if (entry->engaged == engaged) {
     return;
@@ -410,7 +399,7 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
 
 - (BOOL)isPressRegisteredView:(UIView *)view
 {
-  for (REATouchPressEntry *entry in _pressEntries) {
+  for (REATouchEntry *entry in _pressEntries) {
     if (entry->view == view) {
       return YES;
     }
@@ -423,11 +412,11 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
 - (UIView *)hitTestInWindow:(UIWindow *)window atPoint:(CGPoint)point
 {
   static const CGFloat kHitTestableAlpha = 0.02;
-  NSArray<REATouchEntryBase *> *entryLists[] = {_entries, _pressEntries};
+  NSArray<REATouchEntry *> *entryLists[] = {_entries, _pressEntries};
   NSMutableArray<UIView *> *lifted = nil;
   NSMutableArray<NSNumber *> *savedAlphas = nil;
   for (NSUInteger listIndex = 0; listIndex < 2; listIndex++) {
-    for (REATouchEntryBase *entry in entryLists[listIndex]) {
+    for (REATouchEntry *entry in entryLists[listIndex]) {
       UIView *view = entry->view;
       // A view carrying both `:hover` and `:active` is in both lists, and the bumped alpha reads
       // back a hair below the threshold, so only this check keeps its original alpha restorable.
@@ -452,8 +441,8 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
 
 - (void)hoverBranchOfHitView:(UIView *)hit
 {
-  NSMutableArray<REATouchHoverEntry *> *dead = nil;
-  for (REATouchHoverEntry *entry in _entries) {
+  NSMutableArray<REATouchEntry *> *dead = nil;
+  for (REATouchEntry *entry in _entries) {
     UIView *view = entry->view;
     if (view == nil) {
       [self setEntry:entry engaged:NO];
@@ -480,7 +469,7 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
 
 - (void)clearAll
 {
-  for (REATouchHoverEntry *entry in _entries) {
+  for (REATouchEntry *entry in _entries) {
     [self setEntry:entry engaged:NO];
   }
 }

--- a/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REATouchHoverCoordinator.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REATouchHoverCoordinator.mm
@@ -204,7 +204,7 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
   _observedWindow = nil;
   _primaryTouch = nil;
   [self clearAll];
-  [self deactivateAllPressEntries];
+  [self endPressSequence];
 }
 
 - (void)purgeEntries:(NSArray<REATouchHoverEntry *> *)batch
@@ -259,7 +259,7 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
 - (void)primaryTouchCancelled:(NSSet<UITouch *> *)touches
 {
   if (_primaryTouch != nil && [touches containsObject:_primaryTouch]) {
-    [self deactivateAllPressEntries];
+    [self endPressSequence];
   }
 }
 
@@ -268,7 +268,7 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
   if (_primaryTouch == nil || ![touches containsObject:_primaryTouch]) {
     return;
   }
-  [self deactivateAllPressEntries];
+  [self endPressSequence];
   UIWindow *window = _observedWindow;
   if (window != nil && [self isPointWithinTapSlop:[_primaryTouch locationInView:window]]) {
     return;
@@ -284,7 +284,7 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
 - (void)touchSequenceEnded
 {
   _primaryTouch = nil;
-  [self deactivateAllPressEntries];
+  [self endPressSequence];
 }
 
 - (BOOL)isPointWithinTapSlop:(CGPoint)point
@@ -338,6 +338,13 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
   for (REATouchPressEntry *entry in _pressEntries) {
     [self setEntry:entry engaged:NO];
   }
+}
+
+// The gate outlives the engaged state on purpose: a press dismissed by dragging keeps the touch
+// sequence in charge, exactly as the recognizer path keeps its own claim until the gesture ends.
+- (void)endPressSequence
+{
+  [self deactivateAllPressEntries];
   if (_pressGateHeld) {
     _pressGateHeld = NO;
     REAPseudoPressGateRelease();

--- a/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REATouchHoverCoordinator.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REATouchHoverCoordinator.mm
@@ -82,6 +82,10 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
   __weak UITouch *_primaryTouch;
   CGPoint _primaryTouchDownPoint;
   BOOL _pressGateHeld;
+  __weak UITouch *_resolvedHitsTouch;
+  CGPoint _resolvedHitsPoint;
+  __weak UIView *_resolvedBumpedHit;
+  __weak UIView *_resolvedPlainHit;
 }
 
 + (instancetype)sharedCoordinator
@@ -237,9 +241,11 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
   }
   _primaryTouch = touch;
   _primaryTouchDownPoint = [touch locationInView:window];
-  UIView *hit = [self hitTestInWindow:window atPoint:_primaryTouchDownPoint];
-  [self hoverBranchOfHitView:hit];
-  [self activateRescuedPressEntriesInWindow:window bumpedHit:hit];
+  UIView *bumpedHit = nil;
+  UIView *plainHit = nil;
+  [self resolveHitsForTouch:touch inWindow:window atPoint:_primaryTouchDownPoint bumped:&bumpedHit plain:&plainHit];
+  [self hoverBranchOfHitView:bumpedHit];
+  [self activateRescuedPressEntriesWithBumpedHit:bumpedHit plainHit:plainHit];
 }
 
 - (void)primaryTouchMoved:(NSSet<UITouch *> *)touches
@@ -284,6 +290,7 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
 - (void)touchSequenceEnded
 {
   _primaryTouch = nil;
+  _resolvedHitsTouch = nil;
   [self endPressSequence];
 }
 
@@ -299,21 +306,12 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
 // Activates press entries whose views only became hit-testable thanks to the alpha bump. Views
 // UIKit can reach on its own are excluded here: their UILongPressGestureRecognizer handles the
 // press, so the two paths never both fire for one view.
-- (void)activateRescuedPressEntriesInWindow:(UIWindow *)window bumpedHit:(UIView *)bumpedHit
+- (void)activateRescuedPressEntriesWithBumpedHit:(UIView *)bumpedHit plainHit:(UIView *)plainHit
 {
   if (_pressEntries.count == 0 || bumpedHit == nil) {
     return;
   }
-  UIView *plainHit = [window hitTest:_primaryTouchDownPoint withEvent:nil];
-  UIView *deepestPressView = nil;
-  for (UIView *current = bumpedHit; current != nil && deepestPressView == nil; current = current.superview) {
-    for (REATouchPressEntry *entry in _pressEntries) {
-      if (entry->view == current) {
-        deepestPressView = current;
-        break;
-      }
-    }
-  }
+  UIView *deepestPressView = [self deepestRescuedPressViewUnder:bumpedHit reachableHit:plainHit];
   BOOL engagedAny = NO;
   for (REATouchPressEntry *entry in _pressEntries) {
     UIView *view = entry->view;
@@ -366,27 +364,48 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
 
 - (UIView *)rescuedPressViewForTouch:(UITouch *)touch inWindow:(UIWindow *)window atPoint:(CGPoint)point
 {
-  // Answer only where a fallback press can actually follow: this coordinator's own window, and the
-  // touch it is driving. Vetoing a recognizer for a press nothing then engages leaves the touch dead.
+  // Vetoing a recognizer for a press that nothing then engages would leave the touch dead.
   if (window == nil || window != _observedWindow || _pressEntries.count == 0) {
     return nil;
   }
   if (_primaryTouch != nil && _primaryTouch != touch) {
     return nil;
   }
-  // Deliberately the same hit-test the engaging path uses: deciding over a different one lets the
-  // two disagree, which is how a press ends up suppressed here and never engaged there.
-  UIView *bumpedHit = [self hitTestInWindow:window atPoint:point];
-  if (bumpedHit == nil) {
-    return nil;
-  }
-  UIView *plainHit = [window hitTest:point withEvent:nil];
+  UIView *bumpedHit = nil;
+  UIView *plainHit = nil;
+  [self resolveHitsForTouch:touch inWindow:window atPoint:point bumped:&bumpedHit plain:&plainHit];
+  return [self deepestRescuedPressViewUnder:bumpedHit reachableHit:plainHit];
+}
+
+// The view the press fallback owns at this point: the innermost registered one the alpha bump
+// revealed. Anything UIKit can reach unaided is left to its own recognizer.
+- (UIView *)deepestRescuedPressViewUnder:(UIView *)bumpedHit reachableHit:(UIView *)plainHit
+{
   for (UIView *current = bumpedHit; current != nil; current = current.superview) {
     if ([self isPressRegisteredView:current] && ![self isView:current onBranchOfHitView:plainHit]) {
       return current;
     }
   }
   return nil;
+}
+
+// Both hit tests the press paths need. The engaging path and every :active-deepest recognizer on
+// the way down ask for the same point, so resolving once per touch saves a full window walk each
+// and leaves them no way to decide over different answers.
+- (void)resolveHitsForTouch:(UITouch *)touch
+                   inWindow:(UIWindow *)window
+                    atPoint:(CGPoint)point
+                     bumped:(UIView **)bumpedHit
+                      plain:(UIView **)plainHit
+{
+  if (touch == nil || touch != _resolvedHitsTouch || !CGPointEqualToPoint(point, _resolvedHitsPoint)) {
+    _resolvedHitsTouch = touch;
+    _resolvedHitsPoint = point;
+    _resolvedBumpedHit = [self hitTestInWindow:window atPoint:point];
+    _resolvedPlainHit = [window hitTest:point withEvent:nil];
+  }
+  *bumpedHit = _resolvedBumpedHit;
+  *plainHit = _resolvedPlainHit;
 }
 
 - (BOOL)isPressRegisteredView:(UIView *)view
@@ -410,7 +429,8 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
   for (NSUInteger listIndex = 0; listIndex < 2; listIndex++) {
     for (REATouchEntryBase *entry in entryLists[listIndex]) {
       UIView *view = entry->view;
-      if (view == nil || view.alpha >= kHitTestableAlpha || [lifted containsObject:view]) {
+      // A view registered twice is skipped the second time by its own lifted alpha.
+      if (view == nil || view.alpha >= kHitTestableAlpha) {
         continue;
       }
       if (lifted == nil) {

--- a/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REATouchHoverCoordinator.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REATouchHoverCoordinator.mm
@@ -429,8 +429,9 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
   for (NSUInteger listIndex = 0; listIndex < 2; listIndex++) {
     for (REATouchEntryBase *entry in entryLists[listIndex]) {
       UIView *view = entry->view;
-      // A view registered twice is skipped the second time by its own lifted alpha.
-      if (view == nil || view.alpha >= kHitTestableAlpha) {
+      // A view carrying both `:hover` and `:active` is in both lists, and the bumped alpha reads
+      // back a hair below the threshold, so only this check keeps its original alpha restorable.
+      if (view == nil || view.alpha >= kHitTestableAlpha || [lifted containsObject:view]) {
         continue;
       }
       if (lifted == nil) {

--- a/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REATouchHoverCoordinator.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REATouchHoverCoordinator.mm
@@ -364,14 +364,19 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
   }
 }
 
-- (UIView *)rescuedPressViewInWindow:(UIWindow *)window atPoint:(CGPoint)point
+- (UIView *)rescuedPressViewForTouch:(UITouch *)touch inWindow:(UIWindow *)window atPoint:(CGPoint)point
 {
-  // Only this coordinator's own window gets a fallback press, so anywhere else the recognizers must
-  // keep deciding on their own - suppressing a press nothing would rescue leaves the touch dead.
+  // Answer only where a fallback press can actually follow: this coordinator's own window, and the
+  // touch it is driving. Vetoing a recognizer for a press nothing then engages leaves the touch dead.
   if (window == nil || window != _observedWindow || _pressEntries.count == 0) {
     return nil;
   }
-  UIView *bumpedHit = [self hitTestInWindow:window atPoint:point pressEntriesOnly:YES];
+  if (_primaryTouch != nil && _primaryTouch != touch) {
+    return nil;
+  }
+  // Deliberately the same hit-test the engaging path uses: deciding over a different one lets the
+  // two disagree, which is how a press ends up suppressed here and never engaged there.
+  UIView *bumpedHit = [self hitTestInWindow:window atPoint:point];
   if (bumpedHit == nil) {
     return nil;
   }
@@ -394,19 +399,12 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
   return NO;
 }
 
-- (UIView *)hitTestInWindow:(UIWindow *)window atPoint:(CGPoint)point
-{
-  return [self hitTestInWindow:window atPoint:point pressEntriesOnly:NO];
-}
-
 // UIKit's -hitTest: skips views with alpha below ~0.01, so an `opacity: 0` view is unreachable. Bump each
 // near-zero registered view over the threshold for the hit-test, restoring before compositing (never drawn).
-// Press arbitration passes `pressEntriesOnly` so a hover-registered view - which may read alpha 0 merely
-// because a fade is in flight - cannot displace the pressed view in the answer.
-- (UIView *)hitTestInWindow:(UIWindow *)window atPoint:(CGPoint)point pressEntriesOnly:(BOOL)pressEntriesOnly
+- (UIView *)hitTestInWindow:(UIWindow *)window atPoint:(CGPoint)point
 {
   static const CGFloat kHitTestableAlpha = 0.02;
-  NSArray<REATouchEntryBase *> *entryLists[] = {pressEntriesOnly ? @[] : _entries, _pressEntries};
+  NSArray<REATouchEntryBase *> *entryLists[] = {_entries, _pressEntries};
   NSMutableArray<UIView *> *lifted = nil;
   NSMutableArray<NSNumber *> *savedAlphas = nil;
   for (NSUInteger listIndex = 0; listIndex < 2; listIndex++) {

--- a/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REATouchHoverCoordinator.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REATouchHoverCoordinator.mm
@@ -15,12 +15,25 @@
 @implementation REATouchHoverEntry
 @end
 
+@interface REATouchPressEntry : NSObject {
+ @public
+  __weak id owner;
+  __weak UIView *view;
+  std::function<void(bool)> callback;
+  BOOL deepest;
+  BOOL activated;
+}
+@end
+@implementation REATouchPressEntry
+@end
+
 @interface REAHoverTouchObserver : UIGestureRecognizer
 @property (nonatomic, weak) REATouchHoverCoordinator *coordinator;
 @end
 
 @interface REATouchHoverCoordinator () <UIGestureRecognizerDelegate>
 - (void)primaryTouchBegan:(NSSet<UITouch *> *)touches;
+- (void)primaryTouchMoved:(NSSet<UITouch *> *)touches;
 - (void)primaryTouchEnded:(NSSet<UITouch *> *)touches;
 - (void)touchSequenceEnded;
 @end
@@ -29,6 +42,10 @@
 - (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
   [self.coordinator primaryTouchBegan:touches];
+}
+- (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+  [self.coordinator primaryTouchMoved:touches];
 }
 - (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
@@ -55,6 +72,7 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
 
 @implementation REATouchHoverCoordinator {
   NSMutableArray<REATouchHoverEntry *> *_entries;
+  NSMutableArray<REATouchPressEntry *> *_pressEntries;
   REAHoverTouchObserver *_windowObserver;
   __weak UIWindow *_observedWindow;
   __weak UITouch *_primaryTouch;
@@ -73,6 +91,7 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
 {
   if (self = [super init]) {
     _entries = [NSMutableArray array];
+    _pressEntries = [NSMutableArray array];
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(refreshWindowObserver)
                                                  name:UIWindowDidBecomeKeyNotification
@@ -105,6 +124,40 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
   [self purgeEntries:removed];
 }
 
+- (void)registerPressObserver:(id)owner
+                         view:(UIView *)view
+                      deepest:(BOOL)deepest
+                     callback:(std::function<void(bool)>)callback
+{
+  [self unregisterPressObserver:owner];
+  REATouchPressEntry *entry = [REATouchPressEntry new];
+  entry->owner = owner;
+  entry->view = view;
+  entry->callback = std::move(callback);
+  entry->deepest = deepest;
+  entry->activated = NO;
+  [_pressEntries addObject:entry];
+  [self refreshWindowObserver];
+}
+
+- (void)unregisterPressObserver:(id)owner
+{
+  NSMutableArray<REATouchPressEntry *> *removed = [NSMutableArray array];
+  for (REATouchPressEntry *entry in _pressEntries) {
+    if (entry->owner == nil || entry->owner == owner) {
+      [self setPressEntry:entry activated:NO];
+      [removed addObject:entry];
+    }
+  }
+  if (removed.count == 0) {
+    return;
+  }
+  [_pressEntries removeObjectsInArray:removed];
+  if (_entries.count == 0 && _pressEntries.count == 0) {
+    [self removeWindowObserver];
+  }
+}
+
 - (UIWindow *)activeKeyWindow
 {
   for (UIScene *scene in UIApplication.sharedApplication.connectedScenes) {
@@ -122,7 +175,7 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
 
 - (void)refreshWindowObserver
 {
-  if (_entries.count == 0) {
+  if (_entries.count == 0 && _pressEntries.count == 0) {
     return;
   }
   UIWindow *keyWindow = [self activeKeyWindow];
@@ -150,6 +203,7 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
   _observedWindow = nil;
   _primaryTouch = nil;
   [self clearAll];
+  [self deactivateAllPressEntries];
 }
 
 - (void)purgeEntries:(NSArray<REATouchHoverEntry *> *)batch
@@ -158,7 +212,7 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
     return;
   }
   [_entries removeObjectsInArray:batch];
-  if (_entries.count == 0) {
+  if (_entries.count == 0 && _pressEntries.count == 0) {
     [self removeWindowObserver];
   }
 }
@@ -179,6 +233,24 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
   _primaryTouchDownPoint = [touch locationInView:window];
   UIView *hit = [self hitTestInWindow:window atPoint:_primaryTouchDownPoint];
   [self hoverBranchOfHitView:hit];
+  [self activateRescuedPressEntriesInWindow:window bumpedHit:hit];
+}
+
+- (void)primaryTouchMoved:(NSSet<UITouch *> *)touches
+{
+  if (_primaryTouch == nil || ![touches containsObject:_primaryTouch]) {
+    return;
+  }
+  UIWindow *window = _observedWindow;
+  if (window == nil) {
+    return;
+  }
+  CGPoint point = [_primaryTouch locationInView:window];
+  CGFloat dx = point.x - _primaryTouchDownPoint.x;
+  CGFloat dy = point.y - _primaryTouchDownPoint.y;
+  if (dx * dx + dy * dy > kPrimaryTouchTapMovement * kPrimaryTouchTapMovement) {
+    [self deactivateAllPressEntries];
+  }
 }
 
 - (void)primaryTouchEnded:(NSSet<UITouch *> *)touches
@@ -186,6 +258,7 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
   if (_primaryTouch == nil || ![touches containsObject:_primaryTouch]) {
     return;
   }
+  [self deactivateAllPressEntries];
   UIWindow *window = _observedWindow;
   if (window != nil) {
     CGPoint releasePoint = [_primaryTouch locationInView:window];
@@ -206,6 +279,58 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
 - (void)touchSequenceEnded
 {
   _primaryTouch = nil;
+  [self deactivateAllPressEntries];
+}
+
+#pragma mark - Fallback press path
+
+// Activates press entries whose views only became hit-testable thanks to the alpha bump. Views
+// UIKit can reach on its own are excluded here: their UILongPressGestureRecognizer handles the
+// press, so the two paths never both fire for one view.
+- (void)activateRescuedPressEntriesInWindow:(UIWindow *)window bumpedHit:(UIView *)bumpedHit
+{
+  if (_pressEntries.count == 0 || bumpedHit == nil) {
+    return;
+  }
+  UIView *plainHit = [window hitTest:_primaryTouchDownPoint withEvent:nil];
+  UIView *deepestPressView = nil;
+  for (UIView *current = bumpedHit; current != nil && deepestPressView == nil; current = current.superview) {
+    for (REATouchPressEntry *entry in _pressEntries) {
+      if (entry->view == current) {
+        deepestPressView = current;
+        break;
+      }
+    }
+  }
+  for (REATouchPressEntry *entry in _pressEntries) {
+    UIView *view = entry->view;
+    if (view == nil || ![self isView:view onBranchOfHitView:bumpedHit] ||
+        [self isView:view onBranchOfHitView:plainHit]) {
+      continue;
+    }
+    if (entry->deepest && view != deepestPressView) {
+      continue;
+    }
+    [self setPressEntry:entry activated:YES];
+  }
+}
+
+- (void)deactivateAllPressEntries
+{
+  for (REATouchPressEntry *entry in _pressEntries) {
+    [self setPressEntry:entry activated:NO];
+  }
+}
+
+- (void)setPressEntry:(REATouchPressEntry *)entry activated:(BOOL)activated
+{
+  if (entry->activated == activated) {
+    return;
+  }
+  entry->activated = activated;
+  if (entry->callback) {
+    entry->callback(activated);
+  }
 }
 
 #pragma mark - State reconciliation
@@ -226,11 +351,21 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
 - (UIView *)hitTestInWindow:(UIWindow *)window atPoint:(CGPoint)point
 {
   static const CGFloat kHitTestableAlpha = 0.02;
+  NSMutableArray<UIView *> *candidates = [NSMutableArray arrayWithCapacity:_entries.count + _pressEntries.count];
+  for (REATouchHoverEntry *entry in _entries) {
+    if (entry->view != nil) {
+      [candidates addObject:entry->view];
+    }
+  }
+  for (REATouchPressEntry *entry in _pressEntries) {
+    if (entry->view != nil) {
+      [candidates addObject:entry->view];
+    }
+  }
   NSMutableArray<UIView *> *lifted = nil;
   NSMutableArray<NSNumber *> *savedAlphas = nil;
-  for (REATouchHoverEntry *entry in _entries) {
-    UIView *view = entry->view;
-    if (view == nil || view.alpha >= kHitTestableAlpha || [lifted containsObject:view]) {
+  for (UIView *view in candidates) {
+    if (view.alpha >= kHitTestableAlpha || [lifted containsObject:view]) {
       continue;
     }
     if (lifted == nil) {

--- a/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REATouchHoverCoordinator.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REATouchHoverCoordinator.mm
@@ -364,12 +364,49 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
   }
 }
 
-// UIKit's -hitTest: skips views with alpha below ~0.01, so an `opacity: 0` view is unreachable. Bump each
-// near-zero registered view over the threshold for the hit-test, restoring before compositing (never drawn).
+- (UIView *)rescuedPressViewInWindow:(UIWindow *)window atPoint:(CGPoint)point
+{
+  // Only this coordinator's own window gets a fallback press, so anywhere else the recognizers must
+  // keep deciding on their own - suppressing a press nothing would rescue leaves the touch dead.
+  if (window == nil || window != _observedWindow || _pressEntries.count == 0) {
+    return nil;
+  }
+  UIView *bumpedHit = [self hitTestInWindow:window atPoint:point pressEntriesOnly:YES];
+  if (bumpedHit == nil) {
+    return nil;
+  }
+  UIView *plainHit = [window hitTest:point withEvent:nil];
+  for (UIView *current = bumpedHit; current != nil; current = current.superview) {
+    if ([self isPressRegisteredView:current] && ![self isView:current onBranchOfHitView:plainHit]) {
+      return current;
+    }
+  }
+  return nil;
+}
+
+- (BOOL)isPressRegisteredView:(UIView *)view
+{
+  for (REATouchPressEntry *entry in _pressEntries) {
+    if (entry->view == view) {
+      return YES;
+    }
+  }
+  return NO;
+}
+
 - (UIView *)hitTestInWindow:(UIWindow *)window atPoint:(CGPoint)point
 {
+  return [self hitTestInWindow:window atPoint:point pressEntriesOnly:NO];
+}
+
+// UIKit's -hitTest: skips views with alpha below ~0.01, so an `opacity: 0` view is unreachable. Bump each
+// near-zero registered view over the threshold for the hit-test, restoring before compositing (never drawn).
+// Press arbitration passes `pressEntriesOnly` so a hover-registered view - which may read alpha 0 merely
+// because a fade is in flight - cannot displace the pressed view in the answer.
+- (UIView *)hitTestInWindow:(UIWindow *)window atPoint:(CGPoint)point pressEntriesOnly:(BOOL)pressEntriesOnly
+{
   static const CGFloat kHitTestableAlpha = 0.02;
-  NSArray<REATouchEntryBase *> *entryLists[] = {_entries, _pressEntries};
+  NSArray<REATouchEntryBase *> *entryLists[] = {pressEntriesOnly ? @[] : _entries, _pressEntries};
   NSMutableArray<UIView *> *lifted = nil;
   NSMutableArray<NSNumber *> *savedAlphas = nil;
   for (NSUInteger listIndex = 0; listIndex < 2; listIndex++) {

--- a/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REATouchHoverCoordinator.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REATouchHoverCoordinator.mm
@@ -37,6 +37,7 @@
 - (void)primaryTouchBegan:(NSSet<UITouch *> *)touches;
 - (void)primaryTouchMoved:(NSSet<UITouch *> *)touches;
 - (void)primaryTouchEnded:(NSSet<UITouch *> *)touches;
+- (void)primaryTouchCancelled:(NSSet<UITouch *> *)touches;
 - (void)touchSequenceEnded;
 @end
 
@@ -56,6 +57,7 @@
 }
 - (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
+  [self.coordinator primaryTouchCancelled:touches];
   [self failIfSequenceEnded:event];
 }
 - (void)failIfSequenceEnded:(UIEvent *)event
@@ -79,6 +81,7 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
   __weak UIWindow *_observedWindow;
   __weak UITouch *_primaryTouch;
   CGPoint _primaryTouchDownPoint;
+  BOOL _pressGateHeld;
 }
 
 + (instancetype)sharedCoordinator
@@ -253,6 +256,13 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
   }
 }
 
+- (void)primaryTouchCancelled:(NSSet<UITouch *> *)touches
+{
+  if (_primaryTouch != nil && [touches containsObject:_primaryTouch]) {
+    [self deactivateAllPressEntries];
+  }
+}
+
 - (void)primaryTouchEnded:(NSSet<UITouch *> *)touches
 {
   if (_primaryTouch == nil || ![touches containsObject:_primaryTouch]) {
@@ -304,6 +314,7 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
       }
     }
   }
+  BOOL engagedAny = NO;
   for (REATouchPressEntry *entry in _pressEntries) {
     UIView *view = entry->view;
     if (view == nil || ![self isView:view onBranchOfHitView:bumpedHit] ||
@@ -314,6 +325,11 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
       continue;
     }
     [self setEntry:entry engaged:YES];
+    engagedAny = YES;
+  }
+  if (engagedAny && !_pressGateHeld) {
+    _pressGateHeld = YES;
+    REAPseudoPressGateRetain(_primaryTouch);
   }
 }
 
@@ -321,6 +337,10 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
 {
   for (REATouchPressEntry *entry in _pressEntries) {
     [self setEntry:entry engaged:NO];
+  }
+  if (_pressGateHeld) {
+    _pressGateHeld = NO;
+    REAPseudoPressGateRelease();
   }
 }
 

--- a/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REATouchHoverCoordinator.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REATouchHoverCoordinator.mm
@@ -4,24 +4,26 @@
 
 #import <UIKit/UIKit.h>
 
-@interface REATouchHoverEntry : NSObject {
+@interface REATouchEntryBase : NSObject {
  @public
   __weak id owner;
   __weak UIView *view;
   std::function<void(bool)> callback;
-  BOOL hovered;
+  /// Last state delivered to the callback: hover for hover entries, press for press entries.
+  BOOL engaged;
 }
+@end
+@implementation REATouchEntryBase
+@end
+
+@interface REATouchHoverEntry : REATouchEntryBase
 @end
 @implementation REATouchHoverEntry
 @end
 
-@interface REATouchPressEntry : NSObject {
+@interface REATouchPressEntry : REATouchEntryBase {
  @public
-  __weak id owner;
-  __weak UIView *view;
-  std::function<void(bool)> callback;
   BOOL deepest;
-  BOOL activated;
 }
 @end
 @implementation REATouchPressEntry
@@ -107,7 +109,6 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
   entry->owner = owner;
   entry->view = view;
   entry->callback = std::move(callback);
-  entry->hovered = NO;
   [_entries addObject:entry];
   [self refreshWindowObserver];
 }
@@ -117,7 +118,7 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
   NSMutableArray<REATouchHoverEntry *> *removed = [NSMutableArray array];
   for (REATouchHoverEntry *entry in _entries) {
     if (entry->owner == nil || entry->owner == owner) {
-      [self setEntry:entry hovered:NO];
+      [self setEntry:entry engaged:NO];
       [removed addObject:entry];
     }
   }
@@ -135,7 +136,6 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
   entry->view = view;
   entry->callback = std::move(callback);
   entry->deepest = deepest;
-  entry->activated = NO;
   [_pressEntries addObject:entry];
   [self refreshWindowObserver];
 }
@@ -145,7 +145,7 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
   NSMutableArray<REATouchPressEntry *> *removed = [NSMutableArray array];
   for (REATouchPressEntry *entry in _pressEntries) {
     if (entry->owner == nil || entry->owner == owner) {
-      [self setPressEntry:entry activated:NO];
+      [self setEntry:entry engaged:NO];
       [removed addObject:entry];
     }
   }
@@ -153,9 +153,7 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
     return;
   }
   [_pressEntries removeObjectsInArray:removed];
-  if (_entries.count == 0 && _pressEntries.count == 0) {
-    [self removeWindowObserver];
-  }
+  [self removeWindowObserverIfIdle];
 }
 
 - (UIWindow *)activeKeyWindow
@@ -212,6 +210,11 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
     return;
   }
   [_entries removeObjectsInArray:batch];
+  [self removeWindowObserverIfIdle];
+}
+
+- (void)removeWindowObserverIfIdle
+{
   if (_entries.count == 0 && _pressEntries.count == 0) {
     [self removeWindowObserver];
   }
@@ -245,10 +248,7 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
   if (window == nil) {
     return;
   }
-  CGPoint point = [_primaryTouch locationInView:window];
-  CGFloat dx = point.x - _primaryTouchDownPoint.x;
-  CGFloat dy = point.y - _primaryTouchDownPoint.y;
-  if (dx * dx + dy * dy > kPrimaryTouchTapMovement * kPrimaryTouchTapMovement) {
+  if (![self isPointWithinTapSlop:[_primaryTouch locationInView:window]]) {
     [self deactivateAllPressEntries];
   }
 }
@@ -260,18 +260,13 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
   }
   [self deactivateAllPressEntries];
   UIWindow *window = _observedWindow;
-  if (window != nil) {
-    CGPoint releasePoint = [_primaryTouch locationInView:window];
-    CGFloat dx = releasePoint.x - _primaryTouchDownPoint.x;
-    CGFloat dy = releasePoint.y - _primaryTouchDownPoint.y;
-    if (dx * dx + dy * dy <= kPrimaryTouchTapMovement * kPrimaryTouchTapMovement) {
-      return;
-    }
+  if (window != nil && [self isPointWithinTapSlop:[_primaryTouch locationInView:window]]) {
+    return;
   }
   UIView *hit = window != nil ? [self hitTestInWindow:window atPoint:[_primaryTouch locationInView:window]] : nil;
   for (REATouchHoverEntry *entry in _entries) {
-    if (entry->hovered && ![self isView:entry->view onBranchOfHitView:hit]) {
-      [self setEntry:entry hovered:NO];
+    if (entry->engaged && ![self isView:entry->view onBranchOfHitView:hit]) {
+      [self setEntry:entry engaged:NO];
     }
   }
 }
@@ -280,6 +275,13 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
 {
   _primaryTouch = nil;
   [self deactivateAllPressEntries];
+}
+
+- (BOOL)isPointWithinTapSlop:(CGPoint)point
+{
+  CGFloat dx = point.x - _primaryTouchDownPoint.x;
+  CGFloat dy = point.y - _primaryTouchDownPoint.y;
+  return dx * dx + dy * dy <= kPrimaryTouchTapMovement * kPrimaryTouchTapMovement;
 }
 
 #pragma mark - Fallback press path
@@ -311,38 +313,27 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
     if (entry->deepest && view != deepestPressView) {
       continue;
     }
-    [self setPressEntry:entry activated:YES];
+    [self setEntry:entry engaged:YES];
   }
 }
 
 - (void)deactivateAllPressEntries
 {
   for (REATouchPressEntry *entry in _pressEntries) {
-    [self setPressEntry:entry activated:NO];
-  }
-}
-
-- (void)setPressEntry:(REATouchPressEntry *)entry activated:(BOOL)activated
-{
-  if (entry->activated == activated) {
-    return;
-  }
-  entry->activated = activated;
-  if (entry->callback) {
-    entry->callback(activated);
+    [self setEntry:entry engaged:NO];
   }
 }
 
 #pragma mark - State reconciliation
 
-- (void)setEntry:(REATouchHoverEntry *)entry hovered:(BOOL)hovered
+- (void)setEntry:(REATouchEntryBase *)entry engaged:(BOOL)engaged
 {
-  if (entry->hovered == hovered) {
+  if (entry->engaged == engaged) {
     return;
   }
-  entry->hovered = hovered;
+  entry->engaged = engaged;
   if (entry->callback) {
-    entry->callback(hovered);
+    entry->callback(engaged);
   }
 }
 
@@ -351,30 +342,23 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
 - (UIView *)hitTestInWindow:(UIWindow *)window atPoint:(CGPoint)point
 {
   static const CGFloat kHitTestableAlpha = 0.02;
-  NSMutableArray<UIView *> *candidates = [NSMutableArray arrayWithCapacity:_entries.count + _pressEntries.count];
-  for (REATouchHoverEntry *entry in _entries) {
-    if (entry->view != nil) {
-      [candidates addObject:entry->view];
-    }
-  }
-  for (REATouchPressEntry *entry in _pressEntries) {
-    if (entry->view != nil) {
-      [candidates addObject:entry->view];
-    }
-  }
+  NSArray<REATouchEntryBase *> *entryLists[] = {_entries, _pressEntries};
   NSMutableArray<UIView *> *lifted = nil;
   NSMutableArray<NSNumber *> *savedAlphas = nil;
-  for (UIView *view in candidates) {
-    if (view.alpha >= kHitTestableAlpha || [lifted containsObject:view]) {
-      continue;
+  for (NSUInteger listIndex = 0; listIndex < 2; listIndex++) {
+    for (REATouchEntryBase *entry in entryLists[listIndex]) {
+      UIView *view = entry->view;
+      if (view == nil || view.alpha >= kHitTestableAlpha || [lifted containsObject:view]) {
+        continue;
+      }
+      if (lifted == nil) {
+        lifted = [NSMutableArray array];
+        savedAlphas = [NSMutableArray array];
+      }
+      [lifted addObject:view];
+      [savedAlphas addObject:@(view.alpha)];
+      view.alpha = kHitTestableAlpha;
     }
-    if (lifted == nil) {
-      lifted = [NSMutableArray array];
-      savedAlphas = [NSMutableArray array];
-    }
-    [lifted addObject:view];
-    [savedAlphas addObject:@(view.alpha)];
-    view.alpha = kHitTestableAlpha;
   }
   UIView *hit = [window hitTest:point withEvent:nil];
   [lifted enumerateObjectsUsingBlock:^(UIView *view, NSUInteger index, BOOL *stop) {
@@ -389,14 +373,14 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
   for (REATouchHoverEntry *entry in _entries) {
     UIView *view = entry->view;
     if (view == nil) {
-      [self setEntry:entry hovered:NO];
+      [self setEntry:entry engaged:NO];
       if (dead == nil) {
         dead = [NSMutableArray array];
       }
       [dead addObject:entry];
       continue;
     }
-    [self setEntry:entry hovered:[self isView:view onBranchOfHitView:hit]];
+    [self setEntry:entry engaged:[self isView:view onBranchOfHitView:hit]];
   }
   [self purgeEntries:dead];
 }
@@ -414,7 +398,7 @@ static const CGFloat kPrimaryTouchTapMovement = 10.0;
 - (void)clearAll
 {
   for (REATouchHoverEntry *entry in _entries) {
-    [self setEntry:entry hovered:NO];
+    [self setEntry:entry engaged:NO];
   }
 }
 


### PR DESCRIPTION
## Summary

UIKit's hit-test skips views with `alpha` below ~0.01, so `opacity: { default: 0, ':active': ... }` can never engage `:active` on iOS: the `UILongPressGestureRecognizer` sits on a view touches cannot reach. #9872 solved this for touch `:hover` with an alpha-bumped hit-test in the window coordinator, but the per-view recognizer `:active` uses cannot benefit from it. Android is unaffected, since alpha does not gate hit-testing there.

## Fix

The coordinator gains a press registry. On touch-down it hit-tests with and without the alpha bump, and drives `:active` / `:active-deepest` only for views the bump revealed, which keeps the fallback and the recognizer mutually exclusive by construction. Slop dismissal, release and cancel follow the recognizer, the single-touch gate is held for the rest of the sequence once a press engages, and both paths arbitrate `:active-deepest` over the same hit-test so an invisible descendant outranks a visible ancestor as it does on web.

## Recording

Same scripted input on both builds: pressing CONTROL scales on either (recognizer path), pressing inside the dashed slot does nothing on main and fades the GHOST in on the fix, and press-and-drag never sticks. The ring marks the injected press, as the simulator has no touch overlay.

PLACEHOLDER: drag 9-ios-ghost-active-MAIN-broken.mp4 and 9-ios-ghost-active-WITH-FIX.mp4 here
