### PR TITLE
fix: Text losing its trailing word after a CSS fontSize transition on Android

### DIFF
--- a/packages/react-native-reanimated/CHANGELOG.md
+++ b/packages/react-native-reanimated/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix text losing its trailing word on Android after a CSS `fontSize` transition. ([#10342](https://github.com/software-mansion/react-native-reanimated/pull/10342) by [@MatiPl01](https://github.com/MatiPl01))
 - Fix `EXC_BAD_ACCESS` crash in `-[REANodesManager performOperations]` when called before the `_performOperations` block is registered on iOS. ([#10229](https://github.com/software-mansion/react-native-reanimated/pull/10229) by [@tomekzaw](https://github.com/tomekzaw))
 - Fix missing unmount of ancestors of animated components with exiting animations in experimental Layout Animations Proxy ([#10103](https://github.com/software-mansion/react-native-reanimated/pull/10103) by [@pawicao](https://github.com/pawicao))
 - Fix crash when a CSS animation or transition runs between two keyword values on a property that also accepts relative lengths, such as `width` going from `auto` to `auto`. ([#10281](https://github.com/software-mansion/react-native-reanimated/pull/10281) by [@MatiPl01](https://github.com/MatiPl01))

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/InterpolatorRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/InterpolatorRegistry.cpp
@@ -210,11 +210,11 @@ const InterpolatorFactoriesRecord STYLE_INTERPOLATORS = {
     // Text
     {"color", value<CSSColor>(BLACK)},
     {"fontFamily", value<CSSKeyword>("inherit")},
-    {"fontSize", value<CSSDouble>(14)},
+    {"fontSize", value<CSSTextDouble>(14)},
     {"fontStyle", value<CSSKeyword>("normal")},
     {"fontWeight", value<CSSKeyword>("normal")},
-    {"letterSpacing", value<CSSDouble>(0)},
-    {"lineHeight", value<CSSDouble>(14)}, // TODO - should inherit from fontSize
+    {"letterSpacing", value<CSSTextDouble>(0)},
+    {"lineHeight", value<CSSTextDouble>(14)}, // TODO - should inherit from fontSize
     {"textAlign", value<CSSKeyword>("auto")},
     {"textDecorationLine", value<CSSKeyword>("none")},
     {"textShadowColor", value<CSSColor>(BLACK)},

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSNumber.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSNumber.cpp
@@ -1,9 +1,15 @@
 #include <reanimated/CSS/common/values/CSSNumber.h>
 
 #include <algorithm>
+#include <cmath>
 #include <string>
 
 namespace reanimated::css {
+
+namespace {
+/// Mirrors `facebook::react::kDefaultEpsilon`, React Native's float-equality tolerance.
+constexpr double RN_FLOAT_EQUALITY_EPSILON = 0.005;
+} // namespace
 
 template <typename TDerived, typename TValue>
 CSSNumberBase<TDerived, TValue>::CSSNumberBase() : value(0) {}
@@ -59,9 +65,15 @@ CSSIndex CSSIndex::interpolate(double progress, const CSSIndex &other) const {
   return CSSIndex(progress < 0.5 ? value : other.value);
 }
 
+CSSTextDouble CSSTextDouble::interpolate(double progress, const CSSTextDouble &other) const {
+  const auto interpolated = value + progress * (other.value - value);
+  return std::abs(other.value - interpolated) < RN_FLOAT_EQUALITY_EPSILON ? other : CSSTextDouble(interpolated);
+}
+
 template struct CSSNumberBase<CSSDouble, double>;
 template struct CSSNumberBase<CSSInteger, int>;
 template struct CSSNumberBase<CSSIndex, int>;
+template struct CSSNumberBase<CSSTextDouble, double>;
 
 #ifdef ANDROID
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSNumber.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSNumber.cpp
@@ -60,12 +60,12 @@ CSSIndex CSSIndex::interpolate(double progress, const CSSIndex &other) const {
   return CSSIndex(progress < 0.5 ? value : other.value);
 }
 
-template <typename TPrecision>
-CSSDoubleBase<TPrecision> CSSDoubleBase<TPrecision>::interpolate(double progress, const CSSDoubleBase &other) const {
-  const auto interpolated = CSSNumberBase<CSSDoubleBase<TPrecision>, double>::interpolate(progress, other);
+template <typename TDerived>
+TDerived CSSDoubleBase<TDerived>::interpolate(double progress, const TDerived &other) const {
+  const auto interpolated = CSSNumberBase<TDerived, double>::interpolate(progress, other);
 
-  if constexpr (TPrecision::epsilon > 0) {
-    if (std::abs(other.value - interpolated.value) < TPrecision::epsilon) {
+  if constexpr (TDerived::epsilon > 0) {
+    if (std::abs(other.value - interpolated.value) < TDerived::epsilon) {
       return other;
     }
   }
@@ -77,8 +77,8 @@ template struct CSSNumberBase<CSSDouble, double>;
 template struct CSSNumberBase<CSSTextDouble, double>;
 template struct CSSNumberBase<CSSInteger, int>;
 template struct CSSNumberBase<CSSIndex, int>;
-template struct CSSDoubleBase<CSSExactPrecision>;
-template struct CSSDoubleBase<CSSTextPrecision>;
+template struct CSSDoubleBase<CSSDouble>;
+template struct CSSDoubleBase<CSSTextDouble>;
 
 #ifdef ANDROID
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSNumber.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSNumber.cpp
@@ -44,7 +44,15 @@ std::string CSSNumberBase<TDerived, TValue>::toString() const {
 
 template <typename TDerived, typename TValue>
 TDerived CSSNumberBase<TDerived, TValue>::interpolate(double progress, const TDerived &other) const {
-  return TDerived(value + progress * (other.value - value));
+  const auto interpolated = value + progress * (other.value - value);
+
+  if constexpr (requires { TDerived::epsilon; }) {
+    if (std::abs(other.value - interpolated) < TDerived::epsilon) {
+      return other;
+    }
+  }
+
+  return TDerived(interpolated);
 }
 
 template <typename TDerived, typename TValue>
@@ -60,25 +68,10 @@ CSSIndex CSSIndex::interpolate(double progress, const CSSIndex &other) const {
   return CSSIndex(progress < 0.5 ? value : other.value);
 }
 
-template <typename TDerived>
-TDerived CSSDoubleBase<TDerived>::interpolate(double progress, const TDerived &other) const {
-  const auto interpolated = CSSNumberBase<TDerived, double>::interpolate(progress, other);
-
-  if constexpr (TDerived::epsilon > 0) {
-    if (std::abs(other.value - interpolated.value) < TDerived::epsilon) {
-      return other;
-    }
-  }
-
-  return interpolated;
-}
-
 template struct CSSNumberBase<CSSDouble, double>;
 template struct CSSNumberBase<CSSTextDouble, double>;
 template struct CSSNumberBase<CSSInteger, int>;
 template struct CSSNumberBase<CSSIndex, int>;
-template struct CSSDoubleBase<CSSDouble>;
-template struct CSSDoubleBase<CSSTextDouble>;
 
 #ifdef ANDROID
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSNumber.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSNumber.cpp
@@ -6,11 +6,6 @@
 
 namespace reanimated::css {
 
-namespace {
-/// Mirrors `facebook::react::kDefaultEpsilon`, React Native's float-equality tolerance.
-constexpr double RN_FLOAT_EQUALITY_EPSILON = 0.005;
-} // namespace
-
 template <typename TDerived, typename TValue>
 CSSNumberBase<TDerived, TValue>::CSSNumberBase() : value(0) {}
 
@@ -65,15 +60,25 @@ CSSIndex CSSIndex::interpolate(double progress, const CSSIndex &other) const {
   return CSSIndex(progress < 0.5 ? value : other.value);
 }
 
-CSSTextDouble CSSTextDouble::interpolate(double progress, const CSSTextDouble &other) const {
-  const auto interpolated = value + progress * (other.value - value);
-  return std::abs(other.value - interpolated) < RN_FLOAT_EQUALITY_EPSILON ? other : CSSTextDouble(interpolated);
+template <typename TPrecision>
+CSSDoubleBase<TPrecision> CSSDoubleBase<TPrecision>::interpolate(double progress, const CSSDoubleBase &other) const {
+  const auto interpolated = CSSNumberBase<CSSDoubleBase<TPrecision>, double>::interpolate(progress, other);
+
+  if constexpr (TPrecision::epsilon > 0) {
+    if (std::abs(other.value - interpolated.value) < TPrecision::epsilon) {
+      return other;
+    }
+  }
+
+  return interpolated;
 }
 
 template struct CSSNumberBase<CSSDouble, double>;
+template struct CSSNumberBase<CSSTextDouble, double>;
 template struct CSSNumberBase<CSSInteger, int>;
 template struct CSSNumberBase<CSSIndex, int>;
-template struct CSSNumberBase<CSSTextDouble, double>;
+template struct CSSDoubleBase<CSSExactPrecision>;
+template struct CSSDoubleBase<CSSTextPrecision>;
 
 #ifdef ANDROID
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSNumber.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSNumber.h
@@ -54,6 +54,20 @@ struct CSSIndex : public CSSNumberBase<CSSIndex, int> {
   CSSIndex interpolate(double progress, const CSSIndex &other) const override;
 };
 
+/// A number for text attributes (`fontSize`, `letterSpacing`, `lineHeight`).
+///
+/// React Native compares these with a 0.005 epsilon when deciding whether to
+/// rebuild a paragraph's text state, but lays them out exactly, so a smaller
+/// step moves the frame while the text keeps its old metrics and its trailing
+/// word wraps out of view on Android. Interpolation lands on the endpoint once
+/// it gets that close, keeping consecutive committed values distinguishable.
+struct CSSTextDouble : public CSSNumberBase<CSSTextDouble, double> {
+  // Inherit all constructors from the base class
+  using CSSNumberBase::CSSNumberBase;
+
+  CSSTextDouble interpolate(double progress, const CSSTextDouble &other) const override;
+};
+
 #ifdef ANDROID
 
 // For some reason Android crashes when blurRadius is smaller than 1 so we use a

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSNumber.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSNumber.h
@@ -2,6 +2,8 @@
 
 #include <reanimated/CSS/common/values/CSSValue.h>
 
+#include <react/utils/FloatComparison.h>
+
 #include <string>
 
 namespace reanimated::css {
@@ -43,11 +45,11 @@ struct CSSDouble : public CSSNumberBase<CSSDouble, double> {
 struct CSSTextDouble : public CSSNumberBase<CSSTextDouble, double> {
   using CSSNumberBase::CSSNumberBase;
 
-  /// React Native compares text attributes with a 0.005 epsilon but lays them
-  /// out exactly, so a smaller step moves the frame while the text keeps its
-  /// old metrics. Interpolation lands on the endpoint once it gets that close.
+  /// React Native compares text attributes with this epsilon but lays them out
+  /// exactly, so a smaller step moves the frame while the text keeps its old
+  /// metrics. Interpolation lands on the endpoint once it gets that close.
   /// https://github.com/facebook/react-native/blob/v0.87.0/packages/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.cpp#L174-L177
-  static constexpr double epsilon = 0.005;
+  static constexpr double epsilon = facebook::react::kDefaultEpsilon;
 };
 
 struct CSSInteger : public CSSNumberBase<CSSInteger, int> {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSNumber.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSNumber.h
@@ -35,37 +35,37 @@ std::ostream &operator<<(std::ostream &os, const CSSNumberBase<TDerived, TValue>
 
 #endif // NDEBUG
 
-/// Interpolate exactly - `CSSDoubleBase` compiles its epsilon check away.
-struct CSSExactPrecision {
+/// A double that lands on the endpoint once it gets within `TDerived::epsilon`
+/// of it. Emitting a value the platform cannot tell apart from the endpoint
+/// makes the final, exact value read as no change at all. An epsilon of 0
+/// interpolates exactly and compiles the check away.
+template <typename TDerived>
+struct CSSDoubleBase : public CSSNumberBase<TDerived, double> {
+  // Inherit all constructors from the base class
+  using CSSNumberBase<TDerived, double>::CSSNumberBase;
+
+  TDerived interpolate(double progress, const TDerived &other) const override;
+};
+
+struct CSSDouble : public CSSDoubleBase<CSSDouble> {
+  // Inherit all constructors from the base class
+  using CSSDoubleBase::CSSDoubleBase;
+
   static constexpr double epsilon = 0;
 };
 
-/// React Native compares text attributes with `floatEquality`, whose epsilon is
-/// 0.005, when deciding whether to rebuild a paragraph's text state, but lays
-/// them out exactly. Below that epsilon the frame moves to the new metrics
-/// while the text keeps the old ones, and on Android the trailing word wraps
-/// out of view.
-/// https://github.com/facebook/react-native/blob/v0.87.0/packages/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.cpp#L174-L177
-struct CSSTextPrecision {
+struct CSSTextDouble : public CSSDoubleBase<CSSTextDouble> {
+  // Inherit all constructors from the base class
+  using CSSDoubleBase::CSSDoubleBase;
+
+  /// React Native compares text attributes with `floatEquality`, whose epsilon
+  /// is 0.005, when deciding whether to rebuild a paragraph's text state, but
+  /// lays them out exactly. Below that epsilon the frame moves to the new
+  /// metrics while the text keeps the old ones, and on Android the trailing
+  /// word wraps out of view.
+  /// https://github.com/facebook/react-native/blob/v0.87.0/packages/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.cpp#L174-L177
   static constexpr double epsilon = 0.005;
 };
-
-/// A double that stops short of `TPrecision::epsilon` from the endpoint and
-/// lands on it instead. Emitting a value the platform cannot tell apart from
-/// the endpoint makes the final, exact value read as no change at all.
-///
-/// A precision tag rather than a `double` template argument because floating
-/// point non-type template parameters are not supported by the NDK's compiler.
-template <typename TPrecision>
-struct CSSDoubleBase : public CSSNumberBase<CSSDoubleBase<TPrecision>, double> {
-  // Inherit all constructors from the base class
-  using CSSNumberBase<CSSDoubleBase<TPrecision>, double>::CSSNumberBase;
-
-  CSSDoubleBase interpolate(double progress, const CSSDoubleBase &other) const override;
-};
-
-using CSSDouble = CSSDoubleBase<CSSExactPrecision>;
-using CSSTextDouble = CSSDoubleBase<CSSTextPrecision>;
 
 struct CSSInteger : public CSSNumberBase<CSSInteger, int> {
   // Inherit all constructors from the base class

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSNumber.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSNumber.h
@@ -35,34 +35,17 @@ std::ostream &operator<<(std::ostream &os, const CSSNumberBase<TDerived, TValue>
 
 #endif // NDEBUG
 
-/// A double that lands on the endpoint once it gets within `TDerived::epsilon`
-/// of it. Emitting a value the platform cannot tell apart from the endpoint
-/// makes the final, exact value read as no change at all. An epsilon of 0
-/// interpolates exactly and compiles the check away.
-template <typename TDerived>
-struct CSSDoubleBase : public CSSNumberBase<TDerived, double> {
+struct CSSDouble : public CSSNumberBase<CSSDouble, double> {
   // Inherit all constructors from the base class
-  using CSSNumberBase<TDerived, double>::CSSNumberBase;
-
-  TDerived interpolate(double progress, const TDerived &other) const override;
+  using CSSNumberBase::CSSNumberBase;
 };
 
-struct CSSDouble : public CSSDoubleBase<CSSDouble> {
-  // Inherit all constructors from the base class
-  using CSSDoubleBase::CSSDoubleBase;
+struct CSSTextDouble : public CSSNumberBase<CSSTextDouble, double> {
+  using CSSNumberBase::CSSNumberBase;
 
-  static constexpr double epsilon = 0;
-};
-
-struct CSSTextDouble : public CSSDoubleBase<CSSTextDouble> {
-  // Inherit all constructors from the base class
-  using CSSDoubleBase::CSSDoubleBase;
-
-  /// React Native compares text attributes with `floatEquality`, whose epsilon
-  /// is 0.005, when deciding whether to rebuild a paragraph's text state, but
-  /// lays them out exactly. Below that epsilon the frame moves to the new
-  /// metrics while the text keeps the old ones, and on Android the trailing
-  /// word wraps out of view.
+  /// React Native compares text attributes with a 0.005 epsilon but lays them
+  /// out exactly, so a smaller step moves the frame while the text keeps its
+  /// old metrics. Interpolation lands on the endpoint once it gets that close.
   /// https://github.com/facebook/react-native/blob/v0.87.0/packages/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.cpp#L174-L177
   static constexpr double epsilon = 0.005;
 };

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSNumber.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSNumber.h
@@ -35,10 +35,37 @@ std::ostream &operator<<(std::ostream &os, const CSSNumberBase<TDerived, TValue>
 
 #endif // NDEBUG
 
-struct CSSDouble : public CSSNumberBase<CSSDouble, double> {
-  // Inherit all constructors from the base class
-  using CSSNumberBase::CSSNumberBase;
+/// Interpolate exactly - `CSSDoubleBase` compiles its epsilon check away.
+struct CSSExactPrecision {
+  static constexpr double epsilon = 0;
 };
+
+/// React Native compares text attributes with `floatEquality`, whose epsilon is
+/// 0.005, when deciding whether to rebuild a paragraph's text state, but lays
+/// them out exactly. Below that epsilon the frame moves to the new metrics
+/// while the text keeps the old ones, and on Android the trailing word wraps
+/// out of view.
+/// https://github.com/facebook/react-native/blob/v0.87.0/packages/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.cpp#L174-L177
+struct CSSTextPrecision {
+  static constexpr double epsilon = 0.005;
+};
+
+/// A double that stops short of `TPrecision::epsilon` from the endpoint and
+/// lands on it instead. Emitting a value the platform cannot tell apart from
+/// the endpoint makes the final, exact value read as no change at all.
+///
+/// A precision tag rather than a `double` template argument because floating
+/// point non-type template parameters are not supported by the NDK's compiler.
+template <typename TPrecision>
+struct CSSDoubleBase : public CSSNumberBase<CSSDoubleBase<TPrecision>, double> {
+  // Inherit all constructors from the base class
+  using CSSNumberBase<CSSDoubleBase<TPrecision>, double>::CSSNumberBase;
+
+  CSSDoubleBase interpolate(double progress, const CSSDoubleBase &other) const override;
+};
+
+using CSSDouble = CSSDoubleBase<CSSExactPrecision>;
+using CSSTextDouble = CSSDoubleBase<CSSTextPrecision>;
 
 struct CSSInteger : public CSSNumberBase<CSSInteger, int> {
   // Inherit all constructors from the base class
@@ -52,20 +79,6 @@ struct CSSIndex : public CSSNumberBase<CSSIndex, int> {
   using CSSNumberBase::CSSNumberBase;
 
   CSSIndex interpolate(double progress, const CSSIndex &other) const override;
-};
-
-/// A number for text attributes (`fontSize`, `letterSpacing`, `lineHeight`).
-///
-/// React Native compares these with a 0.005 epsilon when deciding whether to
-/// rebuild a paragraph's text state, but lays them out exactly, so a smaller
-/// step moves the frame while the text keeps its old metrics and its trailing
-/// word wraps out of view on Android. Interpolation lands on the endpoint once
-/// it gets that close, keeping consecutive committed values distinguishable.
-struct CSSTextDouble : public CSSNumberBase<CSSTextDouble, double> {
-  // Inherit all constructors from the base class
-  using CSSNumberBase::CSSNumberBase;
-
-  CSSTextDouble interpolate(double progress, const CSSTextDouble &other) const override;
 };
 
 #ifdef ANDROID

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSNumber.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSNumber.h
@@ -38,7 +38,6 @@ std::ostream &operator<<(std::ostream &os, const CSSNumberBase<TDerived, TValue>
 #endif // NDEBUG
 
 struct CSSDouble : public CSSNumberBase<CSSDouble, double> {
-  // Inherit all constructors from the base class
   using CSSNumberBase::CSSNumberBase;
 };
 
@@ -53,14 +52,12 @@ struct CSSTextDouble : public CSSNumberBase<CSSTextDouble, double> {
 };
 
 struct CSSInteger : public CSSNumberBase<CSSInteger, int> {
-  // Inherit all constructors from the base class
   using CSSNumberBase::CSSNumberBase;
 
   CSSInteger interpolate(double progress, const CSSInteger &other) const override;
 };
 
 struct CSSIndex : public CSSNumberBase<CSSIndex, int> {
-  // Inherit all constructors from the base class
   using CSSNumberBase::CSSNumberBase;
 
   CSSIndex interpolate(double progress, const CSSIndex &other) const override;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSValueVariant.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSValueVariant.cpp
@@ -133,6 +133,7 @@ template class CSSValueVariant<CSSLength>;
 template class CSSValueVariant<CSSLength, CSSKeyword>;
 template class CSSValueVariant<CSSDouble>;
 template class CSSValueVariant<CSSDouble, CSSKeyword>;
+template class CSSValueVariant<CSSTextDouble>;
 template class CSSValueVariant<CSSInteger>;
 template class CSSValueVariant<CSSIndex>;
 template class CSSValueVariant<CSSKeyword>;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/SimpleValueInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/SimpleValueInterpolator.cpp
@@ -63,6 +63,7 @@ template class SimpleValueInterpolator<CSSLength>;
 template class SimpleValueInterpolator<CSSLength, CSSKeyword>;
 template class SimpleValueInterpolator<CSSDouble>;
 template class SimpleValueInterpolator<CSSDouble, CSSKeyword>;
+template class SimpleValueInterpolator<CSSTextDouble>;
 template class SimpleValueInterpolator<CSSInteger>;
 template class SimpleValueInterpolator<CSSIndex>;
 template class SimpleValueInterpolator<CSSAngle>;


### PR DESCRIPTION
## Summary

On Android, transitioning `fontSize` on an `Animated.Text` left the label rendering its old text metrics inside a freshly measured frame, so its trailing word wrapped out of view and read as if the text had disappeared. Reported against the App Settings screen in the CSS transition examples.

React Native compares text attributes with a 0.005 epsilon but lays them out exactly, so the final step of an eased transition can land inside that band and read as no change: the frame moves to the new metrics while the spannable keeps the old ones. `fontSize`, `letterSpacing` and `lineHeight` now interpolate through a `CSSTextDouble` that snaps to the endpoint once it gets that close. Plain numbers are untouched, since the epsilon is text specific.

### Where the epsilon comes from

[`kDefaultEpsilon = 0.005f`](https://github.com/facebook/react-native/blob/v0.87.0/packages/react-native/ReactCommon/react/utils/FloatComparison.h#L14) backs `floatEquality`, and `CSSTextDouble::epsilon` reads it directly rather than duplicating the value. [`TextAttributes::operator==`](https://github.com/facebook/react-native/blob/v0.87.0/packages/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.cpp#L174-L177) compares the three properties through it, so [`ParagraphShadowNode::updateStateIfNeeded`](https://github.com/facebook/react-native/blob/v0.87.0/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.cpp#L174-L176) returns early and builds no new `ParagraphState` while Yoga still measures the exact value. Android turns that gap into whole pixels by quantising the span size: [`TextAttributeProps.setFontSize`](https://github.com/facebook/react-native/blob/v0.87.0/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributeProps.kt#L182-L191) rounds up and [`ReactAbsoluteSizeSpan`](https://github.com/facebook/react-native/blob/v0.87.0/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactAbsoluteSizeSpan.kt#L13) takes an `Int`.

## Test plan

Android emulator, RN 0.87. Automated repro on the App Settings example, cycling font sizes and checking every label still renders in full: 5 of 5 runs broken before the change, 5 of 5 clean after. The screen's other transitions still animate.

### Example recording

https://github.com/user-attachments/assets/5a803fe9-f2a2-4a5f-99bb-c8fb1744bbcd


