### PR TITLE
fix: transition triggered from default values when config is attached to a mounted view

### DIFF
--- a/packages/react-native-reanimated/src/css/native/managers/CSSManager.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/CSSManager.ts
@@ -90,7 +90,7 @@ export default class CSSManager implements ICSSManager {
 
     const transitionDetached = this.cssTransitionsManager.update(
       transitionProperties,
-      normalizedStyle ?? {},
+      normalizedStyle,
       transitionEventMask
     );
 

--- a/packages/react-native-reanimated/src/css/native/managers/CSSTransitionsManager.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/CSSTransitionsManager.ts
@@ -37,15 +37,19 @@ export default class CSSTransitionsManager implements ICSSTransitionsManager {
    */
   update(
     transitionProperties: CSSTransitionProperties | null,
-    nextProps: UnknownRecord = {},
+    nextStyle?: UnknownRecord,
     eventMask = 0
   ): boolean {
     const transitionConfig =
       transitionProperties &&
       normalizeCSSTransitionProperties(transitionProperties);
 
+    const nextProps = nextStyle ?? {};
     const prevProps = this.prevProps;
-    this.prevProps = nextProps;
+    // Only a real style snapshot can serve as a baseline. Keeping the empty
+    // stand-in the caller passes when it builds none would make a later attach
+    // diff every property against undefined, animating it from its default.
+    this.prevProps = nextStyle ?? null;
 
     // If there were no previous props, the view is just mounted so we
     // don't trigger any transitions yet. Also, when there is no transition

--- a/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSManager.test.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSManager.test.ts
@@ -178,7 +178,7 @@ describe('CSSManager', () => {
       });
     });
   });
-  
+
   describe('transition baseline', () => {
     const ANIMATION = {
       animationName: { from: { opacity: 0 }, to: { opacity: 1 } },
@@ -220,6 +220,11 @@ describe('CSSManager', () => {
       manager.update({ opacity: 0.2, ...TRANSITION });
 
       expect(transitionedValues()).toEqual([]);
+
+      // The attached config still takes 0.2 as the baseline of the next change.
+      manager.update({ opacity: 1, ...TRANSITION });
+
+      expect(transitionedValues()).toEqual([[0.2, 1]]);
     });
   });
 });

--- a/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSManager.test.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSManager.test.ts
@@ -178,6 +178,7 @@ describe('CSSManager', () => {
       });
     });
   });
+  
   describe('transition baseline', () => {
     const ANIMATION = {
       animationName: { from: { opacity: 0 }, to: { opacity: 1 } },

--- a/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSManager.test.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSManager.test.ts
@@ -1,7 +1,7 @@
 'use strict';
 import type { ShadowNodeWrapper } from '../../../../commonTypes';
 import { cssCallbacksRegistry } from '../../events';
-import { setViewStyle } from '../../proxy';
+import { runCSSTransition, setViewStyle } from '../../proxy';
 import CSSManager from '../CSSManager';
 
 jest.mock('../../proxy');
@@ -176,6 +176,49 @@ describe('CSSManager', () => {
         propertyName: 'opacity',
         elapsedTime: 0.3,
       });
+    });
+  });
+  describe('transition baseline', () => {
+    const ANIMATION = {
+      animationName: { from: { opacity: 0 }, to: { opacity: 1 } },
+      animationDuration: '1s',
+    } as const;
+
+    const transitionedValues = () =>
+      (runCSSTransition as jest.Mock).mock.calls
+        .map(([, config]) => config?.opacity?.value)
+        .filter(Boolean);
+
+    test('keeps the baseline of an animation-only view for a later transition', () => {
+      manager.update({ opacity: 0, ...ANIMATION });
+      jest.clearAllMocks();
+
+      manager.update({ opacity: 1, ...ANIMATION, ...TRANSITION });
+
+      expect(transitionedValues()).toEqual([[0, 1]]);
+    });
+
+    test('keeps the baseline across a commit whose config normalizes to none', () => {
+      manager.update({ opacity: 0.5, ...TRANSITION });
+      manager.update({
+        opacity: 0.5,
+        transitionProperty: 'opacity',
+        transitionDuration: '0ms',
+      });
+      jest.clearAllMocks();
+
+      manager.update({ opacity: 1, ...TRANSITION });
+
+      expect(transitionedValues()).toEqual([[0.5, 1]]);
+    });
+
+    test('does not transition from default values when a config is attached', () => {
+      manager.update({ opacity: 0.2 });
+      jest.clearAllMocks();
+
+      manager.update({ opacity: 0.2, ...TRANSITION });
+
+      expect(transitionedValues()).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
Adding a transition config to an already-mounted view started a transition for every styled property from its default value, so a view resting at `opacity: 0.2` flashed to full opacity and animated back down.

While no config was attached, the manager kept the caller's empty style snapshot as its diffing baseline, so the first configured update diffed the real style against `{}`. The baseline is now only ever a real snapshot, which makes attaching behave like mounting: it arms silently, and only later changes animate.
