### PR TITLE
ci: enforce the formatting and type checks CI was skipping

### DIFF
--- a/.github/workflows/example-typescript-check-and-lint.yml
+++ b/.github/workflows/example-typescript-check-and-lint.yml
@@ -54,9 +54,8 @@ jobs:
               - apps/common-app/**
             tvos:
               - apps/tvos-example/**
-            # TODO: fix fabric-example
-            # fabric:
-            #   - apps/fabric-example/**
+            fabric:
+              - apps/fabric-example/**
             # TODO: fix macos-example
             # macos:
             #   - apps/macos-example/**
@@ -73,19 +72,19 @@ jobs:
           SHARED: ${{ steps.filter.outputs.shared }}
           COMMON: ${{ steps.filter.outputs.common-app }}
           TVOS: ${{ steps.filter.outputs.tvos }}
-          # FABRIC: ${{ steps.filter.outputs.fabric }}
+          FABRIC: ${{ steps.filter.outputs.fabric }}
           # MACOS: ${{ steps.filter.outputs.macos }}
           # NEXT: ${{ steps.filter.outputs.next }}
           # WEB: ${{ steps.filter.outputs.web }}
         run: |
           if [[ "$IS_PR" != "true" || "$SHARED" == "true" ]]; then
-            ts_apps='["apps/common-app","apps/tvos-example"]'
+            ts_apps='["apps/common-app","apps/tvos-example","apps/fabric-example"]'
             web=true
           else
             apps=()
             [[ "$COMMON" == "true" ]] && apps+=("apps/common-app")
             [[ "$TVOS"   == "true" ]] && apps+=("apps/tvos-example")
-            # [[ "$FABRIC" == "true" ]] && apps+=("apps/fabric-example")
+            [[ "$FABRIC" == "true" ]] && apps+=("apps/fabric-example")
             # [[ "$MACOS"  == "true" ]] && apps+=("apps/macos-example")
             # [[ "$NEXT"   == "true" ]] && apps+=("apps/next-example")
             # [[ "$WEB"    == "true" ]] && apps+=("apps/web-example")

--- a/.github/workflows/monorepo-static-checks.yml
+++ b/.github/workflows/monorepo-static-checks.yml
@@ -3,18 +3,12 @@ env:
   YARN_ENABLE_HARDENED_MODE: 0
 on:
   pull_request:
-    paths-ignore:
-      - packages/
-      - apps/
   merge_group:
     branches:
       - main
   push:
     branches:
       - main
-    paths-ignore:
-      - packages/
-      - apps/
   workflow_call:
   workflow_dispatch:
 

--- a/.lintstagedrc-common.js
+++ b/.lintstagedrc-common.js
@@ -1,6 +1,6 @@
 /** @type {import('lint-staged').Configuration} */
 module.exports = {
-  '*.(js|jsx|ts|tsx)': [
+  '*.(js|jsx|mjs|cjs|ts|tsx|mts|cts)': [
     'yarn eslint --flag v10_config_lookup_from_file',
     'yarn run --top-level oxfmt',
   ],

--- a/apps/fabric-example/.lintstagedrc.js
+++ b/apps/fabric-example/.lintstagedrc.js
@@ -1,0 +1,6 @@
+const commonConfig = require('../../.lintstagedrc-common.js');
+
+/** @type {import('lint-staged').Configuration} */
+module.exports = {
+  ...commonConfig,
+};

--- a/apps/fabric-example/package.json
+++ b/apps/fabric-example/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "@types/react": "19.2.18",
+    "@types/ws": "8.18.1",
     "eslint": "9.37.0",
     "typescript": "5.9.3",
     "ws": "8.21.0"

--- a/apps/fabric-example/scripts/export-runtime-tests-app.js
+++ b/apps/fabric-example/scripts/export-runtime-tests-app.js
@@ -21,6 +21,7 @@ const LIBRARIES = ['reanimated', 'worklets', 'self-tests'];
 const projectRoot = path.resolve(__dirname, '..');
 const iosDir = path.join(projectRoot, 'ios');
 
+/** @type {Record<string, string | true>} */
 const args = {};
 const BOOLEAN_FLAGS = new Set(['print-path', 'allow-debug', 'help']);
 
@@ -59,17 +60,32 @@ Options:
   process.exit(0);
 }
 
-const CONFIGURATION = args.configuration ?? 'ReleaseRuntimeTests';
+const CONFIGURATION =
+  typeof args.configuration === 'string'
+    ? args.configuration
+    : 'ReleaseRuntimeTests';
 const OUT = path.resolve(
   projectRoot,
-  args.out ?? path.join('dist', `FabricExample-${CONFIGURATION}.app.zip`)
+  typeof args.out === 'string'
+    ? args.out
+    : path.join('dist', `FabricExample-${CONFIGURATION}.app.zip`)
 );
 
+/**
+ * @param {string} message
+ * @returns {never}
+ */
 function fail(message) {
   console.error(`[export-app] ${message}`);
   process.exit(1);
 }
 
+/**
+ * @param {string} command
+ * @param {string[]} argv
+ * @param {import('child_process').ExecFileOptions} [options]
+ * @returns {Promise<{ stdout: string; stderr: string }>}
+ */
 function run(command, argv, options = {}) {
   return new Promise((resolve, reject) => {
     execFile(
@@ -113,11 +129,13 @@ async function resolveAppPath() {
     fail(`xcodebuild -showBuildSettings returned no JSON payload`);
   }
 
+  /** @type {{ buildSettings?: Record<string, string> }[]} */
   const entries = JSON.parse(stdout.slice(jsonStart));
 
   const entry =
     entries.find(
-      (candidate) => candidate.buildSettings.WRAPPER_NAME === 'FabricExample.app'
+      (candidate) =>
+        candidate.buildSettings?.WRAPPER_NAME === 'FabricExample.app'
     ) ?? entries[0];
 
   if (!entry?.buildSettings) {
@@ -129,6 +147,7 @@ async function resolveAppPath() {
   return path.join(TARGET_BUILD_DIR, WRAPPER_NAME);
 }
 
+/** @param {string} app */
 function assertExportable(app) {
   if (!fs.existsSync(app)) {
     fail(

--- a/apps/fabric-example/scripts/runtime-tests-remote.mjs
+++ b/apps/fabric-example/scripts/runtime-tests-remote.mjs
@@ -44,11 +44,21 @@ const projectRoot = path.resolve(scriptDir, '..');
 const SERVER_SCRIPT = path.join(scriptDir, 'runtime-tests-server.js');
 const METRO_LOG = path.join(os.tmpdir(), 'metro-runtime-tests.log');
 
+/**
+ * @param {string} message
+ * @returns {never}
+ */
 function fail(message) {
   console.error(`[runtime-tests-remote] ${message}`);
   process.exit(1);
 }
 
+/** @param {unknown} error */
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/** @param {string} message */
 function log(message) {
   console.log(`[runtime-tests-remote] ${message}`);
 }
@@ -56,6 +66,7 @@ function log(message) {
 // ── argument parsing ──
 
 const [SUBCOMMAND, ...rest] = process.argv.slice(2);
+/** @type {Record<string, string>} */
 const args = {};
 for (let i = 0; i < rest.length; i++) {
   const flag = rest[i];
@@ -71,22 +82,35 @@ const LIBRARY = args.library ?? '';
 const CONFIGURATION = args.configuration ?? 'ReleaseRuntimeTests';
 const ONLY = args.only ?? '';
 
+/**
+ * @param {string} name
+ * @param {string | number} value
+ */
 function positiveInt(name, value) {
   const parsed = Number(value);
 
   if (!Number.isInteger(parsed) || parsed <= 0) {
-    fail(`--${name} must be a positive integer, got: ${value}`)
+    fail(`--${name} must be a positive integer, got: ${value}`);
   }
 
   return parsed;
 }
 
-const METRO_PORT = positiveInt('metro-port', args['metro-port'] ?? 8081)
-const CONNECT_TIMEOUT = positiveInt('connect-timeout', args['connect-timeout'] ?? 900)
-const IDLE_TIMEOUT = positiveInt('idle-timeout', args['idle-timeout'] ?? 900)
+const METRO_PORT = positiveInt('metro-port', args['metro-port'] ?? 8081);
+const CONNECT_TIMEOUT = positiveInt(
+  'connect-timeout',
+  args['connect-timeout'] ?? 900
+);
+const IDLE_TIMEOUT = positiveInt('idle-timeout', args['idle-timeout'] ?? 900);
 
 // ── process helpers ──
 
+/**
+ * @param {string} command
+ * @param {string[]} cmdArgs
+ * @param {import('node:child_process').ExecFileOptions} [options]
+ * @returns {Promise<{ stdout: string; stderr: string }>}
+ */
 function run(command, cmdArgs, options = {}) {
   return new Promise((resolve, reject) => {
     execFile(
@@ -108,6 +132,10 @@ function run(command, cmdArgs, options = {}) {
   });
 }
 
+/**
+ * @param {string[]} cmdArgs
+ * @param {import('node:child_process').ExecFileOptions} [options]
+ */
 const simRemote = (cmdArgs, options) => run('sim-remote', cmdArgs, options);
 
 function assertSimRemote() {
@@ -124,12 +152,13 @@ function assertSimRemote() {
 // errors with "tunnel already active" on re-runs — tolerate that (same
 // semantics as argent's proxyStart wrapper) so runs can blindly ensure
 // their tunnels exist.
+/** @param {number} port */
 async function ensureTunnel(port) {
   log(`ensuring reverse tunnel for port ${port}`);
   try {
     await simRemote(['proxy', 'start', UDID, String(port)]);
   } catch (error) {
-    if (/already/i.test(error.message)) {
+    if (/already/i.test(errorMessage(error))) {
       log(`tunnel already active on port ${port}`);
       return;
     }
@@ -157,6 +186,7 @@ function metroRunning() {
   });
 }
 
+/** @param {number} ms */
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 // Start Metro on this host unless one is already serving. Mirrors the local
@@ -199,7 +229,9 @@ async function pick() {
   const candidates = devices
     .filter((device) => device.isAvailable !== false)
     .filter((device) => device.name.startsWith('iPhone'))
-    .sort((a, b) => (a.state === 'Booted' ? 0 : 1) - (b.state === 'Booted' ? 0 : 1));
+    .sort(
+      (a, b) => (a.state === 'Booted' ? 0 : 1) - (b.state === 'Booted' ? 0 : 1)
+    );
   if (candidates.length === 0) {
     fail('no available remote iPhone simulator found');
   }
@@ -241,8 +273,14 @@ async function runLibrary() {
     // Explicitly point the app at this Metro (inside the sim, localhost
     // means the remote Mac — the tunnel makes this address land here).
     await simRemote([
-      'spawn', UDID, '--',
-      'defaults', 'write', BUNDLE_ID, 'RCT_jsLocation', `127.0.0.1:${METRO_PORT}`,
+      'spawn',
+      UDID,
+      '--',
+      'defaults',
+      'write',
+      BUNDLE_ID,
+      'RCT_jsLocation',
+      `127.0.0.1:${METRO_PORT}`,
     ]);
   }
   await ensureTunnel(wsPort);
@@ -254,20 +292,32 @@ async function runLibrary() {
   // cannot race the listener. Server mode: no --launch, the device is ours.
   const serverArgs = [
     SERVER_SCRIPT,
-    '--library', LIBRARY,
-    '--platform', 'ios',
-    '--configuration', CONFIGURATION,
-    '--port', String(wsPort),
-    '--connect-timeout', String(CONNECT_TIMEOUT),
-    '--idle-timeout', String(IDLE_TIMEOUT),
+    '--library',
+    LIBRARY,
+    '--platform',
+    'ios',
+    '--configuration',
+    CONFIGURATION,
+    '--port',
+    String(wsPort),
+    '--connect-timeout',
+    String(CONNECT_TIMEOUT),
+    '--idle-timeout',
+    String(IDLE_TIMEOUT),
   ];
   if (ONLY) {
     serverArgs.push('--only', ONLY);
   }
 
-  const server = spawn('node', serverArgs, { cwd: projectRoot, stdio: 'inherit' });
+  const server = spawn('node', serverArgs, {
+    cwd: projectRoot,
+    stdio: 'inherit',
+  });
 
-  for (const signal of ['SIGINT', 'SIGTERM']) {
+  /** @type {('SIGINT' | 'SIGTERM')[]} */
+  const signals = ['SIGINT', 'SIGTERM'];
+
+  for (const signal of signals) {
     process.once(signal, () => {
       server.kill(signal);
       process.exit(1);
@@ -285,7 +335,7 @@ async function runLibrary() {
   } catch (error) {
     // Don't leave the collector hanging for the full connect timeout.
     server.kill();
-    fail(`launch failed: ${error.message}`);
+    fail(`launch failed: ${errorMessage(error)}`);
   }
 
   const exitCode = await serverExit;
@@ -295,11 +345,14 @@ async function runLibrary() {
 
 // ── dispatch ──
 
+/** @type {Record<string, () => Promise<void>>} */
 const subcommands = { pick, install, run: runLibrary };
 if (!subcommands[SUBCOMMAND]) {
-  fail(`unknown subcommand: ${SUBCOMMAND ?? '(none)'} (expected pick | install | run)`);
+  fail(
+    `unknown subcommand: ${SUBCOMMAND ?? '(none)'} (expected pick | install | run)`
+  );
 }
 assertSimRemote();
 subcommands[SUBCOMMAND]().catch((error) => {
-  fail(error.message);
+  fail(errorMessage(error));
 });

--- a/apps/fabric-example/scripts/runtime-tests-server.js
+++ b/apps/fabric-example/scripts/runtime-tests-server.js
@@ -21,6 +21,16 @@ const SANITIZER_REPORT_DIR = path.join(projectRoot, 'sanitizer-reports');
 // -enable*Sanitizer alone does not reach the Pods project on CI (the built
 // products carried no -fsanitize flags), so each build setting is also forced
 // as a command-line override, which applies to every target.
+/**
+ * @type {Record<
+ *   string,
+ *   {
+ *     buildArgs: string[];
+ *     launchEnv: Record<string, string>;
+ *     runtimePrefix: string;
+ *   }
+ * >}
+ */
 const SANITIZERS = {
   thread: {
     buildArgs: ['-enableThreadSanitizer', 'YES', 'ENABLE_THREAD_SANITIZER=YES'],
@@ -56,25 +66,30 @@ if (args.help) {
 const LIBRARY = String(args.library ?? '').toLowerCase();
 const PLATFORM = String(args.platform ?? 'ios').toLowerCase();
 const METRO_PORT = Number(args['metro-port'] ?? 8081);
-const CONFIGURATION = args.configuration ?? 'DebugRuntimeTests';
+const CONFIGURATION =
+  typeof args.configuration === 'string'
+    ? args.configuration
+    : 'DebugRuntimeTests';
 const IS_RELEASE = CONFIGURATION.startsWith('Release');
 // Release builds have no Metro; the app then reports to port 8082.
 const PORT = Number(args.port ?? (IS_RELEASE ? 8082 : METRO_PORT + 1));
-const ONLY = args.only
-  ? args.only
-      .split(',')
-      .map((s) => s.trim())
-      .filter(Boolean)
-  : null;
+const ONLY =
+  typeof args.only === 'string'
+    ? args.only
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+    : null;
 const CONNECT_TIMEOUT_MS = Number(args['connect-timeout'] ?? 600) * 1000;
 const IDLE_TIMEOUT_MS = Number(args['idle-timeout'] ?? 600) * 1000;
 const SHOULD_LAUNCH = args.launch === true || args.launch === '';
 const BUILD_ONLY = args['build-only'] === true || args['build-only'] === '';
 const SKIP_BUILD = args['skip-build'] === true || args['skip-build'] === '';
-const SIMULATOR = args.simulator ?? 'iPhone 17';
-const UDID = args.udid ?? null;
-const SERIAL = args.serial ?? null;
-const AVD = args.avd ?? null;
+const SIMULATOR =
+  typeof args.simulator === 'string' ? args.simulator : 'iPhone 17';
+const UDID = typeof args.udid === 'string' ? args.udid : null;
+const SERIAL = typeof args.serial === 'string' ? args.serial : null;
+const AVD = typeof args.avd === 'string' ? args.avd : null;
 const SANITIZER = args.sanitizer ? String(args.sanitizer).toLowerCase() : null;
 
 if (!BUILD_ONLY && !LIBRARIES.includes(LIBRARY)) {
@@ -115,18 +130,32 @@ if (BUILD_ONLY && SHOULD_LAUNCH) {
   process.exit(1);
 }
 
+/** @typedef {{ type?: string; [key: string]: any }} DeviceMessage */
+
+/** @type {import('ws').WebSocket | null} */
 let client = null;
 let runStartedAt = 0;
 let exitCode = 1;
 let runFinished = false;
+/** @type {ReturnType<typeof setTimeout> | null} */
 let connectTimer = null;
+/** @type {ReturnType<typeof setTimeout> | null} */
 let idleTimer = null;
+/** @type {import('child_process').ChildProcess | null} */
 let metroChild = null;
+
+/**
+ * @param {unknown} error
+ * @returns {string}
+ */
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
 
 const wss = new WebSocketServer({ port: PORT, host: '0.0.0.0' });
 
 wss.on('error', (error) => {
-  if (error.code === 'EADDRINUSE') {
+  if (/** @type {{ code?: string }} */ (error).code === 'EADDRINUSE') {
     console.error(
       `[runtime-tests] port ${PORT} is already in use — is another runtime-tests server (or Metro) running there? Stop it or pass --port.`
     );
@@ -179,7 +208,10 @@ wss.on('connection', (socket) => {
     try {
       msg = JSON.parse(raw.toString());
     } catch (error) {
-      console.warn('[runtime-tests] failed to parse message:', error.message);
+      console.warn(
+        '[runtime-tests] failed to parse message:',
+        errorMessage(error)
+      );
       return;
     }
     handleMessage(msg);
@@ -216,6 +248,7 @@ wss.on('connection', (socket) => {
   });
 });
 
+/** @param {DeviceMessage} msg */
 function handleMessage(msg) {
   switch (msg.type) {
     case 'hello':
@@ -235,8 +268,11 @@ function handleMessage(msg) {
   }
 }
 
+/** @param {DeviceMessage} msg */
 function onHello(msg) {
-  const declared = (msg.suites ?? []).map((s) => s.name);
+  /** @type {{ name: string }[]} */
+  const suites = msg.suites ?? [];
+  const declared = suites.map((s) => s.name);
   const deviceLibrary = String(msg.library ?? '').toLowerCase();
   console.log(
     `[runtime-tests] hello from ${msg.platform} ${msg.platformVersion} (${deviceLibrary}), ${declared.length} suites declared: ${declared.join(', ')}`
@@ -273,6 +309,7 @@ function onHello(msg) {
   console.log('[runtime-tests] start sent, running tests…');
 }
 
+/** @param {DeviceMessage} msg */
 function onLog(msg) {
   const logArgs = Array.isArray(msg.args) ? msg.args : [];
   const line = logArgs.join(' ');
@@ -288,6 +325,7 @@ function onLog(msg) {
   }
 }
 
+/** @param {DeviceMessage} msg */
 function onDone(msg) {
   const elapsed = ((Date.now() - runStartedAt) / 1000).toFixed(1);
   console.log('');
@@ -314,6 +352,7 @@ function onDone(msg) {
   }
 }
 
+/** @param {DeviceMessage} msg */
 function onError(msg) {
   console.error(`[runtime-tests] device reported error: ${msg.message}`);
   if (msg.stack) {
@@ -328,6 +367,7 @@ function onError(msg) {
   }
 }
 
+/** @param {Record<string, unknown>} payload */
 function send(payload) {
   if (client && client.readyState === client.OPEN) {
     client.send(JSON.stringify(payload));
@@ -344,6 +384,7 @@ function resetIdleTimer() {
   }, IDLE_TIMEOUT_MS);
 }
 
+/** @param {'connect' | 'idle'} which */
 function clearTimer(which) {
   if (which === 'connect' && connectTimer) {
     clearTimeout(connectTimer);
@@ -376,11 +417,12 @@ function printSanitizerReports() {
   );
 }
 
+/** @param {number} code */
 function shutdown(code) {
   printSanitizerReports();
   clearTimer('connect');
   clearTimer('idle');
-  if (metroChild && !metroChild.killed) {
+  if (metroChild && !metroChild.killed && metroChild.pid !== undefined) {
     try {
       process.kill(-metroChild.pid, 'SIGTERM');
     } catch {
@@ -397,6 +439,12 @@ function shutdown(code) {
   setTimeout(() => process.exit(code), 1000).unref();
 }
 
+/**
+ * @param {string} cmd
+ * @param {string[]} cmdArgs
+ * @param {import('child_process').ExecFileOptions} [options]
+ * @returns {Promise<{ stdout: string; stderr: string }>}
+ */
 function run(cmd, cmdArgs, options = {}) {
   return new Promise((resolve, reject) => {
     execFile(
@@ -416,9 +464,16 @@ function run(cmd, cmdArgs, options = {}) {
   });
 }
 
+/**
+ * @param {string} host
+ * @param {number} port
+ * @param {number} [timeoutMs]
+ * @returns {Promise<boolean>}
+ */
 function probeTcp(host, port, timeoutMs = 500) {
   return new Promise((resolve) => {
     const socket = new net.Socket();
+    /** @param {boolean} result */
     const done = (result) => {
       socket.destroy();
       resolve(result);
@@ -431,6 +486,10 @@ function probeTcp(host, port, timeoutMs = 500) {
   });
 }
 
+/**
+ * @param {number} [timeoutMs]
+ * @returns {Promise<boolean>}
+ */
 function probeMetro(timeoutMs = 1000) {
   return new Promise((resolve) => {
     const req = http.get(
@@ -487,10 +546,10 @@ async function ensureMetroRunning() {
       detached: true,
     }
   );
-  metroChild.stdout.on('data', (chunk) => {
+  metroChild.stdout?.on('data', (chunk) => {
     process.stdout.write(`[metro] ${chunk}`);
   });
-  metroChild.stderr.on('data', (chunk) => {
+  metroChild.stderr?.on('data', (chunk) => {
     process.stderr.write(`[metro] ${chunk}`);
   });
   metroChild.on('exit', (code) => {
@@ -546,6 +605,7 @@ async function resolveSimulator() {
   return fallback;
 }
 
+/** @param {{ name: string; udid: string; state: string }} device */
 async function ensureBooted(device) {
   if (device.state !== 'Booted') {
     console.log(`[runtime-tests] booting ${device.name} (${device.udid})`);
@@ -602,16 +662,23 @@ async function appPath() {
     ],
     { cwd: iosDir }
   );
+  /** @type {{ buildSettings?: Record<string, string> }[]} */
   const entries = JSON.parse(stdout.slice(stdout.indexOf('[')));
   const entry =
     entries.find(
       (candidate) =>
-        candidate.buildSettings.WRAPPER_NAME === 'FabricExample.app'
+        candidate.buildSettings?.WRAPPER_NAME === 'FabricExample.app'
     ) ?? entries[0];
+
+  if (!entry?.buildSettings) {
+    throw new Error(`No build settings for configuration ${CONFIGURATION}`);
+  }
+
   const { TARGET_BUILD_DIR, WRAPPER_NAME } = entry.buildSettings;
   return path.join(TARGET_BUILD_DIR, WRAPPER_NAME);
 }
 
+/** @param {string} udid */
 async function installAndLaunch(udid) {
   const app = await appPath();
   if (SANITIZER) {
@@ -650,6 +717,11 @@ async function installAndLaunch(udid) {
   });
 }
 
+/**
+ * @param {string} dir
+ * @param {string} name
+ * @returns {string}
+ */
 function sdkTool(dir, name) {
   const sdkRoot = process.env.ANDROID_HOME || process.env.ANDROID_SDK_ROOT;
   if (sdkRoot) {
@@ -663,10 +735,20 @@ function sdkTool(dir, name) {
 
 const ADB = sdkTool('platform-tools', 'adb');
 
+/**
+ * @param {string} serial
+ * @param {string[]} adbArgs
+ * @param {import('child_process').ExecFileOptions} [options]
+ * @returns {Promise<{ stdout: string; stderr: string }>}
+ */
 function adb(serial, adbArgs, options = {}) {
   return run(ADB, ['-s', serial, ...adbArgs], options);
 }
 
+/**
+ * @param {number} ms
+ * @returns {Promise<void>}
+ */
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -741,6 +823,7 @@ async function resolveAndroidDevice() {
   throw new Error(`Emulator ${avd} did not boot within 300s`);
 }
 
+/** @param {string} serial */
 async function buildAndroidApp(serial) {
   const abi = await adb(serial, ['shell', 'getprop', 'ro.product.cpu.abi'])
     .then(({ stdout }) => stdout.trim())
@@ -758,6 +841,7 @@ async function buildAndroidApp(serial) {
   await run(path.join(androidDir, 'gradlew'), gradleArgs, { cwd: androidDir });
 }
 
+/** @param {string} serial */
 async function installAndLaunchAndroid(serial) {
   const buildType = CONFIGURATION[0].toLowerCase() + CONFIGURATION.slice(1);
   const apk = path.join(
@@ -829,6 +913,7 @@ if (SHOULD_LAUNCH) {
   });
 }
 
+/** @param {Error & { stdout?: string; stderr?: string }} error */
 function printCommandFailure(error) {
   console.error(`[runtime-tests] ${error.message}`);
   if (error.stdout) {
@@ -839,7 +924,12 @@ function printCommandFailure(error) {
   }
 }
 
+/** @param {string} app */
 function assertSanitizerRuntimeEmbedded(app) {
+  if (!SANITIZER) {
+    return;
+  }
+
   const prefix = SANITIZERS[SANITIZER].runtimePrefix;
   const frameworks = path.join(app, 'Frameworks');
   const embedded =
@@ -912,7 +1002,12 @@ Ports and timeouts
   --help                    Show this message.`);
 }
 
+/**
+ * @param {string[]} argv
+ * @returns {Record<string, string | true>}
+ */
 function parseArgs(argv) {
+  /** @type {Record<string, string | true>} */
   const out = {};
   for (let i = 0; i < argv.length; i++) {
     const token = argv[i];

--- a/apps/fabric-example/tsconfig.json
+++ b/apps/fabric-example/tsconfig.json
@@ -6,6 +6,6 @@
       "@/*": ["../common-app/src/*"]
     }
   },
-  "include": ["."],
+  "include": [".", "../common-app/src/images.d.ts"],
   "exclude": ["android", "ios", ".bundle", "vendor", "assets"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10202,7 +10202,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/ws@npm:^8.5.10":
+"@types/ws@npm:8.18.1, @types/ws@npm:^8.5.10":
   version: 8.18.1
   resolution: "@types/ws@npm:8.18.1"
   dependencies:
@@ -18360,6 +18360,7 @@ __metadata:
   resolution: "fabric-example@workspace:apps/fabric-example"
   dependencies:
     "@types/react": "npm:19.2.18"
+    "@types/ws": "npm:8.18.1"
     common-app: "workspace:*"
     eslint: "npm:9.37.0"
     react: "npm:19.2.8"


### PR DESCRIPTION
## Summary

Some directories weren't linted and formatted and this causes `yarn format` on main branch actually produce changes.

## Test plan

CI

## Changelog

- [x] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.
