### PR TITLE
fix: Prime platform transitions before the first frame draws

### DIFF
--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/css/CSSPlatformTransitionsManager.kt
@@ -306,7 +306,10 @@ internal class CSSPlatformTransitionsManager(
     private fun onPreDraw(): Boolean {
         commands.drain()
         repairClobberedValues()
-        return animators.isNotEmpty() || commands.hasPending()
+        // Retiring while idle leaves the next start with only its posted message to beat the
+        // draw that React's commit triggers, and losing that race shows the committed target
+        // for a frame. Both calls above are no-ops while nothing is queued or running.
+        return !invalidated
     }
 
     /** Re-asserts each animator's own value wherever a commit overwrote it. */


### PR DESCRIPTION
A platform-routed transition could draw React's committed target for one frame before the animator took over, then continue correctly.

The pre-draw hook primes the animator's start value after React writes the target and before the frame draws, but it retired itself whenever nothing was animating. The next transition then had only its posted message to beat the draw the commit triggers, and it lost that race often enough to be seen. It now stays until the context goes away; both calls it makes are no-ops while nothing is queued or running.

Measured over 30 starts from idle, a platform-routed view against an identical loop-driven one: 2 flashed frames before, 0 after.

## Showcase

https://github.com/user-attachments/assets/0e3866f5-6de9-4afc-8eba-26c517ead0ea

