### PR TITLE
fix: clamp perspective interpolation endpoints to the 1px spec minimum

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformOperationInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformOperationInterpolator.cpp
@@ -5,6 +5,7 @@
 #include <reanimated/CSS/interpolation/transforms/operations/skew.h>
 #include <reanimated/CSS/interpolation/transforms/operations/translate.h>
 
+#include <algorithm>
 #include <cmath>
 #include <limits>
 #include <utility>
@@ -40,8 +41,12 @@ std::unique_ptr<StyleOperation> TransformOperationInterpolator<PerspectiveOperat
   // directly gives inf + t*(d - inf) = NaN. Interpolate in reciprocal space
   // instead (1/inf = 0, matching how perspective enters the matrix as -1/d).
   if (std::isinf(fromValue.value) || std::isinf(toValue.value)) {
-    const double fromReciprocal = 1.0 / fromValue.value;
-    const double toReciprocal = 1.0 / toValue.value;
+    // css-transforms-2: a depth below 1px "must be treated as 1px ... when
+    // used as the endpoint of interpolation", which also keeps 1/0 from
+    // reintroducing the inf - inf = NaN this branch exists to avoid.
+    // https://drafts.csswg.org/css-transforms-2/#perspective
+    const double fromReciprocal = 1.0 / std::max(fromValue.value, 1.0);
+    const double toReciprocal = 1.0 / std::max(toValue.value, 1.0);
     const double reciprocal = fromReciprocal + progress * (toReciprocal - fromReciprocal);
     return std::make_unique<PerspectiveOperation>(
         reciprocal == 0.0 ? std::numeric_limits<double>::infinity() : 1.0 / reciprocal);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformOperationInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformOperationInterpolator.cpp
@@ -29,6 +29,14 @@ TransformOperationInterpolator<PerspectiveOperation>::TransformOperationInterpol
     const std::shared_ptr<PerspectiveOperation> &defaultOperation)
     : StyleOperationInterpolator(defaultOperation) {}
 
+namespace {
+
+double clampPerspectiveDepth(const double depth) {
+  return depth >= 0.0 && depth < 1.0 ? 1.0 : depth;
+}
+
+} // namespace
+
 std::unique_ptr<StyleOperation> TransformOperationInterpolator<PerspectiveOperation>::interpolate(
     double progress,
     const std::shared_ptr<StyleOperation> &from,
@@ -43,10 +51,12 @@ std::unique_ptr<StyleOperation> TransformOperationInterpolator<PerspectiveOperat
   if (std::isinf(fromValue.value) || std::isinf(toValue.value)) {
     // css-transforms-2: a depth below 1px "must be treated as 1px ... when
     // used as the endpoint of interpolation", which also keeps 1/0 from
-    // reintroducing the inf - inf = NaN this branch exists to avoid.
+    // reintroducing the inf - inf = NaN this branch exists to avoid. Negative
+    // depths are invalid on the web, but React Native accepts them and they
+    // interpolate finitely, so they pass through unchanged.
     // https://drafts.csswg.org/css-transforms-2/#perspective
-    const double fromReciprocal = 1.0 / std::max(fromValue.value, 1.0);
-    const double toReciprocal = 1.0 / std::max(toValue.value, 1.0);
+    const double fromReciprocal = 1.0 / clampPerspectiveDepth(fromValue.value);
+    const double toReciprocal = 1.0 / clampPerspectiveDepth(toValue.value);
     const double reciprocal = fromReciprocal + progress * (toReciprocal - fromReciprocal);
     return std::make_unique<PerspectiveOperation>(
         reciprocal == 0.0 ? std::numeric_limits<double>::infinity() : 1.0 / reciprocal);


### PR DESCRIPTION
#9712 moved perspective interpolation into reciprocal space, which fixed the NaN when animating between a finite distance and the "no perspective" default. Removing the old zero guards with it left one corner: `perspective: 0` against that default computes `1/0 = inf` for the reciprocal, and the lerp is `inf + p * (0 - inf)` = NaN at every progress.

[css-transforms-2](https://drafts.csswg.org/css-transforms-2/#perspective) defines what a zero depth means:

> If the depth value is less than 1px, it must be treated as 1px for the purpose of rendering, for computing the resolved value of transform, and when used as the endpoint of interpolation.

Endpoints in `[0, 1)` are now clamped to 1 before the reciprocal. Verified against Chrome via WAAPI: its matrices for `perspective(0px) -> none` carry `m34 = -1, -0.75, -0.5, -0.25, 0` and the clamped lerp reproduces that exactly.

Negative depths are left untouched: the web rejects them at parse time, but React Native accepts them and they already interpolate finitely, so clamping them would change working behaviour.

Only reachable with a literal `perspective: 0` in an animated transform.

### Recording

<!-- attach pr-10361-perspective-zero-before-after.mp4 here -->
