### PR TITLE
chore: warn when a press pseudo selector cannot receive touches on iOS

### DIFF
--- a/docs/docs-reanimated/docs/css-transitions/pseudo-selectors.mdx
+++ b/docs/docs-reanimated/docs/css-transitions/pseudo-selectors.mdx
@@ -214,7 +214,7 @@ Reanimated hit-tests the front-most element, so when SVG shapes overlap only the
 
 - While a selector matches, its properties win. A re-render or a regular transition can't override a value that a pseudo selector is currently applying.
 
-- A fully transparent view can't be pressed on iOS. The system stops delivering touches below 1% opacity, so `opacity: { default: 0, ':active': 1 }` never activates there, while the same style works on Android and the web. Write `opacity: { default: 0.01, ':active': 1 }` instead - indistinguishable on screen, and still touchable. Development builds warn when they spot this.
+- iOS stops delivering input to a view below 1% opacity, so anything that relies on the system routing input to it breaks there: `opacity: { default: 0, ':active': 1 }` never activates, a mouse, trackpad or pencil never hovers the view, and it can't be tapped to take `:focus`. Touch `:hover` is the exception, as Reanimated resolves that one itself. Android and the web have no such rule. Write `opacity: { default: 0.01, ':active': 1 }` instead - indistinguishable on screen, and still reachable. Development builds warn about press selectors.
 
 - Pseudo selectors are a feature of CSS styles. They don't work in [`useAnimatedStyle`](/docs/core/useAnimatedStyle), where the animation is driven by [shared values](/docs/fundamentals/glossary#shared-value) instead.
 

--- a/docs/docs-reanimated/docs/css-transitions/pseudo-selectors.mdx
+++ b/docs/docs-reanimated/docs/css-transitions/pseudo-selectors.mdx
@@ -214,7 +214,7 @@ Reanimated hit-tests the front-most element, so when SVG shapes overlap only the
 
 - While a selector matches, its properties win. A re-render or a regular transition can't override a value that a pseudo selector is currently applying.
 
-- iOS stops delivering input to a view at or below 1% opacity, so anything that relies on the system routing input to it breaks there: `opacity: { default: 0, ':active': 1 }` never activates, a mouse, trackpad or pencil never hovers the view, and it can't be tapped to take `:focus`. Touch `:hover` is the exception, as Reanimated resolves that one itself. Android and the web have no such rule. Write `opacity: { default: 0.02, ':active': 1 }` instead - indistinguishable on screen, and still reachable. Development builds warn about press selectors.
+- iOS won't deliver input to a view at or below 1% opacity, so `opacity: { default: 0, ':active': 1 }` never activates there, while the same style works on Android and the web. Write `opacity: { default: 0.02, ':active': 1 }` instead - indistinguishable on screen, and still reachable. Touch `:hover` is the exception and keeps working.
 
 - Pseudo selectors are a feature of CSS styles. They don't work in [`useAnimatedStyle`](/docs/core/useAnimatedStyle), where the animation is driven by [shared values](/docs/fundamentals/glossary#shared-value) instead.
 

--- a/docs/docs-reanimated/docs/css-transitions/pseudo-selectors.mdx
+++ b/docs/docs-reanimated/docs/css-transitions/pseudo-selectors.mdx
@@ -214,6 +214,8 @@ Reanimated hit-tests the front-most element, so when SVG shapes overlap only the
 
 - While a selector matches, its properties win. A re-render or a regular transition can't override a value that a pseudo selector is currently applying.
 
+- A fully transparent view can't be pressed on iOS. The system stops delivering touches below 1% opacity, so `opacity: { default: 0, ':active': 1 }` never activates there, while the same style works on Android and the web. Write `opacity: { default: 0.01, ':active': 1 }` instead - indistinguishable on screen, and still touchable. Development builds warn when they spot this.
+
 - Pseudo selectors are a feature of CSS styles. They don't work in [`useAnimatedStyle`](/docs/core/useAnimatedStyle), where the animation is driven by [shared values](/docs/fundamentals/glossary#shared-value) instead.
 
 - Every selector other than the five cross-platform ones is supported on the web only. Android and iOS ignore them, with a warning in development builds.

--- a/docs/docs-reanimated/docs/css-transitions/pseudo-selectors.mdx
+++ b/docs/docs-reanimated/docs/css-transitions/pseudo-selectors.mdx
@@ -214,7 +214,7 @@ Reanimated hit-tests the front-most element, so when SVG shapes overlap only the
 
 - While a selector matches, its properties win. A re-render or a regular transition can't override a value that a pseudo selector is currently applying.
 
-- iOS stops delivering input to a view below 1% opacity, so anything that relies on the system routing input to it breaks there: `opacity: { default: 0, ':active': 1 }` never activates, a mouse, trackpad or pencil never hovers the view, and it can't be tapped to take `:focus`. Touch `:hover` is the exception, as Reanimated resolves that one itself. Android and the web have no such rule. Write `opacity: { default: 0.01, ':active': 1 }` instead - indistinguishable on screen, and still reachable. Development builds warn about press selectors.
+- iOS stops delivering input to a view at or below 1% opacity, so anything that relies on the system routing input to it breaks there: `opacity: { default: 0, ':active': 1 }` never activates, a mouse, trackpad or pencil never hovers the view, and it can't be tapped to take `:focus`. Touch `:hover` is the exception, as Reanimated resolves that one itself. Android and the web have no such rule. Write `opacity: { default: 0.02, ':active': 1 }` instead - indistinguishable on screen, and still reachable. Development builds warn about press selectors.
 
 - Pseudo selectors are a feature of CSS styles. They don't work in [`useAnimatedStyle`](/docs/core/useAnimatedStyle), where the animation is driven by [shared values](/docs/fundamentals/glossary#shared-value) instead.
 

--- a/packages/react-native-reanimated/src/css/constants/pseudoSelectors.ts
+++ b/packages/react-native-reanimated/src/css/constants/pseudoSelectors.ts
@@ -12,7 +12,3 @@ export const PRESS_PSEUDO_SELECTORS: readonly NativePseudoSelectorKey[] = [
   ':active',
   ':active-deepest',
 ];
-
-// UIKit skips views below this alpha when hit-testing, so a fully transparent one never receives
-// the touch its press selector is written for. Android and the web deliver it either way.
-export const IOS_MIN_HIT_TESTABLE_OPACITY = 0.01;

--- a/packages/react-native-reanimated/src/css/constants/pseudoSelectors.ts
+++ b/packages/react-native-reanimated/src/css/constants/pseudoSelectors.ts
@@ -7,3 +7,12 @@ export const NATIVE_PSEUDO_SELECTORS_PRIORITY: readonly NativePseudoSelectorKey[
 
 export const NATIVE_PSEUDO_SELECTORS: ReadonlySet<NativePseudoSelectorKey> =
   new Set(NATIVE_PSEUDO_SELECTORS_PRIORITY);
+
+export const PRESS_PSEUDO_SELECTORS: readonly NativePseudoSelectorKey[] = [
+  ':active',
+  ':active-deepest',
+];
+
+// UIKit skips views below this alpha when hit-testing, so a fully transparent one never receives
+// the touch its press selector is written for. Android and the web deliver it either way.
+export const IOS_MIN_HIT_TESTABLE_OPACITY = 0.01;

--- a/packages/react-native-reanimated/src/css/native/managers/CSSManager.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/CSSManager.ts
@@ -57,7 +57,8 @@ export default class CSSManager implements ICSSManager {
     this.cssPseudoStylesManager = new CSSPseudoStylesManager(
       wrapper,
       tag,
-      this.propsBuilder
+      this.propsBuilder,
+      compoundComponentName
     );
   }
 

--- a/packages/react-native-reanimated/src/css/native/managers/CSSPseudoStylesManager.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/CSSPseudoStylesManager.ts
@@ -1,12 +1,8 @@
 'use strict';
 import type { NativePropsBuilder, UnknownRecord } from '../../../common';
-import { IS_IOS, logger } from '../../../common';
+import { logger } from '../../../common';
 import type { ShadowNodeWrapper } from '../../../commonTypes';
-import {
-  IOS_MIN_HIT_TESTABLE_OPACITY,
-  NATIVE_PSEUDO_SELECTORS,
-  PRESS_PSEUDO_SELECTORS,
-} from '../../constants';
+import { NATIVE_PSEUDO_SELECTORS } from '../../constants';
 import type {
   CSSTransitionProperties,
   ICSSPseudoStylesManager,
@@ -21,6 +17,7 @@ import type {
   CSSTransitionConfig,
   NormalizedCSSTransitionConfig,
 } from '../types';
+import { validatePseudoStyles } from './validatePseudoStyles';
 
 export default class CSSPseudoStylesManager implements ICSSPseudoStylesManager {
   private readonly viewTag: number;
@@ -30,7 +27,7 @@ export default class CSSPseudoStylesManager implements ICSSPseudoStylesManager {
   private prevPseudoStylesBySelector: PseudoStylesBySelector | null = null;
   private prevTransitionProperties: CSSTransitionProperties | null = null;
   private isRegistered = false;
-  private hasWarnedAboutTransparentPress = false;
+  private hasValidated = false;
 
   constructor(
     shadowNodeWrapper: ShadowNodeWrapper,
@@ -84,10 +81,10 @@ export default class CSSPseudoStylesManager implements ICSSPseudoStylesManager {
         Object.assign(mergedDefaultStyle, defaultStyle);
       }
     }
-    this.warnIfPressedWhileFullyTransparent(
-      pseudoStylesBySelector,
-      mergedDefaultStyle
-    );
+    if (__DEV__ && !this.hasValidated) {
+      this.hasValidated = true;
+      validatePseudoStyles(pseudoStylesBySelector, mergedDefaultStyle);
+    }
 
     const builtDefaultStyle = this.propsBuilder.build(mergedDefaultStyle, {
       includeUnprocessed: true,
@@ -123,33 +120,6 @@ export default class CSSPseudoStylesManager implements ICSSPseudoStylesManager {
       });
       this.isRegistered = true;
     }
-  }
-
-  // iOS refuses to deliver touches to a fully transparent view, so its press selector would never
-  // run while the same style works on Android and the web. Nothing here can fix that without
-  // rewriting the opacity the user asked for, so point at the one-character workaround instead.
-  private warnIfPressedWhileFullyTransparent(
-    pseudoStylesBySelector: PseudoStylesBySelector,
-    defaultStyle: UnknownRecord
-  ) {
-    if (!__DEV__ || !IS_IOS || this.hasWarnedAboutTransparentPress) {
-      return;
-    }
-    const opacity = defaultStyle.opacity;
-    if (
-      typeof opacity !== 'number' ||
-      opacity >= IOS_MIN_HIT_TESTABLE_OPACITY ||
-      !PRESS_PSEUDO_SELECTORS.some(
-        (selector) => selector in pseudoStylesBySelector
-      )
-    ) {
-      return;
-    }
-    this.hasWarnedAboutTransparentPress = true;
-    logger.warn(
-      `A view with "opacity: ${opacity}" won't receive presses on iOS, so its press selector will never activate. ` +
-        `Use "opacity: ${IOS_MIN_HIT_TESTABLE_OPACITY}" instead - it is indistinguishable on screen and stays touchable.`
-    );
   }
 
   unmountCleanup(): void {

--- a/packages/react-native-reanimated/src/css/native/managers/CSSPseudoStylesManager.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/CSSPseudoStylesManager.ts
@@ -27,7 +27,6 @@ export default class CSSPseudoStylesManager implements ICSSPseudoStylesManager {
   private prevPseudoStylesBySelector: PseudoStylesBySelector | null = null;
   private prevTransitionProperties: CSSTransitionProperties | null = null;
   private isRegistered = false;
-  private hasValidated = false;
 
   constructor(
     shadowNodeWrapper: ShadowNodeWrapper,
@@ -81,8 +80,7 @@ export default class CSSPseudoStylesManager implements ICSSPseudoStylesManager {
         Object.assign(mergedDefaultStyle, defaultStyle);
       }
     }
-    if (__DEV__ && !this.hasValidated) {
-      this.hasValidated = true;
+    if (__DEV__) {
       validatePseudoStyles(pseudoStylesBySelector, mergedDefaultStyle);
     }
 

--- a/packages/react-native-reanimated/src/css/native/managers/CSSPseudoStylesManager.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/CSSPseudoStylesManager.ts
@@ -112,7 +112,7 @@ export default class CSSPseudoStylesManager implements ICSSPseudoStylesManager {
     }
 
     if (selectors.length > 0) {
-      if (__DEV__ && !this.isRegistered) {
+      if (__DEV__) {
         validatePseudoStyles(
           pseudoStylesBySelector,
           mergedDefaultStyle,

--- a/packages/react-native-reanimated/src/css/native/managers/CSSPseudoStylesManager.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/CSSPseudoStylesManager.ts
@@ -23,6 +23,7 @@ export default class CSSPseudoStylesManager implements ICSSPseudoStylesManager {
   private readonly viewTag: number;
   private readonly shadowNodeWrapper: ShadowNodeWrapper;
   private readonly propsBuilder: NativePropsBuilder;
+  private readonly componentName: string;
 
   private prevPseudoStylesBySelector: PseudoStylesBySelector | null = null;
   private prevTransitionProperties: CSSTransitionProperties | null = null;
@@ -31,11 +32,13 @@ export default class CSSPseudoStylesManager implements ICSSPseudoStylesManager {
   constructor(
     shadowNodeWrapper: ShadowNodeWrapper,
     viewTag: number,
-    propsBuilder: NativePropsBuilder
+    propsBuilder: NativePropsBuilder,
+    componentName: string
   ) {
     this.shadowNodeWrapper = shadowNodeWrapper;
     this.viewTag = viewTag;
     this.propsBuilder = propsBuilder;
+    this.componentName = componentName;
   }
 
   update(
@@ -110,7 +113,11 @@ export default class CSSPseudoStylesManager implements ICSSPseudoStylesManager {
 
     if (selectors.length > 0) {
       if (__DEV__ && !this.isRegistered) {
-        validatePseudoStyles(pseudoStylesBySelector, mergedDefaultStyle);
+        validatePseudoStyles(
+          pseudoStylesBySelector,
+          mergedDefaultStyle,
+          this.componentName
+        );
       }
       registerPseudoStyles(this.shadowNodeWrapper, {
         defaultStyle: builtDefaultStyle,

--- a/packages/react-native-reanimated/src/css/native/managers/CSSPseudoStylesManager.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/CSSPseudoStylesManager.ts
@@ -80,9 +80,6 @@ export default class CSSPseudoStylesManager implements ICSSPseudoStylesManager {
         Object.assign(mergedDefaultStyle, defaultStyle);
       }
     }
-    if (__DEV__) {
-      validatePseudoStyles(pseudoStylesBySelector, mergedDefaultStyle);
-    }
 
     const builtDefaultStyle = this.propsBuilder.build(mergedDefaultStyle, {
       includeUnprocessed: true,
@@ -112,6 +109,9 @@ export default class CSSPseudoStylesManager implements ICSSPseudoStylesManager {
     }
 
     if (selectors.length > 0) {
+      if (__DEV__ && !this.isRegistered) {
+        validatePseudoStyles(pseudoStylesBySelector, mergedDefaultStyle);
+      }
       registerPseudoStyles(this.shadowNodeWrapper, {
         defaultStyle: builtDefaultStyle,
         selectors,

--- a/packages/react-native-reanimated/src/css/native/managers/CSSPseudoStylesManager.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/CSSPseudoStylesManager.ts
@@ -1,8 +1,12 @@
 'use strict';
 import type { NativePropsBuilder, UnknownRecord } from '../../../common';
-import { logger } from '../../../common';
+import { IS_IOS, logger } from '../../../common';
 import type { ShadowNodeWrapper } from '../../../commonTypes';
-import { NATIVE_PSEUDO_SELECTORS } from '../../constants';
+import {
+  IOS_MIN_HIT_TESTABLE_OPACITY,
+  NATIVE_PSEUDO_SELECTORS,
+  PRESS_PSEUDO_SELECTORS,
+} from '../../constants';
 import type {
   CSSTransitionProperties,
   ICSSPseudoStylesManager,
@@ -26,6 +30,7 @@ export default class CSSPseudoStylesManager implements ICSSPseudoStylesManager {
   private prevPseudoStylesBySelector: PseudoStylesBySelector | null = null;
   private prevTransitionProperties: CSSTransitionProperties | null = null;
   private isRegistered = false;
+  private hasWarnedAboutTransparentPress = false;
 
   constructor(
     shadowNodeWrapper: ShadowNodeWrapper,
@@ -79,6 +84,11 @@ export default class CSSPseudoStylesManager implements ICSSPseudoStylesManager {
         Object.assign(mergedDefaultStyle, defaultStyle);
       }
     }
+    this.warnIfPressedWhileFullyTransparent(
+      pseudoStylesBySelector,
+      mergedDefaultStyle
+    );
+
     const builtDefaultStyle = this.propsBuilder.build(mergedDefaultStyle, {
       includeUnprocessed: true,
     });
@@ -113,6 +123,33 @@ export default class CSSPseudoStylesManager implements ICSSPseudoStylesManager {
       });
       this.isRegistered = true;
     }
+  }
+
+  // iOS refuses to deliver touches to a fully transparent view, so its press selector would never
+  // run while the same style works on Android and the web. Nothing here can fix that without
+  // rewriting the opacity the user asked for, so point at the one-character workaround instead.
+  private warnIfPressedWhileFullyTransparent(
+    pseudoStylesBySelector: PseudoStylesBySelector,
+    defaultStyle: UnknownRecord
+  ) {
+    if (!__DEV__ || !IS_IOS || this.hasWarnedAboutTransparentPress) {
+      return;
+    }
+    const opacity = defaultStyle.opacity;
+    if (
+      typeof opacity !== 'number' ||
+      opacity >= IOS_MIN_HIT_TESTABLE_OPACITY ||
+      !PRESS_PSEUDO_SELECTORS.some(
+        (selector) => selector in pseudoStylesBySelector
+      )
+    ) {
+      return;
+    }
+    this.hasWarnedAboutTransparentPress = true;
+    logger.warn(
+      `A view with "opacity: ${opacity}" won't receive presses on iOS, so its press selector will never activate. ` +
+        `Use "opacity: ${IOS_MIN_HIT_TESTABLE_OPACITY}" instead - it is indistinguishable on screen and stays touchable.`
+    );
   }
 
   unmountCleanup(): void {

--- a/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSPseudoStylesManager.test.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSPseudoStylesManager.test.ts
@@ -49,9 +49,10 @@ describe('CSSPseudoStylesManager', () => {
       );
     });
 
-    test('does not warn again while the style is unchanged', () => {
+    test('warns once per registration, even when the style keeps changing', () => {
       pushStyle(manager, { opacity: { default: 0, ':active': 1 } });
-      pushStyle(manager, { opacity: { default: 0, ':active': 1 } });
+      pushStyle(manager, { opacity: { default: 0, ':active': 0.9 } });
+      pushStyle(manager, { opacity: { default: 0, ':active': 0.8 } });
 
       expect(console.warn).toHaveBeenCalledTimes(1);
     });

--- a/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSPseudoStylesManager.test.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSPseudoStylesManager.test.ts
@@ -38,6 +38,41 @@ describe('CSSPseudoStylesManager', () => {
     );
   });
 
+  describe('fully transparent press warning', () => {
+    test('warns when a press selector is styled on a fully transparent view', () => {
+      pushStyle(manager, {
+        opacity: { default: 0, ':active': 1 },
+      });
+
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining("won't receive presses on iOS")
+      );
+    });
+
+    test('warns only once for the same view', () => {
+      pushStyle(manager, { opacity: { default: 0, ':active': 1 } });
+      pushStyle(manager, { opacity: { default: 0, ':active': 0.5 } });
+
+      expect(console.warn).toHaveBeenCalledTimes(1);
+    });
+
+    test('stays quiet when the resting opacity is hit-testable', () => {
+      pushStyle(manager, {
+        opacity: { default: 0.01, ':active': 1 },
+      });
+
+      expect(console.warn).not.toHaveBeenCalled();
+    });
+
+    test('stays quiet for a transparent view without a press selector', () => {
+      pushStyle(manager, {
+        opacity: { default: 0, ':hover': 1 },
+      });
+
+      expect(console.warn).not.toHaveBeenCalled();
+    });
+  });
+
   describe('register', () => {
     test('registers a pseudo style on first update', () => {
       pushStyle(manager, {

--- a/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSPseudoStylesManager.test.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSPseudoStylesManager.test.ts
@@ -57,9 +57,27 @@ describe('CSSPseudoStylesManager', () => {
       expect(console.warn).toHaveBeenCalledTimes(1);
     });
 
-    test('stays quiet when the resting opacity is hit-testable', () => {
+    test('warns at 0.01, which the float-backed alpha puts under the threshold', () => {
       pushStyle(manager, {
         opacity: { default: 0.01, ':active': 1 },
+      });
+
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining("won't receive presses on iOS")
+      );
+    });
+
+    test('stays quiet when the resting opacity is hit-testable', () => {
+      pushStyle(manager, {
+        opacity: { default: 0.02, ':active': 1 },
+      });
+
+      expect(console.warn).not.toHaveBeenCalled();
+    });
+
+    test('stays quiet just above the threshold, where presses still land', () => {
+      pushStyle(manager, {
+        opacity: { default: 0.011, ':active': 1 },
       });
 
       expect(console.warn).not.toHaveBeenCalled();

--- a/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSPseudoStylesManager.test.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSPseudoStylesManager.test.ts
@@ -48,6 +48,10 @@ describe('CSSPseudoStylesManager', () => {
       expect(console.warn).toHaveBeenCalledWith(
         expect.stringContaining("won't receive presses on iOS")
       );
+      // 0.01 reads back below the threshold, so it must not be the value we suggest.
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Use "opacity: 0.02"')
+      );
     });
 
     test('does not repeat while the style is unchanged', () => {

--- a/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSPseudoStylesManager.test.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSPseudoStylesManager.test.ts
@@ -34,7 +34,8 @@ describe('CSSPseudoStylesManager', () => {
     manager = new CSSPseudoStylesManager(
       shadowNodeWrapper,
       viewTag,
-      propsBuilder
+      propsBuilder,
+      'RCTView$View'
     );
   });
 
@@ -79,6 +80,19 @@ describe('CSSPseudoStylesManager', () => {
       pushStyle(manager, {
         opacity: { default: 0.011, ':active': 1 },
       });
+
+      expect(console.warn).not.toHaveBeenCalled();
+    });
+
+    test('stays quiet for an SVG shape, which is hit-tested without opacity', () => {
+      const svgManager = new CSSPseudoStylesManager(
+        shadowNodeWrapper,
+        viewTag,
+        propsBuilder,
+        'RNSVGCircle$Circle'
+      );
+
+      pushStyle(svgManager, { opacity: { default: 0, ':active': 1 } });
 
       expect(console.warn).not.toHaveBeenCalled();
     });

--- a/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSPseudoStylesManager.test.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSPseudoStylesManager.test.ts
@@ -50,12 +50,35 @@ describe('CSSPseudoStylesManager', () => {
       );
     });
 
-    test('warns once per registration, even when the style keeps changing', () => {
+    test('does not repeat while the style is unchanged', () => {
       pushStyle(manager, { opacity: { default: 0, ':active': 1 } });
-      pushStyle(manager, { opacity: { default: 0, ':active': 0.9 } });
-      pushStyle(manager, { opacity: { default: 0, ':active': 0.8 } });
+      pushStyle(manager, { opacity: { default: 0, ':active': 1 } });
 
       expect(console.warn).toHaveBeenCalledTimes(1);
+    });
+
+    test('warns when a view only becomes transparent on a later render', () => {
+      pushStyle(manager, { opacity: { default: 1, ':active': 0.5 } });
+      expect(console.warn).not.toHaveBeenCalled();
+
+      pushStyle(manager, { opacity: { default: 0, ':active': 1 } });
+
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining("won't receive presses on iOS")
+      );
+    });
+
+    test('warns when a press selector is added to an already transparent view', () => {
+      pushStyle(manager, { opacity: { default: 0, ':hover': 1 } });
+      expect(console.warn).not.toHaveBeenCalled();
+
+      pushStyle(manager, {
+        opacity: { default: 0, ':hover': 1, ':active': 1 },
+      });
+
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining("won't receive presses on iOS")
+      );
     });
 
     test('warns at 0.01, which the float-backed alpha puts under the threshold', () => {

--- a/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSPseudoStylesManager.test.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSPseudoStylesManager.test.ts
@@ -49,9 +49,9 @@ describe('CSSPseudoStylesManager', () => {
       );
     });
 
-    test('warns only once for the same view', () => {
+    test('does not warn again while the style is unchanged', () => {
       pushStyle(manager, { opacity: { default: 0, ':active': 1 } });
-      pushStyle(manager, { opacity: { default: 0, ':active': 0.5 } });
+      pushStyle(manager, { opacity: { default: 0, ':active': 1 } });
 
       expect(console.warn).toHaveBeenCalledTimes(1);
     });

--- a/packages/react-native-reanimated/src/css/native/managers/validatePseudoStyles.ios.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/validatePseudoStyles.ios.ts
@@ -4,11 +4,10 @@ import { logger } from '../../../common';
 import { PRESS_PSEUDO_SELECTORS } from '../../constants';
 import type { PseudoStylesBySelector } from '../../utils';
 
-// UIKit skips views below this alpha when hit-testing, so one under it never receives the touch
-// its press selector is written for. Android and the web deliver it either way.
+// UIKit skips views under this alpha when hit-testing, so a press selector on one never fires.
 const HIT_TEST_ALPHA_THRESHOLD = 0.01;
-// The alpha is stored in a float, which puts a written 0.01 just under the threshold. This is the
-// alpha the touch `:hover` hit test bumps to for the same reason.
+// The alpha is float-backed, so a written 0.01 lands just below the threshold. Same value the
+// touch `:hover` hit test bumps to.
 const REACHABLE_OPACITY = 0.02;
 
 export function validatePseudoStyles(
@@ -19,9 +18,9 @@ export function validatePseudoStyles(
   const opacity = defaultStyle.opacity;
   if (
     typeof opacity !== 'number' ||
-    // Mirrors the float the alpha is narrowed to natively, so this matches to the last bit.
+    // Matches the float narrowing the alpha goes through natively.
     Math.fround(opacity) >= HIT_TEST_ALPHA_THRESHOLD ||
-    // SVG shapes are reached through the SVG hit test, which ignores opacity entirely.
+    // SVG hit-tests through its own path, which ignores opacity.
     componentName.startsWith('RNSVG') ||
     !PRESS_PSEUDO_SELECTORS.some(
       (selector) => selector in pseudoStylesBySelector

--- a/packages/react-native-reanimated/src/css/native/managers/validatePseudoStyles.ios.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/validatePseudoStyles.ios.ts
@@ -1,0 +1,29 @@
+'use strict';
+import type { UnknownRecord } from '../../../common';
+import { logger } from '../../../common';
+import { PRESS_PSEUDO_SELECTORS } from '../../constants';
+import type { PseudoStylesBySelector } from '../../utils';
+
+// UIKit skips views below this alpha when hit-testing, so a fully transparent one never receives
+// the touch its press selector is written for. Android and the web deliver it either way.
+const MIN_HIT_TESTABLE_OPACITY = 0.01;
+
+export function validatePseudoStyles(
+  pseudoStylesBySelector: PseudoStylesBySelector,
+  defaultStyle: UnknownRecord
+) {
+  const opacity = defaultStyle.opacity;
+  if (
+    typeof opacity !== 'number' ||
+    opacity >= MIN_HIT_TESTABLE_OPACITY ||
+    !PRESS_PSEUDO_SELECTORS.some(
+      (selector) => selector in pseudoStylesBySelector
+    )
+  ) {
+    return;
+  }
+  logger.warn(
+    `A view with "opacity: ${opacity}" won't receive presses on iOS, so its press selector will never activate. ` +
+      `Use "opacity: ${MIN_HIT_TESTABLE_OPACITY}" instead - it is indistinguishable on screen and stays touchable.`
+  );
+}

--- a/packages/react-native-reanimated/src/css/native/managers/validatePseudoStyles.ios.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/validatePseudoStyles.ios.ts
@@ -4,9 +4,12 @@ import { logger } from '../../../common';
 import { PRESS_PSEUDO_SELECTORS } from '../../constants';
 import type { PseudoStylesBySelector } from '../../utils';
 
-// UIKit skips views below this alpha when hit-testing, so a fully transparent one never receives
-// the touch its press selector is written for. Android and the web deliver it either way.
-const MIN_HIT_TESTABLE_OPACITY = 0.01;
+// UIKit skips views below this alpha when hit-testing, so one under it never receives the touch
+// its press selector is written for. Android and the web deliver it either way.
+const HIT_TEST_ALPHA_THRESHOLD = 0.01;
+// The alpha is stored in a float, which puts a written 0.01 just under the threshold. This is the
+// alpha the touch `:hover` hit test bumps to for the same reason.
+const REACHABLE_OPACITY = 0.02;
 
 export function validatePseudoStyles(
   pseudoStylesBySelector: PseudoStylesBySelector,
@@ -15,7 +18,8 @@ export function validatePseudoStyles(
   const opacity = defaultStyle.opacity;
   if (
     typeof opacity !== 'number' ||
-    opacity >= MIN_HIT_TESTABLE_OPACITY ||
+    // Mirrors the float the alpha is narrowed to natively, so this matches to the last bit.
+    Math.fround(opacity) >= HIT_TEST_ALPHA_THRESHOLD ||
     !PRESS_PSEUDO_SELECTORS.some(
       (selector) => selector in pseudoStylesBySelector
     )
@@ -24,6 +28,6 @@ export function validatePseudoStyles(
   }
   logger.warn(
     `A view with "opacity: ${opacity}" won't receive presses on iOS, so its press selector will never activate. ` +
-      `Use "opacity: ${MIN_HIT_TESTABLE_OPACITY}" instead - it is indistinguishable on screen and stays touchable.`
+      `Use "opacity: ${REACHABLE_OPACITY}" instead - it is indistinguishable on screen and stays touchable.`
   );
 }

--- a/packages/react-native-reanimated/src/css/native/managers/validatePseudoStyles.ios.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/validatePseudoStyles.ios.ts
@@ -13,13 +13,16 @@ const REACHABLE_OPACITY = 0.02;
 
 export function validatePseudoStyles(
   pseudoStylesBySelector: PseudoStylesBySelector,
-  defaultStyle: UnknownRecord
+  defaultStyle: UnknownRecord,
+  componentName: string
 ) {
   const opacity = defaultStyle.opacity;
   if (
     typeof opacity !== 'number' ||
     // Mirrors the float the alpha is narrowed to natively, so this matches to the last bit.
     Math.fround(opacity) >= HIT_TEST_ALPHA_THRESHOLD ||
+    // SVG shapes are reached through the SVG hit test, which ignores opacity entirely.
+    componentName.startsWith('RNSVG') ||
     !PRESS_PSEUDO_SELECTORS.some(
       (selector) => selector in pseudoStylesBySelector
     )

--- a/packages/react-native-reanimated/src/css/native/managers/validatePseudoStyles.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/validatePseudoStyles.ts
@@ -1,0 +1,10 @@
+'use strict';
+import type { UnknownRecord } from '../../../common';
+import type { PseudoStylesBySelector } from '../../utils';
+
+export function validatePseudoStyles(
+  _pseudoStylesBySelector: PseudoStylesBySelector,
+  _defaultStyle: UnknownRecord
+) {
+  // Only iOS restricts which views may receive input, so there is nothing to check anywhere else.
+}

--- a/packages/react-native-reanimated/src/css/native/managers/validatePseudoStyles.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/validatePseudoStyles.ts
@@ -7,5 +7,5 @@ export function validatePseudoStyles(
   _defaultStyle: UnknownRecord,
   _componentName: string
 ) {
-  // Only iOS restricts which views may receive input, so there is nothing to check anywhere else.
+  // Only iOS gates input on opacity, so there is nothing to check elsewhere.
 }

--- a/packages/react-native-reanimated/src/css/native/managers/validatePseudoStyles.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/validatePseudoStyles.ts
@@ -4,7 +4,8 @@ import type { PseudoStylesBySelector } from '../../utils';
 
 export function validatePseudoStyles(
   _pseudoStylesBySelector: PseudoStylesBySelector,
-  _defaultStyle: UnknownRecord
+  _defaultStyle: UnknownRecord,
+  _componentName: string
 ) {
   // Only iOS restricts which views may receive input, so there is nothing to check anywhere else.
 }


### PR DESCRIPTION
## Summary

UIKit skips views below 1% alpha when hit-testing, so a view styled `opacity: { default: 0, ':active': 1 }` never receives the press it is written for on iOS, while the same style works on Android and the web. Today that fails silently.

Fixing it in the engine is not worth what it costs. The per-view recognizer cannot fire for such a view at all, and the only thing that sees the touch anyway - a window-level recognizer - cannot recognize without breaking RN's touch handling app-wide, since `RCTSurfaceTouchHandler` requires external ancestor recognizers to fail and cancels its own touches when one does not. What remains is a second press path in the window coordinator that has to relearn slop, cancellation, single-touch arbitration and `:active-deepest` resolution, then stay reconciled with the recognizer path. That was #10308, and it is closed.

## Fix

Make the case discoverable instead. A development-only warning fires when a press selector is registered on a view whose resting opacity is below the hit-test threshold, pointing at `opacity: 0.01` - indistinguishable on screen and touchable. The warning is iOS-only, fires once per view, and the docs gain a matching remark.

Nothing about the rendered output changes: the opacity you write is the opacity you get.
