### PR TITLE
chore(Worklets): use getWorkletRuntimes in tests

### DIFF
--- a/apps/common-app/runtime-tests/ReJest/RuntimeTestsApi.ts
+++ b/apps/common-app/runtime-tests/ReJest/RuntimeTestsApi.ts
@@ -191,10 +191,6 @@ export async function waitForNotifications(
   return notificationRegistry.waitForNotifications(names, timeout);
 }
 
-export function getWorkletRuntimeFromPool(name: string) {
-  return workletRuntimePool.getOrCreateWorkletRuntime(name);
-}
-
 export function getWorkletRuntimesFromPool(count: number) {
   return workletRuntimePool.getOrCreateWorkletRuntimes(count);
 }

--- a/apps/common-app/runtime-tests/ReJest/TestRunner/WorkletRuntimePool.ts
+++ b/apps/common-app/runtime-tests/ReJest/TestRunner/WorkletRuntimePool.ts
@@ -4,7 +4,7 @@ import { createWorkletRuntime } from 'react-native-worklets';
 export class WorkletRuntimePool {
   private _runtimes: Map<string, WorkletRuntime> = new Map();
 
-  public getOrCreateWorkletRuntime(name: string): WorkletRuntime {
+  private getOrCreateWorkletRuntime(name: string): WorkletRuntime {
     const existing = this._runtimes.get(name);
     if (existing) {
       return existing;

--- a/apps/common-app/runtime-tests/self-tests/tests/TestsOfTestingFramework.test.tsx
+++ b/apps/common-app/runtime-tests/self-tests/tests/TestsOfTestingFramework.test.tsx
@@ -16,7 +16,7 @@ import {
   getRegisteredValue,
   getTestComponent,
   getTrackerCallCount,
-  getWorkletRuntimeFromPool,
+  getWorkletRuntimesFromPool,
   notify,
   Presets,
   registerValue,
@@ -433,7 +433,7 @@ describe('Tests of Test Framework', () => {
 
       const [state3, setState3] = createTestValue('not_ok');
       const notification3 = 'notification3';
-      const rt = getWorkletRuntimeFromPool('test');
+      const [rt] = getWorkletRuntimesFromPool(1);
       scheduleOnRuntime(rt, () => {
         'worklet';
         setState3('ok', notification3);

--- a/apps/common-app/runtime-tests/worklets/tests/memory/createSerializable.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/memory/createSerializable.test.tsx
@@ -14,7 +14,7 @@ import {
   beforeEach,
   describe,
   expect,
-  getWorkletRuntimeFromPool,
+  getWorkletRuntimesFromPool,
   notify,
   test,
   waitForNotification,
@@ -26,7 +26,7 @@ describe('Test createSerializable', () => {
   let result = false;
   let errorMessage = '';
 
-  const workletRuntime = getWorkletRuntimeFromPool('test');
+  const [workletRuntime] = getWorkletRuntimesFromPool(1);
 
   const targets = [
     {
@@ -42,7 +42,7 @@ describe('Test createSerializable', () => {
         scheduleOnRuntime(workletRuntime, worklet);
       },
       targetRuntime: 'Worker',
-      runtimeName: 'test',
+      runtimeName: workletRuntime.name,
     },
   ];
 
@@ -182,9 +182,8 @@ describe('Test createSerializable', () => {
       });
 
       test('createSerializableHostObject', async () => {
-        const hostObjectValue = getWorkletRuntimeFromPool(
-          'test'
-        ) as unknown as Record<string, unknown>;
+        const [runtime] = getWorkletRuntimesFromPool(1);
+        const hostObjectValue = runtime as unknown as Record<string, unknown>;
         const hostObjectKeys = Object.keys(hostObjectValue);
         scheduleOnTarget(() => {
           'worklet';

--- a/apps/common-app/runtime-tests/worklets/tests/memory/customSerializable.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/memory/customSerializable.test.tsx
@@ -5,7 +5,7 @@
 import {
   describe,
   expect,
-  getWorkletRuntimeFromPool,
+  getWorkletRuntimesFromPool,
   notify,
   test,
   waitForNotification,
@@ -61,7 +61,7 @@ const unpack = (value: { constructorName: string }) => {
 };
 
 describe('Test CustomSerializables', () => {
-  const workletRuntime = getWorkletRuntimeFromPool('test');
+  const [workletRuntime] = getWorkletRuntimesFromPool(1);
 
   test('registers without failure', () => {
     // Arrange

--- a/apps/common-app/runtime-tests/worklets/tests/memory/hybridObjectSupport.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/memory/hybridObjectSupport.test.tsx
@@ -4,7 +4,7 @@
 import {
   describe,
   expect,
-  getWorkletRuntimeFromPool,
+  getWorkletRuntimesFromPool,
   notify,
   test,
   waitForNotification,
@@ -74,7 +74,7 @@ const getTestData = () => {
 };
 
 describe('Test HybridObject Support', () => {
-  const workletRuntime = getWorkletRuntimeFromPool('test');
+  const [workletRuntime] = getWorkletRuntimesFromPool(1);
 
   test('passes HybridObjects from RN runtime to UI runtime', () => {
     // Arrange

--- a/apps/common-app/runtime-tests/worklets/tests/memory/isSerializableRef.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/memory/isSerializableRef.test.tsx
@@ -3,7 +3,7 @@ import { isSerializableRef, createSerializable } from 'react-native-worklets';
 import {
   describe,
   expect,
-  getWorkletRuntimeFromPool,
+  getWorkletRuntimesFromPool,
   test,
 } from '../../../ReJest/RuntimeTestsApi';
 
@@ -157,7 +157,7 @@ describe('Test isSerializableRef', () => {
   });
 
   test('check if createSerializable<host object> returns serializable ref', () => {
-    const hostObjectValue = getWorkletRuntimeFromPool('test');
+    const [hostObjectValue] = getWorkletRuntimesFromPool(1);
     const serializableRef = createSerializable(hostObjectValue);
 
     expect(isSerializableRef(serializableRef)).toBe(true);

--- a/apps/common-app/runtime-tests/worklets/tests/memory/shareable.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/memory/shareable.test.tsx
@@ -15,7 +15,7 @@ import {
 import {
   describe,
   expect,
-  getWorkletRuntimeFromPool,
+  getWorkletRuntimesFromPool,
   notify,
   test,
   waitForNotification,
@@ -118,7 +118,7 @@ const callbackFail = (rea: string) => {
 };
 
 describe('Shareable hosted on UI', () => {
-  const runtime = getWorkletRuntimeFromPool('test');
+  const [runtime] = getWorkletRuntimesFromPool(1);
 
   test.each(initModes)('can be hosted on UI (%s)', async (initMode) => {
     const fn = () => createShareable(UIRuntimeId, 0, getInitOptions(initMode));
@@ -379,7 +379,7 @@ describe('Shareable hosted on UI', () => {
         ...getInitOptions(initMode),
         guestDecorator: decorateGuestProperty,
       });
-      const runtime = getWorkletRuntimeFromPool('test');
+      const [runtime] = getWorkletRuntimesFromPool(1);
 
       const decoration = runOnRuntimeSync(runtime, () => {
         'worklet';
@@ -397,7 +397,7 @@ describe('Shareable hosted on UI', () => {
         ...getInitOptions(initMode),
         guestDecorator: decorateGuestFunction,
       });
-      const runtime = getWorkletRuntimeFromPool('test');
+      const [runtime] = getWorkletRuntimesFromPool(1);
 
       const decorationResult = runOnRuntimeSync(runtime, () => {
         'worklet';
@@ -415,7 +415,7 @@ describe('Shareable hosted on UI', () => {
         ...getInitOptions(initMode),
         guestDecorator: decorateGuestOverride,
       });
-      const runtime = getWorkletRuntimeFromPool('test');
+      const [runtime] = getWorkletRuntimesFromPool(1);
 
       const getSyncValue = runOnRuntimeSync(runtime, () => {
         'worklet';
@@ -428,8 +428,7 @@ describe('Shareable hosted on UI', () => {
 });
 
 describe('Shareable hosted on Worker Runtime', () => {
-  const host = getWorkletRuntimeFromPool('test');
-  const otherGuest = getWorkletRuntimeFromPool('test2');
+  const [host, otherGuest] = getWorkletRuntimesFromPool(2);
 
   beforeEach(() => {
     value = 0;

--- a/apps/common-app/runtime-tests/worklets/tests/runLoop/dispatchWorklet.ts
+++ b/apps/common-app/runtime-tests/worklets/tests/runLoop/dispatchWorklet.ts
@@ -4,9 +4,9 @@ import {
   UIRuntimeId,
 } from 'react-native-worklets';
 
-import { getWorkletRuntimeFromPool } from '../../../ReJest/RuntimeTestsApi';
+import { getWorkletRuntimesFromPool } from '../../../ReJest/RuntimeTestsApi';
 
-const workletRuntime = getWorkletRuntimeFromPool('test');
+const [workletRuntime] = getWorkletRuntimesFromPool(1);
 
 export function dispatchWorklet(worklet: () => void, runtimeKind: RuntimeKind) {
   const runtimeId =

--- a/apps/common-app/runtime-tests/worklets/tests/runLoop/executionOrder.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/runLoop/executionOrder.test.tsx
@@ -3,7 +3,7 @@ import {
   expect,
   createOrderConstraint,
   createTestValue,
-  getWorkletRuntimeFromPool,
+  getWorkletRuntimesFromPool,
   test,
   waitForNotifications,
 } from '../../../ReJest/RuntimeTestsApi';
@@ -37,7 +37,7 @@ const NESTED_TIMER_BEFORE_ANIMATION_FRAME: [MethodsName, MethodsName][] =
   );
 
 describe('Test mixed order of execution', () => {
-  const rt = getWorkletRuntimeFromPool('test');
+  const [rt] = getWorkletRuntimesFromPool(1);
 
   test.each(EXPECTED_ORDER_OF_EXECUTION_2_METHODS)(
     'two methods, **${0}**[**${1}**], **${2}**[**${3}**], runtime: **${4}**',

--- a/apps/common-app/runtime-tests/worklets/tests/runLoop/finalizers.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/runLoop/finalizers.test.tsx
@@ -7,7 +7,7 @@ import {
   createOrderConstraint,
   describe,
   expect,
-  getWorkletRuntimeFromPool,
+  getWorkletRuntimesFromPool,
   notify,
   test,
   waitForNotification,
@@ -105,7 +105,7 @@ describe('requestAnimationFrameFinalizer', () => {
   });
 
   test('is not installed on Worker Runtimes', () => {
-    const workletRuntime = getWorkletRuntimeFromPool('test');
+    const [workletRuntime] = getWorkletRuntimesFromPool(1);
 
     const finalizerType = runOnRuntimeSyncWithId(
       workletRuntime.runtimeId,
@@ -192,7 +192,7 @@ describe('microtask queue finalizers', () => {
   });
 
   test('are not installed on Worker Runtimes', () => {
-    const workletRuntime = getWorkletRuntimeFromPool('test');
+    const [workletRuntime] = getWorkletRuntimesFromPool(1);
 
     const finalizersType = runOnRuntimeSyncWithId(
       workletRuntime.runtimeId,

--- a/apps/common-app/runtime-tests/worklets/tests/runtimes/errorTraces.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/runtimes/errorTraces.test.tsx
@@ -6,7 +6,7 @@ import {
   expect,
   notify,
   waitForNotification,
-  getWorkletRuntimeFromPool,
+  getWorkletRuntimesFromPool,
 } from '../../../ReJest/RuntimeTestsApi';
 import {
   runOnUISync,
@@ -27,7 +27,7 @@ const originalReportFatalRemoteError = globalThis.__reportFatalRemoteError;
 describe('Error traces from UI', () => {
   let errorData: Error | null = null;
 
-  const testRuntime = getWorkletRuntimeFromPool('test');
+  const [testRuntime] = getWorkletRuntimesFromPool(1);
 
   beforeEach(() => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -81,8 +81,10 @@ describe('Error traces from UI', () => {
     });
 
     await waitForNotification('errorReported');
-    expect(errorData?.stack).toInclude('at [test]:');
-    expect(errorData?.stack).toInclude('at [test]: functionNameB');
+    expect(errorData?.stack).toInclude(`at [${testRuntime.name}]:`);
+    expect(errorData?.stack).toInclude(
+      `at [${testRuntime.name}]: functionNameB`
+    );
   });
 
   test('runOnUISync has good stack trace added', async () => {
@@ -113,8 +115,10 @@ describe('Error traces from UI', () => {
     });
 
     await waitForNotification('errorReported');
-    expect(errorData?.stack).toInclude('at [test]:');
-    expect(errorData?.stack).toInclude('at [test]: functionNameD');
+    expect(errorData?.stack).toInclude(`at [${testRuntime.name}]:`);
+    expect(errorData?.stack).toInclude(
+      `at [${testRuntime.name}]: functionNameD`
+    );
   });
 
   test('batched scheduleOnUI: throw in middle job does not break siblings, each job has its own stack', async () => {

--- a/apps/common-app/runtime-tests/worklets/tests/runtimes/microtaskDrains.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/runtimes/microtaskDrains.test.tsx
@@ -17,7 +17,7 @@ import {
   beforeEach,
   describe,
   expect,
-  getWorkletRuntimeFromPool,
+  getWorkletRuntimesFromPool,
   notify,
   test,
   waitForNotification,
@@ -26,7 +26,7 @@ import {
 const DONE_NOTIFICATION = 'DONE';
 
 describe('microtask draining', () => {
-  const workletRuntime = getWorkletRuntimeFromPool('test');
+  const [workletRuntime] = getWorkletRuntimesFromPool(1);
 
   const microtaskDrainCount = createSynchronizable(0);
 

--- a/apps/common-app/runtime-tests/worklets/tests/runtimes/reactNativeImportShim.test.ts
+++ b/apps/common-app/runtime-tests/worklets/tests/runtimes/reactNativeImportShim.test.ts
@@ -4,12 +4,12 @@ import { runOnUISync, runOnRuntimeSync } from 'react-native-worklets';
 import {
   describe,
   expect,
-  getWorkletRuntimeFromPool,
+  getWorkletRuntimesFromPool,
   test,
 } from '../../../ReJest/RuntimeTestsApi';
 
 describe("importing 'react-native' on Worklet Runtimes", () => {
-  const workerRuntime = getWorkletRuntimeFromPool('test');
+  const [workerRuntime] = getWorkletRuntimesFromPool(1);
 
   const testFn = globalThis._WORKLETS_BUNDLE_MODE_ENABLED ? test : test.skip;
 

--- a/apps/common-app/runtime-tests/worklets/tests/runtimes/runOnRuntimeAsync.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/runtimes/runOnRuntimeAsync.test.tsx
@@ -9,7 +9,7 @@ import {
   beforeEach,
   describe,
   expect,
-  getWorkletRuntimeFromPool,
+  getWorkletRuntimesFromPool,
   notify,
   test,
   waitForNotification,
@@ -21,8 +21,7 @@ describe('runOnRuntimeAsync', () => {
   let value = 0;
   let reason = '';
 
-  const workletRuntime1 = getWorkletRuntimeFromPool('test');
-  const workletRuntime2 = getWorkletRuntimeFromPool('test2');
+  const [workletRuntime1, workletRuntime2] = getWorkletRuntimesFromPool(2);
 
   const callbackPass = (num: number) => {
     value = num;

--- a/apps/common-app/runtime-tests/worklets/tests/runtimes/runOnRuntimeAsyncWithId.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/runtimes/runOnRuntimeAsyncWithId.test.tsx
@@ -10,7 +10,7 @@ import {
   beforeEach,
   describe,
   expect,
-  getWorkletRuntimeFromPool,
+  getWorkletRuntimesFromPool,
   notify,
   test,
   waitForNotification,
@@ -33,8 +33,7 @@ describe('runOnRuntimeAsyncWithId', () => {
     notify(FAIL_NOTIFICATION);
   };
 
-  const workletRuntime1 = getWorkletRuntimeFromPool('test');
-  const workletRuntime2 = getWorkletRuntimeFromPool('test2');
+  const [workletRuntime1, workletRuntime2] = getWorkletRuntimesFromPool(2);
 
   beforeEach(() => {
     value = 0;

--- a/apps/common-app/runtime-tests/worklets/tests/runtimes/runOnRuntimeSync.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/runtimes/runOnRuntimeSync.test.tsx
@@ -8,7 +8,7 @@ import {
   beforeEach,
   describe,
   expect,
-  getWorkletRuntimeFromPool,
+  getWorkletRuntimesFromPool,
   notify,
   test,
   waitForNotification,
@@ -20,8 +20,7 @@ describe('runOnRuntimeSync', () => {
   let value = 0;
   let reason = '';
 
-  const workletRuntime1 = getWorkletRuntimeFromPool('test');
-  const workletRuntime2 = getWorkletRuntimeFromPool('test2');
+  const [workletRuntime1, workletRuntime2] = getWorkletRuntimesFromPool(2);
 
   const callbackPass = (num: number) => {
     value = num;

--- a/apps/common-app/runtime-tests/worklets/tests/runtimes/runOnRuntimeSyncWithId.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/runtimes/runOnRuntimeSyncWithId.test.tsx
@@ -8,7 +8,7 @@ import {
 import {
   describe,
   expect,
-  getWorkletRuntimeFromPool,
+  getWorkletRuntimesFromPool,
   notify,
   test,
   waitForNotification,
@@ -32,8 +32,7 @@ describe('runOnRuntimeSyncWithId', () => {
     notify(FAIL_NOTIFICATION);
   };
 
-  const workletRuntime1 = getWorkletRuntimeFromPool('test');
-  const workletRuntime2 = getWorkletRuntimeFromPool('test2');
+  const [workletRuntime1, workletRuntime2] = getWorkletRuntimesFromPool(2);
 
   beforeEach(() => {
     value = 0;

--- a/apps/common-app/runtime-tests/worklets/tests/runtimes/runOnUIAsync.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/runtimes/runOnUIAsync.test.tsx
@@ -9,7 +9,7 @@ import {
   beforeEach,
   describe,
   expect,
-  getWorkletRuntimeFromPool,
+  getWorkletRuntimesFromPool,
   notify,
   test,
   waitForNotification,
@@ -21,7 +21,7 @@ describe('runOnUIAsync', () => {
   let value = 0;
   let reason = '';
 
-  const workletRuntime = getWorkletRuntimeFromPool('test');
+  const [workletRuntime] = getWorkletRuntimesFromPool(1);
 
   const callbackPass = (num: number) => {
     value = num;

--- a/apps/common-app/runtime-tests/worklets/tests/runtimes/runOnUISync.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/runtimes/runOnUISync.test.tsx
@@ -8,7 +8,7 @@ import {
   beforeEach,
   describe,
   expect,
-  getWorkletRuntimeFromPool,
+  getWorkletRuntimesFromPool,
   notify,
   test,
   waitForNotification,
@@ -20,7 +20,7 @@ describe('runOnUISync', () => {
   let value = 0;
   let reason = '';
 
-  const workletRuntime = getWorkletRuntimeFromPool('test');
+  const [workletRuntime] = getWorkletRuntimesFromPool(1);
 
   const callbackPass = (num: number) => {
     value = num;

--- a/apps/common-app/runtime-tests/worklets/tests/runtimes/scheduleOnRN.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/runtimes/scheduleOnRN.test.tsx
@@ -6,7 +6,7 @@ import {
 import {
   describe,
   expect,
-  getWorkletRuntimeFromPool,
+  getWorkletRuntimesFromPool,
   notify,
   test,
   waitForNotification,
@@ -19,7 +19,7 @@ describe('scheduleOnRN', () => {
   const FAIL_NOTIFICATION = 'FAIL';
   let errorMessage = '';
 
-  const workletRuntime = getWorkletRuntimeFromPool('test');
+  const [workletRuntime] = getWorkletRuntimesFromPool(1);
 
   const callbackPass = (num: number) => {
     value = num;

--- a/apps/common-app/runtime-tests/worklets/tests/runtimes/scheduleOnRuntime.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/runtimes/scheduleOnRuntime.test.tsx
@@ -8,7 +8,7 @@ import {
   beforeEach,
   describe,
   expect,
-  getWorkletRuntimeFromPool,
+  getWorkletRuntimesFromPool,
   notify,
   test,
   waitForNotification,
@@ -18,8 +18,7 @@ describe('scheduleOnRuntime', () => {
   const PASS_NOTIFICATION = 'PASS';
   let value = 0;
 
-  const workletRuntime1 = getWorkletRuntimeFromPool('test');
-  const workletRuntime2 = getWorkletRuntimeFromPool('test2');
+  const [workletRuntime1, workletRuntime2] = getWorkletRuntimesFromPool(2);
 
   const callbackPass = (num: number) => {
     value = num;

--- a/apps/common-app/runtime-tests/worklets/tests/runtimes/scheduleOnRuntimeWithId.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/runtimes/scheduleOnRuntimeWithId.test.tsx
@@ -9,7 +9,7 @@ import {
 import {
   describe,
   expect,
-  getWorkletRuntimeFromPool,
+  getWorkletRuntimesFromPool,
   notify,
   test,
   waitForNotification,
@@ -33,8 +33,7 @@ describe('scheduleOnRuntimeWithId', () => {
     notify(FAIL_NOTIFICATION);
   };
 
-  const workletRuntime1 = getWorkletRuntimeFromPool('test');
-  const workletRuntime2 = getWorkletRuntimeFromPool('test2');
+  const [workletRuntime1, workletRuntime2] = getWorkletRuntimesFromPool(2);
 
   beforeEach(() => {
     value = 0;

--- a/apps/common-app/runtime-tests/worklets/tests/runtimes/scheduleOnUI.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/runtimes/scheduleOnUI.test.tsx
@@ -7,7 +7,7 @@ import {
   beforeEach,
   describe,
   expect,
-  getWorkletRuntimeFromPool,
+  getWorkletRuntimesFromPool,
   notify,
   test,
   waitForNotification,
@@ -19,7 +19,7 @@ describe('scheduleOnUI', () => {
   let value = 0;
   let reason = '';
 
-  const workletRuntime = getWorkletRuntimeFromPool('test');
+  const [workletRuntime] = getWorkletRuntimesFromPool(1);
 
   const callbackPass = (num: number) => {
     value = num;

--- a/apps/common-app/runtime-tests/worklets/tests/runtimes/turboModuleRegistryShim.test.ts
+++ b/apps/common-app/runtime-tests/worklets/tests/runtimes/turboModuleRegistryShim.test.ts
@@ -3,7 +3,7 @@ import { runOnUISync, runOnRuntimeSync } from 'react-native-worklets';
 import {
   describe,
   expect,
-  getWorkletRuntimeFromPool,
+  getWorkletRuntimesFromPool,
   test,
 } from '../../../ReJest/RuntimeTestsApi';
 
@@ -18,7 +18,7 @@ const fetchPreviewEnabled =
   bundleModeEnabled && !!proxy?.getStaticFeatureFlag('FETCH_PREVIEW_ENABLED');
 
 describe('accessing Turbo Modules on Worklet Runtimes', () => {
-  const workerRuntime = getWorkletRuntimeFromPool('test');
+  const [workerRuntime] = getWorkletRuntimesFromPool(1);
 
   const testFn = bundleModeEnabled ? test : test.skip;
   const previewOnFn = fetchPreviewEnabled ? test : test.skip;

--- a/apps/common-app/runtime-tests/worklets/tests/runtimes/weakRef.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/runtimes/weakRef.test.tsx
@@ -8,12 +8,12 @@ import {
 import {
   describe,
   expect,
-  getWorkletRuntimeFromPool,
+  getWorkletRuntimesFromPool,
   test,
 } from '../../../ReJest/RuntimeTestsApi';
 
 describe('WeakRef on Worklet Runtime', () => {
-  const workletRuntime = getWorkletRuntimeFromPool('test');
+  const [workletRuntime] = getWorkletRuntimesFromPool(1);
   const runtimes = [
     {
       name: 'UI',


### PR DESCRIPTION
https://github.com/software-mansion/react-native-reanimated/pull/10300 introduced getWorkletRuntimes which is better as it does not require naming each runtime (e.g. "test", "test1") unlike its predecessor, getWorkletRuntime

This PR updates all the tests using getWorkletRuntime into using getWorkletRuntimes