### PR TITLE
fix: commit the values a transition settles within its starting frame

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.cpp
@@ -49,6 +49,7 @@ folly::dynamic CSSTransition::run(jsi::Runtime &rt, CSSTransitionConfig &&config
       platformTransitionProxy_->processConfig(rt, getViewTag(), config, routing_, eventMask_ == 0, timestamp);
 
   if (!loopConfig.empty()) {
+    dropPending(loopConfig.removedProperties);
     ensureLoopTransition().updateSettings(
         loopConfig.changedPropertiesSettings, loopConfig.removedProperties, timestamp);
   }
@@ -83,13 +84,17 @@ folly::dynamic CSSTransition::run(
 }
 
 folly::dynamic CSSTransition::takeUpdates() {
-  // Runs that already settled hand their frame over here, where the flush can still commit it,
-  // and whatever is still running overrides them.
   auto updates = std::exchange(pendingInitialUpdate_, folly::dynamic::object());
   if (loopTransition_) {
     updates.update(loopTransition_->computeCurrentStyle(shadowNode_));
   }
   return updates;
+}
+
+void CSSTransition::dropPending(const std::vector<std::string> &propertyNames) {
+  for (const auto &propertyName : propertyNames) {
+    pendingInitialUpdate_.erase(propertyName);
+  }
 }
 
 void CSSTransition::setPseudoLockedProperties(TransitionProperties properties) {
@@ -107,9 +112,7 @@ void CSSTransition::cancel() {
 }
 
 void CSSTransition::removeProperties(const std::vector<std::string> &propertyNames, const double timestamp) {
-  for (const auto &propertyName : propertyNames) {
-    pendingInitialUpdate_.erase(propertyName);
-  }
+  dropPending(propertyNames);
 
   TransitionProperties platformProperties;
   for (const auto &propertyName : propertyNames) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.cpp
@@ -58,10 +58,11 @@ folly::dynamic CSSTransition::run(jsi::Runtime &rt, CSSTransitionConfig &&config
     return folly::dynamic::object();
   }
 
-  pendingInitialUpdate_ =
+  auto initialUpdate =
       ensureLoopTransition().run(rt, shadowNode_, loopConfig.changedProperties, lastUpdates, timestamp);
   scheduleLoop(timestamp);
-  return pendingInitialUpdate_;
+  pendingInitialUpdate_.update(initialUpdate);
+  return initialUpdate;
 }
 
 folly::dynamic CSSTransition::run(
@@ -75,14 +76,15 @@ folly::dynamic CSSTransition::run(
     return folly::dynamic::object();
   }
 
-  pendingInitialUpdate_ = ensureLoopTransition().run(shadowNode_, loopDiffs, lastUpdates, timestamp);
+  auto initialUpdate = ensureLoopTransition().run(shadowNode_, loopDiffs, lastUpdates, timestamp);
   scheduleLoop(timestamp);
-  return pendingInitialUpdate_;
+  pendingInitialUpdate_.update(initialUpdate);
+  return initialUpdate;
 }
 
-folly::dynamic CSSTransition::computeCurrentLoopStyle() {
-  // Hand over the settled frame here, where the flush can still commit it, and let whatever is
-  // running override it.
+folly::dynamic CSSTransition::takeUpdates() {
+  // Runs that already settled hand their frame over here, where the flush can still commit it,
+  // and whatever is still running overrides them.
   auto updates = std::exchange(pendingInitialUpdate_, folly::dynamic::object());
   if (loopTransition_) {
     updates.update(loopTransition_->computeCurrentStyle(shadowNode_));

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.cpp
@@ -58,10 +58,10 @@ folly::dynamic CSSTransition::run(jsi::Runtime &rt, CSSTransitionConfig &&config
     return folly::dynamic::object();
   }
 
-  auto initialUpdate =
+  pendingInitialUpdate_ =
       ensureLoopTransition().run(rt, shadowNode_, loopConfig.changedProperties, lastUpdates, timestamp);
   scheduleLoop(timestamp);
-  return initialUpdate;
+  return pendingInitialUpdate_;
 }
 
 folly::dynamic CSSTransition::run(
@@ -75,16 +75,19 @@ folly::dynamic CSSTransition::run(
     return folly::dynamic::object();
   }
 
-  auto initialUpdate = ensureLoopTransition().run(shadowNode_, loopDiffs, lastUpdates, timestamp);
+  pendingInitialUpdate_ = ensureLoopTransition().run(shadowNode_, loopDiffs, lastUpdates, timestamp);
   scheduleLoop(timestamp);
-  return initialUpdate;
+  return pendingInitialUpdate_;
 }
 
 folly::dynamic CSSTransition::computeCurrentLoopStyle() {
-  if (!loopTransition_) {
-    return folly::dynamic::object();
+  // Hand over the settled frame here, where the flush can still commit it, and let whatever is
+  // running override it.
+  auto updates = std::exchange(pendingInitialUpdate_, folly::dynamic::object());
+  if (loopTransition_) {
+    updates.update(loopTransition_->computeCurrentStyle(shadowNode_));
   }
-  return loopTransition_->computeCurrentStyle(shadowNode_);
+  return updates;
 }
 
 void CSSTransition::setPseudoLockedProperties(TransitionProperties properties) {
@@ -92,6 +95,7 @@ void CSSTransition::setPseudoLockedProperties(TransitionProperties properties) {
 }
 
 void CSSTransition::cancel() {
+  pendingInitialUpdate_ = folly::dynamic::object();
   if (loopTransition_) {
     // Report the cancel before the operation goes away, as animations do.
     loopTransition_->abort(loop_->resolveTimestamp());
@@ -101,6 +105,10 @@ void CSSTransition::cancel() {
 }
 
 void CSSTransition::removeProperties(const std::vector<std::string> &propertyNames, const double timestamp) {
+  for (const auto &propertyName : propertyNames) {
+    pendingInitialUpdate_.erase(propertyName);
+  }
+
   TransitionProperties platformProperties;
   for (const auto &propertyName : propertyNames) {
     if (routing_.platform.erase(propertyName) > 0) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.h
@@ -51,7 +51,7 @@ class CSSTransition {
   /// a platform-routed value lives natively, and a stale copy would be re-injected.
   TransitionProperties getLoopProperties() const;
 
-  folly::dynamic computeCurrentLoopStyle();
+  folly::dynamic takeUpdates();
 
   /// Applies a config: routes props between the platform and loop sides and runs them.
   folly::dynamic run(jsi::Runtime &rt, CSSTransitionConfig &&config, const folly::dynamic &lastUpdates);
@@ -78,8 +78,9 @@ class CSSTransition {
   std::shared_ptr<CSSLoopTransition> loopTransition_;
 
   CSSEventMask eventMask_{0};
-  // The frame a run settles on. Its interpolator is retired in the same call that produces it, so
-  // a run finishing within its starting frame leaves nothing to recompute afterwards.
+  // What runs have settled since the last flush. An interpolator is retired by the same call that
+  // produces its final frame, so a run finishing within its starting frame leaves nothing to
+  // recompute afterwards. Several runs can land before one flush, so they accumulate here.
   folly::dynamic pendingInitialUpdate_ = folly::dynamic::object();
 
   CSSLoopTransition &ensureLoopTransition();

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.h
@@ -78,6 +78,9 @@ class CSSTransition {
   std::shared_ptr<CSSLoopTransition> loopTransition_;
 
   CSSEventMask eventMask_{0};
+  // The frame a run settles on. Its interpolator is retired in the same call that produces it, so
+  // a run finishing within its starting frame leaves nothing to recompute afterwards.
+  folly::dynamic pendingInitialUpdate_ = folly::dynamic::object();
 
   CSSLoopTransition &ensureLoopTransition();
   void scheduleLoop(double timestamp);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.h
@@ -84,6 +84,7 @@ class CSSTransition {
   folly::dynamic pendingInitialUpdate_ = folly::dynamic::object();
 
   CSSLoopTransition &ensureLoopTransition();
+  void dropPending(const std::vector<std::string> &propertyNames);
   void scheduleLoop(double timestamp);
   void observeMilestones(CSSLoopTransition &loopTransition);
   void reportMilestone(RunMilestone milestone, const std::string &propertyName, double elapsedTime);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSTransitionsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSTransitionsRegistry.cpp
@@ -127,7 +127,7 @@ void CSSTransitionsRegistry::flushUpdates(UpdatesBatch &updatesBatch) {
     }
 
     auto &transition = it->second;
-    const auto updates = transition->computeCurrentLoopStyle();
+    const auto updates = transition->takeUpdates();
     if (!updates.empty()) {
       addUpdatesToBatch(transition->getShadowNodeFamily(), updates);
     }
@@ -147,7 +147,7 @@ void CSSTransitionsRegistry::flushUpdates(UpdatesBatchAnimatedProps &updatesBatc
     }
 
     auto &transition = it->second;
-    const auto updates = transition->computeCurrentLoopStyle();
+    const auto updates = transition->takeUpdates();
     if (!updates.empty()) {
       addRawPropsToAnimatedPropsBatch(transition->getShadowNodeFamily(), updates);
       // Legacy flushes merge each frame into the updates registry; animated-props flushes do not.


### PR DESCRIPTION
A CSS pseudo selector written without a `transitionDuration` never applies.

The value such a transition settles on is computed once, when the run starts, and the interpolator that produced it is retired by that same call. The flush that follows finds nothing to recompute, so the value never reaches the commit batch. Longer transitions keep their interpolator and are unaffected.

The transition now holds the frames its runs settle on until the next flush and hands them over there, with anything still running overriding them. `computeCurrentLoopStyle` becomes `takeUpdates`, since it now also returns frames the loop has finished with, and consumes them.

https://github.com/user-attachments/assets/51dd014a-d3b5-4eea-ae08-0436c20ccc43
