### PR TITLE
fix: Stop re-injecting stale values after a CSS transition changes routing

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.cpp
@@ -10,11 +10,11 @@ CSSPlatformTransitionProxy::CSSPlatformTransitionProxy(
     CSSCanRoutePropertyFunction canRoute,
     CSSApplyTransitionFunction applyTransition,
     CSSRemoveTransitionFunction removeTransition,
-    CSSCurrentPlatformValueFunction currentPlatformValue)
+    CSSGetPlatformValueFunction getPlatformValue)
     : canRoute_(std::move(canRoute)),
       applyTransition_(std::move(applyTransition)),
       removeTransition_(std::move(removeTransition)),
-      currentPlatformValue_(std::move(currentPlatformValue)) {}
+      getPlatformValue_(std::move(getPlatformValue)) {}
 
 bool CSSPlatformTransitionProxy::canRoute(const std::string &propertyName, const EasingConfig &easing) const {
   return canRoute_ && canRoute_(propertyName, easing);
@@ -80,7 +80,7 @@ CSSTransitionConfig CSSPlatformTransitionProxy::processConfig(
       std::optional<double> resumeFrom;
       if (routing.platform.erase(propertyName) > 0) {
         if (hasValue) {
-          resumeFrom = resumeValue(viewTag, propertyName, timestamp);
+          resumeFrom = getResumeValue(viewTag, propertyName, timestamp);
         }
         remove(viewTag, propertyName);
       }
@@ -131,7 +131,7 @@ PropertyValueDynamicDiffsMap CSSPlatformTransitionProxy::processDynamicDiffs(
       }
       routing.platform.erase(propertyName);
       // Read before remove(): it drops the platform-side state this resumes from.
-      const auto resumeFrom = resumeValue(viewTag, propertyName, timestamp);
+      const auto resumeFrom = getResumeValue(viewTag, propertyName, timestamp);
       remove(viewTag, propertyName);
       routing.loop.insert(propertyName);
       if (resumeFrom) {
@@ -144,14 +144,14 @@ PropertyValueDynamicDiffsMap CSSPlatformTransitionProxy::processDynamicDiffs(
   return loopDiffs;
 }
 
-std::optional<double> CSSPlatformTransitionProxy::resumeValue(
+std::optional<double> CSSPlatformTransitionProxy::getResumeValue(
     const Tag viewTag,
     const std::string &propertyName,
     const double timestamp) const {
-  if (!currentPlatformValue_) {
+  if (!getPlatformValue_) {
     return std::nullopt;
   }
-  const auto value = currentPlatformValue_(viewTag, propertyName, timestamp);
+  const auto value = getPlatformValue_(viewTag, propertyName, timestamp);
   if (!value) {
     return std::nullopt;
   }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.cpp
@@ -9,10 +9,12 @@ namespace reanimated::css {
 CSSPlatformTransitionProxy::CSSPlatformTransitionProxy(
     CSSCanRoutePropertyFunction canRoute,
     CSSApplyTransitionFunction applyTransition,
-    CSSRemoveTransitionFunction removeTransition)
+    CSSRemoveTransitionFunction removeTransition,
+    CSSCurrentPlatformValueFunction currentPlatformValue)
     : canRoute_(std::move(canRoute)),
       applyTransition_(std::move(applyTransition)),
-      removeTransition_(std::move(removeTransition)) {}
+      removeTransition_(std::move(removeTransition)),
+      currentPlatformValue_(std::move(currentPlatformValue)) {}
 
 bool CSSPlatformTransitionProxy::canRoute(const std::string &propertyName, const EasingConfig &easing) const {
   return canRoute_ && canRoute_(propertyName, easing);
@@ -74,15 +76,26 @@ CSSTransitionConfig CSSPlatformTransitionProxy::processConfig(
       }
       routing.platform.insert(propertyName);
     } else {
-      // platform -> loop migration cancels on the platform side.
+      // platform -> loop migration cancels on the platform side. The loop diff
+      // carries the committed from-value, which the platform animator has long
+      // painted past, so resume from the platform's computed current value.
+      std::optional<double> resumeFrom;
       if (routing.platform.erase(propertyName) > 0) {
+        if (hasValue && currentPlatformValue_) {
+          const auto liveValue = currentPlatformValue_(viewTag, propertyName, timestamp);
+          if (liveValue) {
+            if (const auto *scalar = std::get_if<double>(&*liveValue)) {
+              resumeFrom = *scalar;
+            }
+          }
+        }
         remove(viewTag, propertyName);
       }
       routing.loop.insert(propertyName);
       if (hasValue) {
+        auto fromValue = resumeFrom ? jsi::Value(*resumeFrom) : jsi::Value(rt, valueIt->second.first);
         loopConfig.changedProperties.emplace(
-            propertyName,
-            std::make_pair(jsi::Value(rt, valueIt->second.first), jsi::Value(rt, valueIt->second.second)));
+            propertyName, std::make_pair(std::move(fromValue), jsi::Value(rt, valueIt->second.second)));
       }
       loopConfig.changedPropertiesSettings.emplace(propertyName, settings);
     }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.cpp
@@ -76,18 +76,11 @@ CSSTransitionConfig CSSPlatformTransitionProxy::processConfig(
       }
       routing.platform.insert(propertyName);
     } else {
-      // platform -> loop migration cancels on the platform side. The loop diff
-      // carries the committed from-value, which the platform animator has long
-      // painted past, so resume from the platform's computed current value.
+      // platform -> loop migration cancels on the platform side.
       std::optional<double> resumeFrom;
       if (routing.platform.erase(propertyName) > 0) {
-        if (hasValue && currentPlatformValue_) {
-          const auto liveValue = currentPlatformValue_(viewTag, propertyName, timestamp);
-          if (liveValue) {
-            if (const auto *scalar = std::get_if<double>(&*liveValue)) {
-              resumeFrom = *scalar;
-            }
-          }
+        if (hasValue) {
+          resumeFrom = resumeValue(viewTag, propertyName, timestamp);
         }
         remove(viewTag, propertyName);
       }
@@ -137,12 +130,33 @@ PropertyValueDynamicDiffsMap CSSPlatformTransitionProxy::processDynamicDiffs(
         }
       }
       routing.platform.erase(propertyName);
+      // Read before remove(): it drops the platform-side state this resumes from.
+      const auto resumeFrom = resumeValue(viewTag, propertyName, timestamp);
       remove(viewTag, propertyName);
       routing.loop.insert(propertyName);
+      if (resumeFrom) {
+        loopDiffs.emplace(propertyName, std::make_pair(folly::dynamic(*resumeFrom), propertyDiff.second));
+        continue;
+      }
     }
     loopDiffs.emplace(propertyName, propertyDiff);
   }
   return loopDiffs;
+}
+
+std::optional<double> CSSPlatformTransitionProxy::resumeValue(
+    const Tag viewTag,
+    const std::string &propertyName,
+    const double timestamp) const {
+  if (!currentPlatformValue_) {
+    return std::nullopt;
+  }
+  const auto value = currentPlatformValue_(viewTag, propertyName, timestamp);
+  if (!value) {
+    return std::nullopt;
+  }
+  const auto *scalar = std::get_if<double>(&*value);
+  return scalar != nullptr ? std::optional(*scalar) : std::nullopt;
 }
 
 void CSSPlatformTransitionProxy::cancelAll(const Tag viewTag, const TransitionProperties &properties) const {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.h
@@ -33,9 +33,8 @@ using CSSApplyTransitionFunction = std::function<bool(
     double timestamp)>;
 /// Cancels the property's native transition and drops its platform-side state.
 using CSSRemoveTransitionFunction = std::function<void(Tag viewTag, const std::string &propertyName)>;
-/// The property's current animated value computed from the platform-side
-/// timeline, so a platform -> loop migration can resume from what is on screen.
-/// Absent (or nullopt) when the backend cannot reconstruct it.
+/// The value the platform animation currently shows, so a demotion can resume from it.
+/// Unset, or nullopt, when the backend cannot reconstruct it.
 using CSSCurrentPlatformValueFunction =
     std::function<std::optional<PlatformValue>(Tag viewTag, const std::string &propertyName, double timestamp)>;
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.h
@@ -34,7 +34,6 @@ using CSSApplyTransitionFunction = std::function<bool(
 /// Cancels the property's native transition and drops its platform-side state.
 using CSSRemoveTransitionFunction = std::function<void(Tag viewTag, const std::string &propertyName)>;
 /// The value the platform animation currently shows, so a demotion can resume from it.
-/// Unset, or nullopt, when the backend cannot reconstruct it.
 using CSSCurrentPlatformValueFunction =
     std::function<std::optional<PlatformValue>(Tag viewTag, const std::string &propertyName, double timestamp)>;
 
@@ -92,8 +91,8 @@ class CSSPlatformTransitionProxy {
       bool persistent,
       double timestamp) const;
   void remove(Tag viewTag, const std::string &propertyName) const;
-  /// Where a demoted property has to pick up: its diff carries the committed style,
-  /// which the native animation has already painted past. nullopt keeps the diff.
+  /// The diff's from-value is the committed style the animation already painted past;
+  /// nullopt keeps that diff untouched.
   std::optional<double> resumeValue(Tag viewTag, const std::string &propertyName, double timestamp) const;
 
   CSSCanRoutePropertyFunction canRoute_;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.h
@@ -34,7 +34,7 @@ using CSSApplyTransitionFunction = std::function<bool(
 /// Cancels the property's native transition and drops its platform-side state.
 using CSSRemoveTransitionFunction = std::function<void(Tag viewTag, const std::string &propertyName)>;
 /// The value the platform animation currently shows, so a demotion can resume from it.
-using CSSCurrentPlatformValueFunction =
+using CSSGetPlatformValueFunction =
     std::function<std::optional<PlatformValue>(Tag viewTag, const std::string &propertyName, double timestamp)>;
 
 /// A view's transition partition: which properties animate on the platform vs the
@@ -54,7 +54,7 @@ class CSSPlatformTransitionProxy {
       CSSCanRoutePropertyFunction canRoute,
       CSSApplyTransitionFunction applyTransition,
       CSSRemoveTransitionFunction removeTransition,
-      CSSCurrentPlatformValueFunction currentPlatformValue);
+      CSSGetPlatformValueFunction getPlatformValue);
 
   /// Routes the config between platform and loop, updating `routing` and returning
   /// the loop-routed remainder to run.
@@ -91,14 +91,13 @@ class CSSPlatformTransitionProxy {
       bool persistent,
       double timestamp) const;
   void remove(Tag viewTag, const std::string &propertyName) const;
-  /// The diff's from-value is the committed style the animation already painted past;
-  /// nullopt keeps that diff untouched.
-  std::optional<double> resumeValue(Tag viewTag, const std::string &propertyName, double timestamp) const;
+  /// nullopt keeps the diff's own from-value, which the animation has painted past.
+  std::optional<double> getResumeValue(Tag viewTag, const std::string &propertyName, double timestamp) const;
 
   CSSCanRoutePropertyFunction canRoute_;
   CSSApplyTransitionFunction applyTransition_;
   CSSRemoveTransitionFunction removeTransition_;
-  CSSCurrentPlatformValueFunction currentPlatformValue_;
+  CSSGetPlatformValueFunction getPlatformValue_;
 };
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.h
@@ -33,6 +33,11 @@ using CSSApplyTransitionFunction = std::function<bool(
     double timestamp)>;
 /// Cancels the property's native transition and drops its platform-side state.
 using CSSRemoveTransitionFunction = std::function<void(Tag viewTag, const std::string &propertyName)>;
+/// The property's current animated value computed from the platform-side
+/// timeline, so a platform -> loop migration can resume from what is on screen.
+/// Absent (or nullopt) when the backend cannot reconstruct it.
+using CSSCurrentPlatformValueFunction =
+    std::function<std::optional<PlatformValue>(Tag viewTag, const std::string &propertyName, double timestamp)>;
 
 /// A view's transition partition: which properties animate on the platform vs the
 /// C++ loop. Owned per-view by CSSTransition; updated by the proxy on migrations.
@@ -50,7 +55,8 @@ class CSSPlatformTransitionProxy {
   CSSPlatformTransitionProxy(
       CSSCanRoutePropertyFunction canRoute,
       CSSApplyTransitionFunction applyTransition,
-      CSSRemoveTransitionFunction removeTransition);
+      CSSRemoveTransitionFunction removeTransition,
+      CSSCurrentPlatformValueFunction currentPlatformValue);
 
   /// Routes the config between platform and loop, updating `routing` and returning
   /// the loop-routed remainder to run.
@@ -91,6 +97,7 @@ class CSSPlatformTransitionProxy {
   CSSCanRoutePropertyFunction canRoute_;
   CSSApplyTransitionFunction applyTransition_;
   CSSRemoveTransitionFunction removeTransition_;
+  CSSCurrentPlatformValueFunction currentPlatformValue_;
 };
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.h
@@ -93,6 +93,9 @@ class CSSPlatformTransitionProxy {
       bool persistent,
       double timestamp) const;
   void remove(Tag viewTag, const std::string &propertyName) const;
+  /// Where a demoted property has to pick up: its diff carries the committed style,
+  /// which the native animation has already painted past. nullopt keeps the diff.
+  std::optional<double> resumeValue(Tag viewTag, const std::string &propertyName, double timestamp) const;
 
   CSSCanRoutePropertyFunction canRoute_;
   CSSApplyTransitionFunction applyTransition_;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.cpp
@@ -29,10 +29,8 @@ CSSTransition::~CSSTransition() {
   }
 }
 
-TransitionProperties CSSTransition::getProperties() const {
-  TransitionProperties result = routing_.loop;
-  result.insert(routing_.platform.begin(), routing_.platform.end());
-  return result;
+TransitionProperties CSSTransition::getLoopProperties() const {
+  return routing_.loop;
 }
 
 folly::dynamic CSSTransition::run(jsi::Runtime &rt, CSSTransitionConfig &&config, const folly::dynamic &lastUpdates) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.h
@@ -47,9 +47,8 @@ class CSSTransition {
     return shadowNode_->getFamilyShared();
   }
 
-  /// Properties animating on the C++ loop. The updates registry retains only
-  /// these: a platform-routed property's values live natively, and a retained
-  /// copy would re-inject its pre-routing value over later committed styles.
+  /// Properties animating on the C++ loop. The updates registry retains only these:
+  /// a platform-routed value lives natively, and a stale copy would be re-injected.
   TransitionProperties getLoopProperties() const;
 
   folly::dynamic computeCurrentLoopStyle();

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.h
@@ -47,7 +47,10 @@ class CSSTransition {
     return shadowNode_->getFamilyShared();
   }
 
-  TransitionProperties getProperties() const;
+  /// Properties animating on the C++ loop. The updates registry retains only
+  /// these: a platform-routed property's values live natively, and a retained
+  /// copy would re-inject its pre-routing value over later committed styles.
+  TransitionProperties getLoopProperties() const;
 
   folly::dynamic computeCurrentLoopStyle();
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSTransitionsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSTransitionsRegistry.cpp
@@ -198,8 +198,6 @@ void CSSTransitionsRegistry::updateInUpdatesRegistry(
   folly::dynamic filteredUpdates = folly::dynamic::object;
 
   if (!lastUpdates.empty()) {
-    // Keep only loop-routed properties from the last updates and overlay the
-    // new transition starting values.
     for (const auto &prop : transitionProperties) {
       if (lastUpdates.count(prop)) {
         filteredUpdates[prop] = lastUpdates[prop];
@@ -232,9 +230,8 @@ const std::shared_ptr<CSSTransition> &CSSTransitionsRegistry::getOrCreateTransit
 void CSSTransitionsRegistry::recordInitialUpdate(
     const std::shared_ptr<CSSTransition> &transition,
     const folly::dynamic &initialUpdate) {
-  // Run the filter even with no new updates: a run that moved a property off
-  // the loop must evict its retained value, or the commit hook keeps
-  // re-injecting the pre-routing value over later committed styles.
+  // Filter even with no new updates: a run that moved a property off the loop
+  // must evict its retained value, which the commit hook would keep re-injecting.
   updateInUpdatesRegistry(transition, initialUpdate);
   if (!initialUpdate.empty()) {
     updatedTags_.insert(transition->getViewTag());

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSTransitionsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSTransitionsRegistry.cpp
@@ -190,13 +190,16 @@ void CSSTransitionsRegistry::updateInUpdatesRegistry(
     const folly::dynamic &updates) {
   const auto &shadowNode = transition->getShadowNode();
   const auto &lastUpdates = getUpdatesFromRegistry(shadowNode->getTag());
-  const auto &transitionProperties = transition->getProperties();
+  if (updates.empty() && lastUpdates.empty()) {
+    return;
+  }
+  const auto &transitionProperties = transition->getLoopProperties();
 
   folly::dynamic filteredUpdates = folly::dynamic::object;
 
   if (!lastUpdates.empty()) {
-    // Otherwise, we keep only allowed properties from the last updates
-    // and update the object with the new transition starting values
+    // Keep only loop-routed properties from the last updates and overlay the
+    // new transition starting values.
     for (const auto &prop : transitionProperties) {
       if (lastUpdates.count(prop)) {
         filteredUpdates[prop] = lastUpdates[prop];
@@ -207,7 +210,11 @@ void CSSTransitionsRegistry::updateInUpdatesRegistry(
   // updated object contains only allowed properties so we don't need
   // to do additional filtering here
   filteredUpdates.update(updates);
-  setInUpdatesRegistry(shadowNode->getFamilyShared(), filteredUpdates);
+  if (filteredUpdates.empty()) {
+    removeFromUpdatesRegistry(shadowNode->getTag());
+  } else {
+    setInUpdatesRegistry(shadowNode->getFamilyShared(), filteredUpdates);
+  }
 }
 
 const std::shared_ptr<CSSTransition> &CSSTransitionsRegistry::getOrCreateTransition(
@@ -225,11 +232,13 @@ const std::shared_ptr<CSSTransition> &CSSTransitionsRegistry::getOrCreateTransit
 void CSSTransitionsRegistry::recordInitialUpdate(
     const std::shared_ptr<CSSTransition> &transition,
     const folly::dynamic &initialUpdate) {
-  if (initialUpdate.empty()) {
-    return;
-  }
+  // Run the filter even with no new updates: a run that moved a property off
+  // the loop must evict its retained value, or the commit hook keeps
+  // re-injecting the pre-routing value over later committed styles.
   updateInUpdatesRegistry(transition, initialUpdate);
-  updatedTags_.insert(transition->getViewTag());
+  if (!initialUpdate.empty()) {
+    updatedTags_.insert(transition->getViewTag());
+  }
 }
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/platform.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/platform.cpp
@@ -151,7 +151,6 @@ std::optional<PlatformValue>
 lerpPlatformValues(const PlatformValue &from, const PlatformValue &to, const double progress) {
   return std::visit(
       [&to, progress](const auto &fromValue) -> std::optional<PlatformValue> {
-        // Endpoints of different kinds have nothing to interpolate along.
         const auto *toValue = std::get_if<std::decay_t<decltype(fromValue)>>(&to);
         if (toValue == nullptr) {
           return std::nullopt;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/platform.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/platform.cpp
@@ -3,6 +3,7 @@
 #include <reanimated/Tools/FeatureFlags.h>
 
 #include <array>
+#include <cstddef>
 #include <cstdint>
 #include <type_traits>
 #include <unordered_map>
@@ -103,6 +104,20 @@ std::optional<PlatformValue> parseValue(const CSSPropertyTraits &traits, const f
   return std::nullopt;
 }
 
+double lerpValue(const double from, const double to, const double progress) {
+  return from + (to - from) * progress;
+}
+
+template <std::size_t N>
+std::array<double, N>
+lerpValue(const std::array<double, N> &from, const std::array<double, N> &to, const double progress) {
+  std::array<double, N> result{};
+  for (std::size_t i = 0; i < N; ++i) {
+    result[i] = lerpValue(from[i], to[i], progress);
+  }
+  return result;
+}
+
 } // namespace
 
 bool canRouteCSSProperty(const std::string &propertyName, const EasingConfig &easing) {
@@ -134,26 +149,16 @@ bool canRouteCSSProperty(const std::string &propertyName, const EasingConfig &ea
 
 std::optional<PlatformValue>
 lerpPlatformValues(const PlatformValue &from, const PlatformValue &to, const double progress) {
-  const auto lerp = [progress](const double start, const double end) {
-    return start + (end - start) * progress;
-  };
   return std::visit(
-      [&lerp](const auto &fromValue, const auto &toValue) -> std::optional<PlatformValue> {
-        using Kind = std::decay_t<decltype(fromValue)>;
-        if constexpr (!std::is_same_v<Kind, std::decay_t<decltype(toValue)>>) {
+      [&to, progress](const auto &fromValue) -> std::optional<PlatformValue> {
+        // Endpoints of different kinds have nothing to interpolate along.
+        const auto *toValue = std::get_if<std::decay_t<decltype(fromValue)>>(&to);
+        if (toValue == nullptr) {
           return std::nullopt;
-        } else if constexpr (std::is_same_v<Kind, double>) {
-          return lerp(fromValue, toValue);
-        } else {
-          Kind blended{};
-          for (size_t i = 0; i < blended.size(); ++i) {
-            blended[i] = lerp(fromValue[i], toValue[i]);
-          }
-          return blended;
         }
+        return lerpValue(fromValue, *toValue, progress);
       },
-      from,
-      to);
+      from);
 }
 
 std::optional<PlatformValuePair> parsePlatformValues(

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/platform.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/platform.cpp
@@ -103,31 +103,6 @@ std::optional<PlatformValue> parseValue(const CSSPropertyTraits &traits, const f
   return std::nullopt;
 }
 
-// A color endpoint that is only there because the property is unset carries no hue
-// of its own, so CSSColor::interpolate fades the other endpoint's hue out instead of
-// sliding through black. The platform backends interpolate the raw channels, so the
-// substitution has to happen here for them to match the loop.
-void applyTransparentEndpointRule(
-    const CSSPropertyTraits &traits,
-    const bool fromIsUnset,
-    const bool toIsUnset,
-    PlatformValue &from,
-    PlatformValue &to) {
-  if (traits.kind != CSSValueKind::Color) {
-    return;
-  }
-  auto *fromChannels = std::get_if<std::array<double, 4>>(&from);
-  auto *toChannels = std::get_if<std::array<double, 4>>(&to);
-  if (fromChannels == nullptr || toChannels == nullptr) {
-    return;
-  }
-  if (fromIsUnset) {
-    *fromChannels = {(*toChannels)[0], (*toChannels)[1], (*toChannels)[2], 0.0};
-  } else if (toIsUnset) {
-    *toChannels = {(*fromChannels)[0], (*fromChannels)[1], (*fromChannels)[2], 0.0};
-  }
-}
-
 } // namespace
 
 bool canRouteCSSProperty(const std::string &propertyName, const EasingConfig &easing) {
@@ -190,13 +165,11 @@ std::optional<PlatformValuePair> parsePlatformValues(
   if (traits == nullptr) {
     return std::nullopt;
   }
-  auto from = parseValue(*traits, rt, fromValue);
-  auto to = parseValue(*traits, rt, toValue);
+  const auto from = parseValue(*traits, rt, fromValue);
+  const auto to = parseValue(*traits, rt, toValue);
   if (!from || !to) {
     return std::nullopt;
   }
-  applyTransparentEndpointRule(
-      *traits, fromValue.isNull() || fromValue.isUndefined(), toValue.isNull() || toValue.isUndefined(), *from, *to);
   return PlatformValuePair{*from, *to};
 }
 
@@ -206,12 +179,11 @@ parsePlatformValues(const std::string &propertyName, const folly::dynamic &fromV
   if (traits == nullptr) {
     return std::nullopt;
   }
-  auto from = parseValue(*traits, fromValue);
-  auto to = parseValue(*traits, toValue);
+  const auto from = parseValue(*traits, fromValue);
+  const auto to = parseValue(*traits, toValue);
   if (!from || !to) {
     return std::nullopt;
   }
-  applyTransparentEndpointRule(*traits, fromValue.isNull(), toValue.isNull(), *from, *to);
   return PlatformValuePair{*from, *to};
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/platform.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/platform.cpp
@@ -4,7 +4,9 @@
 
 #include <array>
 #include <cstdint>
+#include <type_traits>
 #include <unordered_map>
+#include <variant>
 
 namespace reanimated::css {
 
@@ -128,6 +130,30 @@ bool canRouteCSSProperty(const std::string &propertyName, const EasingConfig &ea
   // No native routing backend on this platform yet; every property runs on the loop.
   return false;
 #endif // __APPLE__
+}
+
+std::optional<PlatformValue>
+lerpPlatformValues(const PlatformValue &from, const PlatformValue &to, const double progress) {
+  const auto lerp = [progress](const double start, const double end) {
+    return start + (end - start) * progress;
+  };
+  return std::visit(
+      [&lerp](const auto &fromValue, const auto &toValue) -> std::optional<PlatformValue> {
+        using Kind = std::decay_t<decltype(fromValue)>;
+        if constexpr (!std::is_same_v<Kind, std::decay_t<decltype(toValue)>>) {
+          return std::nullopt;
+        } else if constexpr (std::is_same_v<Kind, double>) {
+          return lerp(fromValue, toValue);
+        } else {
+          Kind blended{};
+          for (size_t i = 0; i < blended.size(); ++i) {
+            blended[i] = lerp(fromValue[i], toValue[i]);
+          }
+          return blended;
+        }
+      },
+      from,
+      to);
 }
 
 std::optional<PlatformValuePair> parsePlatformValues(

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/platform.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/platform.cpp
@@ -103,6 +103,31 @@ std::optional<PlatformValue> parseValue(const CSSPropertyTraits &traits, const f
   return std::nullopt;
 }
 
+// A color endpoint that is only there because the property is unset carries no hue
+// of its own, so CSSColor::interpolate fades the other endpoint's hue out instead of
+// sliding through black. The platform backends interpolate the raw channels, so the
+// substitution has to happen here for them to match the loop.
+void applyTransparentEndpointRule(
+    const CSSPropertyTraits &traits,
+    const bool fromIsUnset,
+    const bool toIsUnset,
+    PlatformValue &from,
+    PlatformValue &to) {
+  if (traits.kind != CSSValueKind::Color) {
+    return;
+  }
+  auto *fromChannels = std::get_if<std::array<double, 4>>(&from);
+  auto *toChannels = std::get_if<std::array<double, 4>>(&to);
+  if (fromChannels == nullptr || toChannels == nullptr) {
+    return;
+  }
+  if (fromIsUnset) {
+    *fromChannels = {(*toChannels)[0], (*toChannels)[1], (*toChannels)[2], 0.0};
+  } else if (toIsUnset) {
+    *toChannels = {(*fromChannels)[0], (*fromChannels)[1], (*fromChannels)[2], 0.0};
+  }
+}
+
 } // namespace
 
 bool canRouteCSSProperty(const std::string &propertyName, const EasingConfig &easing) {
@@ -165,11 +190,13 @@ std::optional<PlatformValuePair> parsePlatformValues(
   if (traits == nullptr) {
     return std::nullopt;
   }
-  const auto from = parseValue(*traits, rt, fromValue);
-  const auto to = parseValue(*traits, rt, toValue);
+  auto from = parseValue(*traits, rt, fromValue);
+  auto to = parseValue(*traits, rt, toValue);
   if (!from || !to) {
     return std::nullopt;
   }
+  applyTransparentEndpointRule(
+      *traits, fromValue.isNull() || fromValue.isUndefined(), toValue.isNull() || toValue.isUndefined(), *from, *to);
   return PlatformValuePair{*from, *to};
 }
 
@@ -179,11 +206,12 @@ parsePlatformValues(const std::string &propertyName, const folly::dynamic &fromV
   if (traits == nullptr) {
     return std::nullopt;
   }
-  const auto from = parseValue(*traits, fromValue);
-  const auto to = parseValue(*traits, toValue);
+  auto from = parseValue(*traits, fromValue);
+  auto to = parseValue(*traits, toValue);
   if (!from || !to) {
     return std::nullopt;
   }
+  applyTransparentEndpointRule(*traits, fromValue.isNull(), toValue.isNull(), *from, *to);
   return PlatformValuePair{*from, *to};
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/platform.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/platform.h
@@ -22,8 +22,7 @@ using PlatformValue = std::variant<double, std::array<double, 2>, std::array<dou
 /// subset of properties; everything else runs on the C++ loop.
 bool canRouteCSSProperty(const std::string &propertyName, const EasingConfig &easing);
 
-/// Blends two platform values at the given progress, per component. nullopt when
-/// the endpoints are of different kinds, which no interpolation can bridge.
+/// Blends two platform values per component; nullopt when their kinds differ.
 std::optional<PlatformValue> lerpPlatformValues(const PlatformValue &from, const PlatformValue &to, double progress);
 
 /// Parses a transition's endpoints, looking the property up once. Null/undefined

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/platform.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/platform.h
@@ -22,7 +22,6 @@ using PlatformValue = std::variant<double, std::array<double, 2>, std::array<dou
 /// subset of properties; everything else runs on the C++ loop.
 bool canRouteCSSProperty(const std::string &propertyName, const EasingConfig &easing);
 
-/// Blends two platform values per component; nullopt when their kinds differ.
 std::optional<PlatformValue> lerpPlatformValues(const PlatformValue &from, const PlatformValue &to, double progress);
 
 /// Parses a transition's endpoints, looking the property up once. Null/undefined

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/platform.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/platform.h
@@ -22,6 +22,10 @@ using PlatformValue = std::variant<double, std::array<double, 2>, std::array<dou
 /// subset of properties; everything else runs on the C++ loop.
 bool canRouteCSSProperty(const std::string &propertyName, const EasingConfig &easing);
 
+/// Blends two platform values at the given progress, per component. nullopt when
+/// the endpoints are of different kinds, which no interpolation can bridge.
+std::optional<PlatformValue> lerpPlatformValues(const PlatformValue &from, const PlatformValue &to, double progress);
+
 /// Parses a transition's endpoints, looking the property up once. Null/undefined
 /// falls back to its CSS default; nullopt means the platform can't express the
 /// pair, so it runs on the loop. jsi::Value is the config path, folly::dynamic the

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -226,7 +226,7 @@ ReanimatedModuleProxy::ReanimatedModuleProxy(
               platformDepMethodsHolder.cssCanRouteProperty,
               platformDepMethodsHolder.cssApplyTransition,
               platformDepMethodsHolder.cssRemoveTransition,
-              platformDepMethodsHolder.cssCurrentPlatformValue),
+              platformDepMethodsHolder.cssGetPlatformValue),
           cssEventsEmitter_)),
       pseudoStylesRegistry_(std::make_shared<PseudoStylesRegistry>(
           platformDepMethodsHolder.attachPseudoSelector,

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -225,7 +225,8 @@ ReanimatedModuleProxy::ReanimatedModuleProxy(
           std::make_shared<CSSPlatformTransitionProxy>(
               platformDepMethodsHolder.cssCanRouteProperty,
               platformDepMethodsHolder.cssApplyTransition,
-              platformDepMethodsHolder.cssRemoveTransition),
+              platformDepMethodsHolder.cssRemoveTransition,
+              platformDepMethodsHolder.cssCurrentPlatformValue),
           cssEventsEmitter_)),
       pseudoStylesRegistry_(std::make_shared<PseudoStylesRegistry>(
           platformDepMethodsHolder.attachPseudoSelector,

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Tools/PlatformDepMethodsHolder.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Tools/PlatformDepMethodsHolder.h
@@ -73,7 +73,7 @@ struct PlatformDepMethodsHolder {
   css::CSSCanRoutePropertyFunction cssCanRouteProperty;
   css::CSSApplyTransitionFunction cssApplyTransition;
   css::CSSRemoveTransitionFunction cssRemoveTransition;
-  css::CSSCurrentPlatformValueFunction cssCurrentPlatformValue;
+  css::CSSGetPlatformValueFunction cssGetPlatformValue;
   // Last so a platform that does not supply it can omit it and get value-init.
   std::shared_ptr<css::CSSPlatformAnimationFactory> platformAnimationFactory;
 };

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Tools/PlatformDepMethodsHolder.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Tools/PlatformDepMethodsHolder.h
@@ -74,8 +74,7 @@ struct PlatformDepMethodsHolder {
   css::CSSApplyTransitionFunction cssApplyTransition;
   css::CSSRemoveTransitionFunction cssRemoveTransition;
   css::CSSCurrentPlatformValueFunction cssCurrentPlatformValue;
-  // Last so a platform initializer that does not supply it can omit it and rely
-  // on value-init (= null shared_ptr).
+  // Last so a platform that does not supply it can omit it and get value-init.
   std::shared_ptr<css::CSSPlatformAnimationFactory> platformAnimationFactory;
 };
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Tools/PlatformDepMethodsHolder.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Tools/PlatformDepMethodsHolder.h
@@ -73,10 +73,9 @@ struct PlatformDepMethodsHolder {
   css::CSSCanRoutePropertyFunction cssCanRouteProperty;
   css::CSSApplyTransitionFunction cssApplyTransition;
   css::CSSRemoveTransitionFunction cssRemoveTransition;
-  // The trailing members are optional: platform initializers that don't supply
-  // them (iOS omits both, Android supplies only cssCurrentPlatformValue) rely
-  // on value-init (= null function / null shared_ptr).
   css::CSSCurrentPlatformValueFunction cssCurrentPlatformValue;
+  // Last so a platform initializer that does not supply it can omit it and rely
+  // on value-init (= null shared_ptr).
   std::shared_ptr<css::CSSPlatformAnimationFactory> platformAnimationFactory;
 };
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Tools/PlatformDepMethodsHolder.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Tools/PlatformDepMethodsHolder.h
@@ -73,8 +73,10 @@ struct PlatformDepMethodsHolder {
   css::CSSCanRoutePropertyFunction cssCanRouteProperty;
   css::CSSApplyTransitionFunction cssApplyTransition;
   css::CSSRemoveTransitionFunction cssRemoveTransition;
-  // Last so platform initializers that don't supply it (iOS, Android today)
-  // can omit it and rely on value-init (= null shared_ptr).
+  // The trailing members are optional: platform initializers that don't supply
+  // them (iOS omits both, Android supplies only cssCurrentPlatformValue) rely
+  // on value-init (= null function / null shared_ptr).
+  css::CSSCurrentPlatformValueFunction cssCurrentPlatformValue;
   std::shared_ptr<css::CSSPlatformAnimationFactory> platformAnimationFactory;
 };
 

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
@@ -107,7 +107,7 @@ bool CSSPlatformTransitions::applyTransition(
     adjustedStart = active->adjustedEnd;
     // The backend resumes a reversal from the live value, which the outgoing
     // timeline still describes; active_ is only re-assigned below.
-    startValue = currentValue(viewTag, propertyName, timestamp);
+    startValue = getCurrentValue(viewTag, propertyName, timestamp);
   } else if (active == nullptr) {
     adjustedStart = startValue = fromValue;
   } else if (timestamp >= active->reversing.startTimestamp + active->reversing.duration) {
@@ -140,8 +140,10 @@ bool CSSPlatformTransitions::applyTransition(
   return true;
 }
 
-std::optional<css::PlatformValue>
-CSSPlatformTransitions::currentValue(const Tag viewTag, const std::string &propertyName, const double timestamp) const {
+std::optional<css::PlatformValue> CSSPlatformTransitions::getCurrentValue(
+    const Tag viewTag,
+    const std::string &propertyName,
+    const double timestamp) const {
   const auto *active = activeTransitionFor(viewTag, propertyName);
   if (active == nullptr || !active->startValue) {
     return std::nullopt;

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
@@ -102,12 +102,16 @@ bool CSSPlatformTransitions::applyTransition(
 
   // https://drafts.csswg.org/css-transitions/#reversing
   std::optional<css::PlatformValue> adjustedStart;
+  std::optional<css::PlatformValue> startValue;
   if (isReversal) {
     adjustedStart = active->adjustedEnd;
+    // The backend resumes a reversal from the live value, which the outgoing
+    // timeline still describes; active_ is only re-assigned below.
+    startValue = currentValue(viewTag, propertyName, timestamp);
   } else if (active == nullptr) {
-    adjustedStart = fromValue;
+    adjustedStart = startValue = fromValue;
   } else if (timestamp >= active->reversing.startTimestamp + active->reversing.duration) {
-    adjustedStart = active->adjustedEnd;
+    adjustedStart = startValue = active->adjustedEnd;
   }
 
   const int easingId = easings_->acquire(toPlatformEasing(resolvedSettings.easingConfig));
@@ -132,21 +136,21 @@ bool CSSPlatformTransitions::applyTransition(
   }
 
   active_[viewTag][propertyName] =
-      ActiveTransition{adjustedStart, toValue, std::move(reversing), resolvedSettings, easingId};
+      ActiveTransition{adjustedStart, startValue, toValue, std::move(reversing), resolvedSettings, easingId};
   return true;
 }
 
 std::optional<css::PlatformValue>
 CSSPlatformTransitions::currentValue(const Tag viewTag, const std::string &propertyName, const double timestamp) const {
   const auto *active = activeTransitionFor(viewTag, propertyName);
-  if (active == nullptr || !active->adjustedStart) {
+  if (active == nullptr || !active->startValue) {
     return std::nullopt;
   }
   const auto &reversing = active->reversing;
   const double progress =
       reversing.duration > 0 ? std::clamp((timestamp - reversing.startTimestamp) / reversing.duration, 0.0, 1.0) : 1.0;
   return css::lerpPlatformValues(
-      *active->adjustedStart, active->adjustedEnd, css::getEasingFunctionFromConfig(reversing.easing)(progress));
+      *active->startValue, active->adjustedEnd, css::getEasingFunctionFromConfig(reversing.easing)(progress));
 }
 
 void CSSPlatformTransitions::removeTransition(const Tag viewTag, const std::string &propertyName) {

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
@@ -100,18 +100,18 @@ bool CSSPlatformTransitions::applyTransition(
       : css::makeReversingState(
             timestamp, resolvedSettings.duration, resolvedSettings.delay, resolvedSettings.easingConfig);
 
-  // https://drafts.csswg.org/css-transitions/#reversing
   std::optional<css::PlatformValue> adjustedStart;
   std::optional<css::PlatformValue> startValue;
-  if (isReversal) {
-    adjustedStart = active->adjustedEnd;
-    // The backend resumes a reversal from the live value, which the outgoing
-    // timeline still describes; active_ is only re-assigned below.
-    startValue = getCurrentValue(viewTag, propertyName, timestamp);
-  } else if (active == nullptr) {
+  if (active == nullptr) {
     adjustedStart = startValue = fromValue;
-  } else if (timestamp >= active->reversing.startTimestamp + active->reversing.duration) {
-    adjustedStart = startValue = active->adjustedEnd;
+  } else {
+    // An interruption starts from the value on screen, which the outgoing timeline
+    // still describes; active_ is only re-assigned below. A finished transition
+    // retraces to its own end, so this covers that case too.
+    startValue = getCurrentValue(viewTag, propertyName, timestamp);
+    // https://drafts.csswg.org/css-transitions/#reversing: a reversal has to target
+    // where the interrupted one began, anything else starts its own reversing run.
+    adjustedStart = isReversal ? active->adjustedEnd : startValue;
   }
 
   const int easingId = easings_->acquire(toPlatformEasing(resolvedSettings.easingConfig));

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
@@ -136,6 +136,24 @@ bool CSSPlatformTransitions::applyTransition(
   return true;
 }
 
+std::optional<css::PlatformValue>
+CSSPlatformTransitions::currentValue(const Tag viewTag, const std::string &propertyName, const double timestamp) const {
+  const auto *active = activeTransitionFor(viewTag, propertyName);
+  if (active == nullptr || !active->adjustedStart) {
+    return std::nullopt;
+  }
+  const auto &reversing = active->reversing;
+  const double linearProgress =
+      reversing.duration > 0 ? std::clamp((timestamp - reversing.startTimestamp) / reversing.duration, 0.0, 1.0) : 1.0;
+  const double easedProgress = css::getEasingFunctionFromConfig(reversing.easing)(linearProgress);
+  const auto *from = std::get_if<double>(&*active->adjustedStart);
+  const auto *to = std::get_if<double>(&active->adjustedEnd);
+  if (from == nullptr || to == nullptr) {
+    return std::nullopt;
+  }
+  return *from + (*to - *from) * easedProgress;
+}
+
 void CSSPlatformTransitions::removeTransition(const Tag viewTag, const std::string &propertyName) {
   const auto propertiesIt = active_.find(viewTag);
   if (propertiesIt != active_.end()) {

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.cpp
@@ -143,15 +143,10 @@ CSSPlatformTransitions::currentValue(const Tag viewTag, const std::string &prope
     return std::nullopt;
   }
   const auto &reversing = active->reversing;
-  const double linearProgress =
+  const double progress =
       reversing.duration > 0 ? std::clamp((timestamp - reversing.startTimestamp) / reversing.duration, 0.0, 1.0) : 1.0;
-  const double easedProgress = css::getEasingFunctionFromConfig(reversing.easing)(linearProgress);
-  const auto *from = std::get_if<double>(&*active->adjustedStart);
-  const auto *to = std::get_if<double>(&active->adjustedEnd);
-  if (from == nullptr || to == nullptr) {
-    return std::nullopt;
-  }
-  return *from + (*to - *from) * easedProgress;
+  return css::lerpPlatformValues(
+      *active->adjustedStart, active->adjustedEnd, css::getEasingFunctionFromConfig(reversing.easing)(progress));
 }
 
 void CSSPlatformTransitions::removeTransition(const Tag viewTag, const std::string &propertyName) {

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
@@ -49,16 +49,16 @@ class CSSPlatformTransitions {
 
   void removeTransition(Tag viewTag, const std::string &propertyName);
 
-  /// The value the animator shows at `timestamp`, retraced from the stored timeline.
   /// nullopt after a non-reversing interruption, which resumed from the live view value.
-  std::optional<css::PlatformValue> currentValue(Tag viewTag, const std::string &propertyName, double timestamp) const;
+  std::optional<css::PlatformValue> getCurrentValue(Tag viewTag, const std::string &propertyName, double timestamp)
+      const;
 
  private:
   struct ActiveTransition {
     /// Reversing-adjusted start value: what a later reversal has to target. A reversal
     /// resumes from the live value, so this is not where the animator started.
     std::optional<css::PlatformValue> adjustedStart;
-    /// Where the animator started, so currentValue can retrace what it plays.
+    /// Where the animator started, so getCurrentValue can retrace what it plays.
     std::optional<css::PlatformValue> startValue;
     css::PlatformValue adjustedEnd;
     css::ReversingState reversing;

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
@@ -51,12 +51,16 @@ class CSSPlatformTransitions {
 
   /// The value the animator shows at `timestamp`, reconstructed from the stored
   /// timeline. nullopt when the start value is not known on this side (a
-  /// mid-flight interruption resumed from the live view value).
+  /// non-reversing mid-flight interruption resumed from the live view value).
   std::optional<css::PlatformValue> currentValue(Tag viewTag, const std::string &propertyName, double timestamp) const;
 
  private:
   struct ActiveTransition {
+    /// Reversing-adjusted start value: what a later reversal has to target. A reversal
+    /// resumes from the live value, so this is not where the animator started.
     std::optional<css::PlatformValue> adjustedStart;
+    /// Where the animator started, so currentValue can retrace what it plays.
+    std::optional<css::PlatformValue> startValue;
     css::PlatformValue adjustedEnd;
     css::ReversingState reversing;
     css::CSSTransitionPropertySettings settings;

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
@@ -49,9 +49,8 @@ class CSSPlatformTransitions {
 
   void removeTransition(Tag viewTag, const std::string &propertyName);
 
-  /// The value the animator shows at `timestamp`, reconstructed from the stored
-  /// timeline. nullopt when the start value is not known on this side (a
-  /// non-reversing mid-flight interruption resumed from the live view value).
+  /// The value the animator shows at `timestamp`, retraced from the stored timeline.
+  /// nullopt after a non-reversing interruption, which resumed from the live view value.
   std::optional<css::PlatformValue> currentValue(Tag viewTag, const std::string &propertyName, double timestamp) const;
 
  private:

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/CSS/CSSPlatformTransitions.h
@@ -49,6 +49,11 @@ class CSSPlatformTransitions {
 
   void removeTransition(Tag viewTag, const std::string &propertyName);
 
+  /// The value the animator shows at `timestamp`, reconstructed from the stored
+  /// timeline. nullopt when the start value is not known on this side (a
+  /// mid-flight interruption resumed from the live view value).
+  std::optional<css::PlatformValue> currentValue(Tag viewTag, const std::string &propertyName, double timestamp) const;
+
  private:
   struct ActiveTransition {
     std::optional<css::PlatformValue> adjustedStart;

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
@@ -399,8 +399,8 @@ PlatformDepMethodsHolder NativeProxy::getPlatformDependentMethods() {
     transitions->removeTransition(std::forward<decltype(args)>(args)...);
   };
 
-  auto cssCurrentPlatformValue = [transitions = cssPlatformTransitions](auto &&...args) {
-    return transitions->currentValue(std::forward<decltype(args)>(args)...);
+  auto cssGetPlatformValue = [transitions = cssPlatformTransitions](auto &&...args) {
+    return transitions->getCurrentValue(std::forward<decltype(args)>(args)...);
   };
 
   return {
@@ -419,7 +419,7 @@ PlatformDepMethodsHolder NativeProxy::getPlatformDependentMethods() {
       cssCanRouteProperty,
       cssApplyTransition,
       cssRemoveTransition,
-      cssCurrentPlatformValue,
+      cssGetPlatformValue,
   };
 }
 

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
@@ -399,6 +399,10 @@ PlatformDepMethodsHolder NativeProxy::getPlatformDependentMethods() {
     transitions->removeTransition(std::forward<decltype(args)>(args)...);
   };
 
+  auto cssCurrentPlatformValue = [transitions = cssPlatformTransitions](auto &&...args) {
+    return transitions->currentValue(std::forward<decltype(args)>(args)...);
+  };
+
   return {
       requestRender,
       preserveMountedTags,
@@ -415,6 +419,7 @@ PlatformDepMethodsHolder NativeProxy::getPlatformDependentMethods() {
       cssCanRouteProperty,
       cssApplyTransition,
       cssRemoveTransition,
+      cssCurrentPlatformValue,
   };
 }
 

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPropertyWriter.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPropertyWriter.kt
@@ -19,9 +19,8 @@ private object AlphaProperty : FloatProperty<View>("alpha") {
         view: View,
         value: Float,
     ) {
-        // ReactViewGroup owns opacity: it hides the view when backfaceVisibility is hidden and
-        // a rotation turns it away, and re-applies the value it stored on every transform
-        // commit. Writing alpha directly would defeat the first and be reverted by the second.
+        // ReactViewGroup owns opacity: it zeroes alpha when a hidden backface turns away, and
+        // re-applies its stored value on every transform commit. A direct alpha write loses both.
         if (view is ReactViewGroup) {
             view.setOpacityIfPossible(value)
         } else {

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPropertyWriter.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPropertyWriter.kt
@@ -2,6 +2,7 @@ package com.swmansion.reanimated.css
 
 import android.util.FloatProperty
 import android.view.View
+import com.facebook.react.views.view.ReactViewGroup
 
 /**
  * The View property React Native itself writes, so a commit can overwrite a running animation.
@@ -18,7 +19,14 @@ private object AlphaProperty : FloatProperty<View>("alpha") {
         view: View,
         value: Float,
     ) {
-        view.alpha = value
+        // ReactViewGroup owns opacity: it hides the view when backfaceVisibility is hidden and
+        // a rotation turns it away, and re-applies the value it stored on every transform
+        // commit. Writing alpha directly would defeat the first and be reverted by the second.
+        if (view is ReactViewGroup) {
+            view.setOpacityIfPossible(value)
+        } else {
+            view.alpha = value
+        }
     }
 
     override fun get(view: View): Float = view.alpha

--- a/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.h
@@ -31,10 +31,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)removeTransitionForTag:(facebook::react::Tag)viewTag propertyName:(const std::string &)propertyName;
 
-/// The value the native animation shows at `timestamp`, reconstructed from the
-/// stored timeline. The presentation layer holds the same value, but only the main
-/// thread may read it, and routing needs the answer inline. nullopt once a
-/// mid-flight interruption has dropped the start value.
+/// The value the animation shows at `timestamp`, retraced from the stored timeline;
+/// the presentation layer has it too, but only the main thread may read that and
+/// routing needs the answer inline. nullopt after a non-reversing interruption.
 - (std::optional<reanimated::css::PlatformValue>)currentValueForTag:(facebook::react::Tag)viewTag
                                                        propertyName:(const std::string &)propertyName
                                                           timestamp:(double)timestamp;

--- a/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.h
@@ -31,12 +31,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)removeTransitionForTag:(facebook::react::Tag)viewTag propertyName:(const std::string &)propertyName;
 
-/// The value the animation shows at `timestamp`, retraced from the stored timeline:
-/// the presentation layer has it, but only the main thread may read it. nullopt after
-/// a non-reversing interruption.
-- (std::optional<reanimated::css::PlatformValue>)currentValueForTag:(facebook::react::Tag)viewTag
-                                                       propertyName:(const std::string &)propertyName
-                                                          timestamp:(double)timestamp;
+/// Retraced from the stored timeline: the presentation layer has this value, but only
+/// the main thread may read it. nullopt after a non-reversing interruption.
+- (std::optional<reanimated::css::PlatformValue>)getCurrentValueForTag:(facebook::react::Tag)viewTag
+                                                          propertyName:(const std::string &)propertyName
+                                                             timestamp:(double)timestamp;
 
 @end
 

--- a/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.h
@@ -31,9 +31,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)removeTransitionForTag:(facebook::react::Tag)viewTag propertyName:(const std::string &)propertyName;
 
-/// The value the animation shows at `timestamp`, retraced from the stored timeline;
-/// the presentation layer has it too, but only the main thread may read that and
-/// routing needs the answer inline. nullopt after a non-reversing interruption.
+/// The value the animation shows at `timestamp`, retraced from the stored timeline:
+/// the presentation layer has it, but only the main thread may read it. nullopt after
+/// a non-reversing interruption.
 - (std::optional<reanimated::css::PlatformValue>)currentValueForTag:(facebook::react::Tag)viewTag
                                                        propertyName:(const std::string &)propertyName
                                                           timestamp:(double)timestamp;

--- a/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.h
@@ -9,6 +9,7 @@
 
 #import <Foundation/Foundation.h>
 
+#import <optional>
 #import <string>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -29,6 +30,14 @@ NS_ASSUME_NONNULL_BEGIN
                     timestamp:(double)timestamp;
 
 - (void)removeTransitionForTag:(facebook::react::Tag)viewTag propertyName:(const std::string &)propertyName;
+
+/// The value the native animation shows at `timestamp`, reconstructed from the
+/// stored timeline. The presentation layer holds the same value, but only the main
+/// thread may read it, and routing needs the answer inline. nullopt once a
+/// mid-flight interruption has dropped the start value.
+- (std::optional<reanimated::css::PlatformValue>)currentValueForTag:(facebook::react::Tag)viewTag
+                                                       propertyName:(const std::string &)propertyName
+                                                          timestamp:(double)timestamp;
 
 @end
 

--- a/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.mm
@@ -109,7 +109,7 @@ struct ActiveTransition {
     adjustedStart = active->adjustedEnd;
     // A reversal resumes from the presentation value, which the outgoing timeline
     // still describes; _active is only re-assigned below.
-    startValue = [self currentValueForTag:viewTag propertyName:propertyName timestamp:timestamp];
+    startValue = [self getCurrentValueForTag:viewTag propertyName:propertyName timestamp:timestamp];
   } else if (active == nullptr) {
     adjustedStart = startValue = fromValue;
   } else if (timestamp >= active->reversing.startTimestamp + active->reversing.duration) {
@@ -187,9 +187,9 @@ struct ActiveTransition {
   });
 }
 
-- (std::optional<PlatformValue>)currentValueForTag:(Tag)viewTag
-                                      propertyName:(const std::string &)propertyName
-                                         timestamp:(double)timestamp
+- (std::optional<PlatformValue>)getCurrentValueForTag:(Tag)viewTag
+                                         propertyName:(const std::string &)propertyName
+                                            timestamp:(double)timestamp
 {
   const ActiveTransition *active = [self activeTransitionForTag:viewTag propertyName:propertyName];
   if (active == nullptr || !active->startValue) {

--- a/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.mm
@@ -105,15 +105,16 @@ struct ActiveTransition {
   // https://drafts.csswg.org/css-transitions/#reversing
   std::optional<PlatformValue> adjustedStart;
   std::optional<PlatformValue> startValue;
-  if (isReversal) {
-    adjustedStart = active->adjustedEnd;
-    // A reversal resumes from the presentation value, which the outgoing timeline
-    // still describes; _active is only re-assigned below.
-    startValue = [self getCurrentValueForTag:viewTag propertyName:propertyName timestamp:timestamp];
-  } else if (active == nullptr) {
+  if (active == nullptr) {
     adjustedStart = startValue = fromValue;
-  } else if (timestamp >= active->reversing.startTimestamp + active->reversing.duration) {
-    adjustedStart = startValue = active->adjustedEnd;
+  } else {
+    // An interruption starts from the presentation value, which the outgoing timeline
+    // still describes; _active is only re-assigned below. A finished animation
+    // retraces to its own end, so this covers that case too.
+    startValue = [self getCurrentValueForTag:viewTag propertyName:propertyName timestamp:timestamp];
+    // https://drafts.csswg.org/css-transitions/#reversing: a reversal has to target
+    // where the interrupted one began, anything else starts its own reversing run.
+    adjustedStart = isReversal ? active->adjustedEnd : startValue;
   }
 
   [self animateTag:viewTag

--- a/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.mm
@@ -32,7 +32,7 @@ struct ActiveTransition {
   /// Reversing-adjusted start value: what a later reversal has to target. A reversal
   /// resumes from the live value, so this is not where the animation started.
   std::optional<PlatformValue> adjustedStart;
-  /// Where the animation started, so currentValue can retrace what it plays.
+  /// Where the animation started, so getCurrentValueForTag: can retrace what it plays.
   std::optional<PlatformValue> startValue;
   PlatformValue adjustedEnd;
   ReversingState reversing;

--- a/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.mm
@@ -29,8 +29,12 @@ namespace {
 // and the reversing snapshot handle interruptions; settings are reused by the
 // toggle path.
 struct ActiveTransition {
-  // Unset after a mid-flight interruption - the live start value can't match any target.
+  /// Reversing-adjusted start value: what a later reversal has to target. A reversal
+  /// resumes from the live value, so this is not where the animation started.
+  /// Unset after a non-reversing interruption - the live value can't match any target.
   std::optional<PlatformValue> adjustedStart;
+  /// Where the animation started, so currentValue can retrace what it plays.
+  std::optional<PlatformValue> startValue;
   PlatformValue adjustedEnd;
   ReversingState reversing;
   CSSTransitionPropertySettings settings;
@@ -101,12 +105,16 @@ struct ActiveTransition {
 
   // https://drafts.csswg.org/css-transitions/#reversing
   std::optional<PlatformValue> adjustedStart;
+  std::optional<PlatformValue> startValue;
   if (isReversal) {
     adjustedStart = active->adjustedEnd;
+    // A reversal resumes from the presentation value, which the outgoing timeline
+    // still describes; _active is only re-assigned below.
+    startValue = [self currentValueForTag:viewTag propertyName:propertyName timestamp:timestamp];
   } else if (active == nullptr) {
-    adjustedStart = fromValue;
+    adjustedStart = startValue = fromValue;
   } else if (timestamp >= active->reversing.startTimestamp + active->reversing.duration) {
-    adjustedStart = active->adjustedEnd;
+    adjustedStart = startValue = active->adjustedEnd;
   }
 
   [self animateTag:viewTag
@@ -117,7 +125,8 @@ struct ActiveTransition {
        startTimeMs:reversing.startTimestamp
             easing:resolvedSettings.easingConfig
         persistent:persistent];
-  _active[viewTag][propertyName] = ActiveTransition{adjustedStart, toValue, std::move(reversing), resolvedSettings};
+  _active[viewTag][propertyName] =
+      ActiveTransition{adjustedStart, startValue, toValue, std::move(reversing), resolvedSettings};
   return YES;
 }
 
@@ -184,14 +193,14 @@ struct ActiveTransition {
                                          timestamp:(double)timestamp
 {
   const ActiveTransition *active = [self activeTransitionForTag:viewTag propertyName:propertyName];
-  if (active == nullptr || !active->adjustedStart) {
+  if (active == nullptr || !active->startValue) {
     return std::nullopt;
   }
   const auto &reversing = active->reversing;
   const double progress =
       reversing.duration > 0 ? std::clamp((timestamp - reversing.startTimestamp) / reversing.duration, 0.0, 1.0) : 1.0;
   return lerpPlatformValues(
-      *active->adjustedStart, active->adjustedEnd, getEasingFunctionFromConfig(reversing.easing)(progress));
+      *active->startValue, active->adjustedEnd, getEasingFunctionFromConfig(reversing.easing)(progress));
 }
 
 - (void)removeTransitionForTag:(Tag)viewTag propertyName:(const std::string &)propertyName

--- a/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.mm
@@ -31,7 +31,6 @@ namespace {
 struct ActiveTransition {
   /// Reversing-adjusted start value: what a later reversal has to target. A reversal
   /// resumes from the live value, so this is not where the animation started.
-  /// Unset after a non-reversing interruption - the live value can't match any target.
   std::optional<PlatformValue> adjustedStart;
   /// Where the animation started, so currentValue can retrace what it plays.
   std::optional<PlatformValue> startValue;

--- a/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.mm
@@ -13,6 +13,8 @@
 
 #import <QuartzCore/QuartzCore.h>
 
+#import <algorithm>
+#import <optional>
 #import <string>
 #import <unordered_map>
 #import <utility>
@@ -175,6 +177,21 @@ struct ActiveTransition {
     [layer addAnimation:anim forKey:keyPath];
     [CATransaction commit];
   });
+}
+
+- (std::optional<PlatformValue>)currentValueForTag:(Tag)viewTag
+                                      propertyName:(const std::string &)propertyName
+                                         timestamp:(double)timestamp
+{
+  const ActiveTransition *active = [self activeTransitionForTag:viewTag propertyName:propertyName];
+  if (active == nullptr || !active->adjustedStart) {
+    return std::nullopt;
+  }
+  const auto &reversing = active->reversing;
+  const double progress =
+      reversing.duration > 0 ? std::clamp((timestamp - reversing.startTimestamp) / reversing.duration, 0.0, 1.0) : 1.0;
+  return lerpPlatformValues(
+      *active->adjustedStart, active->adjustedEnd, getEasingFunctionFromConfig(reversing.easing)(progress));
 }
 
 - (void)removeTransitionForTag:(Tag)viewTag propertyName:(const std::string &)propertyName

--- a/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.mm
@@ -159,10 +159,10 @@ css::CSSRemoveTransitionFunction makeCSSRemoveTransition(REACSSPlatformTransitio
   };
 }
 
-css::CSSCurrentPlatformValueFunction makeCSSCurrentPlatformValue(REACSSPlatformTransitions *platformTransitions)
+css::CSSGetPlatformValueFunction makeCSSGetPlatformValue(REACSSPlatformTransitions *platformTransitions)
 {
   return [platformTransitions](Tag viewTag, const std::string &propertyName, double timestamp) {
-    return [platformTransitions currentValueForTag:viewTag propertyName:propertyName timestamp:timestamp];
+    return [platformTransitions getCurrentValueForTag:viewTag propertyName:propertyName timestamp:timestamp];
   };
 }
 
@@ -232,7 +232,7 @@ PlatformDepMethodsHolder makePlatformDepMethodsHolder(RCTModuleRegistry *moduleR
   auto cssCanRouteProperty = makeCSSCanRouteProperty();
   auto cssApplyTransition = makeCSSApplyTransition(platformTransitions);
   auto cssRemoveTransition = makeCSSRemoveTransition(platformTransitions);
-  auto cssCurrentPlatformValue = makeCSSCurrentPlatformValue(platformTransitions);
+  auto cssGetPlatformValue = makeCSSGetPlatformValue(platformTransitions);
 
   PlatformDepMethodsHolder platformDepMethodsHolder = {
       requestRender,
@@ -250,7 +250,7 @@ PlatformDepMethodsHolder makePlatformDepMethodsHolder(RCTModuleRegistry *moduleR
       cssCanRouteProperty,
       cssApplyTransition,
       cssRemoveTransition,
-      cssCurrentPlatformValue,
+      cssGetPlatformValue,
   };
   return platformDepMethodsHolder;
 }

--- a/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.mm
@@ -159,6 +159,13 @@ css::CSSRemoveTransitionFunction makeCSSRemoveTransition(REACSSPlatformTransitio
   };
 }
 
+css::CSSCurrentPlatformValueFunction makeCSSCurrentPlatformValue(REACSSPlatformTransitions *platformTransitions)
+{
+  return [platformTransitions](Tag viewTag, const std::string &propertyName, double timestamp) {
+    return [platformTransitions currentValueForTag:viewTag propertyName:propertyName timestamp:timestamp];
+  };
+}
+
 ForceScreenSnapshotFunction makeForceScreenSnapshotFunction(REANodesManager *nodesManager)
 {
   auto forceScreenSnapshot = [=](Tag tag) {
@@ -225,6 +232,7 @@ PlatformDepMethodsHolder makePlatformDepMethodsHolder(RCTModuleRegistry *moduleR
   auto cssCanRouteProperty = makeCSSCanRouteProperty();
   auto cssApplyTransition = makeCSSApplyTransition(platformTransitions);
   auto cssRemoveTransition = makeCSSRemoveTransition(platformTransitions);
+  auto cssCurrentPlatformValue = makeCSSCurrentPlatformValue(platformTransitions);
 
   PlatformDepMethodsHolder platformDepMethodsHolder = {
       requestRender,
@@ -242,6 +250,7 @@ PlatformDepMethodsHolder makePlatformDepMethodsHolder(RCTModuleRegistry *moduleR
       cssCanRouteProperty,
       cssApplyTransition,
       cssRemoveTransition,
+      cssCurrentPlatformValue,
   };
   return platformDepMethodsHolder;
 }


### PR DESCRIPTION
When a property moves between the C++ loop and the platform path, two things went stale.

The updates registry kept the property's last settled value after it moved to the platform, so the commit hook re-injected it over the committed style and the view snapped back. Retention now covers loop-routed properties only, and runs on every transition run so a promotion evicts what it leaves behind.

A mid-flight demotion restarted the loop from the old committed value, flashing before gliding to the new one. The backend now reports the value its animation currently shows, and the demoted transition resumes from there.

Both were reproduced on a physical device and re-verified after the fix. Behavior with `ANDROID_CSS_PLATFORM_TRANSITIONS` off is unchanged.
