### PR TITLE
feat(Worklets): treat navigator as a known global in the Babel plugin

### DIFF
--- a/packages/react-native-worklets/CHANGELOG.md
+++ b/packages/react-native-worklets/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - Add `isOnUIThread` to the Worklets Stable API.
 - Add the fast-path `fixedType` option to `createSynchronizable`. A fixed-type Synchronizable holds a number or a boolean without serialization and exposes `setDirty`, a non-exclusive write that doesn't wait for other `setDirty` calls. ([#10296](https://github.com/software-mansion/react-native-reanimated/pull/10296) by [@tjzel](https://github.com/tjzel))
+- The Babel plugin treats `navigator` as a known global: worklets resolve it on their own runtime instead of capturing the main runtime's object by closure. ([#10364](https://github.com/software-mansion/react-native-reanimated/pull/10364) by [@wcandillon](https://github.com/wcandillon))
 
 ### 🐛 Bug fixes
 

--- a/packages/react-native-worklets/plugin/__tests__/__snapshots__/plugin-shared.test.ts.snap
+++ b/packages/react-native-worklets/plugin/__tests__/__snapshots__/plugin-shared.test.ts.snap
@@ -76,6 +76,20 @@ exports[`babel plugin core (bundle mode) closure handling does not capture defau
 });"
 `;
 
+exports[`babel plugin core (bundle mode) closure handling does not capture navigator 1`] = `
+"export default (function f_testJs1Factory({}) {
+  const f = function () {
+    "use no memo";
+
+    return navigator.gpu;
+  };
+  f.__closure = {};
+  f.__workletHash = 16685825262470;
+  f.__pluginVersion = "x.y.z";
+  return f;
+});"
+`;
+
 exports[`babel plugin core (bundle mode) for react-compiler prevents outlining from worklet functions 1`] = `
 "export default (function testJs1Factory({}) {
   const testJs1 = function () {
@@ -299,6 +313,31 @@ const f = function f_testJs1Factory({
   return f;
 }({
   _worklet_861694609719_init_data
+});"
+`;
+
+exports[`babel plugin core (bundleless mode) closure handling does not capture navigator 1`] = `
+"const _worklet_16685825262470_init_data = {
+  code: "(function f_testJs1(){return navigator.gpu;})",
+  location: "test.js"
+};
+const f = function f_testJs1Factory({
+  _worklet_16685825262470_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const f = function () {
+    "use no memo";
+
+    return navigator.gpu;
+  };
+  f.__closure = {};
+  f.__workletHash = 16685825262470;
+  f.__pluginVersion = "x.y.z";
+  f.__initData = _worklet_16685825262470_init_data;
+  f.__stackDetails = _e;
+  return f;
+}({
+  _worklet_16685825262470_init_data
 });"
 `;
 

--- a/packages/react-native-worklets/plugin/__tests__/plugin-shared.test.ts
+++ b/packages/react-native-worklets/plugin/__tests__/plugin-shared.test.ts
@@ -158,6 +158,18 @@ describe.each([
       expect(workletText(result, bundleMode)).toMatchSnapshot();
     });
 
+    test('does not capture navigator', () => {
+      const input = html`<script>
+        function f() {
+          'worklet';
+          return navigator.gpu;
+        }
+      </script>`;
+
+      const result = runPlugin(input, { bundleMode });
+      expect(workletText(result, bundleMode)).toMatchSnapshot();
+    });
+
     test('captures locally bound variables shadowing globals', () => {
       const input = html`<script>
         const console = {

--- a/packages/react-native-worklets/plugin/index.js
+++ b/packages/react-native-worklets/plugin/index.js
@@ -1123,6 +1123,7 @@ var require_globals = __commonJS({
       "self",
       "console",
       "performance",
+      "navigator",
       "arguments",
       // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments
       "require",

--- a/packages/react-native-worklets/plugin/src/globals.ts
+++ b/packages/react-native-worklets/plugin/src/globals.ts
@@ -112,6 +112,7 @@ const notCapturedIdentifiers = [
   'self',
   'console',
   'performance',
+  'navigator',
   'arguments', // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments
   'require',
   'fetch',


### PR DESCRIPTION
> [!NOTE]
> This pull request was authored by AI on behalf of wcandillon.

## Summary

Add `navigator` to the Babel plugin's known globals (`notCapturedIdentifiers`), alongside the other Web API globals it already knows (`fetch`, `performance`, `WebSocket`, `console`).

Motivation: react-native-webgpu is adding support for `navigator.gpu` on worklet runtimes (its `installWebGPU()` helper installs `navigator.gpu` on the calling runtime). Because `navigator` is not a known global, a bare `navigator` inside a worklet is currently captured by closure from the definition site on the main runtime instead of being resolved on the worklet runtime. That has several downsides:

- The captured object is a snapshot of the main runtime's `navigator`, which shadows whatever `navigator` the worklet runtime itself provides.
- The whole object is re-serialized on every worklet transfer, and its contents are not guaranteed to be plain data: React Native defines `navigator.product` via a lazy `defineProperty` getter (`setUpNavigator.js`), and third-party libraries attach more properties to it.
- Users have to write `globalThis.navigator` to force a true global lookup, which is easy to get wrong silently.

Behavior note: after this change, a bare `navigator` in a worklet resolves at runtime on the worklet runtime, where it may be `undefined` unless something installed it. This matches the existing treatment of `fetch` and friends, and a local binding named `navigator` that shadows the global is still captured as before (covered by the existing "captures locally bound variables shadowing globals" test).

## Test plan

- Added a `does not capture navigator` test to `plugin-shared.test.ts`; the new snapshots show an empty `__closure` with `navigator.gpu` left as a global lookup, in both bundle and bundleless modes.
- `yarn test` in `packages/react-native-worklets/plugin`: 4 suites, 219 tests passed.
- `yarn build` in the plugin regenerates `index.js` with a one-line diff (the new list entry).

## Changelog

- [x] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CfmYddDYmUnQ8csf214a44
