### PR TITLE
fix(Worklets): release the Synchronizable lock when a setter throws

### DIFF
--- a/apps/common-app/runtime-tests/worklets/tests/memory/synchronizable.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/memory/synchronizable.test.tsx
@@ -13,6 +13,7 @@ import {
 import {
   describe,
   expect,
+  getWorkletRuntimesFromPool,
   notify,
   test,
   waitForNotification,
@@ -390,5 +391,35 @@ describe('Test Synchronizable serialization', () => {
       synchronizable.setBlocking({ a: 3 });
     });
     expect(synchronizable.getBlocking().a).toBe(3);
+  });
+});
+
+describe('Test Synchronizable error handling', () => {
+  const lockReleaseTest = __DEV__ ? test : test.skip;
+
+  lockReleaseTest('a throwing setter function releases the lock', async () => {
+    const READ_DONE = 'READ_DONE';
+    const synchronizable = createSynchronizable(initialValue);
+    const [observerRuntime] = getWorkletRuntimesFromPool(1);
+
+    await expect(() => {
+      synchronizable.setBlocking(() => {
+        throw new Error('setter failure');
+      });
+    }).toThrow('setter failure');
+
+    let observed = -1;
+    const onReadDone = (value: number) => {
+      observed = value;
+      notify(READ_DONE);
+    };
+
+    scheduleOnRuntime(observerRuntime, () => {
+      'worklet';
+      scheduleOnRN(onReadDone, synchronizable.getBlocking());
+    });
+
+    await waitForNotification(READ_DONE);
+    expect(observed).toBe(initialValue);
   });
 });

--- a/packages/react-native-worklets/CHANGELOG.md
+++ b/packages/react-native-worklets/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 - Fix a crash on Android when the React instance is recreated while animations are running - `AnimationFrameQueue` kept delivering frames after `WorkletsModule` was invalidated. ([#10278](https://github.com/software-mansion/react-native-reanimated/pull/10278) by [@shubhamdeol](https://github.com/shubhamdeol))
 - Fix a data race between `getDirty` and `setBlocking` on a Synchronizable - the pointer holding the value is now read and written atomically. ([#10292](https://github.com/software-mansion/react-native-reanimated/pull/10292) by [@tjzel](https://github.com/tjzel))
+- Fix `setBlocking` leaving a Synchronizable locked forever in development builds when the updater function or the serializer throws. ([#10331](https://github.com/software-mansion/react-native-reanimated/pull/10331) by [@tjzel](https://github.com/tjzel))
 
 ### 💡 Others
 

--- a/packages/react-native-worklets/src/memory/synchronizableUnpacker.native.ts
+++ b/packages/react-native-worklets/src/memory/synchronizableUnpacker.native.ts
@@ -28,23 +28,29 @@ export function installSynchronizableUnpacker() {
     synchronizable.getBlocking = () => {
       return proxy.synchronizableGetBlocking(synchronizable);
     };
+    const setBlockingValue = (newValue: TValue) => {
+      proxy.synchronizableSetBlocking(synchronizable, serializer(newValue));
+    };
     synchronizable.setBlocking = (
       valueOrFunction: TValue | ((prev: TValue) => TValue)
     ) => {
-      let newValue: TValue;
       if (typeof valueOrFunction === 'function') {
         const func = valueOrFunction as (prev: TValue) => TValue;
         synchronizable.lock();
-        const prev = synchronizable.getBlocking();
-        newValue = func(prev);
-
-        proxy.synchronizableSetBlocking(synchronizable, serializer(newValue));
-
-        synchronizable.unlock();
+        if (__DEV__) {
+          try {
+            const prev = synchronizable.getBlocking();
+            setBlockingValue(func(prev));
+          } finally {
+            synchronizable.unlock();
+          }
+        } else {
+          const prev = synchronizable.getBlocking();
+          setBlockingValue(func(prev));
+          synchronizable.unlock();
+        }
       } else {
-        const value = valueOrFunction;
-        newValue = value;
-        proxy.synchronizableSetBlocking(synchronizable, serializer(newValue));
+        setBlockingValue(valueOrFunction);
       }
     };
     synchronizable.lock = () => {


### PR DESCRIPTION
## Summary

Extracted from #10296.

Throwing inside `setBlocking` would lead into never releasing the lock. I added a __DEV__ check to release that lock in this situation.

## Test plan

New runtime test passes.

## Changelog

- [x] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.
