### PR TITLE
refactor(Worklets): identify the Synchronizable lock owner with std::thread::id

### DIFF
--- a/packages/react-native-worklets/CHANGELOG.md
+++ b/packages/react-native-worklets/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fix a crash on Android when the React instance is recreated while animations are running - `AnimationFrameQueue` kept delivering frames after `WorkletsModule` was invalidated. ([#10278](https://github.com/software-mansion/react-native-reanimated/pull/10278) by [@shubhamdeol](https://github.com/shubhamdeol))
 - Fix a data race between `getDirty` and `setBlocking` on a Synchronizable - the pointer holding the value is now read and written atomically. ([#10292](https://github.com/software-mansion/react-native-reanimated/pull/10292) by [@tjzel](https://github.com/tjzel))
 - Fix `setBlocking` leaving a Synchronizable locked forever in development builds when the updater function or the serializer throws. ([#10331](https://github.com/software-mansion/react-native-reanimated/pull/10331) by [@tjzel](https://github.com/tjzel))
+- Compare the Synchronizable's imperative lock owner with `std::thread::id` instead of comparing `pthread_t` with `==`, which POSIX doesn't define. ([#10349](https://github.com/software-mansion/react-native-reanimated/pull/10349) by [@tjzel](https://github.com/tjzel))
 
 ### 💡 Others
 

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/SynchronizableAccess.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/SynchronizableAccess.cpp
@@ -1,12 +1,14 @@
 #include <worklets/SharedItems/SynchronizableAccess.h>
 
 #include <mutex>
+#include <thread>
 
 namespace worklets {
 void SynchronizableAccess::getBlockingBefore() {
   std::unique_lock<std::mutex> lock(accessLock_);
   queue_.wait(lock, [this]() {
-    return !blockingWriter_ /* && dirtyWriters_ == 0 */ && (!imperativelyLocked_ || imperativeOwner_ == pthread_self());
+    return !blockingWriter_ /* && dirtyWriters_ == 0 */ &&
+        (!imperativelyLocked_ || imperativeOwner_ == std::this_thread::get_id());
   });
   blockingReaders_++;
 }
@@ -25,7 +27,7 @@ void SynchronizableAccess::getBlockingAfter() {
 //   std::unique_lock<std::mutex> lock(accessLock_);
 //   queue_.wait(lock, [this]() {
 //     return !blockingWriter_ && blockingReaders_ == 0 &&
-//         (!imperativelyLocked_ || imperativeOwner_ == pthread_self());
+//         (!imperativelyLocked_ || imperativeOwner_ == std::this_thread::get_id());
 //   });
 //   dirtyWriters_++;
 // }
@@ -44,7 +46,7 @@ void SynchronizableAccess::setBlockingBefore() {
   std::unique_lock<std::mutex> lock(accessLock_);
   queue_.wait(lock, [this]() {
     return !blockingWriter_ && blockingReaders_ == 0 /* && dirtyWriters_ == 0 */ &&
-        (!imperativelyLocked_ || imperativeOwner_ == pthread_self());
+        (!imperativelyLocked_ || imperativeOwner_ == std::this_thread::get_id());
   });
   blockingWriter_ = true;
 }
@@ -59,15 +61,15 @@ void SynchronizableAccess::lock() {
   std::unique_lock<std::mutex> lock(accessLock_);
   queue_.wait(lock, [this]() {
     return !blockingWriter_ && blockingReaders_ == 0 /* && dirtyWriters_ == 0 */ &&
-        (!imperativelyLocked_ || imperativeOwner_ == pthread_self());
+        (!imperativelyLocked_ || imperativeOwner_ == std::this_thread::get_id());
   });
   imperativelyLocked_ = true;
-  imperativeOwner_ = pthread_self();
+  imperativeOwner_ = std::this_thread::get_id();
 }
 
 void SynchronizableAccess::unlock() {
   std::unique_lock<std::mutex> lock(accessLock_);
-  if (imperativeOwner_ != pthread_self()) {
+  if (imperativeOwner_ != std::this_thread::get_id()) {
     return;
   }
   imperativelyLocked_ = false;

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/SynchronizableAccess.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/SynchronizableAccess.h
@@ -2,6 +2,7 @@
 
 #include <condition_variable>
 #include <mutex>
+#include <thread>
 
 namespace worklets {
 
@@ -36,7 +37,7 @@ class SynchronizableAccess {
   // int dirtyWriters_{0};
   bool blockingWriter_{false};
   bool imperativelyLocked_{false};
-  pthread_t imperativeOwner_{};
+  std::thread::id imperativeOwner_{};
   std::mutex accessLock_;
   std::recursive_mutex imperativeLock_;
   std::condition_variable queue_;


### PR DESCRIPTION
> [!NOTE]
> This pull request was authored by AI on behalf of @tjzel.

## Summary

`SynchronizableAccess` tracks the owner of an imperative lock so the owning thread can re-enter its own lock. It stored that owner as a `pthread_t` and compared it with `==` and `!=`. POSIX leaves `pthread_t` opaque and permits it to be a struct, and specifies `pthread_equal` for comparison - the comparison only compiles today because it happens to be a pointer on Apple and Android. I replaced it with `std::thread::id` and `std::this_thread::get_id()`, which are comparable by definition and default-construct to a distinct "no thread" value, so `imperativeOwner_ = {}` keeps meaning "unowned".

This also removes the POSIX dependency from the header, which no longer needs `pthread.h` to declare its members.

## Test plan

Runtime tests pass. `memory/synchronizable.test` covers imperative locking, including the re-entrancy path this member guards.

## Changelog

- [x] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.
