### PR TITLE
fix: TS nightly run failure

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -46,6 +46,7 @@ npmPreapprovedPackages:
   - 'hermes-parser'
   - 'hermes-estree'
   - '@swmansion/t-rex-ui'
+  - 'flow-parser'
 
 tsEnableAutoTypes: false
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/software-mansion/react-native-reanimated/actions/runs/32062172112/job/95663148007

## Test plan

n/a

## Changelog

- [x] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.
