### PR TITLE
fix: keep the reversing shortening factor within [0, 1]

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/reversingShortening.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/reversingShortening.h
@@ -33,9 +33,8 @@ reverseShorten(const ReversingState &previous, double timestamp, double duration
   const double elapsed = std::clamp(timestamp - previous.startTimestamp, 0.0, previous.duration);
   const double linearProgress = previous.duration > 0 ? elapsed / previous.duration : 1.0;
   const double easedProgress = getEasingFunctionFromConfig(previous.easing)(linearProgress);
-  // "the absolute value, clamped to the range [0, 1]" - both exist, per the
-  // spec's own note, "to handle timing functions that have y1 or y2 outside
-  // the range [0, 1]", which only the y control points may be.
+  // Absolute value and clamp are both required by the spec, which adds them
+  // "to handle timing functions that have y1 or y2 outside the range [0, 1]".
   const double factor = std::clamp(std::abs(easedProgress * previous.factor + (1 - previous.factor)), 0.0, 1.0);
   duration *= factor;
   if (delay < 0) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/reversingShortening.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/reversingShortening.h
@@ -3,6 +3,7 @@
 #include <reanimated/CSS/easing/EasingConfigs.h>
 
 #include <algorithm>
+#include <cmath>
 #include <utility>
 
 namespace reanimated::css {
@@ -32,7 +33,10 @@ reverseShorten(const ReversingState &previous, double timestamp, double duration
   const double elapsed = std::clamp(timestamp - previous.startTimestamp, 0.0, previous.duration);
   const double linearProgress = previous.duration > 0 ? elapsed / previous.duration : 1.0;
   const double easedProgress = getEasingFunctionFromConfig(previous.easing)(linearProgress);
-  const double factor = easedProgress * previous.factor + (1 - previous.factor);
+  // The spec takes the absolute value and clamps to [0, 1]. Only the x control
+  // points of a cubic bezier are restricted to [0, 1], so an easing may
+  // legally overshoot, and an unclamped factor turns the duration negative.
+  const double factor = std::clamp(std::abs(easedProgress * previous.factor + (1 - previous.factor)), 0.0, 1.0);
   duration *= factor;
   if (delay < 0) {
     delay *= factor;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/reversingShortening.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/reversingShortening.h
@@ -33,9 +33,9 @@ reverseShorten(const ReversingState &previous, double timestamp, double duration
   const double elapsed = std::clamp(timestamp - previous.startTimestamp, 0.0, previous.duration);
   const double linearProgress = previous.duration > 0 ? elapsed / previous.duration : 1.0;
   const double easedProgress = getEasingFunctionFromConfig(previous.easing)(linearProgress);
-  // The spec takes the absolute value and clamps to [0, 1]. Only the x control
-  // points of a cubic bezier are restricted to [0, 1], so an easing may
-  // legally overshoot, and an unclamped factor turns the duration negative.
+  // "the absolute value, clamped to the range [0, 1]" - both exist, per the
+  // spec's own note, "to handle timing functions that have y1 or y2 outside
+  // the range [0, 1]", which only the y control points may be.
   const double factor = std::clamp(std::abs(easedProgress * previous.factor + (1 - previous.factor)), 0.0, 1.0);
   duration *= factor;
   if (delay < 0) {


### PR DESCRIPTION
When a new transition reverses one that is still running, its duration is shortened by the reversing shortening factor, so a half-finished transition reverses in about half the time. [css-transitions-1](https://drafts.csswg.org/css-transitions/#reversing) defines that factor as

> the absolute value, clamped to the range [0, 1]

of `easedProgress * oldFactor + (1 - oldFactor)`, and its note explains why: "to handle timing functions that have y1 or y2 outside the range [0, 1]". `reverseShorten` computed the formula but applied neither the absolute value nor the clamp.

That is exactly the case the note warns about. Only the x control points of a cubic bezier are restricted, so an overshoot easing legally returns values outside [0, 1], and reversing while its output is negative produces a negative factor - and with it a negative duration. The transition then reports `Pending` forever and never runs, and the next reversal calls `std::clamp(v, 0.0, negativeDuration)`, which is undefined behaviour for `lo > hi`. Reachable today: `FlexGallery` uses `cubicBezier(0.5, -0.6, 0.6, 1.5)` at 200ms, and re-tapping a row 5-65ms after a tap kills its transition.

One disclosed judgment call: Chrome clamps without the absolute value (measured via the new transition's computed duration), so a reversal during the negative phase completes instantly there instead of taking `|factor|` of the duration. This PR follows the spec text; dropping `std::abs` would match Chrome instead. Either way the factor stays in [0, 1].

Boundary values for a 1000ms transition (a negative delay scales by the same factor):

| easing output at reversal | factor: main -> fixed | new duration: main -> fixed |
| --- | --- | --- |
| 0.700 (in range) | 0.700 -> 0.700 | 700ms -> 700ms |
| -0.261 (`y1 = -2`) | -0.261 -> 0.261 | -261ms -> 261ms |
| 1.471 (`y2 = 3`) | 1.471 -> 1.000 | 1471ms -> 1000ms |

### Recording

Both sides carry #10358; row 3 is the only difference. The row's easing undershoots past its start for the first third of the curve, so the box dips off the left edge - the fix is whether it ever comes back.

https://github.com/user-attachments/assets/c78d526b-62b4-4b5a-83fc-845f84e8f10a

<details>
<summary>Source code</summary>

```tsx
import React, { useEffect, useState } from 'react';
import { StyleSheet, View } from 'react-native';
import Animated, { cubicBezier } from 'react-native-reanimated';

// y1 = -2, so the output is below 0 for the first third of the curve
const OVERSHOOT = cubicBezier(0.5, -2, 0.5, 3);

export default function App() {
  const [open, setOpen] = useState(false);

  useEffect(() => {
    const id = setInterval(() => {
      setOpen(true);
      // reverse while the easing output is still below 0
      setTimeout(() => setOpen(false), 250);
    }, 3000);
    return () => clearInterval(id);
  }, []);

  return (
    <View style={styles.root}>
      <Animated.View
        style={[
          styles.box,
          {
            transitionProperty: 'transform',
            transitionDuration: 2000,
            transitionTimingFunction: OVERSHOOT,
          },
          { transform: [{ translateX: open ? 200 : 0 }] },
        ]}
      />
    </View>
  );
}

const styles = StyleSheet.create({
  root: { flex: 1, justifyContent: 'center', padding: 22 },
  box: { width: 54, height: 54, borderRadius: 10, backgroundColor: '#2563eb' },
});
```

</details>
