### PR TITLE
fix(Reanimated): route per-view updates through one path

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/SettledPropsLeakExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/SettledPropsLeakExample.tsx
@@ -9,6 +9,7 @@ import Animated, {
   useSharedValue,
   withTiming,
 } from 'react-native-reanimated';
+import type { WithTimingConfig } from 'react-native-reanimated';
 
 const Box = forwardRef<
   React.ComponentRef<typeof TextInput>,
@@ -24,12 +25,62 @@ const Box = forwardRef<
 
 const AnimatedBox = Animated.createAnimatedComponent(Box);
 
+const SLOW_TIMING_CONFIG: WithTimingConfig = { duration: 1000 };
+
 export default function SettledPropsLeakExample() {
+  const defaultBoxProps = useBoxProps();
+  const slowBoxProps = useBoxProps(SLOW_TIMING_CONFIG);
+
+  return (
+    <View style={styles.container}>
+      <Text>
+        The boxes below animates from red to lime and from 0 to 100. Once the
+        animations settle, the input should stay lime and display 100.
+      </Text>
+      <View style={styles.examples}>
+        <Text>useAnimatedStyle + useAnimatedProps</Text>
+        <View style={styles.row}>
+          <AnimatedBox
+            style={[styles.box, defaultBoxProps.animatedStyle]}
+            animatedProps={defaultBoxProps.animatedProps}
+          />
+          <AnimatedBox
+            style={[styles.box, slowBoxProps.animatedStyle]}
+            animatedProps={slowBoxProps.animatedProps}
+          />
+        </View>
+        <Text>inline styles + inline props</Text>
+        <View style={styles.row}>
+          <AnimatedBox
+            style={[
+              styles.box,
+              { backgroundColor: defaultBoxProps.backgroundColor },
+            ]}
+            // @ts-expect-error `text` is the native prop backing TextInput's value
+            text={defaultBoxProps.text}
+            defaultValue={defaultBoxProps.text}
+          />
+          <AnimatedBox
+            style={[
+              styles.box,
+              { backgroundColor: slowBoxProps.backgroundColor },
+            ]}
+            // @ts-expect-error `text` is the native prop backing TextInput's value
+            text={slowBoxProps.text}
+            defaultValue={slowBoxProps.text}
+          />
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function useBoxProps(timingConfig?: WithTimingConfig) {
   const sv = useSharedValue(0);
 
   useEffect(() => {
-    sv.value = withTiming(1);
-  }, [sv]);
+    sv.value = withTiming(1, timingConfig);
+  }, [sv, timingConfig]);
 
   const text = useDerivedValue(() => `${Math.round(sv.value * 100)}`);
 
@@ -46,26 +97,7 @@ export default function SettledPropsLeakExample() {
     defaultValue: text.value,
   }));
 
-  return (
-    <View style={styles.container}>
-      <Text>
-        The box below animates from red to lime and from 0 to 100. Once the
-        animations settle, the input should stay lime and display 100.
-      </Text>
-      <Text>useAnimatedStyle + useAnimatedProps</Text>
-      <AnimatedBox
-        style={[styles.box, animatedStyle]}
-        animatedProps={animatedProps}
-      />
-      <Text>inline styles + inline props</Text>
-      <AnimatedBox
-        style={[styles.box, { backgroundColor }]}
-        // @ts-expect-error `text` is the native prop backing TextInput's value
-        text={text}
-        defaultValue={text}
-      />
-    </View>
-  );
+  return { animatedStyle, animatedProps, backgroundColor, text };
 }
 
 const styles = StyleSheet.create({
@@ -74,6 +106,16 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     paddingHorizontal: 50,
+    gap: 12,
+  },
+  examples: {
+    gap: 12,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 12,
   },
   box: {
     width: 100,

--- a/apps/common-app/src/apps/reanimated/examples/SettledPropsLeakExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/SettledPropsLeakExample.tsx
@@ -34,7 +34,7 @@ export default function SettledPropsLeakExample() {
   return (
     <View style={styles.container}>
       <Text>
-        The boxes below animates from red to lime and from 0 to 100. Once the
+        The boxes below animate from red to lime and from 0 to 100. Once the
         animations settle, the input should stay lime and display 100.
       </Text>
       <View style={styles.examples}>

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -81,7 +81,7 @@ constexpr bool shouldUseSynchronousUpdatesInPerformOperations() {
 }
 #endif
 
-std::pair<UpdatesBatch, UpdatesBatch> partitionUpdates(UpdatesBatch updatesBatch, const bool allowPartialUpdates) {
+std::pair<UpdatesBatch, UpdatesBatch> partitionUpdates(UpdatesBatch &&updatesBatch, const bool allowPartialUpdates) {
   static const std::unordered_set<std::string> synchronousPropNames = {
       "opacity",
       "elevation",

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -171,10 +171,10 @@ std::pair<UpdatesBatch, UpdatesBatch> partitionUpdates(UpdatesBatch &&updatesBat
 
   std::unordered_set<const ShadowNodeFamily *> familiesRequiringCommit;
   for (const auto &[shadowNodeFamily, props] : updatesBatch) {
-    const bool hasNonSynchronousProps = std::any_of(props.items().begin(), props.items().end(), [&](const auto &kv) {
-      return !isSynchronous(kv.first.asString(), kv.second);
+    const bool hasOnlySynchronousProps = std::all_of(props.items().begin(), props.items().end(), [&](const auto &kv) {
+      return isSynchronous(kv.first.asString(), kv.second);
     });
-    if (hasNonSynchronousProps) {
+    if (!hasOnlySynchronousProps) {
       familiesRequiringCommit.insert(shadowNodeFamily.get());
     }
   }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -81,9 +81,7 @@ constexpr bool shouldUseSynchronousUpdatesInPerformOperations() {
 }
 #endif
 
-std::pair<UpdatesBatch, UpdatesBatch> partitionUpdates(
-    const UpdatesBatch &updatesBatch,
-    const bool allowPartialUpdates) {
+std::pair<UpdatesBatch, UpdatesBatch> partitionUpdates(UpdatesBatch updatesBatch, const bool allowPartialUpdates) {
   static const std::unordered_set<std::string> synchronousPropNames = {
       "opacity",
       "elevation",
@@ -145,8 +143,8 @@ std::pair<UpdatesBatch, UpdatesBatch> partitionUpdates(
   UpdatesBatch synchronousUpdatesBatch;
   UpdatesBatch shadowTreeUpdatesBatch;
 
-  for (const auto &[shadowNodeFamily, props] : updatesBatch) {
-    if (allowPartialUpdates) {
+  if (allowPartialUpdates) {
+    for (const auto &[shadowNodeFamily, props] : updatesBatch) {
       folly::dynamic synchronousProps = folly::dynamic::object();
       folly::dynamic shadowTreeProps = folly::dynamic::object();
 
@@ -166,17 +164,25 @@ std::pair<UpdatesBatch, UpdatesBatch> partitionUpdates(
       if (!shadowTreeProps.empty()) {
         shadowTreeUpdatesBatch.emplace_back(shadowNodeFamily, std::move(shadowTreeProps));
       }
-    } else {
-      const bool hasOnlySynchronousProps = std::all_of(props.items().begin(), props.items().end(), [&](const auto &kv) {
-        return isSynchronous(kv.first.asString(), kv.second);
-      });
-
-      if (hasOnlySynchronousProps) {
-        synchronousUpdatesBatch.emplace_back(shadowNodeFamily, props);
-      } else {
-        shadowTreeUpdatesBatch.emplace_back(shadowNodeFamily, props);
-      }
     }
+
+    return {std::move(synchronousUpdatesBatch), std::move(shadowTreeUpdatesBatch)};
+  }
+
+  std::unordered_set<const ShadowNodeFamily *> familiesRequiringCommit;
+  for (const auto &[shadowNodeFamily, props] : updatesBatch) {
+    const bool hasNonSynchronousProps = std::any_of(props.items().begin(), props.items().end(), [&](const auto &kv) {
+      return !isSynchronous(kv.first.asString(), kv.second);
+    });
+    if (hasNonSynchronousProps) {
+      familiesRequiringCommit.insert(shadowNodeFamily.get());
+    }
+  }
+
+  for (auto &[shadowNodeFamily, props] : updatesBatch) {
+    auto &targetBatch =
+        familiesRequiringCommit.contains(shadowNodeFamily.get()) ? shadowTreeUpdatesBatch : synchronousUpdatesBatch;
+    targetBatch.emplace_back(shadowNodeFamily, std::move(props));
   }
 
   return {std::move(synchronousUpdatesBatch), std::move(shadowTreeUpdatesBatch)};
@@ -1027,7 +1033,8 @@ bool ReanimatedModuleProxy::handleEventAndFlush(
 }
 
 void ReanimatedModuleProxy::applySynchronousUpdates(UpdatesBatch &updatesBatch, const bool allowPartialUpdates) {
-  auto [synchronousUpdatesBatch, shadowTreeUpdatesBatch] = partitionUpdates(updatesBatch, allowPartialUpdates);
+  auto [synchronousUpdatesBatch, shadowTreeUpdatesBatch] =
+      partitionUpdates(std::move(updatesBatch), allowPartialUpdates);
 
 #ifdef ANDROID
   if (!synchronousUpdatesBatch.empty()) {


### PR DESCRIPTION
> [!NOTE]
> This pull request was authored by AI on behalf of [@pawicao](https://github.com/pawicao).

## Summary

When `IOS_SYNCHRONOUSLY_UPDATE_UI_PROPS` is on, one view can produce two update entries in one frame:
- one from an animated style,
- one from animated props.

`partitionUpdates` routed each entry alone. The style entry (for example `backgroundColor`) took the synchronous path, while the props entry (for example `text`) went into a shadow-tree commit for the same view, same as e.g. layout properties styles would.

The mount for that commit wrote the stale shadow-tree color back, because `RCTViewComponentView` protects only `opacity` and `transform` from this. As a result, in `SettledPropsLeakExample` the numbers counted up while the color stayed red until the settled render.

This change routes all update entries of one view through one path. A first pass collects the views that have any non-synchronous prop in the batch; a second pass sends every entry of such a view into the shadow-tree commit for that frame. Entries stay separate, and the commit already applies several entries per view in order, so later writers of a key still win, same as before.

Views with only synchronous props keep the fast path. The partial-updates path (Android draw pass) already gets one entry per tag from `getPendingUpdates`, so its behavior does not change.

**Before**

https://github.com/user-attachments/assets/35df92ed-997e-44ee-bcd3-b52524e8eea7

**After**

https://github.com/user-attachments/assets/d926ac93-1d63-49db-9c11-885db2fba25d

## Test plan

1. In `apps/fabric-example/package.json`, set `IOS_SYNCHRONOUSLY_UPDATE_UI_PROPS: true` and `ENABLE_SHARED_ELEMENT_TRANSITIONS: false`. Install pods and build.
2. Open the `Settled props leak` example.
3. Check that both boxes animate from red to lime while the text counts from 0 to 100, stay lime with 100 after the animation settles, and never receive `backgroundColor` as a top-level prop (the example throws if they do).

Verified on the iPhone 17 Pro simulator. Before the change, the `useAnimatedProps` box stayed red for the full count, while the inline box flashed between red and the current animated color on frames where the counter did not increment. After the change, both boxes pass through the intermediate colors and settle correctly. Temporary native logs confirmed that views which animate only synchronous props (for example `zIndex` + `transform`) still take the synchronous path.

Tested also with `IOS_SYNCHRONOUSLY_UPDATE_UI_PROPS` set to `false`

## Changelog

- [ ] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.

