### PR TITLE
fix(repo): eslint error rule for concatenated strings

### DIFF
--- a/packages/eslint-plugin-reanimated/__tests__/useReanimatedError.test.tsx
+++ b/packages/eslint-plugin-reanimated/__tests__/useReanimatedError.test.tsx
@@ -11,6 +11,9 @@ ruleTester.run('use-reanimated-error', rules['use-reanimated-error'], {
     'const err = new Error(`[Reanimated] ${message}`);',
     `const err = new Error();`,
     `const err = new TypeError('Something went wrong');`,
+    `const err = new Error('[Reanimated] Something ' + 'went wrong');`,
+    "const err = new Error('[Reanimated] Something ' + `went ${wrong}`);",
+    'const err = new Error(`[Reanimated] Something ` + went + wrong);',
   ],
   invalid: [
     {
@@ -37,6 +40,16 @@ ruleTester.run('use-reanimated-error', rules['use-reanimated-error'], {
       code: `throw new Error(message);`,
       errors: [{ messageId: 'useReanimatedError' }],
       output: 'throw new Error(`[Reanimated] ${message}`);',
+    },
+    {
+      code: `throw new Error('Something ' + 'went wrong');`,
+      errors: [{ messageId: 'useReanimatedError' }],
+      output: `throw new Error("[Reanimated] Something " + 'went wrong');`,
+    },
+    {
+      code: 'throw new Error(`Something ${bad}` + suffix);',
+      errors: [{ messageId: 'useReanimatedError' }],
+      output: 'throw new Error(`[Reanimated] Something ${bad}` + suffix);',
     },
   ],
 });

--- a/packages/eslint-plugin-reanimated/index.js
+++ b/packages/eslint-plugin-reanimated/index.js
@@ -360,6 +360,12 @@ var useLogger_default = rule4;
 
 // public/createErrorPrefixRule.js
 var import_utils5 = require('@typescript-eslint/utils');
+function leftmostOperand(node) {
+  return node.type === import_utils5.AST_NODE_TYPES.BinaryExpression &&
+    node.operator === '+'
+    ? leftmostOperand(node.left)
+    : node;
+}
 function createErrorPrefixRule(prefix, messageId) {
   var _a;
   return {
@@ -378,7 +384,7 @@ function createErrorPrefixRule(prefix, messageId) {
           if (args.length === 0) {
             return;
           }
-          var first = args[0];
+          var first = leftmostOperand(args[0]);
           if (
             first.type === import_utils5.AST_NODE_TYPES.Literal &&
             typeof first.value === 'string'

--- a/packages/eslint-plugin-reanimated/src/createErrorPrefixRule.ts
+++ b/packages/eslint-plugin-reanimated/src/createErrorPrefixRule.ts
@@ -2,6 +2,12 @@ import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
 // eslint-disable-next-line import/no-unresolved
 import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 
+function leftmostOperand(node: TSESTree.Node): TSESTree.Node {
+  return node.type === AST_NODE_TYPES.BinaryExpression && node.operator === '+'
+    ? leftmostOperand(node.left)
+    : node;
+}
+
 export function createErrorPrefixRule<MessageId extends string>(
   prefix: string,
   messageId: MessageId
@@ -27,7 +33,9 @@ export function createErrorPrefixRule<MessageId extends string>(
             return;
           }
 
-          const first = args[0];
+          // A concatenated message (`'[Prefix] a' + 'b'`) carries its prefix in
+          // the left-most operand, so that's the node to check and to fix.
+          const first = leftmostOperand(args[0]);
 
           if (
             first.type === AST_NODE_TYPES.Literal &&

--- a/packages/eslint-plugin-reanimated/src/createErrorPrefixRule.ts
+++ b/packages/eslint-plugin-reanimated/src/createErrorPrefixRule.ts
@@ -33,8 +33,6 @@ export function createErrorPrefixRule<MessageId extends string>(
             return;
           }
 
-          // A concatenated message (`'[Prefix] a' + 'b'`) carries its prefix in
-          // the left-most operand, so that's the node to check and to fix.
           const first = leftmostOperand(args[0]);
 
           if (


### PR DESCRIPTION
Our rule that enforces that errors in the repo start with [Worklets] or [Reanimated] didnt handle string concatenation correctly, this PR fixes that.

Before: new Error("[Worklets] blabla: " + msg) - error
After: new Error("[Worklets] blabla: " + msg) - fine