### PR TITLE
fix: correct the cubic-bezier x-derivative used to solve CSS easings

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.cpp
@@ -63,7 +63,10 @@ double solveCurve(const double x, const CurveCoefficients &curve) {
   // falls outside [0, 1]. Running it to full precision rather than stopping at
   // the first sample within kEpsilon keeps the fallback accurate on curves with
   // a near-flat region, where a small error in x is a large one in t.
-  // Callers clamp x to [0, 1]. CSS requires tangent extension outside this range.
+  // For x outside [0, 1], css-easing-1 prescribes extension along the endpoint
+  // tangents instead of this nearest-endpoint clamp; callers clamp progress to
+  // [0, 1] today, so the difference is unobservable. Implement the tangent
+  // extension if that clamp ever goes away.
   double low = 0.0, high = 1.0;
   for (std::uint8_t iteration = 0; iteration < kMaxBisectionIterations; ++iteration) {
     const double middle = (low + high) / 2.0;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.cpp
@@ -1,30 +1,90 @@
 #include <reanimated/CSS/easing/cubicBezier.h>
 
 #include <algorithm>
+#include <cmath>
+#include <cstdint>
 
 namespace reanimated::css {
 
 namespace {
 
-/// Polynomial coefficients of a unit cubic Bezier with control points
-/// (0,0), (p1, ...), (p2, ...), (1,1), as used by WebKit's UnitBezier.
-/// Deriving the curve and its derivative from the same coefficients keeps them
-/// consistent - an independently expanded derivative is easy to get wrong, and
-/// a wrong one sends Newton's method outside [0, 1].
+/// Newton's method converges within a few steps for the curves CSS allows;
+/// the bisection fallback covers the rest.
+constexpr std::uint8_t kMaxNewtonIterations = 8;
+
+/// Polynomial coefficients of one axis of a unit cubic Bezier with control
+/// points (0, 0), (p1, ...), (p2, ...), (1, 1):
+///
+///   f(t) = ((a * t + b) * t + c) * t   with c = 3 * p1,
+///                                          b = 3 * (p2 - p1) - c,
+///                                          a = 1 - c - b
+///
+/// Expanding that gives the Bernstein polynomial the CSS easing spec defines,
+/// and it is the form WebKit's UnitBezier uses:
+/// https://www.w3.org/TR/css-easing-1/#cubic-bezier-easing-functions
+/// https://github.com/WebKit/WebKit/blob/main/Source/WebCore/platform/graphics/UnitBezier.h
+///
+/// The derivative comes from the same coefficients so the two cannot disagree -
+/// a separately expanded derivative is easy to get wrong, and a wrong one sends
+/// Newton's method outside [0, 1].
 struct Coefficients {
   // Declared in initialisation order: b depends on c, a depends on both.
   double c, b, a;
 
-  explicit Coefficients(const double p1, const double p2) : c(3.0 * p1), b(3.0 * (p2 - p1) - c), a(1.0 - c - b) {}
+  constexpr Coefficients(const double p1, const double p2) : c(3.0 * p1), b(3.0 * (p2 - p1) - c), a(1.0 - c - b) {}
 
-  double sample(const double t) const {
+  constexpr double sample(const double t) const {
     return ((a * t + b) * t + c) * t;
   }
 
-  double sampleDerivative(const double t) const {
+  constexpr double sampleDerivative(const double t) const {
     return (3.0 * a * t + 2.0 * b) * t + c;
   }
 };
+
+/// Inverts x over the curve's own domain. x is monotonic on [0, 1] for the
+/// control points CSS permits, so the root there is unique.
+double solveCurve(const double x, const Coefficients &curve, const double epsilon) {
+  double t = x;
+
+  for (std::uint8_t iteration = 0; iteration < kMaxNewtonIterations; ++iteration) {
+    const double distance = curve.sample(t) - x;
+    if (std::abs(distance) < epsilon) {
+      // A cubic can also cross x outside [0, 1]; such a root is not a solution.
+      if (t >= 0.0 && t <= 1.0) {
+        return t;
+      }
+      break;
+    }
+    const double slope = curve.sampleDerivative(t);
+    if (std::abs(slope) < epsilon) {
+      break;
+    }
+    t = t - distance / slope;
+  }
+
+  double low = 0.0, high = 1.0;
+  t = std::clamp(x, low, high);
+
+  while (low < high) {
+    const double sampled = curve.sample(t);
+    if (std::abs(sampled - x) < epsilon) {
+      return t;
+    }
+    if (x > sampled) {
+      low = t;
+    } else {
+      high = t;
+    }
+    const double next = (low + high) / 2.0;
+    if (next == t) {
+      break;
+    }
+    t = next;
+  }
+
+  return t;
+}
 
 } // namespace
 
@@ -41,53 +101,17 @@ double sampleCurveDerivativeX(const double t, const double x1, const double x2) 
 }
 
 double solveCurveX(const double x, const double x1, const double x2, const double epsilon) {
-  const Coefficients coefficients(x1, x2);
-  double t2 = x;
-
-  for (int iterations = 0; iterations < 8; ++iterations) {
-    const double xValue = coefficients.sample(t2) - x;
-    if (std::abs(xValue) < epsilon) {
-      // A cubic can also cross x outside [0, 1]; only a root within the curve's
-      // own domain is a valid solution.
-      if (t2 >= 0.0 && t2 <= 1.0) {
-        return t2;
-      }
-      break;
-    }
-    const double dX = coefficients.sampleDerivative(t2);
-    if (std::abs(dX) < epsilon) {
-      break;
-    }
-    t2 = t2 - xValue / dX;
-  }
-
-  double t0 = 0.0, t1 = 1.0;
-  t2 = std::clamp(x, t0, t1);
-
-  while (t0 < t1) {
-    const double xValue = coefficients.sample(t2);
-    if (std::abs(xValue - x) < epsilon) {
-      return t2;
-    }
-    if (x > xValue) {
-      t0 = t2;
-    } else {
-      t1 = t2;
-    }
-    const double next = (t0 + t1) / 2.0;
-    if (next == t2) {
-      break;
-    }
-    t2 = next;
-  }
-
-  return t2;
+  return solveCurve(x, Coefficients(x1, x2), epsilon);
 }
 
 EasingFunction cubicBezier(const double x1, const double y1, const double x2, const double y2) {
-  return [=](double x) {
-    const double t = solveCurveX(x, x1, x2);
-    return sampleCurveY(t, y1, y2);
+  // Both axes are fixed for the lifetime of the easing, so their coefficients
+  // are computed here rather than on every sample.
+  const Coefficients xCurve(x1, x2);
+  const Coefficients yCurve(y1, y2);
+
+  return [xCurve, yCurve](const double x) {
+    return yCurve.sample(solveCurve(x, xCurve, kCubicBezierEpsilon));
   };
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.cpp
@@ -1,6 +1,5 @@
 #include <reanimated/CSS/easing/cubicBezier.h>
 
-#include <algorithm>
 #include <cmath>
 #include <cstdint>
 
@@ -10,6 +9,8 @@ namespace {
 
 constexpr double kEpsilon = 1e-6;
 constexpr std::uint8_t kMaxNewtonIterations = 8;
+/// Enough halvings of [0, 1] to reach double precision.
+constexpr std::uint8_t kMaxBisectionIterations = 60;
 
 /// One axis of a unit cubic Bezier in Horner form, as in WebKit's UnitBezier.
 /// The derivative shares these coefficients so the two cannot disagree.
@@ -51,23 +52,21 @@ double solveCurve(const double x, const CurveCoefficients &curve) {
     t -= distance / slope;
   }
 
+  // Bisection converges on the unique root, and on the nearest endpoint when x
+  // falls outside [0, 1]. Running it to full precision rather than stopping at
+  // the first sample within kEpsilon keeps the fallback accurate on curves with
+  // a near-flat region, where a small error in x is a large one in t.
   double low = 0.0, high = 1.0;
-  t = std::clamp(x, low, high);
-
-  while (low < high) {
-    const double sampled = curve.sample(t);
-    if (std::abs(sampled - x) < kEpsilon) {
-      return t;
+  for (std::uint8_t iteration = 0; iteration < kMaxBisectionIterations; ++iteration) {
+    const double middle = (low + high) / 2.0;
+    if (curve.sample(middle) < x) {
+      low = middle;
+    } else {
+      high = middle;
     }
-    (x > sampled ? low : high) = t;
-    const double next = (low + high) / 2.0;
-    if (next == t) {
-      break;
-    }
-    t = next;
   }
 
-  return t;
+  return (low + high) / 2.0;
 }
 
 } // namespace

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.cpp
@@ -9,8 +9,9 @@ namespace {
 
 constexpr double kEpsilon = 1e-6;
 constexpr std::uint8_t kMaxNewtonIterations = 8;
-/// Enough halvings of [0, 1] to reach double precision.
-constexpr std::uint8_t kMaxBisectionIterations = 60;
+/// Halving [0, 1] this many times takes the interval below kEpsilon, which is
+/// the tolerance the solver works to; further halving cannot improve on it.
+constexpr std::uint8_t kMaxBisectionIterations = 20;
 
 /// One axis of a unit cubic Bezier in Horner form, as in WebKit's UnitBezier.
 /// The derivative shares these coefficients so the two cannot disagree.
@@ -53,9 +54,9 @@ double solveCurve(const double x, const CurveCoefficients &curve) {
   }
 
   // Bisection converges on the unique root, and on the nearest endpoint when x
-  // falls outside [0, 1]. Running it to full precision rather than stopping at
-  // the first sample within kEpsilon keeps the fallback accurate on curves with
-  // a near-flat region, where a small error in x is a large one in t.
+  // falls outside [0, 1]. Narrowing the interval rather than returning the first
+  // sample within kEpsilon keeps the fallback accurate on curves with a
+  // near-flat region, where a small error in x is a large one in t.
   double low = 0.0, high = 1.0;
   for (std::uint8_t iteration = 0; iteration < kMaxBisectionIterations; ++iteration) {
     const double middle = (low + high) / 2.0;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.cpp
@@ -8,27 +8,17 @@ namespace reanimated::css {
 
 namespace {
 
-/// Newton's method converges within a few steps for the curves CSS allows;
-/// the bisection fallback covers the rest.
+constexpr double kEpsilon = 1e-6;
 constexpr std::uint8_t kMaxNewtonIterations = 8;
 
-/// Polynomial coefficients of one axis of a unit cubic Bezier with control
-/// points (0, 0), (p1, ...), (p2, ...), (1, 1):
-///
-///   f(t) = ((a * t + b) * t + c) * t   with c = 3 * p1,
-///                                          b = 3 * (p2 - p1) - c,
-///                                          a = 1 - c - b
-///
-/// Expanding that gives the Bernstein polynomial the CSS easing spec defines,
-/// and it is the form WebKit's UnitBezier uses:
+/// One axis of a unit cubic Bezier in Horner form, as in WebKit's UnitBezier:
 /// https://www.w3.org/TR/css-easing-1/#cubic-bezier-easing-functions
 /// https://github.com/WebKit/WebKit/blob/main/Source/WebCore/platform/graphics/UnitBezier.h
-///
-/// The derivative comes from the same coefficients so the two cannot disagree -
-/// a separately expanded derivative is easy to get wrong, and a wrong one sends
-/// Newton's method outside [0, 1].
+/// The derivative shares these coefficients, so the two cannot disagree - a
+/// separately expanded one is easy to get wrong, and a wrong one sends Newton's
+/// method outside [0, 1].
 struct Coefficients {
-  // Declared in initialisation order: b depends on c, a depends on both.
+  // Declared in initialisation order: b needs c, a needs both.
   double c, b, a;
 
   constexpr Coefficients(const double p1, const double p2) : c(3.0 * p1), b(3.0 * (p2 - p1) - c), a(1.0 - c - b) {}
@@ -42,25 +32,25 @@ struct Coefficients {
   }
 };
 
-/// Inverts x over the curve's own domain. x is monotonic on [0, 1] for the
-/// control points CSS permits, so the root there is unique.
-double solveCurve(const double x, const Coefficients &curve, const double epsilon) {
+/// Inverts x over the curve's own domain, where CSS control points make it
+/// monotonic and the root unique.
+double solveCurve(const double x, const Coefficients &curve) {
   double t = x;
 
   for (std::uint8_t iteration = 0; iteration < kMaxNewtonIterations; ++iteration) {
     const double distance = curve.sample(t) - x;
-    if (std::abs(distance) < epsilon) {
-      // A cubic can also cross x outside [0, 1]; such a root is not a solution.
+    if (std::abs(distance) < kEpsilon) {
+      // A cubic also crosses x outside [0, 1]; such a root is not a solution.
       if (t >= 0.0 && t <= 1.0) {
         return t;
       }
       break;
     }
     const double slope = curve.sampleDerivative(t);
-    if (std::abs(slope) < epsilon) {
+    if (std::abs(slope) < kEpsilon) {
       break;
     }
-    t = t - distance / slope;
+    t -= distance / slope;
   }
 
   double low = 0.0, high = 1.0;
@@ -68,14 +58,10 @@ double solveCurve(const double x, const Coefficients &curve, const double epsilo
 
   while (low < high) {
     const double sampled = curve.sample(t);
-    if (std::abs(sampled - x) < epsilon) {
+    if (std::abs(sampled - x) < kEpsilon) {
       return t;
     }
-    if (x > sampled) {
-      low = t;
-    } else {
-      high = t;
-    }
+    (x > sampled ? low : high) = t;
     const double next = (low + high) / 2.0;
     if (next == t) {
       break;
@@ -88,22 +74,6 @@ double solveCurve(const double x, const Coefficients &curve, const double epsilo
 
 } // namespace
 
-double sampleCurveX(const double t, const double x1, const double x2) {
-  return Coefficients(x1, x2).sample(t);
-}
-
-double sampleCurveY(const double t, const double y1, const double y2) {
-  return Coefficients(y1, y2).sample(t);
-}
-
-double sampleCurveDerivativeX(const double t, const double x1, const double x2) {
-  return Coefficients(x1, x2).sampleDerivative(t);
-}
-
-double solveCurveX(const double x, const double x1, const double x2, const double epsilon) {
-  return solveCurve(x, Coefficients(x1, x2), epsilon);
-}
-
 EasingFunction cubicBezier(const double x1, const double y1, const double x2, const double y2) {
   // Both axes are fixed for the lifetime of the easing, so their coefficients
   // are computed here rather than on every sample.
@@ -111,7 +81,7 @@ EasingFunction cubicBezier(const double x1, const double y1, const double x2, co
   const Coefficients yCurve(y1, y2);
 
   return [xCurve, yCurve](const double x) {
-    return yCurve.sample(solveCurve(x, xCurve, kCubicBezierEpsilon));
+    return yCurve.sample(solveCurve(x, xCurve));
   };
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.cpp
@@ -9,9 +9,8 @@ namespace {
 
 constexpr double kEpsilon = 1e-6;
 constexpr std::uint8_t kMaxNewtonIterations = 8;
-/// Halving [0, 1] this many times takes the interval below kEpsilon, which is
-/// the tolerance the solver works to; further halving cannot improve on it.
-constexpr std::uint8_t kMaxBisectionIterations = 20;
+/// Enough halvings of [0, 1] to reach double precision.
+constexpr std::uint8_t kMaxBisectionIterations = 60;
 
 /// One axis of a unit cubic Bezier in Horner form, as in WebKit's UnitBezier.
 /// The derivative shares these coefficients so the two cannot disagree.
@@ -39,7 +38,7 @@ double solveCurve(const double x, const CurveCoefficients &curve) {
 
   for (std::uint8_t iteration = 0; iteration < kMaxNewtonIterations; ++iteration) {
     const double distance = curve.sample(t) - x;
-    if (std::abs(distance) < kEpsilon) {
+    if (distance == 0.0) {
       // A cubic also crosses x outside [0, 1]; that root is not a solution.
       if (t >= 0.0 && t <= 1.0) {
         return t;
@@ -50,13 +49,19 @@ double solveCurve(const double x, const CurveCoefficients &curve) {
     if (std::abs(slope) < kEpsilon) {
       break;
     }
+    if (std::abs(distance) < kEpsilon) {
+      if (t >= 0.0 && t <= 1.0) {
+        return t;
+      }
+      break;
+    }
     t -= distance / slope;
   }
 
   // Bisection converges on the unique root, and on the nearest endpoint when x
-  // falls outside [0, 1]. Narrowing the interval rather than returning the first
-  // sample within kEpsilon keeps the fallback accurate on curves with a
-  // near-flat region, where a small error in x is a large one in t.
+  // falls outside [0, 1]. Running it to full precision rather than stopping at
+  // the first sample within kEpsilon keeps the fallback accurate on curves with
+  // a near-flat region, where a small error in x is a large one in t.
   double low = 0.0, high = 1.0;
   for (std::uint8_t iteration = 0; iteration < kMaxBisectionIterations; ++iteration) {
     const double middle = (low + high) / 2.0;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.cpp
@@ -50,19 +50,20 @@ double solveCurve(const double x, const CurveCoefficients &curve) {
       break;
     }
     const double step = distance / slope;
+    t -= step;
     if (std::abs(distance) < kEpsilon && std::abs(step) < kEpsilon) {
       if (t >= 0.0 && t <= 1.0) {
         return t;
       }
       break;
     }
-    t -= step;
   }
 
   // Bisection converges on the unique root, and on the nearest endpoint when x
   // falls outside [0, 1]. Running it to full precision rather than stopping at
   // the first sample within kEpsilon keeps the fallback accurate on curves with
   // a near-flat region, where a small error in x is a large one in t.
+  // Callers clamp x to [0, 1]. CSS requires tangent extension outside this range.
   double low = 0.0, high = 1.0;
   for (std::uint8_t iteration = 0; iteration < kMaxBisectionIterations; ++iteration) {
     const double middle = (low + high) / 2.0;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.cpp
@@ -11,17 +11,15 @@ namespace {
 constexpr double kEpsilon = 1e-6;
 constexpr std::uint8_t kMaxNewtonIterations = 8;
 
-/// One axis of a unit cubic Bezier in Horner form, as in WebKit's UnitBezier:
+/// One axis of a unit cubic Bezier in Horner form, as in WebKit's UnitBezier.
+/// The derivative shares these coefficients so the two cannot disagree.
 /// https://www.w3.org/TR/css-easing-1/#cubic-bezier-easing-functions
 /// https://github.com/WebKit/WebKit/blob/main/Source/WebCore/platform/graphics/UnitBezier.h
-/// The derivative shares these coefficients, so the two cannot disagree - a
-/// separately expanded one is easy to get wrong, and a wrong one sends Newton's
-/// method outside [0, 1].
-struct Coefficients {
+struct CurveCoefficients {
   // Declared in initialisation order: b needs c, a needs both.
   double c, b, a;
 
-  constexpr Coefficients(const double p1, const double p2) : c(3.0 * p1), b(3.0 * (p2 - p1) - c), a(1.0 - c - b) {}
+  constexpr CurveCoefficients(const double p1, const double p2) : c(3.0 * p1), b(3.0 * (p2 - p1) - c), a(1.0 - c - b) {}
 
   constexpr double sample(const double t) const {
     return ((a * t + b) * t + c) * t;
@@ -32,15 +30,15 @@ struct Coefficients {
   }
 };
 
-/// Inverts x over the curve's own domain, where CSS control points make it
-/// monotonic and the root unique.
-double solveCurve(const double x, const Coefficients &curve) {
+/// Inverts x over [0, 1], where CSS control points keep the curve monotonic and
+/// the root unique.
+double solveCurve(const double x, const CurveCoefficients &curve) {
   double t = x;
 
   for (std::uint8_t iteration = 0; iteration < kMaxNewtonIterations; ++iteration) {
     const double distance = curve.sample(t) - x;
     if (std::abs(distance) < kEpsilon) {
-      // A cubic also crosses x outside [0, 1]; such a root is not a solution.
+      // A cubic also crosses x outside [0, 1]; that root is not a solution.
       if (t >= 0.0 && t <= 1.0) {
         return t;
       }
@@ -75,10 +73,9 @@ double solveCurve(const double x, const Coefficients &curve) {
 } // namespace
 
 EasingFunction cubicBezier(const double x1, const double y1, const double x2, const double y2) {
-  // Both axes are fixed for the lifetime of the easing, so their coefficients
-  // are computed here rather than on every sample.
-  const Coefficients xCurve(x1, x2);
-  const Coefficients yCurve(y1, y2);
+  // Fixed for the lifetime of the easing, so not recomputed per sample.
+  const CurveCoefficients xCurve(x1, x2);
+  const CurveCoefficients yCurve(y1, y2);
 
   return [xCurve, yCurve](const double x) {
     return yCurve.sample(solveCurve(x, xCurve));

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.cpp
@@ -1,40 +1,71 @@
 #include <reanimated/CSS/easing/cubicBezier.h>
 
+#include <algorithm>
+
 namespace reanimated::css {
 
+namespace {
+
+/// Polynomial coefficients of a unit cubic Bezier with control points
+/// (0,0), (p1, ...), (p2, ...), (1,1), as used by WebKit's UnitBezier.
+/// Deriving the curve and its derivative from the same coefficients keeps them
+/// consistent - an independently expanded derivative is easy to get wrong, and
+/// a wrong one sends Newton's method outside [0, 1].
+struct Coefficients {
+  // Declared in initialisation order: b depends on c, a depends on both.
+  double c, b, a;
+
+  explicit Coefficients(const double p1, const double p2) : c(3.0 * p1), b(3.0 * (p2 - p1) - c), a(1.0 - c - b) {}
+
+  double sample(const double t) const {
+    return ((a * t + b) * t + c) * t;
+  }
+
+  double sampleDerivative(const double t) const {
+    return (3.0 * a * t + 2.0 * b) * t + c;
+  }
+};
+
+} // namespace
+
 double sampleCurveX(const double t, const double x1, const double x2) {
-  return 3 * (1 - t) * (1 - t) * t * x1 + 3 * (1 - t) * t * t * x2 + t * t * t;
+  return Coefficients(x1, x2).sample(t);
 }
 
 double sampleCurveY(const double t, const double y1, const double y2) {
-  return 3 * (1 - t) * (1 - t) * t * y1 + 3 * (1 - t) * t * t * y2 + t * t * t;
+  return Coefficients(y1, y2).sample(t);
 }
 
 double sampleCurveDerivativeX(const double t, const double x1, const double x2) {
-  return -6 * (1 - t) * t * x1 + 3 * (1 - t) * (1 - t) * x1 + 6 * (1 - t) * t * x2 - 6 * t * t * x2 + 3 * t * t;
+  return Coefficients(x1, x2).sampleDerivative(t);
 }
 
 double solveCurveX(const double x, const double x1, const double x2, const double epsilon) {
-  double t0 = 0.0, t1 = 1.0, t2 = x, xValue, dX;
-  int iterations = 0;
+  const Coefficients coefficients(x1, x2);
+  double t2 = x;
 
-  while (iterations < 8) {
-    xValue = sampleCurveX(t2, x1, x2) - x;
+  for (int iterations = 0; iterations < 8; ++iterations) {
+    const double xValue = coefficients.sample(t2) - x;
     if (std::abs(xValue) < epsilon) {
-      return t2;
+      // A cubic can also cross x outside [0, 1]; only a root within the curve's
+      // own domain is a valid solution.
+      if (t2 >= 0.0 && t2 <= 1.0) {
+        return t2;
+      }
+      break;
     }
-    dX = sampleCurveDerivativeX(t2, x1, x2);
+    const double dX = coefficients.sampleDerivative(t2);
     if (std::abs(dX) < epsilon) {
       break;
     }
     t2 = t2 - xValue / dX;
-    iterations++;
   }
 
-  // Fallback: Use binary search
+  double t0 = 0.0, t1 = 1.0;
+  t2 = std::clamp(x, t0, t1);
+
   while (t0 < t1) {
-    t2 = (t0 + t1) / 2.0;
-    xValue = sampleCurveX(t2, x1, x2);
+    const double xValue = coefficients.sample(t2);
     if (std::abs(xValue - x) < epsilon) {
       return t2;
     }
@@ -43,6 +74,11 @@ double solveCurveX(const double x, const double x1, const double x2, const doubl
     } else {
       t1 = t2;
     }
+    const double next = (t0 + t1) / 2.0;
+    if (next == t2) {
+      break;
+    }
+    t2 = next;
   }
 
   return t2;
@@ -50,7 +86,7 @@ double solveCurveX(const double x, const double x1, const double x2, const doubl
 
 EasingFunction cubicBezier(const double x1, const double y1, const double x2, const double y2) {
   return [=](double x) {
-    double t = solveCurveX(x, x1, x2);
+    const double t = solveCurveX(x, x1, x2);
     return sampleCurveY(t, y1, y2);
   };
 }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.cpp
@@ -49,13 +49,14 @@ double solveCurve(const double x, const CurveCoefficients &curve) {
     if (std::abs(slope) < kEpsilon) {
       break;
     }
-    if (std::abs(distance) < kEpsilon) {
+    const double step = distance / slope;
+    if (std::abs(distance) < kEpsilon && std::abs(step) < kEpsilon) {
       if (t >= 0.0 && t <= 1.0) {
         return t;
       }
       break;
     }
-    t -= distance / slope;
+    t -= step;
   }
 
   // Bisection converges on the unique root, and on the nearest endpoint when x

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.h
@@ -4,15 +4,6 @@
 
 namespace reanimated::css {
 
-double sampleCurveX(double t, double x1, double x2);
-double sampleCurveY(double t, double y1, double y2);
-double sampleCurveDerivativeX(double t, double x1, double x2);
-/// Tolerance on x when inverting the curve; a single source of truth so the
-/// declaration and the solver cannot disagree.
-inline constexpr double kCubicBezierEpsilon = 1e-6;
-
-double solveCurveX(double x, double x1, double x2, double epsilon = kCubicBezierEpsilon);
-
 EasingFunction cubicBezier(double x1, double y1, double x2, double y2);
 EasingFunction cubicBezier(jsi::Runtime &rt, const jsi::Object &easingConfig);
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.h
@@ -7,7 +7,11 @@ namespace reanimated::css {
 double sampleCurveX(double t, double x1, double x2);
 double sampleCurveY(double t, double y1, double y2);
 double sampleCurveDerivativeX(double t, double x1, double x2);
-double solveCurveX(double x, double x1, double x2, double epsilon = 1e-6);
+/// Tolerance on x when inverting the curve; a single source of truth so the
+/// declaration and the solver cannot disagree.
+inline constexpr double kCubicBezierEpsilon = 1e-6;
+
+double solveCurveX(double x, double x1, double x2, double epsilon = kCubicBezierEpsilon);
 
 EasingFunction cubicBezier(double x1, double y1, double x2, double y2);
 EasingFunction cubicBezier(jsi::Runtime &rt, const jsi::Object &easingConfig);


### PR DESCRIPTION
`sampleCurveDerivativeX` returned the wrong derivative of the easing curve's x-component: the `x2` term differentiated to `-6 * t * t * x2` instead of `-3 * t * t * x2`. At `t = 0.9` that gives `-0.076` against a true `+1.334`, so Newton's method stepped the wrong way, left `[0, 1]` and converged on a root the cubic also has outside its own domain. The solver returned that root and the sampled y extrapolated past the endpoints, so a transition committed a value beyond its target for a single frame - a brief flicker across every view animating at that moment. The error grows with `t`, which put the failure late in a transition, on roughly 0.04% of progress values.

Curve and derivative now come from the same polynomial coefficients, the form WebKit's `UnitBezier` uses, so they cannot drift apart again. A root outside `[0, 1]` falls back to bisection, which is safe because x is monotonic over `[0, 1]` for the control points CSS allows.

Against a high-precision solve, max error for `ease-out` drops from `0.844` to `1.7e-06` and for `cubic-bezier(0.1, 0.9, 0.9, 0.1)` from `3.99` to `8.4e-06`, with no out-of-range outputs in 2.4M samples. On device, logging every committed transition value: one overshoot per 141s before (`opacity: 1.7102`), none in 28 minutes after. Any `cubic-bezier()` can be affected, not just `ease-out`.

## Examples

<img width="300" alt="4overshootframe" src="https://github.com/user-attachments/assets/66e28408-9aad-4412-ac8a-b21cd8bf2107" />

https://github.com/user-attachments/assets/0b47b9da-97f2-444e-bf71-8b8cc2dc92d7

