### PR TITLE
chore: add a CSS transition callbacks example screen

### DIFF
--- a/apps/common-app/src/apps/css/examples/transitions/routes.ts
+++ b/apps/common-app/src/apps/css/examples/transitions/routes.ts
@@ -64,6 +64,10 @@ const routes = {
         name: 'Reversing Shortening',
         Component: miscellaneous.ReversingShortening,
       },
+      TransitionCallbacks: {
+        name: 'Transition Callbacks',
+        Component: miscellaneous.TransitionCallbacks,
+      },
     },
   },
   RealWorldExamples: {

--- a/apps/common-app/src/apps/css/examples/transitions/screens/miscellaneous/TransitionCallbacks.tsx
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/miscellaneous/TransitionCallbacks.tsx
@@ -5,32 +5,44 @@ import type {
   CSSTransitionProperties,
   StyleProps,
 } from 'react-native-reanimated';
-import Animated from 'react-native-reanimated';
+import Animated, { LinearTransition } from 'react-native-reanimated';
 
+import type { SelectableConfig } from '@/apps/css/components';
 import {
   Button,
+  Checkbox,
+  ConfigSelector,
   ScrollScreen,
   Section,
   Stagger,
   Text,
+  useSelectableConfig,
 } from '@/apps/css/components';
-import { TransitionConfiguration } from '@/apps/css/examples/transitions/components';
+import { TransitionStyleChange } from '@/apps/css/examples/transitions/components';
 import { colors, flex, radius, sizes, spacing } from '@/theme';
 
-const SIMPLE: CSSTransitionProperties<ViewStyle> = {
-  transitionDuration: '1s',
-  transitionProperty: 'width',
-};
-
-const DELAYED: CSSTransitionProperties<ViewStyle> = {
-  transitionDelay: '500ms',
-  transitionDuration: '1s',
-  transitionProperty: 'width',
-};
-
-const MULTIPLE: CSSTransitionProperties<ViewStyle> = {
-  transitionDuration: '1s',
-  transitionProperty: ['width', 'opacity'],
+const DEFAULT_TRANSITION_CONFIG: SelectableConfig<
+  CSSTransitionProperties<ViewStyle>
+> = {
+  $transitionProperty: {
+    canDisable: true,
+    maxNumberOfValues: 2,
+    options: ['width', 'opacity'],
+    value: ['width', 'opacity'],
+  },
+  // eslint-disable-next-line perfectionist/sort-objects
+  $transitionDuration: {
+    canDisable: true,
+    options: ['0s', '0.5s', '1s', '2s'],
+    value: '1s',
+  },
+  // eslint-disable-next-line perfectionist/sort-objects
+  $transitionDelay: {
+    canDisable: true,
+    disabled: true,
+    options: ['0s', '250ms', '500ms', '1s'],
+    value: '500ms',
+  },
 };
 
 const TRANSITION_STYLES: Array<StyleProps> = [
@@ -44,11 +56,15 @@ type LoggedEvent = {
 };
 
 export default function TransitionCallbacks() {
+  const [selectableConfig, setSelectableConfig] = useState(
+    DEFAULT_TRANSITION_CONFIG
+  );
+  const transition = useSelectableConfig(selectableConfig);
+
   const [events, setEvents] = useState<Array<LoggedEvent>>([]);
-  const [transition, setTransition] =
-    useState<CSSTransitionProperties<ViewStyle> | null>(SIMPLE);
-  const [isExpanded, setIsExpanded] = useState(false);
+  const [styleIndex, setStyleIndex] = useState(0);
   const [isMounted, setIsMounted] = useState(true);
+  const [displayStyleChanges, setDisplayStyleChanges] = useState(true);
 
   // Time of the change that started the transition, so the log can show the
   // delay that `elapsedTime` deliberately leaves out.
@@ -78,28 +94,22 @@ export default function TransitionCallbacks() {
     []
   );
 
-  const changeStyle = useCallback(
-    (properties: CSSTransitionProperties<ViewStyle>) => {
-      cancelPendingTrigger();
-      setEvents([]);
-      setIsMounted(true);
-      // The settings have to reach the view before the value changes, or the
-      // transition starts with whatever was configured before.
-      setTransition(properties);
-      triggerFrame.current = requestAnimationFrame(() => {
-        triggerFrame.current = null;
-        triggeredAt.current = Date.now();
-        setIsExpanded((expanded) => !expanded);
-      });
-    },
-    [cancelPendingTrigger]
-  );
-
-  const removeTransition = useCallback(() => {
+  const trigger = useCallback(() => {
     cancelPendingTrigger();
-    setTransition(null);
+    setEvents([]);
+    setIsMounted(true);
+    // A remounted view has to reach the screen with its current style before
+    // the value flips, otherwise there is nothing to transition from.
+    triggerFrame.current = requestAnimationFrame(() => {
+      triggerFrame.current = null;
+      triggeredAt.current = Date.now();
+      setStyleIndex((index) => (index + 1) % TRANSITION_STYLES.length);
+    });
   }, [cancelPendingTrigger]);
 
+  // Unmounting is one of the two ways a running transition gets interrupted.
+  // The other one is removing `transitionProperty` in the settings above, and
+  // both report `cancel` instead of `end`.
   const unmountView = useCallback(() => {
     cancelPendingTrigger();
     setIsMounted(false);
@@ -109,39 +119,24 @@ export default function TransitionCallbacks() {
     <ScrollScreen>
       <Stagger>
         <Section
-          description="Transition lifecycle callbacks fired by the **native** CSS engine. They are reported **per property**. `elapsedTime` is in **seconds** and excludes the delay, while the value in brackets is the time since the change that started the transition."
-          title="Transition Callbacks">
+          title="Transition Callbacks"
+          description={[
+            'Transition lifecycle callbacks fired by the **native** CSS engine. They are reported **per property**. `elapsedTime` is in **seconds** and excludes the delay, while the value in brackets is the time since the change that started the transition.',
+            '- press a **checkbox** to add or remove a transition setting',
+            '- press **Trigger** to change the style, or interrupt a running transition by unmounting the view or removing `transitionProperty`',
+          ]}>
           <View style={styles.content}>
-            <View style={styles.buttons}>
+            <ConfigSelector
+              config={selectableConfig}
+              onChange={setSelectableConfig}
+            />
+
+            <View style={styles.row}>
+              <Button style={styles.action} title="Trigger" onPress={trigger} />
               <Button
-                style={flex.grow}
-                title="Change width"
-                onPress={() => changeStyle(SIMPLE)}
-              />
-              <Button
-                style={flex.grow}
-                title="Change width (delayed)"
-                onPress={() => changeStyle(DELAYED)}
-              />
-              <Button
-                style={flex.grow}
-                title="Change width + opacity"
-                onPress={() => changeStyle(MULTIPLE)}
-              />
-              <Button
-                style={flex.grow}
-                title="Remove transition"
-                onPress={removeTransition}
-              />
-              <Button
-                style={flex.grow}
+                style={styles.action}
                 title="Unmount view"
                 onPress={unmountView}
-              />
-              <Button
-                style={flex.grow}
-                title="Clear log"
-                onPress={() => setEvents([])}
               />
             </View>
 
@@ -151,10 +146,7 @@ export default function TransitionCallbacks() {
                   style={[
                     styles.box,
                     transition,
-                    {
-                      opacity: isExpanded ? 1 : 0.25,
-                      width: isExpanded ? sizes.xl : sizes.md,
-                    },
+                    TRANSITION_STYLES[styleIndex],
                   ]}
                   onCSSTransitionCancel={({ elapsedTime, propertyName }) =>
                     log('cancel', propertyName, elapsedTime)
@@ -171,30 +163,47 @@ export default function TransitionCallbacks() {
                 />
               )}
             </View>
+
+            <Animated.View
+              layout={LinearTransition}
+              style={styles.styleChangeWrapper}>
+              {displayStyleChanges && (
+                <TransitionStyleChange
+                  activeStyleIndex={styleIndex}
+                  transitionStyles={TRANSITION_STYLES}
+                />
+              )}
+            </Animated.View>
+            <Checkbox
+              label="Display style changes"
+              selected={displayStyleChanges}
+              onChange={setDisplayStyleChanges}
+            />
           </View>
         </Section>
 
         <Section description="In order of arrival" title="Event Log">
-          <View style={styles.log}>
-            {events.length === 0 ? (
-              <Text variant="subHeading3">No events yet</Text>
-            ) : (
-              events.map((event) => (
-                <Text key={event.id} variant="body1">
-                  {event.label}
-                </Text>
-              ))
-            )}
+          <View style={styles.content}>
+            <View style={styles.logHeader}>
+              <Text variant="label2">{events.length} events</Text>
+              <Button
+                size="small"
+                title="Clear"
+                onPress={() => setEvents([])}
+              />
+            </View>
+            <View style={styles.log}>
+              {events.length === 0 ? (
+                <Text variant="body1">No events yet</Text>
+              ) : (
+                events.map((event) => (
+                  <Text key={event.id} variant="body1">
+                    {event.label}
+                  </Text>
+                ))
+              )}
+            </View>
           </View>
-        </Section>
-
-        <Section
-          description="Transition configuration consists of the style changes that will be animated and the transition settings."
-          title="Transition configuration">
-          <TransitionConfiguration
-            transitionProperties={transition ?? {}}
-            transitionStyles={TRANSITION_STYLES}
-          />
         </Section>
       </Stagger>
     </ScrollScreen>
@@ -202,19 +211,17 @@ export default function TransitionCallbacks() {
 }
 
 const styles = StyleSheet.create({
+  action: {
+    flexBasis: 0,
+    flexGrow: 1,
+  },
   box: {
     backgroundColor: colors.primary,
     borderRadius: radius.sm,
     height: sizes.md,
   },
-  buttons: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    gap: spacing.xxs,
-    justifyContent: 'space-between',
-  },
   content: {
-    gap: spacing.xs,
+    gap: spacing.sm,
   },
   log: {
     backgroundColor: colors.background2,
@@ -223,10 +230,22 @@ const styles = StyleSheet.create({
     minHeight: sizes.xxl,
     padding: spacing.xs,
   },
+  logHeader: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
   preview: {
     ...flex.center,
     backgroundColor: colors.background2,
     borderRadius: radius.md,
     height: sizes.xxl,
+  },
+  row: {
+    flexDirection: 'row',
+    gap: spacing.xxs,
+  },
+  styleChangeWrapper: {
+    overflow: 'hidden',
   },
 });

--- a/apps/common-app/src/apps/css/examples/transitions/screens/miscellaneous/TransitionCallbacks.tsx
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/miscellaneous/TransitionCallbacks.tsx
@@ -33,15 +33,17 @@ const DEFAULT_TRANSITION_CONFIG: SelectableConfig<
   // eslint-disable-next-line perfectionist/sort-objects
   $transitionDuration: {
     canDisable: true,
+    maxNumberOfValues: 2,
     options: ['0s', '0.5s', '1s', '2s'],
-    value: '1s',
+    value: ['1s', '2s'],
   },
   // eslint-disable-next-line perfectionist/sort-objects
   $transitionDelay: {
     canDisable: true,
     disabled: true,
+    maxNumberOfValues: 2,
     options: ['0s', '250ms', '500ms', '1s'],
-    value: '500ms',
+    value: ['0s', '500ms'],
   },
 };
 
@@ -120,7 +122,7 @@ export default function TransitionCallbacks() {
           title="Transition Callbacks"
           description={[
             'Transition lifecycle callbacks fired by the **native** CSS engine, reported **per property**.',
-            '- press a **checkbox** to add or remove a transition setting',
+            '- press a **checkbox** to add or remove a transition setting, or add a second value to give each property its own timing',
             '- press **Trigger** to change the style, or **Unmount view** to interrupt a running transition, which reports `cancel` instead of `end`',
           ]}>
           <View style={styles.content}>

--- a/apps/common-app/src/apps/css/examples/transitions/screens/miscellaneous/TransitionCallbacks.tsx
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/miscellaneous/TransitionCallbacks.tsx
@@ -1,0 +1,201 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { ViewStyle } from 'react-native';
+import { FlatList, StyleSheet, View } from 'react-native';
+import type { CSSTransitionProperties } from 'react-native-reanimated';
+import Animated from 'react-native-reanimated';
+
+import { Button, Screen, Section, Text } from '@/apps/css/components';
+import { colors, flex, radius, sizes, spacing } from '@/theme';
+
+const SIMPLE: CSSTransitionProperties<ViewStyle> = {
+  transitionDuration: '1s',
+  transitionProperty: 'width',
+};
+
+const DELAYED: CSSTransitionProperties<ViewStyle> = {
+  transitionDelay: '500ms',
+  transitionDuration: '1s',
+  transitionProperty: 'width',
+};
+
+const MULTIPLE: CSSTransitionProperties<ViewStyle> = {
+  transitionDuration: '1s',
+  transitionProperty: ['width', 'opacity'],
+};
+
+type LoggedEvent = {
+  id: number;
+  label: string;
+};
+
+export default function TransitionCallbacks() {
+  const [events, setEvents] = useState<Array<LoggedEvent>>([]);
+  const [transition, setTransition] =
+    useState<CSSTransitionProperties<ViewStyle> | null>(SIMPLE);
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [isMounted, setIsMounted] = useState(true);
+
+  // Time of the change that started the transition, so the log can show the
+  // delay that `elapsedTime` deliberately leaves out.
+  const triggeredAt = useRef(Date.now());
+  const triggerFrame = useRef<null | number>(null);
+
+  const cancelPendingTrigger = useCallback(() => {
+    if (triggerFrame.current !== null) {
+      cancelAnimationFrame(triggerFrame.current);
+      triggerFrame.current = null;
+    }
+  }, []);
+
+  useEffect(() => cancelPendingTrigger, [cancelPendingTrigger]);
+
+  const log = useCallback(
+    (type: string, propertyName: string, elapsedTime: number) => {
+      const sinceTrigger = (Date.now() - triggeredAt.current) / 1000;
+      setEvents((current) => [
+        ...current,
+        {
+          id: current.length,
+          label: `${type} (${propertyName}) at ${elapsedTime.toFixed(2)}s (+${sinceTrigger.toFixed(2)}s)`,
+        },
+      ]);
+    },
+    []
+  );
+
+  const run = useCallback(
+    (properties: CSSTransitionProperties<ViewStyle>) => {
+      cancelPendingTrigger();
+      setEvents([]);
+      setIsMounted(true);
+      // The settings have to reach the view before the value changes, or the
+      // browser starts the transition with whatever was configured before.
+      setTransition(properties);
+      triggerFrame.current = requestAnimationFrame(() => {
+        triggerFrame.current = null;
+        triggeredAt.current = Date.now();
+        setIsExpanded((expanded) => !expanded);
+      });
+    },
+    [cancelPendingTrigger]
+  );
+
+  return (
+    <Screen style={styles.screen}>
+      <Section
+        description="Transition lifecycle callbacks fired by the **native** CSS engine. They are reported **per property**. `elapsedTime` is in **seconds** and excludes the delay, while the value in brackets is the time since the change that started the transition."
+        title="Transition Callbacks">
+        <View style={styles.content}>
+          <View style={styles.buttons}>
+            <Button style={flex.grow} title="Run" onPress={() => run(SIMPLE)} />
+            <Button
+              style={flex.grow}
+              title="With delay"
+              onPress={() => run(DELAYED)}
+            />
+            <Button
+              style={flex.grow}
+              title="Two properties"
+              onPress={() => run(MULTIPLE)}
+            />
+            <Button
+              style={flex.grow}
+              title="Cancel"
+              onPress={() => {
+                cancelPendingTrigger();
+                setTransition(null);
+              }}
+            />
+            <Button
+              style={flex.grow}
+              title="Unmount"
+              onPress={() => {
+                cancelPendingTrigger();
+                setIsMounted(false);
+              }}
+            />
+            <Button
+              style={flex.grow}
+              title="Clear log"
+              onPress={() => setEvents([])}
+            />
+          </View>
+
+          <View style={styles.preview}>
+            {isMounted && (
+              <Animated.View
+                style={[
+                  styles.box,
+                  transition,
+                  {
+                    opacity: isExpanded ? 1 : 0.25,
+                    width: isExpanded ? sizes.xl : sizes.md,
+                  },
+                ]}
+                onCSSTransitionCancel={({ elapsedTime, propertyName }) =>
+                  log('cancel', propertyName, elapsedTime)
+                }
+                onCSSTransitionEnd={({ elapsedTime, propertyName }) =>
+                  log('end', propertyName, elapsedTime)
+                }
+                onCSSTransitionRun={({ elapsedTime, propertyName }) =>
+                  log('run', propertyName, elapsedTime)
+                }
+                onCSSTransitionStart={({ elapsedTime, propertyName }) =>
+                  log('start', propertyName, elapsedTime)
+                }
+              />
+            )}
+          </View>
+        </View>
+      </Section>
+
+      <Section description="In order of arrival" title="Event Log" fill>
+        <FlatList
+          contentContainerStyle={styles.logContent}
+          data={events}
+          keyExtractor={(event) => String(event.id)}
+          ListEmptyComponent={<Text variant="subHeading2">No events yet</Text>}
+          renderItem={({ item }) => <Text variant="body1">{item.label}</Text>}
+          style={styles.log}
+        />
+      </Section>
+    </Screen>
+  );
+}
+
+const styles = StyleSheet.create({
+  box: {
+    backgroundColor: colors.primary,
+    borderRadius: radius.sm,
+    height: sizes.md,
+  },
+  buttons: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.xxs,
+    justifyContent: 'space-between',
+  },
+  content: {
+    gap: spacing.xs,
+  },
+  log: {
+    backgroundColor: colors.background2,
+    borderRadius: radius.sm,
+    flex: 1,
+  },
+  logContent: {
+    gap: spacing.xxxs,
+    padding: spacing.xs,
+  },
+  preview: {
+    ...flex.center,
+    backgroundColor: colors.background2,
+    borderRadius: radius.md,
+    height: sizes.xxl,
+  },
+  screen: {
+    gap: spacing.sm,
+    padding: spacing.sm,
+  },
+});

--- a/apps/common-app/src/apps/css/examples/transitions/screens/miscellaneous/TransitionCallbacks.tsx
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/miscellaneous/TransitionCallbacks.tsx
@@ -160,6 +160,11 @@ export default function TransitionCallbacks() {
                   }
                 />
               )}
+              {!isMounted && (
+                <Text style={styles.placeholder} variant="body2">
+                  View unmounted. Press **Trigger** to mount it again.
+                </Text>
+              )}
             </View>
 
             <Animated.View
@@ -185,7 +190,7 @@ export default function TransitionCallbacks() {
             <View style={styles.logHeader}>
               <View>
                 <Text variant="label2">{events.length} events</Text>
-                <Text variant="body3">
+                <Text style={styles.legend} variant="body3">
                   at `elapsedTime` (+ time since **Trigger**)
                 </Text>
               </View>
@@ -226,6 +231,9 @@ const styles = StyleSheet.create({
   content: {
     gap: spacing.sm,
   },
+  legend: {
+    color: colors.foreground2,
+  },
   log: {
     backgroundColor: colors.background2,
     borderRadius: radius.sm,
@@ -237,6 +245,10 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     flexDirection: 'row',
     justifyContent: 'space-between',
+  },
+  placeholder: {
+    color: colors.foreground3,
+    textAlign: 'center',
   },
   preview: {
     ...flex.center,

--- a/apps/common-app/src/apps/css/examples/transitions/screens/miscellaneous/TransitionCallbacks.tsx
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/miscellaneous/TransitionCallbacks.tsx
@@ -190,7 +190,7 @@ export default function TransitionCallbacks() {
             <View style={styles.logHeader}>
               <View>
                 <Text variant="label2">{events.length} events</Text>
-                <Text style={styles.legend} variant="body3">
+                <Text style={styles.legend} variant="body2">
                   at `elapsedTime` (+ time since **Trigger**)
                 </Text>
               </View>
@@ -232,7 +232,7 @@ const styles = StyleSheet.create({
     gap: spacing.sm,
   },
   legend: {
-    color: colors.foreground2,
+    color: colors.foreground1,
   },
   log: {
     backgroundColor: colors.background2,

--- a/apps/common-app/src/apps/css/examples/transitions/screens/miscellaneous/TransitionCallbacks.tsx
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/miscellaneous/TransitionCallbacks.tsx
@@ -64,7 +64,7 @@ export default function TransitionCallbacks() {
   const [events, setEvents] = useState<Array<LoggedEvent>>([]);
   const [styleIndex, setStyleIndex] = useState(0);
   const [isMounted, setIsMounted] = useState(true);
-  const [displayStyleChanges, setDisplayStyleChanges] = useState(true);
+  const [displayStyleChanges, setDisplayStyleChanges] = useState(false);
 
   // Time of the change that started the transition, so the log can show the
   // delay that `elapsedTime` deliberately leaves out.
@@ -107,9 +107,7 @@ export default function TransitionCallbacks() {
     });
   }, [cancelPendingTrigger]);
 
-  // Unmounting is one of the two ways a running transition gets interrupted.
-  // The other one is removing `transitionProperty` in the settings above, and
-  // both report `cancel` instead of `end`.
+  // Interrupts a running transition, which reports `cancel` instead of `end`.
   const unmountView = useCallback(() => {
     cancelPendingTrigger();
     setIsMounted(false);
@@ -121,9 +119,9 @@ export default function TransitionCallbacks() {
         <Section
           title="Transition Callbacks"
           description={[
-            'Transition lifecycle callbacks fired by the **native** CSS engine. They are reported **per property**. `elapsedTime` is in **seconds** and excludes the delay, while the value in brackets is the time since the change that started the transition.',
+            'Transition lifecycle callbacks fired by the **native** CSS engine, reported **per property**.',
             '- press a **checkbox** to add or remove a transition setting',
-            '- press **Trigger** to change the style, or interrupt a running transition by unmounting the view or removing `transitionProperty`',
+            '- press **Trigger** to change the style, or **Unmount view** to interrupt a running transition, which reports `cancel` instead of `end`',
           ]}>
           <View style={styles.content}>
             <ConfigSelector
@@ -182,10 +180,15 @@ export default function TransitionCallbacks() {
           </View>
         </Section>
 
-        <Section description="In order of arrival" title="Event Log">
+        <Section title="Event Log">
           <View style={styles.content}>
             <View style={styles.logHeader}>
-              <Text variant="label2">{events.length} events</Text>
+              <View>
+                <Text variant="label2">{events.length} events</Text>
+                <Text variant="body3">
+                  at `elapsedTime` (+ time since **Trigger**)
+                </Text>
+              </View>
               <Button
                 size="small"
                 title="Clear"

--- a/apps/common-app/src/apps/css/examples/transitions/screens/miscellaneous/TransitionCallbacks.tsx
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/miscellaneous/TransitionCallbacks.tsx
@@ -1,10 +1,20 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { ViewStyle } from 'react-native';
-import { FlatList, StyleSheet, View } from 'react-native';
-import type { CSSTransitionProperties } from 'react-native-reanimated';
+import { StyleSheet, View } from 'react-native';
+import type {
+  CSSTransitionProperties,
+  StyleProps,
+} from 'react-native-reanimated';
 import Animated from 'react-native-reanimated';
 
-import { Button, Screen, Section, Text } from '@/apps/css/components';
+import {
+  Button,
+  ScrollScreen,
+  Section,
+  Stagger,
+  Text,
+} from '@/apps/css/components';
+import { TransitionConfiguration } from '@/apps/css/examples/transitions/components';
 import { colors, flex, radius, sizes, spacing } from '@/theme';
 
 const SIMPLE: CSSTransitionProperties<ViewStyle> = {
@@ -22,6 +32,11 @@ const MULTIPLE: CSSTransitionProperties<ViewStyle> = {
   transitionDuration: '1s',
   transitionProperty: ['width', 'opacity'],
 };
+
+const TRANSITION_STYLES: Array<StyleProps> = [
+  { opacity: 0.25, width: sizes.md },
+  { opacity: 1, width: sizes.xl },
+];
 
 type LoggedEvent = {
   id: number;
@@ -63,13 +78,13 @@ export default function TransitionCallbacks() {
     []
   );
 
-  const run = useCallback(
+  const changeStyle = useCallback(
     (properties: CSSTransitionProperties<ViewStyle>) => {
       cancelPendingTrigger();
       setEvents([]);
       setIsMounted(true);
       // The settings have to reach the view before the value changes, or the
-      // browser starts the transition with whatever was configured before.
+      // transition starts with whatever was configured before.
       setTransition(properties);
       triggerFrame.current = requestAnimationFrame(() => {
         triggerFrame.current = null;
@@ -80,87 +95,109 @@ export default function TransitionCallbacks() {
     [cancelPendingTrigger]
   );
 
-  return (
-    <Screen style={styles.screen}>
-      <Section
-        description="Transition lifecycle callbacks fired by the **native** CSS engine. They are reported **per property**. `elapsedTime` is in **seconds** and excludes the delay, while the value in brackets is the time since the change that started the transition."
-        title="Transition Callbacks">
-        <View style={styles.content}>
-          <View style={styles.buttons}>
-            <Button style={flex.grow} title="Run" onPress={() => run(SIMPLE)} />
-            <Button
-              style={flex.grow}
-              title="With delay"
-              onPress={() => run(DELAYED)}
-            />
-            <Button
-              style={flex.grow}
-              title="Two properties"
-              onPress={() => run(MULTIPLE)}
-            />
-            <Button
-              style={flex.grow}
-              title="Cancel"
-              onPress={() => {
-                cancelPendingTrigger();
-                setTransition(null);
-              }}
-            />
-            <Button
-              style={flex.grow}
-              title="Unmount"
-              onPress={() => {
-                cancelPendingTrigger();
-                setIsMounted(false);
-              }}
-            />
-            <Button
-              style={flex.grow}
-              title="Clear log"
-              onPress={() => setEvents([])}
-            />
-          </View>
+  const removeTransition = useCallback(() => {
+    cancelPendingTrigger();
+    setTransition(null);
+  }, [cancelPendingTrigger]);
 
-          <View style={styles.preview}>
-            {isMounted && (
-              <Animated.View
-                style={[
-                  styles.box,
-                  transition,
-                  {
-                    opacity: isExpanded ? 1 : 0.25,
-                    width: isExpanded ? sizes.xl : sizes.md,
-                  },
-                ]}
-                onCSSTransitionCancel={({ elapsedTime, propertyName }) =>
-                  log('cancel', propertyName, elapsedTime)
-                }
-                onCSSTransitionEnd={({ elapsedTime, propertyName }) =>
-                  log('end', propertyName, elapsedTime)
-                }
-                onCSSTransitionRun={({ elapsedTime, propertyName }) =>
-                  log('run', propertyName, elapsedTime)
-                }
-                onCSSTransitionStart={({ elapsedTime, propertyName }) =>
-                  log('start', propertyName, elapsedTime)
-                }
+  const unmountView = useCallback(() => {
+    cancelPendingTrigger();
+    setIsMounted(false);
+  }, [cancelPendingTrigger]);
+
+  return (
+    <ScrollScreen>
+      <Stagger>
+        <Section
+          description="Transition lifecycle callbacks fired by the **native** CSS engine. They are reported **per property**. `elapsedTime` is in **seconds** and excludes the delay, while the value in brackets is the time since the change that started the transition."
+          title="Transition Callbacks">
+          <View style={styles.content}>
+            <View style={styles.buttons}>
+              <Button
+                style={flex.grow}
+                title="Change width"
+                onPress={() => changeStyle(SIMPLE)}
               />
+              <Button
+                style={flex.grow}
+                title="Change width (delayed)"
+                onPress={() => changeStyle(DELAYED)}
+              />
+              <Button
+                style={flex.grow}
+                title="Change width + opacity"
+                onPress={() => changeStyle(MULTIPLE)}
+              />
+              <Button
+                style={flex.grow}
+                title="Remove transition"
+                onPress={removeTransition}
+              />
+              <Button
+                style={flex.grow}
+                title="Unmount view"
+                onPress={unmountView}
+              />
+              <Button
+                style={flex.grow}
+                title="Clear log"
+                onPress={() => setEvents([])}
+              />
+            </View>
+
+            <View style={styles.preview}>
+              {isMounted && (
+                <Animated.View
+                  style={[
+                    styles.box,
+                    transition,
+                    {
+                      opacity: isExpanded ? 1 : 0.25,
+                      width: isExpanded ? sizes.xl : sizes.md,
+                    },
+                  ]}
+                  onCSSTransitionCancel={({ elapsedTime, propertyName }) =>
+                    log('cancel', propertyName, elapsedTime)
+                  }
+                  onCSSTransitionEnd={({ elapsedTime, propertyName }) =>
+                    log('end', propertyName, elapsedTime)
+                  }
+                  onCSSTransitionRun={({ elapsedTime, propertyName }) =>
+                    log('run', propertyName, elapsedTime)
+                  }
+                  onCSSTransitionStart={({ elapsedTime, propertyName }) =>
+                    log('start', propertyName, elapsedTime)
+                  }
+                />
+              )}
+            </View>
+          </View>
+        </Section>
+
+        <Section description="In order of arrival" title="Event Log">
+          <View style={styles.log}>
+            {events.length === 0 ? (
+              <Text variant="subHeading3">No events yet</Text>
+            ) : (
+              events.map((event) => (
+                <Text key={event.id} variant="body1">
+                  {event.label}
+                </Text>
+              ))
             )}
           </View>
-        </View>
-      </Section>
+        </Section>
 
-      <Section description="In order of arrival" title="Event Log" fill>
-        <FlatList
-          contentContainerStyle={styles.logContent}
-          data={events}
-          keyExtractor={(event) => String(event.id)}
-          ListEmptyComponent={<Text variant="subHeading2">No events yet</Text>}
-          renderItem={({ item }) => <Text variant="body1">{item.label}</Text>}
-          style={styles.log}
-        />
-      </Section>
-    </Screen>
+        <Section
+          description="Transition configuration consists of the style changes that will be animated and the transition settings."
+          title="Transition configuration">
+          <TransitionConfiguration
+            transitionProperties={transition ?? {}}
+            transitionStyles={TRANSITION_STYLES}
+          />
+        </Section>
+      </Stagger>
+    </ScrollScreen>
   );
 }
 
@@ -182,10 +219,8 @@ const styles = StyleSheet.create({
   log: {
     backgroundColor: colors.background2,
     borderRadius: radius.sm,
-    flex: 1,
-  },
-  logContent: {
     gap: spacing.xxxs,
+    minHeight: sizes.xxl,
     padding: spacing.xs,
   },
   preview: {
@@ -193,9 +228,5 @@ const styles = StyleSheet.create({
     backgroundColor: colors.background2,
     borderRadius: radius.md,
     height: sizes.xxl,
-  },
-  screen: {
-    gap: spacing.sm,
-    padding: spacing.sm,
   },
 });

--- a/apps/common-app/src/apps/css/examples/transitions/screens/miscellaneous/index.ts
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/miscellaneous/index.ts
@@ -1,11 +1,13 @@
 import ChangingTransitionProperty from './ChangingTransitionProperty';
 import MultipleTransitionSettings from './MultipleTransitionSettings';
 import ReversingShortening from './ReversingShortening';
+import TransitionCallbacks from './TransitionCallbacks';
 import UpdatingTransitionSettings from './UpdatingTransitionSettings';
 
 export default {
   ChangingTransitionProperty,
   MultipleTransitionSettings,
   ReversingShortening,
+  TransitionCallbacks,
   UpdatingTransitionSettings,
 };


### PR DESCRIPTION
Adds a Transition Callbacks screen to the CSS example app, next to the existing Animation Callbacks one, so the transition lifecycle props can be exercised by hand.

A config selector drives the settings, so `transitionProperty`, `transitionDuration` and `transitionDelay` can be added, removed or retuned while the example runs. Duration and delay take a value per property, which makes it easy to see that each property keeps its own timeline. Trigger changes the style, Unmount view interrupts a running transition, and the log records every callback with its `elapsedTime` next to the time since the trigger, which makes the delay that `elapsedTime` excludes visible.

It lives under Miscellaneous, mirroring where the animation counterpart sits.

## Demo


https://github.com/user-attachments/assets/b0f690cc-9f11-4a10-89bd-31ccd9664e34



Verified on device and emulator. With `width`/`opacity` transitioned over `1s`/`2s` and delays of `0s`/`500ms`, the log reports `start (width)` right away and `start (opacity)` half a second later, then `end (width) at 1.00s` and `end (opacity) at 2.00s`, so `elapsedTime` stays free of the delay. Unmounting mid-flight reports `cancel` instead of `end`, and a `0s` duration with no delay produces no transition and no events, matching the CSS rule that the combined duration has to be greater than zero.
