### PR TITLE
fix(Reanimated): stop throwing in LayoutAnimationConfig with non-element children

### DIFF
--- a/packages/react-native-reanimated/__tests__/LayoutAnimationConfig.test.tsx
+++ b/packages/react-native-reanimated/__tests__/LayoutAnimationConfig.test.tsx
@@ -99,6 +99,34 @@ describe('LayoutAnimationConfig view tag resolution', () => {
     expect(setShouldAnimateExitingForTag).toHaveBeenCalledWith(43, false);
   });
 
+  test('supports removing a conditional child', () => {
+    const { rerender } = renderWrapped(<ForwardsHostInstance />);
+
+    expect(() =>
+      rerender(
+        <LayoutAnimationConfig skipExiting>{false}</LayoutAnimationConfig>
+      )
+    ).not.toThrow();
+  });
+
+  test('supports a single child in an array', () => {
+    expect(() =>
+      renderWrapped([<ForwardsHostInstance key="child" />])
+    ).not.toThrow();
+  });
+
+  test('enables exiting when skipExiting is false', () => {
+    const { unmount } = render(
+      <LayoutAnimationConfig skipExiting={false}>
+        <ForwardsHostInstance />
+      </LayoutAnimationConfig>
+    );
+
+    unmount();
+
+    expect(setShouldAnimateExitingForTag).toHaveBeenCalledWith(42, true);
+  });
+
   test('falls back to findNodeHandle for a fragment child', () => {
     const { unmount } = renderWrapped(
       <>

--- a/packages/react-native-reanimated/src/component/LayoutAnimationConfig.tsx
+++ b/packages/react-native-reanimated/src/component/LayoutAnimationConfig.tsx
@@ -92,21 +92,14 @@ export class LayoutAnimationConfig extends Component<LayoutAnimationConfigProps>
 
     if (
       this.props.skipExiting === undefined ||
-      Children.count(children) !== 1
+      !isValidElement<{ ref?: Ref<InstanceWithViewTag> }>(children) ||
+      children.type === Fragment
     ) {
       return children;
     }
 
-    const child = Children.only(children);
-    if (
-      !isValidElement<{ ref?: Ref<InstanceWithViewTag> }>(child) ||
-      child.type === Fragment
-    ) {
-      return children;
-    }
-
-    return cloneElement(child, {
-      ref: this._getMergedRef(child.props.ref),
+    return cloneElement(children, {
+      ref: this._getMergedRef(children.props.ref),
     });
   }
 


### PR DESCRIPTION
> [!NOTE]
> This pull request was authored by AI on behalf of @pawicao.

## Summary

A recent ref-tracking change made `LayoutAnimationConfig` call `Children.only` when `skipExiting` was set and `Children.count` reported one child. This threw for valid React children that were not one direct React element. In the nested layout animation example, hiding an inner box changed `{visible && <Animated.View />}` to `false`, which caused the error. A one-element array caused the same error.

Before the ref-tracking change, `LayoutAnimationConfig` returned these children unchanged. This fix restores that behavior and adds a ref only when the child is one valid React element. The tests cover conditional child removal, a one-element array, and `skipExiting={false}`.

## Test plan

1. Start the Fabric example app:

```sh
cd apps/fabric-example
yarn ios
```

Use `yarn android` instead to test on Android.

2. Open the `[LA] Nested LayoutAnimationConfig` example.
3. Press the inner and outer Hide and Show buttons many times while the animations are still running.
4. Confirm that the boxes continue to enter and exit and that React does not show the `React.Children.only expected to receive a single React element child` error.

Unit tests cover conditional child removal, a single child in an array, and `skipExiting={false}`. Run them with:

```sh
yarn workspace react-native-reanimated test LayoutAnimationConfig.test.tsx --runInBand
```

Result: 9 tests passed.

Lint and format checks:

```sh
yarn eslint packages/react-native-reanimated/__tests__/LayoutAnimationConfig.test.tsx packages/react-native-reanimated/src/component/LayoutAnimationConfig.tsx
yarn oxfmt --check packages/react-native-reanimated/__tests__/LayoutAnimationConfig.test.tsx packages/react-native-reanimated/src/component/LayoutAnimationConfig.tsx
```

## Changelog

- [ ] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.
