### PR TITLE
[int] feat(llms): make the site legible to AI search engines

### DIFF
--- a/.github/actions/docs-build/action.yml
+++ b/.github/actions/docs-build/action.yml
@@ -25,6 +25,21 @@ runs:
       shell: bash
       working-directory: ${{ inputs.REANIMATED_DOCS_DIR }}
       run: yarn build
+    - name: Check Reanimated docs llms.txt
+      shell: bash
+      working-directory: ${{ inputs.REANIMATED_DOCS_DIR }}
+      run: |
+        file=build/llms.txt
+        if [ ! -s "$file" ]; then
+          echo "::error::$file is missing or empty"
+          exit 1
+        fi
+        count=$(grep -c '^- \[.*docs\.swmansion\.com/react-native-reanimated/docs/' "$file" || true)
+        if [ "$count" -eq 0 ]; then
+          echo "::error::$file lists no documentation pages"
+          exit 1
+        fi
+        echo "llms.txt lists $count documentation pages"
 
     - name: Lint check Worklets docs
       shell: bash

--- a/.github/actions/docs-build/action.yml
+++ b/.github/actions/docs-build/action.yml
@@ -34,7 +34,7 @@ runs:
           echo "::error::$file is missing or empty"
           exit 1
         fi
-        count=$(grep -c '^- \[.*docs\.swmansion\.com/react-native-reanimated/docs/' "$file" || true)
+        count=$(grep -cE '^- \[[^]]+\]\(https://docs\.swmansion\.com/react-native-reanimated/docs/[^)]*\)' "$file" || true)
         if [ "$count" -eq 0 ]; then
           echo "::error::$file lists no documentation pages"
           exit 1

--- a/docs/docs-reanimated/docusaurus.config.js
+++ b/docs/docs-reanimated/docusaurus.config.js
@@ -28,6 +28,45 @@ const bannerReservationHeadTags = firstBannerZone
     ]
   : [];
 
+const ORGANIZATION_ID = 'https://swmansion.com/#organization';
+
+// Same @id as swmansion.com, so engines read one company across both domains.
+const structuredDataHeadTag = {
+  tagName: 'script',
+  attributes: { type: 'application/ld+json' },
+  innerHTML: JSON.stringify({
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'Organization',
+        '@id': ORGANIZATION_ID,
+        name: 'Software Mansion',
+        url: 'https://swmansion.com',
+        sameAs: [
+          'https://github.com/software-mansion',
+          'https://www.linkedin.com/company/software-mansion/',
+          'https://twitter.com/swmansion',
+          'https://www.youtube.com/c/SoftwareMansion',
+        ],
+      },
+      {
+        '@type': 'SoftwareSourceCode',
+        name: 'React Native Reanimated',
+        description:
+          "React Native's Animated library reimplemented, with animations and gestures running on the UI thread.",
+        codeRepository:
+          'https://github.com/software-mansion/react-native-reanimated',
+        programmingLanguage: ['TypeScript', 'C++'],
+        runtimePlatform: 'React Native',
+        license:
+          'https://github.com/software-mansion/react-native-reanimated/blob/main/LICENSE',
+        author: { '@id': ORGANIZATION_ID },
+        maintainer: { '@id': ORGANIZATION_ID },
+      },
+    ],
+  }),
+};
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'React Native Reanimated',
@@ -44,7 +83,7 @@ const config = {
   organizationName: 'software-mansion', // Usually your GitHub org/user name.
   projectName: 'react-native-reanimated', // Usually your repo name.
 
-  headTags: bannerReservationHeadTags,
+  headTags: [...bannerReservationHeadTags, structuredDataHeadTag],
 
   scripts: [
     {

--- a/docs/docs-reanimated/docusaurus.config.js
+++ b/docs/docs-reanimated/docusaurus.config.js
@@ -218,6 +218,7 @@ const config = {
         },
       ],
     ].filter(Boolean),
+    require('./plugins/llms-txt')(),
     function svgModulePlugin() {
       return {
         name: 'svg-module-plugin',

--- a/docs/docs-reanimated/docusaurus.config.js
+++ b/docs/docs-reanimated/docusaurus.config.js
@@ -64,7 +64,7 @@ const structuredDataHeadTag = {
         maintainer: { '@id': ORGANIZATION_ID },
       },
     ],
-  }),
+  }).replace(/</g, '\\u003c'),
 };
 
 /** @type {import('@docusaurus/types').Config} */

--- a/docs/docs-reanimated/docusaurus.config.js
+++ b/docs/docs-reanimated/docusaurus.config.js
@@ -218,7 +218,7 @@ const config = {
         },
       ],
     ].filter(Boolean),
-    require('./plugins/llms-txt')(),
+    require('./plugins/llms-txt'),
     function svgModulePlugin() {
       return {
         name: 'svg-module-plugin',

--- a/docs/docs-reanimated/plugins/llms-txt.js
+++ b/docs/docs-reanimated/plugins/llms-txt.js
@@ -1,0 +1,84 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SECTIONS = { docs: 'Documentation', blog: 'Blog', examples: 'Examples' };
+
+// Superseded versions are disallowed at the origin, so they stay out of here too.
+const SUPERSEDED = /^docs\/[123]\.x\//;
+
+const decode = (value) =>
+  value
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#(?:39|x27);/g, "'")
+    .trim();
+
+const metaOf = (html, name) =>
+  new RegExp(`<meta[^>]+name="${name}"[^>]+content="([^"]*)"`, 'i').exec(
+    html,
+  )?.[1] ?? '';
+
+function describe(html, siteTitle) {
+  const raw = /<title[^>]*>([\s\S]*?)<\/title>/i.exec(html)?.[1] ?? '';
+  const title = decode(raw).replace(new RegExp(`\\s*\\|\\s*${siteTitle}$`), '');
+  return { title, description: decode(metaOf(html, 'description')) };
+}
+
+function buildLlmsTxt({ siteConfig, routesPaths, readPage }) {
+  const { baseUrl, title, tagline, url } = siteConfig;
+  const grouped = new Map();
+
+  for (const route of routesPaths) {
+    if (!route.startsWith(baseUrl) || route.endsWith('404.html')) continue;
+
+    const relative = route.slice(baseUrl.length);
+    if (SUPERSEDED.test(relative)) continue;
+
+    const html = readPage(relative);
+    if (!html) continue;
+
+    const page = describe(html, title);
+    if (!page.title) continue;
+
+    const section = SECTIONS[relative.split('/')[0]] ?? 'Pages';
+    const line = `- [${page.title}](${url}${route})${page.description ? `: ${page.description}` : ''}`;
+
+    if (!grouped.has(section)) grouped.set(section, []);
+    grouped.get(section).push(line);
+  }
+
+  const lines = [`# ${title}`];
+  if (tagline) lines.push('', `> ${tagline}`);
+
+  for (const section of ['Documentation', 'Examples', 'Blog', 'Pages']) {
+    const entries = grouped.get(section);
+    if (!entries?.length) continue;
+    lines.push('', `## ${section}`, '', ...entries.sort());
+  }
+
+  lines.push('', '## About', '', `- [Software Mansion](https://swmansion.com): maintainer of ${title}`, '');
+
+  return lines.join('\n');
+}
+
+module.exports = function llmsTxtPlugin() {
+  return {
+    name: 'llms-txt',
+    async postBuild({ siteConfig, routesPaths, outDir }) {
+      const readPage = (relative) => {
+        const file = path.join(outDir, relative, 'index.html');
+        return fs.existsSync(file) ? fs.readFileSync(file, 'utf8') : '';
+      };
+
+      await fs.promises.writeFile(
+        path.join(outDir, 'llms.txt'),
+        buildLlmsTxt({ siteConfig, routesPaths, readPage }),
+        'utf8',
+      );
+    },
+  };
+};
+
+module.exports.buildLlmsTxt = buildLlmsTxt;

--- a/docs/docs-reanimated/plugins/llms-txt.js
+++ b/docs/docs-reanimated/plugins/llms-txt.js
@@ -15,14 +15,20 @@ const decode = (value) =>
     .replace(/&#(?:39|x27);/g, "'")
     .trim();
 
+const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
 const metaOf = (html, name) =>
-  new RegExp(`<meta[^>]+name="${name}"[^>]+content="([^"]*)"`, 'i').exec(
-    html,
-  )?.[1] ?? '';
+  new RegExp(
+    `<meta[^>]+name="${escapeRegExp(name)}"[^>]+content="([^"]*)"`,
+    'i',
+  ).exec(html)?.[1] ?? '';
 
 function describe(html, siteTitle) {
   const raw = /<title[^>]*>([\s\S]*?)<\/title>/i.exec(html)?.[1] ?? '';
-  const title = decode(raw).replace(new RegExp(`\\s*\\|\\s*${siteTitle}$`), '');
+  const title = decode(raw).replace(
+    new RegExp(`\\s*\\|\\s*${escapeRegExp(siteTitle)}$`),
+    '',
+  );
   return { title, description: decode(metaOf(html, 'description')) };
 }
 

--- a/docs/docs-reanimated/static/robots.txt
+++ b/docs/docs-reanimated/static/robots.txt
@@ -1,5 +1,0 @@
-User-agent: *
-Disallow: /react-native-reanimated/docs/1.x/
-Disallow: /react-native-reanimated/docs/2.x/
-Disallow: /react-native-reanimated/docs/3.x/
-Allow: /react-native-reanimated/docs/


### PR DESCRIPTION
Three SEO changes for the docs site. Nothing changes the rendered page.

- **JSON-LD** via `headTags`: `Organization` with the same `@id` as swmansion.com, plus `SoftwareSourceCode` for the library. The identical `@id` is what makes engines read the docs and the company site as one entity instead of two unrelated ones.
- **`llms.txt`**, generated at build by a local plugin — no new dependency. Lists every docs page, skips the 1.x–3.x versions. The docs build now fails if the file is missing or lists nothing.
- **`static/robots.txt` deleted.** It never did anything: `robots.txt` is only read from the origin root, and this one sat at `/react-native-reanimated/robots.txt`. Its 1.x–3.x rules now live at the origin (software-mansion/software-mansion.github.io#1, merged), where they actually apply.

**Check:** CI printed `llms.txt lists 90 documentation pages`.