### PR TITLE
fix: transition events lost when callbacks attach mid-flight

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSLoopTransition.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSLoopTransition.h
@@ -49,8 +49,6 @@ class CSSLoopTransition : public OperationsLoop::LoopOperation, public std::enab
       const std::vector<std::string> &removedProperties,
       double timestamp);
 
-  /// Tracks the lifecycle of properties whose rendering is routed to the platform.
-
   folly::dynamic computeCurrentStyle(const std::shared_ptr<const ShadowNode> &shadowNode);
 
   /// Reports a cancel for every property still transitioning.

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.cpp
@@ -1,5 +1,7 @@
 #include <reanimated/CSS/core/transition/CSSPlatformTransitionProxy.h>
 
+#include <jsi/JSIDynamic.h>
+
 #include <react/debug/react_native_assert.h>
 
 #include <utility>
@@ -74,7 +76,16 @@ CSSTransitionConfig CSSPlatformTransitionProxy::processConfig(
       if (routing.loop.erase(propertyName) > 0) {
         loopConfig.removedProperties.push_back(propertyName);
       }
-      routing.platform.insert(propertyName);
+      // A settings-only config leaves the run that is already on the platform.
+      if (hasValue) {
+        routing.platform.insert_or_assign(
+            propertyName,
+            CSSPlatformRun{
+                jsi::dynamicFromValue(rt, valueIt->second.first),
+                jsi::dynamicFromValue(rt, valueIt->second.second),
+                settings,
+                timestamp});
+      }
     } else {
       // platform -> loop migration cancels on the platform side.
       std::optional<double> resumeFrom;
@@ -109,14 +120,14 @@ CSSTransitionConfig CSSPlatformTransitionProxy::processConfig(
   return loopConfig;
 }
 
-PropertyValueDynamicDiffsMap CSSPlatformTransitionProxy::processDynamicDiffs(
+CSSLoopHandover CSSPlatformTransitionProxy::processDynamicDiffs(
     const Tag viewTag,
     const PropertyValueDynamicDiffsMap &propertyDiffs,
     const TransitionProperties &pseudoLockedProperties,
     CSSTransitionRouting &routing,
     const bool allowPlatform,
     const double timestamp) const {
-  PropertyValueDynamicDiffsMap loopDiffs;
+  CSSLoopHandover handover;
   for (const auto &[propertyName, propertyDiff] : propertyDiffs) {
     // A platform-routed property keeps animating natively while the platform can
     // still express the toggled value; otherwise it migrates to the loop.
@@ -126,22 +137,30 @@ PropertyValueDynamicDiffsMap CSSPlatformTransitionProxy::processDynamicDiffs(
         // Releasing the last selector targets the committed style, which needs no hold.
         const bool persistent = pseudoLockedProperties.contains(propertyName);
         if (values && apply(viewTag, propertyName, values->first, values->second, nullptr, persistent, timestamp)) {
+          // The backend keeps the settings captured when the config was applied.
+          auto &run = routing.platform.at(propertyName);
+          run.fromValue = propertyDiff.first;
+          run.toValue = propertyDiff.second;
+          run.startTimestamp = timestamp;
           continue;
         }
       }
+      // The loop has never seen this run, so it needs the captured settings to
+      // keep animating it instead of snapping with a zero duration.
+      handover.settings.emplace(propertyName, routing.platform.at(propertyName).settings);
       routing.platform.erase(propertyName);
       // Read before remove(): it drops the platform-side state this resumes from.
       const auto resumeFrom = getResumeValue(viewTag, propertyName, timestamp);
       remove(viewTag, propertyName);
       routing.loop.insert(propertyName);
       if (resumeFrom) {
-        loopDiffs.emplace(propertyName, std::make_pair(folly::dynamic(*resumeFrom), propertyDiff.second));
+        handover.diffs.emplace(propertyName, std::make_pair(folly::dynamic(*resumeFrom), propertyDiff.second));
         continue;
       }
     }
-    loopDiffs.emplace(propertyName, propertyDiff);
+    handover.diffs.emplace(propertyName, propertyDiff);
   }
-  return loopDiffs;
+  return handover;
 }
 
 std::optional<double> CSSPlatformTransitionProxy::getResumeValue(
@@ -159,8 +178,8 @@ std::optional<double> CSSPlatformTransitionProxy::getResumeValue(
   return scalar != nullptr ? std::optional(*scalar) : std::nullopt;
 }
 
-void CSSPlatformTransitionProxy::cancelAll(const Tag viewTag, const TransitionProperties &properties) const {
-  for (const auto &propertyName : properties) {
+void CSSPlatformTransitionProxy::cancelAll(const Tag viewTag, const CSSPlatformRuns &runs) const {
+  for (const auto &[propertyName, run] : runs) {
     remove(viewTag, propertyName);
   }
 }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.h
@@ -11,6 +11,7 @@
 
 #include <functional>
 #include <string>
+#include <unordered_map>
 
 namespace reanimated::css {
 
@@ -39,8 +40,26 @@ using CSSGetPlatformValueFunction =
 
 /// A view's transition partition: which properties animate on the platform vs the
 /// C++ loop. Owned per-view by CSSTransition; updated by the proxy on migrations.
+/// What the platform was asked to animate, kept so the run can be handed to the
+/// loop later, backdated to when it started.
+struct CSSPlatformRun {
+  folly::dynamic fromValue;
+  folly::dynamic toValue;
+  CSSTransitionPropertySettings settings;
+  double startTimestamp;
+};
+
+using CSSPlatformRuns = std::unordered_map<std::string, CSSPlatformRun>;
+
+/// What the loop has to pick up from a pseudo toggle: the value diffs to run and
+/// the settings of runs that left the platform, which the loop has never seen.
+struct CSSLoopHandover {
+  PropertyValueDynamicDiffsMap diffs;
+  PropertiesSettingsMap settings;
+};
+
 struct CSSTransitionRouting {
-  TransitionProperties platform;
+  CSSPlatformRuns platform;
   TransitionProperties loop;
 };
 
@@ -67,9 +86,9 @@ class CSSPlatformTransitionProxy {
       double timestamp) const;
 
   /// Re-routes pseudo-selector toggle diffs: a property the platform can no longer
-  /// express migrates to the loop. Updates `routing`, returns the loop diffs.
+  /// express migrates to the loop. Updates `routing`, returns what the loop runs.
   /// Only a property still pseudo-locked after the toggle needs its value held.
-  PropertyValueDynamicDiffsMap processDynamicDiffs(
+  CSSLoopHandover processDynamicDiffs(
       Tag viewTag,
       const PropertyValueDynamicDiffsMap &propertyDiffs,
       const TransitionProperties &pseudoLockedProperties,
@@ -77,8 +96,15 @@ class CSSPlatformTransitionProxy {
       bool allowPlatform,
       double timestamp) const;
 
-  /// Cancels the native transition of every given property (teardown).
-  void cancelAll(Tag viewTag, const TransitionProperties &properties) const;
+  /// Cancels the property's native transition and drops its platform-side state.
+  void remove(Tag viewTag, const std::string &propertyName) const;
+
+  /// The value the property's native animation currently shows, if any.
+  /// nullopt keeps the diff's own from-value, which the animation has painted past.
+  std::optional<double> getResumeValue(Tag viewTag, const std::string &propertyName, double timestamp) const;
+
+  /// Cancels every run of the view (teardown).
+  void cancelAll(Tag viewTag, const CSSPlatformRuns &runs) const;
 
  private:
   bool canRoute(const std::string &propertyName, const EasingConfig &easing) const;
@@ -90,10 +116,6 @@ class CSSPlatformTransitionProxy {
       const CSSTransitionPropertySettings *settings,
       bool persistent,
       double timestamp) const;
-  void remove(Tag viewTag, const std::string &propertyName) const;
-  /// nullopt keeps the diff's own from-value, which the animation has painted past.
-  std::optional<double> getResumeValue(Tag viewTag, const std::string &propertyName, double timestamp) const;
-
   CSSCanRoutePropertyFunction canRoute_;
   CSSApplyTransitionFunction applyTransition_;
   CSSRemoveTransitionFunction removeTransition_;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.cpp
@@ -69,13 +69,19 @@ folly::dynamic CSSTransition::run(
     const folly::dynamic &lastUpdates) {
   const auto timestamp = loop_->resolveTimestamp();
 
-  auto loopDiffs = platformTransitionProxy_->processDynamicDiffs(
+  auto handover = platformTransitionProxy_->processDynamicDiffs(
       getViewTag(), propertyDiffs, pseudoLockedProperties_, routing_, eventMask_ == 0, timestamp);
-  if (loopDiffs.empty() && !loopTransition_) {
+
+  if (handover.diffs.empty() && !loopTransition_) {
     return folly::dynamic::object();
   }
 
-  auto initialUpdate = ensureLoopTransition().run(shadowNode_, loopDiffs, lastUpdates, timestamp);
+  auto &loopTransition = ensureLoopTransition();
+  if (!handover.settings.empty()) {
+    loopTransition.updateSettings(handover.settings, {}, timestamp);
+  }
+
+  auto initialUpdate = loopTransition.run(shadowNode_, handover.diffs, lastUpdates, timestamp);
   scheduleLoop(timestamp);
   return initialUpdate;
 }
@@ -101,17 +107,13 @@ void CSSTransition::cancel() {
 }
 
 void CSSTransition::removeProperties(const std::vector<std::string> &propertyNames, const double timestamp) {
-  TransitionProperties platformProperties;
   for (const auto &propertyName : propertyNames) {
     if (routing_.platform.erase(propertyName) > 0) {
-      platformProperties.insert(propertyName);
+      platformTransitionProxy_->remove(getViewTag(), propertyName);
     }
     routing_.loop.erase(propertyName);
   }
 
-  if (!platformProperties.empty()) {
-    platformTransitionProxy_->cancelAll(getViewTag(), platformProperties);
-  }
   if (loopTransition_) {
     loopTransition_->removeProperties(propertyNames, timestamp);
   }
@@ -133,11 +135,69 @@ void CSSTransition::setEventMask(const CSSEventMask eventMask) {
   if (eventMask == eventMask_) {
     return;
   }
+  // Platform runs have no event source, so they move to the loop before the new
+  // mask takes effect.
+  if (eventMask_ == 0 && eventMask != 0) {
+    migratePlatformRunsToLoop();
+  }
+
   eventMask_ = eventMask;
 
   if (loopTransition_) {
     observeMilestones(*loopTransition_);
   }
+}
+
+void CSSTransition::migratePlatformRunsToLoop() {
+  const auto timestamp = loop_->resolveTimestamp();
+  bool migrated = false;
+
+  for (auto it = routing_.platform.begin(); it != routing_.platform.end();) {
+    // A pseudo-driven run stays where the pseudo machinery put it.
+    if (pseudoLockedProperties_.contains(it->first)) {
+      ++it;
+      continue;
+    }
+
+    migrated |= takeOverPlatformRun(it->first, it->second, timestamp);
+    it = routing_.platform.erase(it);
+  }
+
+  if (migrated) {
+    scheduleLoop(timestamp);
+  }
+}
+
+bool CSSTransition::takeOverPlatformRun(
+    const std::string &propertyName,
+    const CSSPlatformRun &platformRun,
+    const double timestamp) {
+  // Read before the removal below, which drops the state it reports on. A run
+  // the platform can no longer report has nothing left to hand over.
+  const auto isLive = platformTransitionProxy_->getResumeValue(getViewTag(), propertyName, timestamp).has_value();
+  // Cancelled even when the run turns out to have finished below: iOS drops its
+  // per-property state only on an explicit removal, and a stale entry misdates
+  // the reversal of the next run on this property.
+  platformTransitionProxy_->remove(getViewTag(), propertyName);
+
+  const auto endTimestamp = platformRun.startTimestamp + platformRun.settings.delay + platformRun.settings.duration;
+  if (!isLive || timestamp >= endTimestamp) {
+    // A run that already ended stays unheard, as on the web.
+    return false;
+  }
+
+  auto &loopTransition = ensureLoopTransition();
+  loopTransition.updateSettings({{propertyName, platformRun.settings}}, {}, platformRun.startTimestamp);
+
+  PropertyValueDynamicDiffsMap diffs;
+  // The loop replays the run from its own start, so the endpoints have to be the
+  // ones it began with; the backdated progress puts it where the platform is.
+  diffs.emplace(propertyName, std::make_pair(platformRun.fromValue, platformRun.toValue));
+  loopTransition.run(shadowNode_, diffs, folly::dynamic::object(), platformRun.startTimestamp);
+
+  routing_.loop.insert(propertyName);
+
+  return true;
 }
 
 void CSSTransition::observeMilestones(CSSLoopTransition &loopTransition) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.h
@@ -13,6 +13,7 @@
 #include <jsi/jsi.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace reanimated::css {
@@ -81,6 +82,10 @@ class CSSTransition {
 
   CSSLoopTransition &ensureLoopTransition();
   void scheduleLoop(double timestamp);
+  void migratePlatformRunsToLoop();
+  /// Cancels the native run and, unless it already ended, restarts it on the
+  /// loop backdated to its start. Returns whether the loop took it over.
+  bool takeOverPlatformRun(const std::string &propertyName, const CSSPlatformRun &platformRun, double timestamp);
   void observeMilestones(CSSLoopTransition &loopTransition);
   void reportMilestone(RunMilestone milestone, const std::string &propertyName, double elapsedTime);
   void emitEvent(CSSEventType type, const std::string &propertyName, double elapsedTime) const;


### PR DESCRIPTION
A transition that starts on a view with no callback props runs on the platform (Core Animation / ObjectAnimator), which cannot report lifecycle events. Attaching a callback mid-flight only updated the event mask, so the running transition stayed on the silent backend and its remaining events were never emitted, where the web still delivers them.

Runs the platform accepts are now kept in the routing entries and handed to the loop when the first listener attaches, backdated to their original start, so the remaining events fire at the elapsed times the web reports. Runs that already finished are skipped, and pseudo-driven runs stay with the pseudo machinery.

A property that leaves the platform on a pseudo toggle also carries its captured settings to the loop now, which previously ran it with a zero duration.

Known limitation: a run the backend reverse-shortened after an interruption resumes with its configured timing, because the backend reports the value it currently shows but not the duration it resolved.
