### PR TITLE
fix: correct the control points of the predefined `ease` easing function

### DIFF
--- a/packages/react-native-reanimated/CHANGELOG.md
+++ b/packages/react-native-reanimated/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix the predefined `ease` easing function using `cubicBezier(0.25, 0.1, 0.25, 0.1)` instead of the spec-defined `cubic-bezier(0.25, 0.1, 0.25, 1)`. ([#10353](https://github.com/software-mansion/react-native-reanimated/pull/10353) by [@tjzel](https://github.com/tjzel))
 - Fix text losing its trailing word on Android after a CSS `fontSize` transition. ([#10342](https://github.com/software-mansion/react-native-reanimated/pull/10342) by [@MatiPl01](https://github.com/MatiPl01))
 - Fix `EXC_BAD_ACCESS` crash in `-[REANodesManager performOperations]` when called before the `_performOperations` block is registered on iOS. ([#10229](https://github.com/software-mansion/react-native-reanimated/pull/10229) by [@tomekzaw](https://github.com/tomekzaw))
 - Fix missing unmount of ancestors of animated components with exiting animations in experimental Layout Animations Proxy ([#10103](https://github.com/software-mansion/react-native-reanimated/pull/10103) by [@pawicao](https://github.com/pawicao))

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/EasingFunctions.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/EasingFunctions.cpp
@@ -11,7 +11,7 @@ inline const std::unordered_map<std::string, EasingFunction> PREDEFINED_EASING_M
      [](double x) {
        return x;
      }},
-    {"ease", cubicBezier(0.25, 0.1, 0.25, 0.1)},
+    {"ease", cubicBezier(0.25, 0.1, 0.25, 1.0)},
     {"ease-in", cubicBezier(0.42, 0.0, 1.0, 1.0)},
     {"ease-out", cubicBezier(0.0, 0.0, 0.58, 1.0)},
     {"ease-in-out", cubicBezier(0.42, 0.0, 0.58, 1.0)},


### PR DESCRIPTION
> [!NOTE]
> This pull request was authored by AI on behalf of [@tjzel](https://github.com/tjzel).

## Summary

Follow-up to https://github.com/software-mansion/react-native-reanimated/pull/10344, as reported in https://github.com/software-mansion/react-native-reanimated/pull/10344#issuecomment-5358004110.

The native easing registry defined `ease` as `cubicBezier(0.25, 0.1, 0.25, 0.1)`, while the CSS specification defines it as `cubic-bezier(0.25, 0.1, 0.25, 1)`. Since `ease` is the default `timingFunction`, the default native easing shape differed from web. I changed the last control point from `0.1` to `1.0`, matching the already correct definition in `EasingConfigs.cpp`.

## Test plan

The `ease` easing now matches the web behavior.

## Changelog

- [x] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.