### PR TITLE
docs: fix broken JavaScript thread link in useAnimatedSensor

### DIFF
--- a/docs/docs-reanimated/docs/device/useAnimatedSensor.mdx
+++ b/docs/docs-reanimated/docs/device/useAnimatedSensor.mdx
@@ -216,7 +216,7 @@ import AnimatedSensorSrc from '!!raw-loader!@site/src/examples/AnimatedSensor';
 
 - Most of the sensors operate in resolutions up to 100Hz.
 
-- You can read the sensor data on both [UI thread](/docs/fundamentals/glossary#ui-thread) and \[JavaScript th(/docs/docs/fundamentals/glossary#javascript-thread).
+- You can read the sensor data on both [UI thread](/docs/fundamentals/glossary#ui-thread) and [JavaScript thread](/docs/fundamentals/glossary#javascript-thread).
 
 ## Platform compatibility
 


### PR DESCRIPTION
> [!NOTE]
> This pull request was authored by AI on behalf of ralph1233.

## Summary

The `useAnimatedSensor` remarks had a broken markdown link for the JavaScript thread glossary entry (`\[JavaScript th(/docs/docs/...`), so the text rendered incorrectly and pointed at an invalid path. This restores the proper `[JavaScript thread](/docs/fundamentals/glossary#javascript-thread)` link.

## Test plan

- Open the `useAnimatedSensor` docs remarks section
- Confirm the "JavaScript thread" text is a working glossary link, matching the existing "UI thread" link

## Changelog

- [x] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.

Made with [Cursor](https://cursor.com)