### PR TITLE
feat: add `contrastColor` function

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/ContrastColorExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/ContrastColorExample.tsx
@@ -1,0 +1,98 @@
+import React, { useEffect } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import type { SharedValue } from 'react-native-reanimated';
+import Animated, {
+  contrastColor,
+  Easing,
+  interpolateColor,
+  useAnimatedStyle,
+  useDerivedValue,
+  useSharedValue,
+  withRepeat,
+  withTiming,
+} from 'react-native-reanimated';
+
+const COLORS = [
+  'black',
+  'white',
+  'red',
+  'orange',
+  'yellow',
+  'lime',
+  'blue',
+  'magenta',
+  '#757575',
+  '#767676',
+];
+
+function StaticRow({ backgroundColor }: { backgroundColor: string }) {
+  const color = contrastColor(backgroundColor);
+
+  return (
+    <Text style={[styles.row, { backgroundColor, color }]}>
+      {backgroundColor} → {color}
+    </Text>
+  );
+}
+
+function AnimatedRow({
+  backgroundColor,
+  label,
+}: {
+  backgroundColor: SharedValue<string>;
+  label: string;
+}) {
+  const animatedStyle = useAnimatedStyle(() => ({
+    backgroundColor: backgroundColor.value,
+    color: contrastColor(backgroundColor.value),
+  }));
+
+  return (
+    <Animated.Text style={[styles.row, animatedStyle]}>{label}</Animated.Text>
+  );
+}
+
+export default function ContrastColorExample() {
+  const progress = useSharedValue(0);
+
+  const hue = useSharedValue(0);
+
+  useEffect(() => {
+    progress.value = 0;
+    progress.value = withRepeat(withTiming(1, { duration: 1000 }), -1, true);
+
+    hue.value = 0;
+    hue.value = withRepeat(
+      withTiming(360, { duration: 2000, easing: Easing.linear }),
+      -1
+    );
+  }, [progress, hue]);
+
+  const grayscale = useDerivedValue(() =>
+    interpolateColor(progress.value, [0, 1], ['black', 'white'])
+  );
+
+  const rainbow = useDerivedValue(() => `hsl(${hue.value}, 100%, 40%)`);
+
+  return (
+    <View style={styles.container}>
+      <AnimatedRow backgroundColor={grayscale} label="black ↔ white" />
+      <AnimatedRow backgroundColor={rainbow} label="hsl(hue, 100%, 40%)" />
+      {COLORS.map((color) => (
+        <StaticRow backgroundColor={color} key={color} />
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    gap: 20,
+    padding: 20,
+  },
+  row: {
+    textAlign: 'center',
+    padding: 10,
+  },
+});

--- a/apps/common-app/src/apps/reanimated/examples/index.ts
+++ b/apps/common-app/src/apps/reanimated/examples/index.ts
@@ -117,6 +117,8 @@ const ColorInterpolationExample: React.FC = () =>
   React.createElement(
     require('./ColorInterpolationExample').default as React.FC
   );
+const ContrastColorExample: React.FC = () =>
+  React.createElement(require('./ContrastColorExample').default as React.FC);
 const CombinedTest: React.FC = () =>
   React.createElement(
     require('./LayoutAnimations/Combined').default as React.FC
@@ -1077,6 +1079,11 @@ export const EXAMPLES: Record<string, Example> = {
   ColorInterpolationExample: {
     title: 'Color interpolation',
     screen: ColorInterpolationExample,
+  },
+  ContrastColorExample: {
+    icon: '🔲',
+    title: 'Contrast color',
+    screen: ContrastColorExample,
   },
   ExtrapolationExample: {
     title: 'Extrapolation example',

--- a/docs/docs-reanimated/docs/utilities/DynamicColorIOS.mdx
+++ b/docs/docs-reanimated/docs/utilities/DynamicColorIOS.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 ---
 
 # DynamicColorIOS

--- a/docs/docs-reanimated/docs/utilities/contrastColor.mdx
+++ b/docs/docs-reanimated/docs/utilities/contrastColor.mdx
@@ -42,7 +42,7 @@ function App() {
   <summary>Type definitions</summary>
 
   ```typescript
-  function contrastColor(color: unknown): 'white' | 'black';
+  function contrastColor(color: string | number): 'white' | 'black';
   ```
 </details>
 

--- a/docs/docs-reanimated/docs/utilities/contrastColor.mdx
+++ b/docs/docs-reanimated/docs/utilities/contrastColor.mdx
@@ -9,7 +9,12 @@ sidebar_position: 4
 ## Reference
 
 ```jsx
-import { contrastColor, interpolateColor } from 'react-native-reanimated';
+import Animated, {
+  contrastColor,
+  interpolateColor,
+  useAnimatedStyle,
+  useSharedValue,
+} from 'react-native-reanimated';
 
 function App() {
   const progress = useSharedValue(0);
@@ -54,7 +59,7 @@ The background color to contrast against. Accepts any color format supported by 
 ## Remarks
 
 - `contrastColor` is a worklet, so it can be used inside `useAnimatedStyle`, `useDerivedValue` and other worklets, as well as on the JavaScript thread.
-- Just like CSS `contrast-color()`, the result is guaranteed to be the better of the two options but not necessarily to meet the WCAG AA (4.5:1) threshold – mid-tone backgrounds (e.g. `#767676`) don't have enough contrast with either black or white.
+- Just like CSS `contrast-color()`, the result is the better of the two options. With the WCAG 2.x formula, the selected color always has a contrast ratio of at least ~4.58:1 (which meets WCAG AA for normal text), but it doesn't guarantee the WCAG AAA (7:1) threshold – mid-tone backgrounds (e.g. `#767676`) are barely readable with either black or white.
 - Pure red (`#ff0000`) returns `'black'` – this is the correct WCAG result (5.25:1 vs 4:1 for white), even if white may look more natural.
 
 ## Platform compatibility

--- a/docs/docs-reanimated/docs/utilities/contrastColor.mdx
+++ b/docs/docs-reanimated/docs/utilities/contrastColor.mdx
@@ -1,0 +1,62 @@
+---
+sidebar_position: 4
+---
+
+# contrastColor
+
+`contrastColor` lets you pick a text color that stays readable on a given background. It works like the [CSS `contrast-color()`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/contrast-color) function – it returns either `'white'` or `'black'`, whichever has the greater [WCAG contrast ratio](https://www.w3.org/TR/WCAG21/#dfn-contrast-ratio) against the provided color.
+
+## Reference
+
+```jsx
+import { contrastColor, interpolateColor } from 'react-native-reanimated';
+
+function App() {
+  const progress = useSharedValue(0);
+
+  const animatedStyle = useAnimatedStyle(() => {
+    const backgroundColor = interpolateColor(
+      progress.value,
+      [0, 1],
+      ['#000000', '#ffffff']
+    );
+    return {
+      backgroundColor,
+      // highlight-next-line
+      color: contrastColor(backgroundColor),
+    };
+  });
+
+  // ...
+
+  return <Animated.Text style={animatedStyle}>Always readable</Animated.Text>;
+}
+```
+
+<details>
+  <summary>Type definitions</summary>
+
+  ```typescript
+  function contrastColor(color: unknown): 'white' | 'black';
+  ```
+</details>
+
+### Arguments
+
+#### `color`
+
+The background color to contrast against. Accepts any color format supported by Reanimated – e.g. `'red'`, `'#ff0000'`, `'rgb(255, 0, 0)'`, `'rgba(255, 0, 0, 0.5)'`, `'hsl(0, 100%, 50%)'` or a number. The alpha channel is ignored.
+
+### Returns
+
+`contrastColor` returns `'white'` or `'black'` – whichever has the higher contrast ratio with `color`. If both have the same contrast, `'white'` is returned.
+
+## Remarks
+
+- `contrastColor` is a worklet, so it can be used inside `useAnimatedStyle`, `useDerivedValue` and other worklets, as well as on the JavaScript thread.
+- Just like CSS `contrast-color()`, the result is guaranteed to be the better of the two options but not necessarily to meet the WCAG AA (4.5:1) threshold – mid-tone backgrounds (e.g. `#767676`) don't have enough contrast with either black or white.
+- Pure red (`#ff0000`) returns `'black'` – this is the correct WCAG result (5.25:1 vs 4:1 for white), even if white may look more natural.
+
+## Platform compatibility
+
+<PlatformCompatibility android ios web/>

--- a/docs/docs-reanimated/docs/utilities/contrastColor.mdx
+++ b/docs/docs-reanimated/docs/utilities/contrastColor.mdx
@@ -50,7 +50,7 @@ function App() {
 
 #### `color`
 
-The background color to contrast against. Accepts any color format supported by Reanimated – e.g. `'red'`, `'#ff0000'`, `'rgb(255, 0, 0)'`, `'rgba(255, 0, 0, 0.5)'`, `'hsl(0, 100%, 50%)'` or a number. The alpha channel is ignored.
+The background color to contrast against. Accepts any color format supported by Reanimated – e.g. `'red'`, `'#ff0000'`, `'rgb(255, 0, 0)'`, `'rgba(255, 0, 0, 0.5)'`, `'hsl(0, 100%, 50%)'` or a number. The alpha channel is ignored. Invalid colors are treated as transparent black, so `'white'` is returned.
 
 ### Returns
 

--- a/docs/docs-reanimated/docs/utilities/getRelativeCoords.mdx
+++ b/docs/docs-reanimated/docs/utilities/getRelativeCoords.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 # getRelativeCoords

--- a/packages/react-native-reanimated/CHANGELOG.md
+++ b/packages/react-native-reanimated/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🎉 New features
 
+- Add `contrastColor` worklet that returns `'white'` or `'black'`, whichever has the higher WCAG contrast ratio against a given color, mirroring CSS `contrast-color()`. ([#10320](https://github.com/software-mansion/react-native-reanimated/pull/10320) by [@tomekzaw](https://github.com/tomekzaw))
+
 ### 🐛 Bug fixes
 
 - Fix `EXC_BAD_ACCESS` crash in `-[REANodesManager performOperations]` when called before the `_performOperations` block is registered on iOS. ([#10229](https://github.com/software-mansion/react-native-reanimated/pull/10229) by [@tomekzaw](https://github.com/tomekzaw))

--- a/packages/react-native-reanimated/__tests__/contrastColor.test.tsx
+++ b/packages/react-native-reanimated/__tests__/contrastColor.test.tsx
@@ -1,0 +1,24 @@
+import { contrastColor } from '../src/Colors';
+
+describe('contrastColor', () => {
+  test.each([
+    ['black', 'white'],
+    ['white', 'black'],
+    ['#000000', 'white'],
+    ['#757575', 'white'],
+    ['#767676', 'black'],
+    ['#ffffff', 'black'],
+    ['#ff0000', 'black'],
+    ['#00ff00', 'black'],
+    ['#0000ff', 'white'],
+    ['yellow', 'black'],
+    ['cyan', 'black'],
+    ['magenta', 'black'],
+    ['rgb(255, 0, 0)', 'black'],
+    ['rgba(255, 0, 0, 1)', 'black'],
+    ['hsl(0, 100%, 50%)', 'black'],
+    [0x000000ff, 'white'],
+  ])('contrastColor(%p) === %p', (input, expected) => {
+    expect(contrastColor(input)).toBe(expected);
+  });
+});

--- a/packages/react-native-reanimated/__tests__/contrastColor.test.tsx
+++ b/packages/react-native-reanimated/__tests__/contrastColor.test.tsx
@@ -1,4 +1,4 @@
-import { contrastColor } from '../src/Colors';
+import { contrastColor } from '../src';
 
 describe('contrastColor', () => {
   test.each([

--- a/packages/react-native-reanimated/__tests__/contrastColor.test.tsx
+++ b/packages/react-native-reanimated/__tests__/contrastColor.test.tsx
@@ -25,6 +25,7 @@ describe('contrastColor', () => {
     ['hwb(0 0% 0%)', 'black'],
     ['hsl(0, 100%, 50%)', 'black'],
     [0x000000ff, 'white'],
+    ['not-a-color', 'white'], // invalid colors are treated as transparent black
   ])('contrastColor(%p) === %p', (input, expected) => {
     expect(contrastColor(input)).toBe(expected);
   });

--- a/packages/react-native-reanimated/__tests__/contrastColor.test.tsx
+++ b/packages/react-native-reanimated/__tests__/contrastColor.test.tsx
@@ -16,6 +16,13 @@ describe('contrastColor', () => {
     ['magenta', 'black'],
     ['rgb(255, 0, 0)', 'black'],
     ['rgba(255, 0, 0, 1)', 'black'],
+    ['rgba(255, 0, 0, 0)', 'black'], // alpha is ignored
+    ['rgba(0, 0, 0, 0.5)', 'white'],
+    ['rgba(255 0 0 / 0.5)', 'black'],
+    ['#f00', 'black'],
+    ['#00f8', 'white'],
+    ['#ff000080', 'black'],
+    ['hwb(0 0% 0%)', 'black'],
     ['hsl(0, 100%, 50%)', 'black'],
     [0x000000ff, 'white'],
   ])('contrastColor(%p) === %p', (input, expected) => {

--- a/packages/react-native-reanimated/src/Colors.ts
+++ b/packages/react-native-reanimated/src/Colors.ts
@@ -714,7 +714,8 @@ function toLinearChannel(c: number): number {
  * `useAnimatedStyle`.
  *
  * @param color - Any color accepted by Reanimated (`'#ff0000'`, `'rgb(...)'`,
- *   `'hsl(...)'`, named colors, numbers, etc.). Alpha is ignored.
+ *   `'hsl(...)'`, named colors, numbers, etc.). Alpha is ignored. Invalid
+ *   colors are treated as transparent black, so `'white'` is returned.
  * @see https://docs.swmansion.com/react-native-reanimated/docs/utilities/contrastColor
  */
 export function contrastColor(color: string | number): 'white' | 'black' {

--- a/packages/react-native-reanimated/src/Colors.ts
+++ b/packages/react-native-reanimated/src/Colors.ts
@@ -699,3 +699,32 @@ export function toGammaSpace(
   res.push(RGBA[3]);
   return res as ParsedColorArray;
 }
+
+function toLinearChannel(c: number): number {
+  'worklet';
+  return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+}
+
+/**
+ * Lets you pick a text color that stays readable on a given background,
+ * mirroring the CSS `contrast-color()` function.
+ *
+ * Returns `'white'` or `'black'`, whichever has the greater WCAG contrast ratio
+ * against `color` (white wins ties). Can be used in worklets, e.g. inside
+ * `useAnimatedStyle`.
+ *
+ * @param color - Any color accepted by Reanimated (`'#ff0000'`, `'rgb(...)'`,
+ *   `'hsl(...)'`, named colors, numbers, etc.). Alpha is ignored.
+ * @see https://docs.swmansion.com/react-native-reanimated/docs/utilities/contrastColor
+ */
+export function contrastColor(color: unknown): 'white' | 'black' {
+  'worklet';
+  const [r, g, b] = convertToRGBA(color);
+  // WCAG 2.x relative luminance
+  const luminance =
+    0.2126 * toLinearChannel(r) +
+    0.7152 * toLinearChannel(g) +
+    0.0722 * toLinearChannel(b);
+  // contrast(white, bg) >= contrast(bg, black)  <=>  1.05 / (L + 0.05) >= (L + 0.05) / 0.05
+  return 1.05 * 0.05 >= (luminance + 0.05) ** 2 ? 'white' : 'black';
+}

--- a/packages/react-native-reanimated/src/Colors.ts
+++ b/packages/react-native-reanimated/src/Colors.ts
@@ -717,7 +717,7 @@ function toLinearChannel(c: number): number {
  *   `'hsl(...)'`, named colors, numbers, etc.). Alpha is ignored.
  * @see https://docs.swmansion.com/react-native-reanimated/docs/utilities/contrastColor
  */
-export function contrastColor(color: unknown): 'white' | 'black' {
+export function contrastColor(color: string | number): 'white' | 'black' {
   'worklet';
   const [r, g, b] = convertToRGBA(color);
   // WCAG 2.x relative luminance

--- a/packages/react-native-reanimated/src/index.ts
+++ b/packages/react-native-reanimated/src/index.ts
@@ -48,7 +48,7 @@ export {
   withTiming,
 } from './animation';
 export type { ParsedColorArray } from './Colors';
-export { convertToRGBA, isColor } from './Colors';
+export { contrastColor, convertToRGBA, isColor } from './Colors';
 export { ReanimatedLogLevel } from './common';
 export { DynamicColorIOS, PlatformColor, processColor } from './common';
 export type {

--- a/packages/react-native-reanimated/src/mock.ts
+++ b/packages/react-native-reanimated/src/mock.ts
@@ -21,6 +21,7 @@ import type {
 import {
   advanceAnimationByFrame,
   advanceAnimationByTime,
+  contrastColor,
   convertToRGBA,
   css as cssStyleSheet,
   cubicBezier,
@@ -248,6 +249,7 @@ const platformFunctions = {
 };
 
 const Colors = {
+  contrastColor,
   convertToRGBA,
   DynamicColorIOS,
   isColor,


### PR DESCRIPTION
> [!NOTE]
> This pull request was authored by AI on behalf of @tomekzaw.

## Summary

Adds a `contrastColor` worklet that mirrors CSS [`contrast-color()`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/contrast-color): returns `'white'` or `'black'`, whichever has the higher WCAG contrast ratio against the given color (white on ties). Accepts any color format supported by Reanimated; alpha is ignored. Usable inside `useAnimatedStyle` and other worklets as well as on the JS thread.

```ts
const animatedStyle = useAnimatedStyle(() => ({
  backgroundColor: color.value,
  color: contrastColor(color.value),
}));
```

Also adds a docs page (`utilities/contrastColor`), unit tests, and a "Contrast color" example screen.

## Test plan

- `yarn workspace react-native-reanimated test __tests__/contrastColor.test.tsx`
- Open the **Contrast color** example in `fabric-example` – text stays readable on the two animated rows (black ↔ white, hue cycle at 40% lightness) and on all static swatches.

## Changelog

- [x] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.