### PR TITLE
fix(Reanimated): read the window size from the base revision when the LA proxy attaches

### DIFF
--- a/packages/react-native-reanimated/CHANGELOG.md
+++ b/packages/react-native-reanimated/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix other window-relative layout animations not moving on iOS when Reanimated initializes after the surface is laid out: read the window size from the base revision when the Layout Animations Proxy attaches.
+- Fix other window-relative layout animations not moving on iOS when Reanimated initializes after the surface is laid out: read the window size from the base revision when the Layout Animations Proxy attaches. ([#10362](https://github.com/software-mansion/react-native-reanimated/pull/10362) by [@pawicao](https://github.com/pawicao))
 - Fix the predefined `ease` easing function using `cubicBezier(0.25, 0.1, 0.25, 0.1)` instead of the spec-defined `cubic-bezier(0.25, 0.1, 0.25, 1)`. ([#10353](https://github.com/software-mansion/react-native-reanimated/pull/10353) by [@tjzel](https://github.com/tjzel))
 - Fix text losing its trailing word on Android after a CSS `fontSize` transition. ([#10342](https://github.com/software-mansion/react-native-reanimated/pull/10342) by [@MatiPl01](https://github.com/MatiPl01))
 - Fix `EXC_BAD_ACCESS` crash in `-[REANodesManager performOperations]` when called before the `_performOperations` block is registered on iOS. ([#10229](https://github.com/software-mansion/react-native-reanimated/pull/10229) by [@tomekzaw](https://github.com/tomekzaw))

--- a/packages/react-native-reanimated/CHANGELOG.md
+++ b/packages/react-native-reanimated/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix other window-relative layout animations not moving on iOS when Reanimated initializes after the surface is laid out: read the window size from the base revision when the Layout Animations Proxy attaches.
 - Fix the predefined `ease` easing function using `cubicBezier(0.25, 0.1, 0.25, 0.1)` instead of the spec-defined `cubic-bezier(0.25, 0.1, 0.25, 1)`. ([#10353](https://github.com/software-mansion/react-native-reanimated/pull/10353) by [@tjzel](https://github.com/tjzel))
 - Fix text losing its trailing word on Android after a CSS `fontSize` transition. ([#10342](https://github.com/software-mansion/react-native-reanimated/pull/10342) by [@MatiPl01](https://github.com/MatiPl01))
 - Fix `EXC_BAD_ACCESS` crash in `-[REANodesManager performOperations]` when called before the `_performOperations` block is registered on iOS. ([#10229](https://github.com/software-mansion/react-native-reanimated/pull/10229) by [@tomekzaw](https://github.com/tomekzaw))

--- a/packages/react-native-reanimated/CHANGELOG.md
+++ b/packages/react-native-reanimated/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix `SlideIn`, `SlideOut` and other window-relative layout animations not moving on iOS when Reanimated initializes after the surface is laid out: read the window size from the base revision when the Layout Animations Proxy attaches. ([#10362](https://github.com/software-mansion/react-native-reanimated/pull/10362) by [@pawicao](https://github.com/pawicao))
+- Fix other window-relative layout animations not moving on iOS when Reanimated initializes after the surface is laid out: read the window size from the base revision when the Layout Animations Proxy attaches. ([#10362](https://github.com/software-mansion/react-native-reanimated/pull/10362) by [@pawicao](https://github.com/pawicao))
 - Fix the predefined `ease` easing function using `cubicBezier(0.25, 0.1, 0.25, 0.1)` instead of the spec-defined `cubic-bezier(0.25, 0.1, 0.25, 1)`. ([#10353](https://github.com/software-mansion/react-native-reanimated/pull/10353) by [@tjzel](https://github.com/tjzel))
 - Fix text losing its trailing word on Android after a CSS `fontSize` transition. ([#10342](https://github.com/software-mansion/react-native-reanimated/pull/10342) by [@MatiPl01](https://github.com/MatiPl01))
 - Fix `EXC_BAD_ACCESS` crash in `-[REANodesManager performOperations]` when called before the `_performOperations` block is registered on iOS. ([#10229](https://github.com/software-mansion/react-native-reanimated/pull/10229) by [@tomekzaw](https://github.com/tomekzaw))

--- a/packages/react-native-reanimated/CHANGELOG.md
+++ b/packages/react-native-reanimated/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix other window-relative layout animations not moving on iOS when Reanimated initializes after the surface is laid out: read the window size from the base revision when the Layout Animations Proxy attaches. ([#10362](https://github.com/software-mansion/react-native-reanimated/pull/10362) by [@pawicao](https://github.com/pawicao))
+- Fix `SlideIn`, `SlideOut` and other window-relative layout animations not moving on iOS when Reanimated initializes after the surface is laid out: read the window size from the base revision when the Layout Animations Proxy attaches. ([#10362](https://github.com/software-mansion/react-native-reanimated/pull/10362) by [@pawicao](https://github.com/pawicao))
 - Fix the predefined `ease` easing function using `cubicBezier(0.25, 0.1, 0.25, 0.1)` instead of the spec-defined `cubic-bezier(0.25, 0.1, 0.25, 1)`. ([#10353](https://github.com/software-mansion/react-native-reanimated/pull/10353) by [@tjzel](https://github.com/tjzel))
 - Fix text losing its trailing word on Android after a CSS `fontSize` transition. ([#10342](https://github.com/software-mansion/react-native-reanimated/pull/10342) by [@MatiPl01](https://github.com/MatiPl01))
 - Fix `EXC_BAD_ACCESS` crash in `-[REANodesManager performOperations]` when called before the `_performOperations` block is registered on iOS. ([#10229](https://github.com/software-mansion/react-native-reanimated/pull/10229) by [@tomekzaw](https://github.com/tomekzaw))

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
@@ -381,6 +381,10 @@ void LayoutAnimationsProxy_Experimental::initializeLightTree(
 
   const auto lock = std::unique_lock<std::recursive_mutex>(mutex);
   react_native_assert(!isLightTreeInitialized(surfaceId) && "Light tree is already initialized");
+  if (baseRevision.rootShadowNode) {
+    const auto &size = baseRevision.rootShadowNode->getLayoutMetrics().frame.size;
+    surfaceManager.updateWindow(surfaceId, size.width, size.height);
+  }
   const auto root = std::make_shared<LightNode>();
   root->current.componentName = "RootView";
   root->current.tag = surfaceId;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
@@ -1062,11 +1062,18 @@ inline bool MutationNode::isMutationNode() {
 }
 
 void LayoutAnimationsProxy_Legacy::startSurface(const ShadowTree &shadowTree) {
+  const auto surfaceId = shadowTree.getSurfaceId();
+  const auto mountingCoordinator = shadowTree.getMountingCoordinator();
   {
     auto lock = std::unique_lock<std::recursive_mutex>(mutex);
-    surfaceContext_.try_emplace(shadowTree.getSurfaceId());
+    surfaceContext_.try_emplace(surfaceId);
+    const auto baseRevision = mountingCoordinator->getBaseRevision();
+    if (baseRevision.rootShadowNode) {
+      const auto &size = baseRevision.rootShadowNode->getLayoutMetrics().frame.size;
+      surfaceManager.updateWindow(surfaceId, size.width, size.height);
+    }
   }
-  shadowTree.getMountingCoordinator()->setMountingOverrideDelegate(weak_from_this());
+  mountingCoordinator->setMountingOverrideDelegate(weak_from_this());
 }
 
 SurfaceContext &LayoutAnimationsProxy_Legacy::getSurfaceContext(const SurfaceId surfaceId) const {


### PR DESCRIPTION
> [!NOTE]
> This pull request was authored by AI on behalf of @pawicao.

## Summary

`SlideInLeft`, `SlideOutRight` and other layout animations that use `windowWidth` or `windowHeight` do not move on iOS. The card in the `[LA] Carousel` example switches in one frame.

The Layout Animations Proxy learns the window size only from a `RootView` `Update` mutation (`maybeUpdateWindowDimensions`). On iOS the root is laid out before the proxy attaches, and no later root `Update` follows. `SurfaceManager::getWindow` then returns `{0, 0}`, so the animation start equals its end. The animation runs, but nothing moves.

Android is not affected because `ReactSurfaceView` sends its layout constraints again in `onMeasure` and `onLayout`. That commits a root `Update` after the proxy attaches.

Whether the proxy attaches before or after the first root layout depends on a startup race between JS bundle evaluation and surface start. #10343 changed the example app enough to lose that race, which made the bug visible. Any app that imports Reanimated late hits it.

This pull request reads the root size from `MountingCoordinator::getBaseRevision()` when the proxy attaches:

- legacy proxy: in `startSurface`, under the proxy mutex, before `setMountingOverrideDelegate`. A later root `Update` still overwrites the value.
- experimental proxy: in `initializeLightTree`, under the proxy mutex, before the replay of pending transactions. The initial mutations built from the base revision hold no root `Update`, because the empty root is a clone of the base root with the same props and layout.

## Test plan

1. Set `ENABLE_SHARED_ELEMENT_TRANSITIONS` to `false` in `apps/fabric-example/package.json`, run `yarn workspace fabric-example build`, then `yarn ios`.
2. Open `[LA] Carousel` and tap `toggle`.
3. Expected: the old card slides out to the right and the new card slides in from the left. Before this change the card switches in one frame.
4. Repeat with `ENABLE_SHARED_ELEMENT_TRANSITIONS` set to `true`.
5. Run `yarn android` and repeat steps 2 and 3. Behavior must not change.

Measured on an iPhone 17 Pro simulator with a screen recording: 2 changed frames per toggle before, 21 after.

## Changelog

- [x] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.
