### PR TITLE
cherry-pick(worklets-0.12-stable): extract UI-thread check into UIScheduler::isOnUIThread (#10265)

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/Compat/WorkletsApi.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Compat/WorkletsApi.h
@@ -3,7 +3,7 @@
 #include <worklets/Compat/StableApi.h>
 #include <string>
 
-#define EXPECTED_WORKLETS_STABLE_API_VERSION "0.9.0"
+#define EXPECTED_WORKLETS_STABLE_API_VERSION "0.12.1"
 
 static_assert(
     std::string(WORKLETS_STABLE_API_VERSION) == EXPECTED_WORKLETS_STABLE_API_VERSION,

--- a/packages/react-native-worklets/Common/cpp/worklets/Compat/StableApi.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/Compat/StableApi.cpp
@@ -22,6 +22,10 @@ void scheduleOnUI(const std::shared_ptr<UIScheduler> &uiScheduler, const std::fu
   uiScheduler->scheduleOnUI(job);
 }
 
+bool isOnUIThread(const std::shared_ptr<UIScheduler> &uiScheduler) {
+  return uiScheduler->isOnUIThread();
+}
+
 facebook::jsi::Runtime &getJSIRuntimeFromWorkletRuntime(const std::shared_ptr<WorkletRuntime> &workletRuntime) {
   return workletRuntime->getJSIRuntime();
 }

--- a/packages/react-native-worklets/Common/cpp/worklets/Compat/StableApi.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/Compat/StableApi.h
@@ -5,7 +5,7 @@
  * It can be used by libraries to verify they use a compatible version
  * of `react-native-worklets` installed when integrating in C++.
  */
-#define WORKLETS_STABLE_API_VERSION "0.9.0"
+#define WORKLETS_STABLE_API_VERSION "0.12.1"
 
 #include <cstdint>
 #include <functional>
@@ -82,6 +82,8 @@ extern facebook::jsi::Runtime &getJSIRuntimeFromWorkletRuntime(const std::shared
 extern std::weak_ptr<WorkletRuntime> getWeakRuntimeFromJSIRuntime(facebook::jsi::Runtime &rt);
 
 extern void scheduleOnUI(const std::shared_ptr<UIScheduler> &uiScheduler, const std::function<void()> &job);
+
+extern bool isOnUIThread(const std::shared_ptr<UIScheduler> &uiScheduler);
 
 extern std::string JSIValueToStdString(facebook::jsi::Runtime &rt, const facebook::jsi::Value &value);
 

--- a/packages/react-native-worklets/Common/cpp/worklets/Tools/UIScheduler.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/Tools/UIScheduler.cpp
@@ -1,8 +1,11 @@
 #include <worklets/Tools/UIScheduler.h>
 
+#include <optional>
 #include <utility>
 
 namespace worklets {
+
+static thread_local std::optional<bool> tls_isOnUIThread;
 
 void UIScheduler::scheduleOnUI(std::function<void()> job) {
   uiJobs_.push(std::move(job));
@@ -14,6 +17,13 @@ void UIScheduler::triggerUI() {
     const auto job = uiJobs_.pop();
     job();
   }
+}
+
+bool UIScheduler::isOnUIThread() const {
+  if (!tls_isOnUIThread.has_value()) {
+    tls_isOnUIThread = queryIsOnUIThread();
+  }
+  return *tls_isOnUIThread;
 }
 
 } // namespace worklets

--- a/packages/react-native-worklets/Common/cpp/worklets/Tools/UIScheduler.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/Tools/UIScheduler.h
@@ -12,9 +12,12 @@ class UIScheduler {
  public:
   virtual void scheduleOnUI(std::function<void()> job);
   virtual void triggerUI();
+  bool isOnUIThread() const;
   virtual ~UIScheduler() = default;
 
  protected:
+  virtual bool queryIsOnUIThread() const = 0;
+
   std::atomic<bool> scheduledOnUI_{false};
   ThreadSafeQueue<std::function<void()>> uiJobs_;
 };

--- a/packages/react-native-worklets/android/src/main/cpp/worklets/android/AndroidUIScheduler.cpp
+++ b/packages/react-native-worklets/android/src/main/cpp/worklets/android/AndroidUIScheduler.cpp
@@ -7,18 +7,25 @@ namespace worklets {
 using namespace facebook;
 using namespace react;
 
-static thread_local bool tls_isOnUIThread = false;
-
 class UISchedulerWrapper : public UIScheduler {
  private:
   jni::global_ref<AndroidUIScheduler::javaobject> androidUiScheduler_;
+
+  bool queryIsOnUIThread() const override {
+    static const auto method = androidUiScheduler_->getClass()->getMethod<jboolean()>("isOnUIThread");
+    return method(androidUiScheduler_);
+  }
 
  public:
   explicit UISchedulerWrapper(jni::global_ref<AndroidUIScheduler::javaobject> androidUiScheduler)
       : androidUiScheduler_(std::move(androidUiScheduler)) {}
 
+  void triggerUI() override {
+    UIScheduler::triggerUI();
+  }
+
   void scheduleOnUI(std::function<void()> job) override {
-    if (tls_isOnUIThread) {
+    if (isOnUIThread()) {
       job();
       return;
     }
@@ -28,11 +35,6 @@ class UISchedulerWrapper : public UIScheduler {
       static const auto method = androidUiScheduler_->getClass()->getMethod<void()>("scheduleTriggerOnUI");
       method(androidUiScheduler_);
     }
-  }
-
-  void triggerUI() override {
-    tls_isOnUIThread = true;
-    UIScheduler::triggerUI();
   }
 };
 

--- a/packages/react-native-worklets/android/src/main/java/com/swmansion/worklets/AndroidUIScheduler.kt
+++ b/packages/react-native-worklets/android/src/main/java/com/swmansion/worklets/AndroidUIScheduler.kt
@@ -31,6 +31,9 @@ class AndroidUIScheduler(
 
     private external fun initHybrid(): HybridData
 
+    @DoNotStrip
+    private fun isOnUIThread(): Boolean = UiThreadUtil.isOnUiThread()
+
     external fun triggerUI()
 
     external fun invalidate()

--- a/packages/react-native-worklets/apple/worklets/apple/IOSUIScheduler.h
+++ b/packages/react-native-worklets/apple/worklets/apple/IOSUIScheduler.h
@@ -9,6 +9,9 @@ using namespace worklets;
 class IOSUIScheduler : public UIScheduler, public std::enable_shared_from_this<IOSUIScheduler> {
  public:
   void scheduleOnUI(std::function<void()> job) override;
+
+ protected:
+  bool queryIsOnUIThread() const override;
 };
 
 } // namespace worklets

--- a/packages/react-native-worklets/apple/worklets/apple/IOSUIScheduler.mm
+++ b/packages/react-native-worklets/apple/worklets/apple/IOSUIScheduler.mm
@@ -5,9 +5,14 @@ namespace worklets {
 using namespace facebook;
 using namespace react;
 
+bool IOSUIScheduler::queryIsOnUIThread() const
+{
+  return [NSThread isMainThread];
+}
+
 void IOSUIScheduler::scheduleOnUI(std::function<void()> job)
 {
-  if ([NSThread isMainThread]) {
+  if (isOnUIThread()) {
     job();
     return;
   }


### PR DESCRIPTION
Cherry-picking #10265, Worklets changes only.

Deviations from a plain cherry-pick:

- The Reanimated-side refactor from #10265 (`LayoutAnimationsProxy_Legacy` dropping `uiThreadId_` in favour of the new helper) is **not** picked.
- The `CHANGELOG.md` entry is **not** picked, matching prior cherry-picks onto Worklets stable branches (#10215, #10217, #10218, #10041 all ship without one).
- The one-line `EXPECTED_WORKLETS_STABLE_API_VERSION` bump in `reanimated/Compat/WorkletsApi.h` **is** picked, as a separate commit. It is not optional: #10265 bumps `WORKLETS_STABLE_API_VERSION` to `0.12.1`, and Reanimated compiles against the in-repo Worklets headers via the workspace symlink, so leaving the expected constant at `0.9.0` fails the `static_assert` in every translation unit that includes `WorkletsApi.h`.

Two checks are expected to fail on this branch and are not caused by this diff:

- `npm-worklets-publish-check` — runs on every PR into `worklets-*-stable` and asserts the `package.json` version is not already on npm. The branch sits at the published `0.12.0`; this clears when the `0.12.1` release bump lands.
- `changelog-check` — the Worklets exemption in `scripts/check-changelog.mts` is keyed to version `0.12.0-main`, which does not match `0.12.0` on this stable branch, so it demands a CHANGELOG entry that stable-branch cherry-picks do not carry.