### PR TITLE
fix: reject non-finite CSS durations and delays

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TimeProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TimeProgressProvider.cpp
@@ -1,5 +1,7 @@
 #include <reanimated/CSS/progress/TimeProgressProvider.h>
 
+#include <cmath>
+
 namespace reanimated::css {
 
 TimeProgressProvider::TimeProgressProvider(const double timestamp, const double duration, const double delay)
@@ -30,13 +32,13 @@ void TimeProgressProvider::update(const double timestamp) {
     return;
   }
 
-  // Negated so that a NaN fails both tests and is discarded: every ordered
-  // comparison against NaN is false, so `< 0` and `>= 1` would both let one
-  // through, and the interpolators would turn it into a NaN style value.
+  // Every ordered comparison against NaN is false, so a bare `< 0` / `>= 1`
+  // pair would let one through and the interpolators would turn it into a NaN
+  // style value. Testing for it by name keeps both bounds reading normally.
   const double progress = rawProgress_.value();
-  if (!(progress >= 0)) {
+  if (std::isnan(progress) || progress < 0) {
     rawProgress_.reset();
-  } else if (!(progress < 1)) {
+  } else if (progress >= 1) {
     rawProgress_ = 1;
   }
 }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TimeProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TimeProgressProvider.cpp
@@ -1,7 +1,5 @@
 #include <reanimated/CSS/progress/TimeProgressProvider.h>
 
-#include <cmath>
-
 namespace reanimated::css {
 
 TimeProgressProvider::TimeProgressProvider(const double timestamp, const double duration, const double delay)
@@ -32,12 +30,9 @@ void TimeProgressProvider::update(const double timestamp) {
     return;
   }
 
-  // Every ordered comparison against NaN is false, so a NaN would clear both
-  // bounds and reach the interpolators as a NaN style value.
-  const double progress = rawProgress_.value();
-  if (std::isnan(progress) || progress < 0) {
+  if (rawProgress_.value() < 0) {
     rawProgress_.reset();
-  } else if (progress >= 1) {
+  } else if (rawProgress_.value() >= 1) {
     rawProgress_ = 1;
   }
 }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TimeProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TimeProgressProvider.cpp
@@ -32,9 +32,8 @@ void TimeProgressProvider::update(const double timestamp) {
     return;
   }
 
-  // Every ordered comparison against NaN is false, so a bare `< 0` / `>= 1`
-  // pair would let one through and the interpolators would turn it into a NaN
-  // style value. Testing for it by name keeps both bounds reading normally.
+  // Every ordered comparison against NaN is false, so a NaN would clear both
+  // bounds and reach the interpolators as a NaN style value.
   const double progress = rawProgress_.value();
   if (std::isnan(progress) || progress < 0) {
     rawProgress_.reset();

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TimeProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TimeProgressProvider.cpp
@@ -30,9 +30,13 @@ void TimeProgressProvider::update(const double timestamp) {
     return;
   }
 
-  if (rawProgress_.value() < 0) {
+  // Negated so that a NaN fails both tests and is discarded: every ordered
+  // comparison against NaN is false, so `< 0` and `>= 1` would both let one
+  // through, and the interpolators would turn it into a NaN style value.
+  const double progress = rawProgress_.value();
+  if (!(progress >= 0)) {
     rawProgress_.reset();
-  } else if (rawProgress_.value() >= 1) {
+  } else if (!(progress < 1)) {
     rawProgress_ = 1;
   }
 }

--- a/packages/react-native-reanimated/src/css/native/normalization/common/__tests__/settings.test.ts
+++ b/packages/react-native-reanimated/src/css/native/normalization/common/__tests__/settings.test.ts
@@ -57,6 +57,14 @@ describe(normalizeDelay, () => {
       }
     );
   });
+
+  describe('when a non-finite number is passed', () => {
+    test.each([NaN, Infinity, -Infinity])('throws an error for %p', (delay) => {
+      expect(() => normalizeDelay(delay)).toThrow(
+        new Error(`[Reanimated] ${ERROR_MESSAGES.invalidDelay(delay)}`)
+      );
+    });
+  });
 });
 
 describe(normalizeDuration, () => {
@@ -95,6 +103,17 @@ describe(normalizeDuration, () => {
         const value = duration as TimeUnit;
         expect(() => normalizeDuration(value)).toThrow(
           new Error(`[Reanimated] ${ERROR_MESSAGES.invalidDuration(value)}`)
+        );
+      }
+    );
+  });
+
+  describe('when a non-finite number is passed', () => {
+    test.each([NaN, Infinity, -Infinity])(
+      'throws an error for %p',
+      (duration) => {
+        expect(() => normalizeDuration(duration)).toThrow(
+          new Error(`[Reanimated] ${ERROR_MESSAGES.invalidDuration(duration)}`)
         );
       }
     );

--- a/packages/react-native-reanimated/src/css/utils/__tests__/parsers.test.ts
+++ b/packages/react-native-reanimated/src/css/utils/__tests__/parsers.test.ts
@@ -1,5 +1,7 @@
 'use strict';
 import { parseBoxShadowString } from '../../../common';
+import type { TimeUnit } from '../../types';
+import { normalizeTimeUnit } from '../parsers';
 
 describe(parseBoxShadowString, () => {
   describe('correct number of shadows', () => {
@@ -93,4 +95,37 @@ describe(parseBoxShadowString, () => {
       ]);
     });
   });
+});
+
+describe(normalizeTimeUnit, () => {
+  test.each([0, 100, -100, 0.5])(
+    'passes the finite number %p through',
+    (value) => {
+      expect(normalizeTimeUnit(value)).toBe(value);
+    }
+  );
+
+  test.each([
+    ['100ms', 100],
+    ['0ms', 0],
+    ['-100ms', -100],
+    ['1s', 1000],
+    ['0.1s', 100],
+    ['-1s', -1000],
+  ] satisfies [TimeUnit, number][])('converts %p to %p', (value, expected) => {
+    expect(normalizeTimeUnit(value)).toBe(expected);
+  });
+
+  // A non-finite value reaching native makes every progress computed from it
+  // NaN, so it has to be rejected here where it can still be reported.
+  test.each([NaN, Infinity, -Infinity])('rejects %p', (value) => {
+    expect(normalizeTimeUnit(value)).toBeNull();
+  });
+
+  test.each(['invalid', 'mss', '100mms', '1', '1.1', ''])(
+    'rejects %p',
+    (value) => {
+      expect(normalizeTimeUnit(value as TimeUnit)).toBeNull();
+    }
+  );
 });

--- a/packages/react-native-reanimated/src/css/utils/parsers.ts
+++ b/packages/react-native-reanimated/src/css/utils/parsers.ts
@@ -102,7 +102,9 @@ export function parseSingleTransitionShorthand(
 
 export function normalizeTimeUnit(timeUnit: TimeUnit): number | null {
   if (typeof timeUnit === 'number') {
-    return timeUnit;
+    // A non-finite value would reach the C++ timing math and make every
+    // progress it computes NaN, which lands on the view as a NaN style value.
+    return Number.isFinite(timeUnit) ? timeUnit : null;
   } else if (MILLISECONDS_REGEX.test(timeUnit)) {
     return parseInt(timeUnit, 10);
   } else if (SECONDS_REGEX.test(timeUnit)) {


### PR DESCRIPTION
`normalizeTimeUnit` returns any `number` unchecked:

```ts
if (typeof timeUnit === 'number') {
  return timeUnit;
}
```

`normalizeDuration` only rejects `null` and negatives, and a NaN is neither - `NaN === null` is false and `NaN < 0` is false - so `transitionDuration: NaN` reaches the C++ timing math, where `duration_ == 0` is false as well and `elapsed / NaN` makes the progress NaN. That progress is what every interpolator on the node is sampled at, so the view gets a NaN style value and stops drawing. `Infinity` gets through the same way and pins progress at 0, so the transition never advances.

### Recording

https://github.com/user-attachments/assets/ec7bdc76-322f-4d35-b867-d83608ec4ba1
