### PR TITLE
docs: note that platform colors keep a property on the loop (hold for #10305)

### DIFF
--- a/docs/docs-reanimated/docs/guides/feature-flags.md
+++ b/docs/docs-reanimated/docs/guides/feature-flags.md
@@ -159,6 +159,7 @@ Routing is decided per property, so a single transition may run partly on the pl
 
 - it is listed in the table below,
 - the animated component has no CSS transition callbacks. `onCSSTransitionRun`, `onCSSTransitionStart`, `onCSSTransitionEnd` and `onCSSTransitionCancel` work as usual, but only the animation loop reports them, so a component using any of them keeps all of its properties there,
+- for a color property, both of its endpoints are plain colors. `PlatformColor` and `DynamicColorIOS` values don't reduce to the single number the platform animation takes, so they keep the property on the loop,
 - on iOS, its timing function is `linear` or a cubic Bezier curve, since `CAMediaTimingFunction` cannot express `steps` or `linear` easing with stops. There is no such limitation on Android, where `TimeInterpolator` carries any curve that CSS transitions support.
 
 #### Properties routed to the platform


### PR DESCRIPTION
Follow-up to #10328, to land together with platform color support (#10305), not before it.

The routing rules for platform-driven CSS transitions list the table, the callbacks and the iOS easing restriction, but not the shape a color value has to have. Only numeric colors reach the platform: `parseValue` accepts a color solely when `value.isNumber()`, and `parsePlatformValues` returns nothing when either endpoint fails to parse, so a `PlatformColor` on one end keeps the whole property on the animation loop.

Held as a draft on purpose. CSS does not support platform colors yet, so documenting how they route would describe something users cannot write. Once #10305 lands, this note belongs next to the other routing conditions, and the wording should be re-checked against whatever resolution that PR settles on.
