### PR TITLE
refactor(LayoutAnimations): centralize animation lifecycle and UI operations

### DIFF
--- a/packages/react-native-reanimated/CHANGELOG.md
+++ b/packages/react-native-reanimated/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fix animated styles on sticky headers throwing an immutable-object mutation error in development. ([#10389](https://github.com/software-mansion/react-native-reanimated/pull/10389) by [@ngocdevv](https://github.com/ngocdevv))
 - Fix shared element transitions never running on Android for npm installs by publishing `react-native.config.js`, which registers the Shared Transition Boundary component descriptor for autolinking. ([#10375](https://github.com/software-mansion/react-native-reanimated/pull/10375) by [@dennytosp](https://github.com/dennytosp))
 - Keep exiting views at their position in the host tree, so they no longer draw above later siblings. ([#10392](https://github.com/software-mansion/react-native-reanimated/pull/10392) by [@pawicao](https://github.com/pawicao))
+- Fix Layout Animations replacement and completion ordering by centralizing native lifecycle operations. ([#10369](https://github.com/software-mansion/react-native-reanimated/pull/10369) by [@bartlomiejbloniarz](https://github.com/bartlomiejbloniarz))
 - Fix Layout Animations state leaking between Fabric surfaces by using one proxy per surface. ([#10368](https://github.com/software-mansion/react-native-reanimated/pull/10368) by [@bartlomiejbloniarz](https://github.com/bartlomiejbloniarz))
 
 ### 💡 Others

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationType.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationType.h
@@ -8,4 +8,5 @@ typedef enum class LayoutAnimationType : std::uint8_t {
   LAYOUT = 3,
   SHARED_ELEMENT_TRANSITION = 4,
   SHARED_ELEMENT_TRANSITION_NATIVE_ID = 5,
+  PROGRESS = 6,
 } LayoutAnimationType;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsManager.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsManager.cpp
@@ -1,5 +1,7 @@
 #include <reanimated/LayoutAnimations/LayoutAnimationsManager.h>
 
+#include <react/debug/react_native_assert.h>
+
 #include <memory>
 #include <unordered_map>
 #include <utility>
@@ -25,7 +27,7 @@ void LayoutAnimationsManager::configureAnimationBatch(const std::vector<LayoutAn
     if (type == LayoutAnimationType::SHARED_ELEMENT_TRANSITION) {
       if (config == nullptr) {
         // TODO (future): if the view was transitioned (e.g. so we are on the second screen)
-        // and we remove the config, we should also bring back the view (probably using tagsToRestore_)
+        // and we remove the config, we should also bring back the view (probably using TransactionMeta::tagsToRestore)
         sharedTransitions_.erase(tag);
         sharedTransitionManager_->tagToName_.erase(tag);
       } else {
@@ -52,9 +54,24 @@ bool LayoutAnimationsManager::shouldAnimateExiting(const int tag, const bool sho
   return shouldAnimateExitingForTag_.contains(tag) ? shouldAnimateExitingForTag_[tag] : shouldAnimate;
 }
 
-bool LayoutAnimationsManager::hasLayoutAnimation(const int tag, const LayoutAnimationType type) {
+std::shared_ptr<Serializable> LayoutAnimationsManager::getLayoutAnimationConfig(
+    const int tag,
+    const LayoutAnimationType type) {
   auto lock = std::unique_lock<std::recursive_mutex>(animationsMutex_);
-  return getConfigsForType(type).contains(tag);
+  const auto &configs = getConfigsForType(type);
+  const auto configIt = configs.find(tag);
+  return configIt == configs.end() ? nullptr : configIt->second;
+}
+
+std::shared_ptr<Serializable> LayoutAnimationsManager::takeExitingAnimationConfigAndClearTag(const int tag) {
+  auto lock = std::unique_lock<std::recursive_mutex>(animationsMutex_);
+  const auto configIt = exitingAnimations_.find(tag);
+  auto config = configIt == exitingAnimations_.end() ? nullptr : configIt->second;
+  enteringAnimations_.erase(tag);
+  exitingAnimations_.erase(tag);
+  layoutAnimations_.erase(tag);
+  shouldAnimateExitingForTag_.erase(tag);
+  return config;
 }
 
 void LayoutAnimationsManager::clearLayoutAnimationConfig(const int tag) {
@@ -69,14 +86,11 @@ void LayoutAnimationsManager::startLayoutAnimation(
     jsi::Runtime &rt,
     const int tag,
     const LayoutAnimationType type,
-    const jsi::Object &values) {
-  std::shared_ptr<Serializable> config;
-  {
-    auto lock = std::unique_lock<std::recursive_mutex>(animationsMutex_);
-    if (!getConfigsForType(type).contains(tag)) {
-      return;
-    }
-    config = getConfigsForType(type)[tag];
+    const jsi::Object &values,
+    const std::shared_ptr<Serializable> &config) {
+  react_native_assert(config && "layout animation config is null");
+  if (!config) {
+    return;
   }
   // TODO: cache the following!!
   jsi::Value layoutAnimationRepositoryAsValue =
@@ -110,11 +124,6 @@ void LayoutAnimationsManager::transferConfigFromNativeID(const int nativeId, con
   }
   sharedTransitionsForNativeID_.erase(nativeId);
   sharedTransitionManager_->nativeIDToName_.erase(nativeId);
-}
-
-void LayoutAnimationsManager::transferSharedConfig(const Tag from, const Tag to) {
-  auto lock = std::unique_lock<std::recursive_mutex>(animationsMutex_);
-  sharedTransitions_[to] = sharedTransitions_[from];
 }
 
 std::shared_ptr<SharedTransitionManager> LayoutAnimationsManager::getSharedTransitionManager() {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsManager.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsManager.h
@@ -6,16 +6,11 @@
 #include <reanimated/LayoutAnimations/LayoutAnimationType.h>
 
 #include <jsi/jsi.h>
-#include <stdio.h>
-#include <functional>
 #include <memory>
 #include <mutex>
 #include <optional>
-#include <stack>
 #include <string>
 #include <unordered_map>
-#include <unordered_set>
-#include <utility>
 #include <vector>
 
 namespace reanimated {
@@ -32,15 +27,15 @@ struct Transition {
   std::optional<Transform> transform[2];
 };
 
+using TransitionMap = std::unordered_map<SharedTag, Transition>;
+using Transitions = std::vector<std::pair<SharedTag, Transition>>;
+
 struct SharedTransitionManager {
   std::mutex mutex_;
   std::unordered_map<Tag, std::string> tagToName_;
   std::unordered_map<Tag, std::string> nativeIDToName_;
   Tag nextContainerTag_{10000002};
 };
-
-using TransitionMap = std::unordered_map<SharedTag, Transition>;
-using Transitions = std::vector<std::pair<SharedTag, Transition>>;
 
 struct LayoutAnimationConfig {
   int tag;
@@ -58,12 +53,17 @@ class LayoutAnimationsManager {
   void configureAnimationBatch(const std::vector<LayoutAnimationConfig> &layoutAnimationsBatch);
   void setShouldAnimateExiting(const int tag, const bool value);
   bool shouldAnimateExiting(const int tag, const bool shouldAnimate);
-  bool hasLayoutAnimation(const int tag, const LayoutAnimationType type);
-  void startLayoutAnimation(jsi::Runtime &rt, const int tag, const LayoutAnimationType type, const jsi::Object &values);
+  std::shared_ptr<Serializable> getLayoutAnimationConfig(const int tag, const LayoutAnimationType type);
+  std::shared_ptr<Serializable> takeExitingAnimationConfigAndClearTag(int tag);
+  void startLayoutAnimation(
+      jsi::Runtime &rt,
+      const int tag,
+      const LayoutAnimationType type,
+      const jsi::Object &values,
+      const std::shared_ptr<Serializable> &config);
   void clearLayoutAnimationConfig(const int tag);
   void cancelLayoutAnimation(jsi::Runtime &rt, const int tag) const;
   void transferConfigFromNativeID(const int nativeId, const int tag);
-  void transferSharedConfig(const Tag from, const Tag to);
   std::shared_ptr<SharedTransitionManager> getSharedTransitionManager();
 
  private:

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.cpp
@@ -31,11 +31,15 @@ const ShadowNode *findShadowNode(const ShadowNode &node, const Tag tag) {
 } // namespace
 #endif
 
-std::optional<facebook::react::SurfaceId> LayoutAnimationsProxyCommon::onTransitionProgress(int, double, bool, bool) {
+std::optional<facebook::react::SurfaceId> LayoutAnimationsProxyCommon::onTransitionProgress(
+    int /*tag*/,
+    double /*progress*/,
+    bool /*isClosing*/,
+    bool /*isGoingForward*/) {
   return std::nullopt;
 }
 
-std::optional<facebook::react::SurfaceId> LayoutAnimationsProxyCommon::onGestureCancel(int) {
+std::optional<facebook::react::SurfaceId> LayoutAnimationsProxyCommon::onGestureCancel(int /*tag*/) {
   return std::nullopt;
 }
 
@@ -103,19 +107,22 @@ void LayoutAnimationsProxyCommon::enqueueLayoutAnimation(ManagedLayoutAnimationS
   react_native_assert(start.config && "layout animation config is null");
   auto lock = std::unique_lock<std::recursive_mutex>(mutex);
   const auto tag = start.tag;
+  const auto type = start.type;
   layoutAnimationOperations_.push_back(std::move(start));
-  pendingLayoutAnimations_.insert_or_assign(tag, layoutAnimationOperations_.size() - 1);
+  pendingLayoutAnimations_.insert_or_assign(tag, PendingLayoutAnimation{type, layoutAnimationOperations_.size() - 1});
 }
 
 void LayoutAnimationsProxyCommon::enqueueLayoutAnimation(ProgressLayoutAnimationStart start) const {
   auto lock = std::unique_lock<std::recursive_mutex>(mutex);
   const auto tag = start.tag;
   layoutAnimationOperations_.push_back(std::move(start));
-  pendingLayoutAnimations_.try_emplace(tag, std::nullopt);
+  pendingLayoutAnimations_.try_emplace(
+      tag, PendingLayoutAnimation{LayoutAnimationType::PROGRESS, layoutAnimationOperations_.size() - 1});
 }
 
 void LayoutAnimationsProxyCommon::flushLayoutAnimationOperations(std::unique_lock<std::recursive_mutex> &lock) const {
-  react_native_assert(lock.owns_lock() && lock.mutex() == &mutex);
+  react_native_assert(
+      lock.owns_lock() && lock.mutex() == &mutex && "flushLayoutAnimationOperations requires the proxy lock");
   if (!worklets::isOnUIThread(uiScheduler_)) {
     if (!layoutAnimationOperations_.empty()) {
       requestLayoutAnimationFlush_(surfaceId_);
@@ -352,9 +359,11 @@ void LayoutAnimationsProxyCommon::updateLayoutAnimationTarget(
     const ShadowView &finalView,
     const std::shared_ptr<Serializable> &config) const {
   auto lock = std::unique_lock<std::recursive_mutex>(mutex);
-  if (const auto pendingIt = pendingLayoutAnimations_.find(tag);
-      pendingIt != pendingLayoutAnimations_.end() && pendingIt->second) {
-    const auto operationIndex = *pendingIt->second;
+  if (const auto pendingIt = pendingLayoutAnimations_.find(tag); pendingIt != pendingLayoutAnimations_.end()) {
+    if (pendingIt->second.type == LayoutAnimationType::PROGRESS) {
+      return;
+    }
+    const auto operationIndex = pendingIt->second.operationIndex;
     react_native_assert(operationIndex < layoutAnimationOperations_.size());
     if (auto *managedStart = std::get_if<ManagedLayoutAnimationStart>(&layoutAnimationOperations_[operationIndex])) {
       managedStart->after = finalView;
@@ -377,8 +386,8 @@ std::optional<ShadowView> LayoutAnimationsProxyCommon::reparentLayoutAnimation(c
   auto lock = std::unique_lock<std::recursive_mutex>(mutex);
   std::optional<ShadowView> pendingCurrentView;
   if (const auto pendingIt = pendingLayoutAnimations_.find(tag);
-      pendingIt != pendingLayoutAnimations_.end() && pendingIt->second) {
-    const auto operationIndex = *pendingIt->second;
+      pendingIt != pendingLayoutAnimations_.end() && pendingIt->second.type != LayoutAnimationType::PROGRESS) {
+    const auto operationIndex = pendingIt->second.operationIndex;
     react_native_assert(operationIndex < layoutAnimationOperations_.size());
     if (auto *managedStart = std::get_if<ManagedLayoutAnimationStart>(&layoutAnimationOperations_[operationIndex])) {
       managedStart->parentTag = parentTag;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.cpp
@@ -1,24 +1,41 @@
+#ifdef ANDROID
 #include <ReactCommon/CallInvoker.h>
-#include <folly/dynamic.h>
 #include <reanimated/Fabric/ShadowTreeCloner.h>
+#endif
+#include <folly/dynamic.h>
+#include <react/debug/react_native_assert.h>
 #include <reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.h>
+#include <reanimated/LayoutAnimations/PropsDiffer.h>
 
 #include <cstring>
-
-#include <functional>
 #include <memory>
-#include <mutex>
+#include <optional>
+#include <unordered_set>
 #include <utility>
-#include <vector>
 
 namespace reanimated {
 
-std::optional<facebook::react::SurfaceId>
-LayoutAnimationsProxyCommon::onTransitionProgress(int tag, double progress, bool isClosing, bool isGoingForward) {
+#ifdef ANDROID
+namespace {
+const ShadowNode *findShadowNode(const ShadowNode &node, const Tag tag) {
+  if (node.getTag() == tag) {
+    return &node;
+  }
+  for (const auto &child : node.getChildren()) {
+    if (const auto *result = findShadowNode(*child, tag)) {
+      return result;
+    }
+  }
+  return nullptr;
+}
+} // namespace
+#endif
+
+std::optional<facebook::react::SurfaceId> LayoutAnimationsProxyCommon::onTransitionProgress(int, double, bool, bool) {
   return std::nullopt;
 }
 
-std::optional<facebook::react::SurfaceId> LayoutAnimationsProxyCommon::onGestureCancel(int tag) {
+std::optional<facebook::react::SurfaceId> LayoutAnimationsProxyCommon::onGestureCancel(int) {
   return std::nullopt;
 }
 
@@ -36,33 +53,34 @@ void LayoutAnimationsProxyCommon::startSurface(
 }
 
 void LayoutAnimationsProxyCommon::surfaceDidUnmount() {
-  cancelAllAnimations();
+  cancelAllLayoutAnimations();
 }
 
-void LayoutAnimationsProxyCommon::cancelAllAnimations() const {
+std::optional<SurfaceId> LayoutAnimationsProxyCommon::progressLayoutAnimation(
+    const int tag,
+    const jsi::Object &newStyle) {
   auto lock = std::unique_lock<std::recursive_mutex>(mutex);
-#ifdef ANDROID
-  for (auto &[_, pendingStart] : pendingStarts_) {
-    pendingStart.handle++;
+  const auto layoutAnimationIt = layoutAnimations_.find(tag);
+  if (layoutAnimationIt == layoutAnimations_.end()) {
+    return {};
   }
+
+  auto &layoutAnimation = layoutAnimationIt->second;
+  if (layoutAnimation.opacity && !newStyle.hasProperty(uiRuntime_, "opacity")) {
+    newStyle.setProperty(uiRuntime_, "opacity", jsi::Value(*layoutAnimation.opacity));
+  }
+
+  auto rawProps = std::make_shared<RawProps>(uiRuntime_, jsi::Value(uiRuntime_, newStyle));
+  const PropsParserContext propsParserContext{surfaceId_, *contextContainer_};
+#ifdef RN_SERIALIZABLE_STATE
+  rawProps = std::make_shared<RawProps>(
+      folly::dynamic::merge(layoutAnimation.finalView.props->rawProps, (folly::dynamic)*rawProps));
 #endif
-  if (layoutAnimations_.empty()) {
-    return;
-  }
-  std::vector<Tag> tags;
-  tags.reserve(layoutAnimations_.size());
-  for (const auto &[tag, _] : layoutAnimations_) {
-    tags.push_back(tag);
-  }
-  layoutAnimations_.clear();
-  maybeSettledAnimationTags_.clear();
-  scheduleOnUI(
-      uiScheduler_,
-      [layoutAnimationsManager = layoutAnimationsManager_, &uiRuntime = uiRuntime_, tags = std::move(tags)]() {
-        for (const auto tag : tags) {
-          layoutAnimationsManager->cancelLayoutAnimation(uiRuntime, tag);
-        }
-      });
+  auto newProps = componentDescriptorRegistry_->at(layoutAnimation.finalView.componentHandle)
+                      .cloneProps(propsParserContext, layoutAnimation.finalView.props, std::move(*rawProps));
+  updateMap_.insert_or_assign(tag, UpdateValues{newProps, Frame(uiRuntime_, newStyle)});
+
+  return surfaceId_;
 }
 
 void LayoutAnimationsProxyCommon::transferConfigFromNativeID(const std::string &nativeIdString, const int tag) const {
@@ -81,6 +99,360 @@ void LayoutAnimationsProxyCommon::transferConfigFromNativeID(const std::string &
   layoutAnimationsManager_->transferConfigFromNativeID(nativeId, tag);
 }
 
+void LayoutAnimationsProxyCommon::enqueueLayoutAnimation(ManagedLayoutAnimationStart start) const {
+  react_native_assert(start.config && "layout animation config is null");
+  auto lock = std::unique_lock<std::recursive_mutex>(mutex);
+  const auto tag = start.tag;
+  layoutAnimationOperations_.push_back(std::move(start));
+  pendingLayoutAnimations_.insert_or_assign(tag, layoutAnimationOperations_.size() - 1);
+}
+
+void LayoutAnimationsProxyCommon::enqueueLayoutAnimation(ProgressLayoutAnimationStart start) const {
+  auto lock = std::unique_lock<std::recursive_mutex>(mutex);
+  const auto tag = start.tag;
+  layoutAnimationOperations_.push_back(std::move(start));
+  pendingLayoutAnimations_.try_emplace(tag, std::nullopt);
+}
+
+void LayoutAnimationsProxyCommon::flushLayoutAnimationOperations(std::unique_lock<std::recursive_mutex> &lock) const {
+  react_native_assert(lock.owns_lock() && lock.mutex() == &mutex);
+  if (!worklets::isOnUIThread(uiScheduler_)) {
+    if (!layoutAnimationOperations_.empty()) {
+      requestLayoutAnimationFlush_(surfaceId_);
+    }
+    return;
+  }
+  flushLayoutAnimationOperationsLocked();
+}
+
+ShadowView LayoutAnimationsProxyCommon::materializeLayoutAnimation(
+    const Tag tag,
+    const ShadowView &before,
+    const ShadowView &after,
+    const Tag parentTag,
+    const std::optional<double> opacity,
+    const LayoutAnimationType type) const {
+  auto currentView = before;
+  const auto activeAnimationIt = layoutAnimations_.find(tag);
+  if (type == LayoutAnimationType::ENTERING) {
+    currentView = after;
+  } else if (activeAnimationIt != layoutAnimations_.end()) {
+    currentView = activeAnimationIt->second.currentView;
+  } else if (const auto completedAnimationIt = completedAnimations_.find(tag);
+             completedAnimationIt != completedAnimations_.end()) {
+    if (!completedAnimationIt->second.shouldRemove) {
+      currentView = completedAnimationIt->second.animation.currentView;
+    }
+  }
+
+  if (activeAnimationIt != layoutAnimations_.end()) {
+    updateMap_.erase(tag);
+  }
+
+  if (const auto completedAnimationIt = completedAnimations_.find(tag);
+      completedAnimationIt != completedAnimations_.end()) {
+    updateMap_.erase(tag);
+    completedAnimations_.erase(completedAnimationIt);
+  }
+
+  layoutAnimations_.insert_or_assign(
+      tag,
+      LayoutAnimation{
+          .finalView = after,
+          .currentView = currentView,
+          .startView = currentView,
+          .parentTag = parentTag,
+          .opacity = opacity,
+          .type = type,
+      });
+  return currentView;
+}
+
+std::optional<LayoutAnimationsProxyCommon::PreparedLayoutAnimationOperation>
+LayoutAnimationsProxyCommon::takeNextLayoutAnimationOperation(std::deque<LayoutAnimationOperation> &operations) const {
+  if (operations.empty()) {
+    return std::nullopt;
+  }
+
+  auto operation = std::move(operations.front());
+  operations.pop_front();
+  if (auto *managedStart = std::get_if<ManagedLayoutAnimationStart>(&operation)) {
+    managedStart->before = materializeLayoutAnimation(
+        managedStart->tag,
+        managedStart->before,
+        managedStart->after,
+        managedStart->parentTag,
+        managedStart->opacity,
+        managedStart->type);
+    return PreparedLayoutAnimationStart{
+        .start = std::move(*managedStart),
+        .window = window_,
+    };
+  }
+  if (const auto *progressStart = std::get_if<ProgressLayoutAnimationStart>(&operation)) {
+    const auto tag = progressStart->tag;
+    const auto activeAnimationIt = layoutAnimations_.find(tag);
+    if (activeAnimationIt != layoutAnimations_.end() &&
+        activeAnimationIt->second.type != LayoutAnimationType::PROGRESS) {
+      activeAnimationIt->second.type = LayoutAnimationType::PROGRESS;
+      operations.push_front(std::move(operation));
+      return LayoutAnimationStop{tag};
+    }
+    materializeLayoutAnimation(
+        tag,
+        progressStart->before,
+        progressStart->after,
+        progressStart->parentTag,
+        std::nullopt,
+        LayoutAnimationType::PROGRESS);
+    return std::monostate{};
+  }
+  const auto cancellation = std::get<LayoutAnimationCancellation>(operation);
+  react_native_assert(cancellation.shouldStopManager);
+  return LayoutAnimationStop{cancellation.tag};
+}
+
+void LayoutAnimationsProxyCommon::reconcileLayoutAnimationOperations(
+    std::deque<LayoutAnimationOperation> &operations) const {
+  std::unordered_set<Tag> cancelledTags;
+  auto reconciled = std::deque<LayoutAnimationOperation>{};
+  for (auto operationIt = operations.rbegin(); operationIt != operations.rend(); operationIt++) {
+    auto &operation = *operationIt;
+    if (const auto *cancellation = std::get_if<LayoutAnimationCancellation>(&operation)) {
+      cancelledTags.insert(cancellation->tag);
+      if (cancellation->shouldStopManager) {
+        reconciled.push_front(std::move(operation));
+      }
+      continue;
+    }
+    const auto tag = std::visit([](const auto &start) { return start.tag; }, operation);
+    if (!cancelledTags.contains(tag)) {
+      reconciled.push_front(std::move(operation));
+    }
+  }
+  operations = std::move(reconciled);
+}
+
+void LayoutAnimationsProxyCommon::flushLayoutAnimationOperationsLocked() const {
+  auto operations = std::exchange(layoutAnimationOperations_, std::deque<LayoutAnimationOperation>{});
+  pendingLayoutAnimations_.clear();
+  reconcileLayoutAnimationOperations(operations);
+  for (auto operation = takeNextLayoutAnimationOperation(operations); operation;
+       operation = takeNextLayoutAnimationOperation(operations)) {
+    if (const auto *stop = std::get_if<LayoutAnimationStop>(&*operation)) {
+      layoutAnimationsManager_->cancelLayoutAnimation(uiRuntime_, stop->tag);
+      continue;
+    }
+    const auto *preparedStart = std::get_if<PreparedLayoutAnimationStart>(&*operation);
+    if (!preparedStart) {
+      continue;
+    }
+    const auto &start = preparedStart->start;
+    const auto &window = preparedStart->window;
+
+    jsi::Object values(uiRuntime_);
+    if (start.type == LayoutAnimationType::SHARED_ELEMENT_TRANSITION) {
+      auto propsDiffer = PropsDiffer(uiRuntime_, start.before, start.after);
+      values = propsDiffer.computeDiff(uiRuntime_);
+    } else {
+      const Snapshot current(start.before, window);
+      const Snapshot target(start.after, window);
+      if (start.type != LayoutAnimationType::ENTERING) {
+        values.setProperty(uiRuntime_, "currentOriginX", current.x);
+        values.setProperty(uiRuntime_, "currentGlobalOriginX", current.x);
+        values.setProperty(uiRuntime_, "currentOriginY", current.y);
+        values.setProperty(uiRuntime_, "currentGlobalOriginY", current.y);
+        values.setProperty(uiRuntime_, "currentWidth", current.width);
+        values.setProperty(uiRuntime_, "currentHeight", current.height);
+      }
+      if (start.type != LayoutAnimationType::EXITING) {
+        values.setProperty(uiRuntime_, "targetOriginX", target.x);
+        values.setProperty(uiRuntime_, "targetGlobalOriginX", target.x);
+        values.setProperty(uiRuntime_, "targetOriginY", target.y);
+        values.setProperty(uiRuntime_, "targetGlobalOriginY", target.y);
+        values.setProperty(uiRuntime_, "targetWidth", target.width);
+        values.setProperty(uiRuntime_, "targetHeight", target.height);
+      }
+    }
+    values.setProperty(uiRuntime_, "windowWidth", window.width);
+    values.setProperty(uiRuntime_, "windowHeight", window.height);
+    layoutAnimationsManager_->startLayoutAnimation(uiRuntime_, start.tag, start.type, values, start.config);
+  }
+  if (!layoutAnimationOperations_.empty()) {
+    requestLayoutAnimationFlush_(surfaceId_);
+  }
+}
+
+void LayoutAnimationsProxyCommon::flushLayoutAnimationOperations() const {
+  react_native_assert(worklets::isOnUIThread(uiScheduler_));
+  auto lock = std::unique_lock<std::recursive_mutex>(mutex);
+  flushLayoutAnimationOperationsLocked();
+}
+
+void LayoutAnimationsProxyCommon::cancelLayoutAnimation(const Tag tag) const {
+  auto lock = std::unique_lock<std::recursive_mutex>(mutex);
+  const auto cancelsPendingStart = pendingLayoutAnimations_.contains(tag);
+  auto shouldStopManager = false;
+
+  if (const auto layoutAnimationIt = layoutAnimations_.find(tag); layoutAnimationIt != layoutAnimations_.end()) {
+    shouldStopManager = layoutAnimationIt->second.type != LayoutAnimationType::PROGRESS;
+    updateMap_.erase(tag);
+    layoutAnimations_.erase(layoutAnimationIt);
+  } else if (const auto completedAnimationIt = completedAnimations_.find(tag);
+             completedAnimationIt != completedAnimations_.end()) {
+    updateMap_.erase(tag);
+    completedAnimations_.erase(completedAnimationIt);
+  }
+  if (cancelsPendingStart || shouldStopManager) {
+    layoutAnimationOperations_.push_back(LayoutAnimationCancellation{tag, shouldStopManager});
+    pendingLayoutAnimations_.erase(tag);
+  }
+}
+
+void LayoutAnimationsProxyCommon::cancelAllLayoutAnimations() const {
+  std::vector<Tag> stops;
+  {
+    auto lock = std::unique_lock<std::recursive_mutex>(mutex);
+    std::unordered_set<Tag> stoppedTags;
+    for (const auto &operation : layoutAnimationOperations_) {
+      if (const auto *cancellation = std::get_if<LayoutAnimationCancellation>(&operation);
+          cancellation && cancellation->shouldStopManager && stoppedTags.insert(cancellation->tag).second) {
+        stops.push_back(cancellation->tag);
+      }
+    }
+    layoutAnimationOperations_.clear();
+    pendingLayoutAnimations_.clear();
+    for (const auto &[tag, animation] : layoutAnimations_) {
+      if (animation.type != LayoutAnimationType::PROGRESS && stoppedTags.insert(tag).second) {
+        stops.push_back(tag);
+      }
+    }
+    updateMap_.clear();
+    layoutAnimations_.clear();
+    completedAnimations_.clear();
+  }
+  if (!stops.empty()) {
+    scheduleOnUI(
+        uiScheduler_,
+        [layoutAnimationsManager = layoutAnimationsManager_, &uiRuntime = uiRuntime_, stops = std::move(stops)]() {
+          for (const auto tag : stops) {
+            layoutAnimationsManager->cancelLayoutAnimation(uiRuntime, tag);
+          }
+        });
+  }
+}
+
+bool LayoutAnimationsProxyCommon::hasPendingLayoutAnimation(const Tag tag) const {
+  auto lock = std::unique_lock<std::recursive_mutex>(mutex);
+  return pendingLayoutAnimations_.contains(tag);
+}
+
+void LayoutAnimationsProxyCommon::updateLayoutAnimationTarget(
+    const Tag tag,
+    const ShadowView &finalView,
+    const std::shared_ptr<Serializable> &config) const {
+  auto lock = std::unique_lock<std::recursive_mutex>(mutex);
+  if (const auto pendingIt = pendingLayoutAnimations_.find(tag);
+      pendingIt != pendingLayoutAnimations_.end() && pendingIt->second) {
+    const auto operationIndex = *pendingIt->second;
+    react_native_assert(operationIndex < layoutAnimationOperations_.size());
+    if (auto *managedStart = std::get_if<ManagedLayoutAnimationStart>(&layoutAnimationOperations_[operationIndex])) {
+      managedStart->after = finalView;
+      if (config) {
+        managedStart->config = config;
+      }
+      return;
+    }
+    react_native_assert(false && "Pending managed layout animation not found");
+  }
+  if (const auto animationIt = layoutAnimations_.find(tag); animationIt != layoutAnimations_.end()) {
+    animationIt->second.finalView = finalView;
+    return;
+  }
+  react_native_assert(false && "Layout animation not found");
+}
+
+std::optional<ShadowView> LayoutAnimationsProxyCommon::reparentLayoutAnimation(const Tag tag, const Tag parentTag)
+    const {
+  auto lock = std::unique_lock<std::recursive_mutex>(mutex);
+  std::optional<ShadowView> pendingCurrentView;
+  if (const auto pendingIt = pendingLayoutAnimations_.find(tag);
+      pendingIt != pendingLayoutAnimations_.end() && pendingIt->second) {
+    const auto operationIndex = *pendingIt->second;
+    react_native_assert(operationIndex < layoutAnimationOperations_.size());
+    if (auto *managedStart = std::get_if<ManagedLayoutAnimationStart>(&layoutAnimationOperations_[operationIndex])) {
+      managedStart->parentTag = parentTag;
+      pendingCurrentView = managedStart->before;
+    } else {
+      react_native_assert(false && "Pending managed layout animation not found");
+    }
+  }
+  if (const auto animationIt = layoutAnimations_.find(tag); animationIt != layoutAnimations_.end()) {
+    animationIt->second.parentTag = parentTag;
+    return animationIt->second.currentView;
+  }
+  if (const auto completedAnimationIt = completedAnimations_.find(tag);
+      completedAnimationIt != completedAnimations_.end() && !completedAnimationIt->second.shouldRemove) {
+    return completedAnimationIt->second.animation.currentView;
+  }
+  return pendingCurrentView;
+}
+
+void LayoutAnimationsProxyCommon::cleanupCompletedAnimations(
+    ShadowViewMutationList &mutations,
+    const PropsParserContext &propsParserContext,
+    const bool preserveRemovals) const {
+#ifdef ANDROID
+  std::vector<OpacityRestoration> opacityRestorations;
+#endif
+  for (auto it = completedAnimations_.begin(); it != completedAnimations_.end();) {
+    const auto tag = it->first;
+    auto &completedAnimation = it->second;
+    if (hasPendingLayoutAnimation(tag)) {
+      ++it;
+      continue;
+    }
+    if (preserveRemovals && completedAnimation.shouldRemove) {
+      ++it;
+      continue;
+    }
+    if (!completedAnimation.shouldRemove && completedAnimation.animation.opacity) {
+      auto &animation = completedAnimation.animation;
+#ifdef ANDROID
+      opacityRestorations.push_back(OpacityRestoration{
+          .shadowView = animation.finalView,
+          .opacity = *animation.opacity,
+      });
+#else
+      auto restoredView = cloneViewWithOpacity(animation.currentView, *animation.opacity, propsParserContext);
+      mutations.push_back(ShadowViewMutation::UpdateMutation(animation.currentView, restoredView, animation.parentTag));
+#endif
+    }
+    updateMap_.erase(tag);
+    it = completedAnimations_.erase(it);
+  }
+#ifdef ANDROID
+  if (!opacityRestorations.empty()) {
+    restoreOpacityInShadowTree(std::move(opacityRestorations));
+  }
+#endif
+}
+
+ShadowView LayoutAnimationsProxyCommon::cloneViewWithOpacity(
+    const ShadowView &shadowView,
+    const double opacity,
+    const PropsParserContext &propsParserContext) const {
+  auto newView = shadowView;
+  folly::dynamic opacityProps = folly::dynamic::object("opacity", opacity);
+  newView.props = componentDescriptorRegistry_->at(newView.componentHandle)
+                      .cloneProps(propsParserContext, newView.props, RawProps(opacityProps));
+  return newView;
+}
+
+void LayoutAnimationsProxyCommon::schedulePullOnNextFrame() const {
+  requestLayoutAnimationFlush_(surfaceId_);
+}
+
 void LayoutAnimationsProxyCommon::maybeUpdateWindowDimensions(const ShadowViewMutation &mutation) const {
   if (mutation.type == ShadowViewMutation::Update &&
       !std::strcmp(mutation.oldChildShadowView.componentName, RootComponentName)) {
@@ -89,62 +461,48 @@ void LayoutAnimationsProxyCommon::maybeUpdateWindowDimensions(const ShadowViewMu
         mutation.newChildShadowView.layoutMetrics.frame.size.height};
   }
 }
+
 #ifdef ANDROID
-
-const facebook::react::ShadowNode *findInShadowTreeByTag(const facebook::react::ShadowNode &node, Tag tag) {
-  if (node.getTag() == tag) {
-    return &node;
-  }
-  for (const auto &child : node.getChildren()) {
-    if (const auto result = findInShadowTreeByTag(*child, tag)) {
-      return result;
-    }
-  }
-  return nullptr;
-}
-
-void LayoutAnimationsProxyCommon::restoreOpacityInCaseOfFlakyEnteringAnimation() const {
-  std::vector<std::pair<double, Tag>> opacityToRestore;
-  for (const auto tag : maybeSettledAnimationTags_) {
-    const auto layoutAnimationIt = layoutAnimations_.find(tag);
-    if (layoutAnimationIt == layoutAnimations_.end() || !layoutAnimationIt->second.isSettled()) {
-      continue;
-    }
-    const auto &opacity = layoutAnimationIt->second.opacity;
-    if (opacity.has_value()) {
-      opacityToRestore.emplace_back(std::pair<double, Tag>{opacity.value(), tag});
-    }
-  }
-  if (opacityToRestore.empty()) {
-    // Animation was successfully finished, and the opacity was restored, so we
-    // don't need to do anything. Only the Entering animation has a set opacity
-    // value.
-    return;
-  }
+void LayoutAnimationsProxyCommon::scheduleCleanupPull() const {
   const std::weak_ptr<UIManager> weakUiManager = uiManager_;
-  jsInvoker_->invokeAsync([weakUiManager, surfaceId = surfaceId_, opacityToRestore](jsi::Runtime &runtime) {
-    auto uiManager = weakUiManager.lock();
-    if (!uiManager) {
-      return;
+  jsInvoker_->invokeAsync([weakUiManager, surfaceId = surfaceId_](jsi::Runtime &) {
+    if (const auto uiManager = weakUiManager.lock()) {
+      uiManager->getShadowTreeRegistry().visit(
+          surfaceId, [](const ShadowTree &shadowTree) { shadowTree.notifyDelegatesOfUpdates(); });
     }
-    uiManager->getShadowTreeRegistry().visit(surfaceId, [=](ShadowTree const &shadowTree) {
-      shadowTree.commit(
-          [=](RootShadowNode const &oldRootShadowNode) {
-            const auto &rootShadowNode = static_cast<const ShadowNode &>(oldRootShadowNode);
-            PropsMap propsMap;
-            for (const auto &[opacity, tag] : opacityToRestore) {
-              const auto *targetShadowNode = findInShadowTreeByTag(rootShadowNode, tag);
-              if (targetShadowNode != nullptr) {
-                propsMap[targetShadowNode->getFamilyShared()].emplace_back(folly::dynamic::object("opacity", opacity));
-              }
-            }
-            return cloneShadowTreeWithNewProps(oldRootShadowNode, propsMap);
-          },
-          {});
-    });
   });
 }
 
-#endif // ANDROID
+void LayoutAnimationsProxyCommon::restoreOpacityInShadowTree(std::vector<OpacityRestoration> restorations) const {
+  const std::weak_ptr<UIManager> weakUiManager = uiManager_;
+  jsInvoker_->invokeAsync(
+      [weakUiManager, surfaceId = surfaceId_, restorations = std::move(restorations)](jsi::Runtime &) {
+        const auto uiManager = weakUiManager.lock();
+        if (!uiManager) {
+          return;
+        }
+        uiManager->getShadowTreeRegistry().visit(surfaceId, [&restorations](const ShadowTree &shadowTree) {
+          shadowTree.commit(
+              [&restorations](const RootShadowNode &oldRootShadowNode) -> RootShadowNode::Unshared {
+                PropsMap propsMap;
+                for (const auto &restoration : restorations) {
+                  if (!restoration.shadowView.eventEmitter) {
+                    continue;
+                  }
+                  const auto *node = findShadowNode(oldRootShadowNode, restoration.shadowView.tag);
+                  if (!node || node->getComponentHandle() != restoration.shadowView.componentHandle ||
+                      node->getEventEmitter() != restoration.shadowView.eventEmitter) {
+                    continue;
+                  }
+                  folly::dynamic opacity = folly::dynamic::object("opacity", restoration.opacity);
+                  propsMap[node->getFamilyShared()].emplace_back(std::move(opacity));
+                }
+                return propsMap.empty() ? nullptr : cloneShadowTreeWithNewProps(oldRootShadowNode, propsMap);
+              },
+              {});
+        });
+      });
+}
+#endif
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.h
@@ -93,14 +93,15 @@ class LayoutAnimationsProxyCommon : public facebook::react::MountingOverrideDele
 #endif
   {
   }
-  virtual std::optional<facebook::react::SurfaceId> onTransitionProgress(int, double, bool, bool);
-  virtual std::optional<facebook::react::SurfaceId> onGestureCancel(int);
+  virtual std::optional<facebook::react::SurfaceId>
+  onTransitionProgress(int tag, double progress, bool isClosing, bool isGoingForward);
+  virtual std::optional<facebook::react::SurfaceId> onGestureCancel(int tag);
   std::optional<SurfaceId> progressLayoutAnimation(int tag, const jsi::Object &newStyle);
   virtual std::optional<SurfaceId> endLayoutAnimation(int tag, bool shouldRemove) = 0;
   virtual void startSurface(
-      const facebook::react::ShadowTree &,
-      std::weak_ptr<const facebook::react::MountingOverrideDelegate>);
-  virtual void shadowTreeWillCommit(bool) {}
+      const facebook::react::ShadowTree &shadowTree,
+      std::weak_ptr<const facebook::react::MountingOverrideDelegate> mountingOverrideDelegate);
+  virtual void shadowTreeWillCommit(bool /*isSurfaceRemoval*/) {}
   virtual void surfaceDidUnmount();
   ~LayoutAnimationsProxyCommon() override = default;
 
@@ -186,8 +187,13 @@ class LayoutAnimationsProxyCommon : public facebook::react::MountingOverrideDele
   void restoreOpacityInShadowTree(std::vector<OpacityRestoration> restorations) const;
 #endif
 
+  struct PendingLayoutAnimation {
+    LayoutAnimationType type;
+    size_t operationIndex;
+  };
+
   mutable std::deque<LayoutAnimationOperation> layoutAnimationOperations_;
-  mutable std::unordered_map<Tag, std::optional<size_t>> pendingLayoutAnimations_;
+  mutable std::unordered_map<Tag, PendingLayoutAnimation> pendingLayoutAnimations_;
 };
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.h
@@ -1,21 +1,22 @@
 #pragma once
 
 #include <jsi/jsi.h>
-#include <react/debug/react_native_assert.h>
 #include <react/renderer/componentregistry/ComponentDescriptorFactory.h>
 #include <react/renderer/mounting/MountingOverrideDelegate.h>
 #include <react/renderer/mounting/ShadowTree.h>
+#include <react/renderer/mounting/ShadowView.h>
 #include <react/renderer/uimanager/UIManager.h>
 #include <reanimated/Compat/WorkletsApi.h>
 #include <reanimated/LayoutAnimations/LayoutAnimationsManager.h>
 #include <reanimated/LayoutAnimations/LayoutAnimationsUtils.h>
 #include <reanimated/Tools/PlatformDepMethodsHolder.h>
 
+#include <deque>
 #include <memory>
 #include <mutex>
 #include <optional>
 #include <unordered_map>
-#include <unordered_set>
+#include <variant>
 #include <vector>
 
 namespace reanimated {
@@ -24,40 +25,37 @@ struct LayoutAnimation {
   ShadowView finalView, currentView, startView;
   Tag parentTag;
   std::optional<double> opacity;
-  bool isViewAlreadyMounted = false;
-  bool isExitingWhenSettled = false;
-  int count = 1;
+  LayoutAnimationType type;
   LayoutAnimation &operator=(const LayoutAnimation &other) = default;
-
-  bool isSettled() const {
-    return count == 0;
-  }
 };
 
-#ifdef ANDROID
-// Bookkeeping for animation starts that were scheduled onto the UI thread but
-// haven't run yet — see `pendingStarts_` below.
-struct PendingStart {
-  int count = 0;
-  uint64_t handle = 0;
+struct CompletedLayoutAnimation {
+  LayoutAnimation animation;
+  bool shouldRemove;
 };
 
-// Removes one pending start for the given tag and returns whether it was
-// cancelled since it was scheduled (i.e. its handle is no longer current).
-// Call under the proxy mutex.
-inline bool
-consumeIsCancelled(std::unordered_map<Tag, PendingStart> &pendingStarts, const Tag tag, const uint64_t handle) {
-  const auto it = pendingStarts.find(tag);
-  // every scheduled start keeps its entry alive until it is consumed —
-  // cancellations only bump the handle, they never erase
-  react_native_assert(it != pendingStarts.end() && "PendingStart not found");
-  const bool isCancelled = it->second.handle != handle;
-  if (--it->second.count == 0) {
-    pendingStarts.erase(it);
-  }
-  return isCancelled;
-}
-#endif
+struct ManagedLayoutAnimationStart {
+  Tag tag;
+  LayoutAnimationType type;
+  ShadowView before, after;
+  Tag parentTag;
+  std::optional<double> opacity;
+  std::shared_ptr<Serializable> config;
+};
+
+struct ProgressLayoutAnimationStart {
+  Tag tag;
+  ShadowView before, after;
+  Tag parentTag;
+};
+
+struct LayoutAnimationCancellation {
+  Tag tag;
+  bool shouldStopManager;
+};
+
+using LayoutAnimationOperation =
+    std::variant<ManagedLayoutAnimationStart, ProgressLayoutAnimationStart, LayoutAnimationCancellation>;
 
 struct LayoutAnimationsProxyDependencies {
   std::shared_ptr<LayoutAnimationsManager> layoutAnimationsManager;
@@ -66,6 +64,7 @@ struct LayoutAnimationsProxyDependencies {
   jsi::Runtime &uiRuntime;
   std::shared_ptr<UIScheduler> uiScheduler;
   std::shared_ptr<facebook::react::UIManager> uiManager;
+  std::function<void(SurfaceId)> requestLayoutAnimationFlush;
 #ifdef ANDROID
   PreserveMountedTagsFunction filterUnmountedTagsFunction;
   std::shared_ptr<facebook::react::CallInvoker> jsInvoker;
@@ -75,18 +74,18 @@ struct LayoutAnimationsProxyDependencies {
 #endif
 };
 
-class LayoutAnimationsProxyCommon : public facebook::react::MountingOverrideDelegate {
+class LayoutAnimationsProxyCommon : public facebook::react::MountingOverrideDelegate,
+                                    public std::enable_shared_from_this<LayoutAnimationsProxyCommon> {
  public:
-  LayoutAnimationsProxyCommon(
-      const facebook::react::SurfaceId surfaceId,
-      const LayoutAnimationsProxyDependencies &dependencies)
+  LayoutAnimationsProxyCommon(SurfaceId surfaceId, const LayoutAnimationsProxyDependencies &dependencies)
       : surfaceId_(surfaceId),
         layoutAnimationsManager_(dependencies.layoutAnimationsManager),
         contextContainer_(dependencies.contextContainer),
         componentDescriptorRegistry_(dependencies.componentDescriptorRegistry),
         uiRuntime_(dependencies.uiRuntime),
         uiScheduler_(dependencies.uiScheduler),
-        uiManager_(dependencies.uiManager)
+        uiManager_(dependencies.uiManager),
+        requestLayoutAnimationFlush_(dependencies.requestLayoutAnimationFlush)
 #ifdef ANDROID
         ,
         preserveMountedTags_(dependencies.filterUnmountedTagsFunction),
@@ -94,55 +93,101 @@ class LayoutAnimationsProxyCommon : public facebook::react::MountingOverrideDele
 #endif
   {
   }
-  virtual std::optional<facebook::react::SurfaceId>
-  onTransitionProgress(int tag, double progress, bool isClosing, bool isGoingForward);
-  virtual std::optional<facebook::react::SurfaceId> onGestureCancel(int tag);
-  virtual std::optional<SurfaceId> progressLayoutAnimation(int tag, const jsi::Object &newStyle) = 0;
+  virtual std::optional<facebook::react::SurfaceId> onTransitionProgress(int, double, bool, bool);
+  virtual std::optional<facebook::react::SurfaceId> onGestureCancel(int);
+  std::optional<SurfaceId> progressLayoutAnimation(int tag, const jsi::Object &newStyle);
   virtual std::optional<SurfaceId> endLayoutAnimation(int tag, bool shouldRemove) = 0;
   virtual void startSurface(
-      const facebook::react::ShadowTree &shadowTree,
-      std::weak_ptr<const facebook::react::MountingOverrideDelegate> mountingOverrideDelegate);
-  virtual void shadowTreeWillCommit(bool isSurfaceRemoval) {}
+      const facebook::react::ShadowTree &,
+      std::weak_ptr<const facebook::react::MountingOverrideDelegate>);
+  virtual void shadowTreeWillCommit(bool) {}
   virtual void surfaceDidUnmount();
   ~LayoutAnimationsProxyCommon() override = default;
 
+  void flushLayoutAnimationOperations() const;
+
  protected:
   void transferConfigFromNativeID(const std::string &nativeId, const int tag) const;
+  void enqueueLayoutAnimation(ManagedLayoutAnimationStart start) const;
+  void enqueueLayoutAnimation(ProgressLayoutAnimationStart start) const;
+  void flushLayoutAnimationOperations(std::unique_lock<std::recursive_mutex> &lock) const;
+  void cancelLayoutAnimation(Tag tag) const;
+  void cancelAllLayoutAnimations() const;
+  bool hasPendingLayoutAnimation(Tag tag) const;
+  void updateLayoutAnimationTarget(
+      Tag tag,
+      const ShadowView &finalView,
+      const std::shared_ptr<Serializable> &config = nullptr) const;
+  std::optional<ShadowView> reparentLayoutAnimation(Tag tag, Tag parentTag) const;
+  void schedulePullOnNextFrame() const;
   void maybeUpdateWindowDimensions(const ShadowViewMutation &mutation) const;
-  void cancelAllAnimations() const;
+  void cleanupCompletedAnimations(
+      ShadowViewMutationList &mutations,
+      const PropsParserContext &propsParserContext,
+      bool preserveRemovals = false) const;
+  ShadowView cloneViewWithOpacity(
+      const ShadowView &shadowView,
+      double opacity,
+      const PropsParserContext &propsParserContext) const;
+#ifdef ANDROID
+  void scheduleCleanupPull() const;
+#endif
 
   const SurfaceId surfaceId_;
   mutable std::recursive_mutex mutex;
-  mutable std::unordered_set<Tag> maybeSettledAnimationTags_;
-  mutable std::unordered_map<Tag, LayoutAnimation> layoutAnimations_;
   mutable std::unordered_map<Tag, UpdateValues> updateMap_;
   mutable Rect window_{0, 0};
+  mutable std::unordered_map<Tag, LayoutAnimation> layoutAnimations_;
+  // endLayoutAnimation runs outside pullTransaction on both platforms, so its
+  // animation state must survive until a pull emits the final update or removal.
+  mutable std::unordered_map<Tag, CompletedLayoutAnimation> completedAnimations_;
   std::shared_ptr<LayoutAnimationsManager> layoutAnimationsManager_;
   std::shared_ptr<const ContextContainer> contextContainer_;
   SharedComponentDescriptorRegistry componentDescriptorRegistry_;
   jsi::Runtime &uiRuntime_;
   const std::shared_ptr<UIScheduler> uiScheduler_;
   std::shared_ptr<facebook::react::UIManager> uiManager_;
-  PreserveMountedTagsFunction preserveMountedTags_;
-
+  std::function<void(SurfaceId)> requestLayoutAnimationFlush_;
 #ifdef ANDROID
+  PreserveMountedTagsFunction preserveMountedTags_;
   std::shared_ptr<facebook::react::CallInvoker> jsInvoker_;
-
-  void restoreOpacityInCaseOfFlakyEnteringAnimation() const;
-
-  // On Android pullTransaction can run on the JS thread, so animation starts
-  // are scheduled onto the UI thread. If `maybeCancelAnimation` is called between the
-  // start was scheduled and the lambda runs, it
-  // finds no `layoutAnimations_` entry to erase (the start lambda hasn't created it
-  // yet) and the cancellation is lost — the stale start would later
-  // "resurrect" the animation for a view whose Remove+Delete are already on
-  // their way to the mounting layer
-  // (https://github.com/software-mansion/react-native-reanimated/issues/7493).
-
-  // To work around this, we keep a separate `pendingStarts_` map that tracks scheduled starts by tag,
-  //  with a generation counter to detect cancellations.
-  mutable std::unordered_map<Tag, PendingStart> pendingStarts_;
 #endif
+
+ private:
+  struct LayoutAnimationStop {
+    Tag tag;
+  };
+
+  struct PreparedLayoutAnimationStart {
+    ManagedLayoutAnimationStart start;
+    Rect window;
+  };
+  using PreparedLayoutAnimationOperation =
+      std::variant<PreparedLayoutAnimationStart, LayoutAnimationStop, std::monostate>;
+#ifdef ANDROID
+  struct OpacityRestoration {
+    ShadowView shadowView;
+    double opacity;
+  };
+#endif
+
+  void reconcileLayoutAnimationOperations(std::deque<LayoutAnimationOperation> &operations) const;
+  void flushLayoutAnimationOperationsLocked() const;
+  std::optional<PreparedLayoutAnimationOperation> takeNextLayoutAnimationOperation(
+      std::deque<LayoutAnimationOperation> &operations) const;
+  ShadowView materializeLayoutAnimation(
+      Tag tag,
+      const ShadowView &before,
+      const ShadowView &after,
+      Tag parentTag,
+      std::optional<double> opacity,
+      LayoutAnimationType type) const;
+#ifdef ANDROID
+  void restoreOpacityInShadowTree(std::vector<OpacityRestoration> restorations) const;
+#endif
+
+  mutable std::deque<LayoutAnimationOperation> layoutAnimationOperations_;
+  mutable std::unordered_map<Tag, std::optional<size_t>> pendingLayoutAnimations_;
 };
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyRegistry.cpp
@@ -80,6 +80,12 @@ std::optional<SurfaceId> LayoutAnimationsProxyRegistry::onGestureCancel(const in
   return {};
 }
 
+void LayoutAnimationsProxyRegistry::flushLayoutAnimationOperations() const {
+  for (const auto &instance : instances()) {
+    instance->flushLayoutAnimationOperations();
+  }
+}
+
 std::vector<std::shared_ptr<LayoutAnimationsProxyCommon>> LayoutAnimationsProxyRegistry::instances() const {
   const std::lock_guard<std::mutex> lock(instancesMutex_);
   std::vector<std::shared_ptr<LayoutAnimationsProxyCommon>> instances;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyRegistry.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyRegistry.h
@@ -25,6 +25,7 @@ class LayoutAnimationsProxyRegistry {
   std::optional<SurfaceId> endLayoutAnimation(int tag, bool shouldRemove);
   std::optional<SurfaceId> onTransitionProgress(int tag, double progress, bool isClosing, bool isGoingForward);
   std::optional<SurfaceId> onGestureCancel(int tag);
+  void flushLayoutAnimationOperations() const;
 
  private:
   std::vector<std::shared_ptr<LayoutAnimationsProxyCommon>> instances() const;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
@@ -52,19 +52,18 @@ std::optional<MountingTransaction> LayoutAnimationsProxy_Experimental::pullTrans
     return MountingTransaction{surfaceId, transactionNumber, std::move(mutations), telemetry};
   }
   const PropsParserContext propsParserContext{surfaceId_, *contextContainer_};
-  ShadowViewMutationList filteredMutations;
+  TransactionMeta transaction;
+  auto &filteredMutations = transaction.filteredMutations;
   auto rootChildCount = static_cast<int>(lightNodes_[surfaceId_]->children.size());
   const std::vector<std::shared_ptr<MutationNode>> roots;
   const bool isInTransition = static_cast<bool>(transitionState_);
-  ShadowViewMutationList teardownMutations;
-
   reconcileContradictedRemovals(mutations, filteredMutations);
 
   if (isInTransition) {
-    updateLightTree(propsParserContext, mutations, filteredMutations, teardownMutations);
-    handleProgressTransition(filteredMutations, mutations, propsParserContext);
+    updateLightTree(propsParserContext, mutations, transaction);
+    handleProgressTransition(transaction, mutations, propsParserContext);
   } else if (!synchronized_) {
-    updateLightTree(propsParserContext, mutations, filteredMutations, teardownMutations);
+    updateLightTree(propsParserContext, mutations, transaction);
     if (!lightNodes_.contains(closingScreenTag_)) {
       topScreen_ = findActiveBoundary(lightNodes_[surfaceId_]);
       synchronized_ = true;
@@ -76,16 +75,16 @@ std::optional<MountingTransaction> LayoutAnimationsProxy_Experimental::pullTrans
     auto beforeTopScreen = topScreen_;
     if (beforeTopScreen) {
       ReanimatedSystraceSection s("find before elements");
-      findSharedElementsOnScreen(beforeTopScreen, BEFORE, propsParserContext);
+      findSharedElementsOnScreen(beforeTopScreen, BEFORE, propsParserContext, transaction);
     }
 
-    updateLightTree(propsParserContext, mutations, filteredMutations, teardownMutations);
+    updateLightTree(propsParserContext, mutations, transaction);
 
     auto afterTopScreen = findActiveBoundary(root);
     topScreen_ = afterTopScreen;
     if (afterTopScreen) {
       ReanimatedSystraceSection s("find after elements");
-      findSharedElementsOnScreen(afterTopScreen, AFTER, propsParserContext);
+      findSharedElementsOnScreen(afterTopScreen, AFTER, propsParserContext, transaction);
 #ifdef __APPLE__
       // TODO (future): this is a temporary workaround for RNScreens on iOS,
       // which takes the snapshot of the popped screen before we hide the
@@ -103,40 +102,37 @@ std::optional<MountingTransaction> LayoutAnimationsProxy_Experimental::pullTrans
       // To keep things simple, we put mutations related to source views before all muatations
       // and mutations to hide target views after all mutations.
       std::vector<ShadowViewMutation> mergedMutations;
-      hideTransitioningViews(BEFORE, mergedMutations, propsParserContext);
+      hideTransitioningViews(BEFORE, transaction.transitions, mergedMutations, propsParserContext);
       mergedMutations.insert(mergedMutations.end(), filteredMutations.begin(), filteredMutations.end());
-      hideTransitioningViews(AFTER, mergedMutations, propsParserContext);
+      hideTransitioningViews(AFTER, transaction.transitions, mergedMutations, propsParserContext);
       std::swap(filteredMutations, mergedMutations);
     }
 
-    handleSharedTransitionsStart(afterTopScreen, beforeTopScreen, filteredMutations, mutations, propsParserContext);
+    handleSharedTransitionsStart(afterTopScreen, beforeTopScreen, transaction, mutations, propsParserContext);
   }
 
-  for (auto &node : entering_) {
-    startEnteringAnimation(node);
+  for (const auto &[node, config] : transaction.entering) {
+    startEnteringAnimation(node, config);
   }
-  for (auto &node : layout_) {
-    startLayoutAnimation(node);
+  for (const auto &[node, config] : transaction.layout) {
+    startLayoutAnimation(node, config);
   }
-  for (auto &node : exiting_) {
-    startExitingAnimation(node);
+  for (const auto &[node, config] : transaction.exiting) {
+    startExitingAnimation(node, config);
   }
-  entering_.clear();
-  layout_.clear();
-  exiting_.clear();
 
-  filteredMutations.insert(filteredMutations.end(), teardownMutations.begin(), teardownMutations.end());
+  filteredMutations.insert(
+      filteredMutations.end(), transaction.teardownMutations.begin(), transaction.teardownMutations.end());
 
-  flushDeadNodes(filteredMutations);
+  handleRemovals(filteredMutations);
+
+  flushLayoutAnimationOperations(lock);
 
   addOngoingAnimations(filteredMutations);
 
-  cleanupAnimations(filteredMutations, propsParserContext);
+  cleanupAnimations(transaction, propsParserContext);
 
-  transitionMap_.clear();
-  transitions_.clear();
-
-  insertContainers(filteredMutations, rootChildCount);
+  insertContainers(transaction, rootChildCount);
 
   return MountingTransaction{surfaceId, transactionNumber, std::move(filteredMutations), telemetry};
 }
@@ -146,7 +142,7 @@ std::optional<MountingTransaction> LayoutAnimationsProxy_Experimental::pullTrans
 // of letting the stale node linger: updateLightTree would overwrite its
 // lightNodes_ entry (the "LightNode already exists" assert is compiled out in
 // release), orphaning the still-mounted exiting view, and the eventual
-// endLayoutAnimation would then remove the wrong, live view and crash the
+// removal flush would then remove the wrong, live view and crash the
 // mounting layer.
 //
 // This must run before updateLightTree (so the tag is re-registered cleanly)
@@ -160,33 +156,18 @@ void LayoutAnimationsProxy_Experimental::reconcileContradictedRemovals(
       continue;
     }
     const auto tag = mutation.newChildShadowView.tag;
-    std::shared_ptr<LightNode> node;
-    if (const auto it = lightNodes_.find(tag); it != lightNodes_.end() && it->second->state != UNDEFINED) {
-      node = it->second;
-      lightNodes_.erase(it);
-      if (node->state == DELETED) {
-        // already unmounted — only the stale map entry had to go
-        continue;
-      }
-    } else {
-      // A settled exiting view (state DEAD) has already left lightNodes_ but is
-      // still mounted, awaiting the deadNodes cleanup in flushDeadNodes. That
-      // cleanup runs at the end of the transaction — after this Create would
-      // have re-registered the tag in the mounting layer's view registry — so
-      // it must be flushed now instead.
-      const auto deadIt = std::find_if(
-          deadNodes.begin(), deadNodes.end(), [tag](const auto &deadNode) { return deadNode->current.tag == tag; });
-      if (deadIt == deadNodes.end()) {
-        continue;
-      }
-      node = *deadIt;
-      deadNodes.erase(deadIt);
-      if (node->state == DELETED) {
-        continue;
-      }
+    const auto it = lightNodes_.find(tag);
+    if (it == lightNodes_.end() || it->second->state == UNDEFINED) {
+      continue;
     }
-    // Flush the withheld removal for this tag (and its withheld subtree) right
-    // now, mirroring the deadNodes cleanup in flushDeadNodes.
+    const auto node = it->second;
+    completedAnimations_.erase(tag);
+    updateMap_.erase(tag);
+    lightNodes_.erase(it);
+    if (node->state == DELETED) {
+      // already unmounted — only the stale map entry had to go
+      continue;
+    }
     const auto parent = node->parent.lock();
     react_native_assert(parent && "Parent node is nullptr");
     if (!parent) {
@@ -212,9 +193,9 @@ bool LayoutAnimationsProxy_Experimental::shouldOverridePullTransaction() const {
 void LayoutAnimationsProxy_Experimental::updateLightTree(
     const PropsParserContext &propsParserContext,
     const ShadowViewMutationList &mutations,
-    ShadowViewMutationList &filteredMutations,
-    ShadowViewMutationList &teardownMutations) const {
+    TransactionMeta &transaction) const {
   ReanimatedSystraceSection s("updateLightTree");
+  auto &filteredMutations = transaction.filteredMutations;
   std::unordered_set<Tag> inserted, moved, deleted;
   std::unordered_map<Tag, IndexCursors> indexCursors;
   for (auto it = mutations.rbegin(); it != mutations.rend(); it++) {
@@ -268,8 +249,8 @@ void LayoutAnimationsProxy_Experimental::updateLightTree(
         node->current = mutation.newChildShadowView;
 #endif // ANDROID
         auto tag = mutation.newChildShadowView.tag;
-        if (layoutAnimationsManager_->hasLayoutAnimation(tag, LAYOUT)) {
-          layout_.push_back(node);
+        if (const auto config = layoutAnimationsManager_->getLayoutAnimationConfig(tag, LAYOUT)) {
+          transaction.layout.push_back({node, config});
         } else {
           filteredMutations.push_back(mutation);
         }
@@ -308,11 +289,13 @@ void LayoutAnimationsProxy_Experimental::updateLightTree(
           auto sharedTransitionLock = std::unique_lock<std::mutex>(sharedTransitionManager_->mutex_);
           hasSharedTransition = sharedTransitionManager_->tagToName_.contains(tag);
         }
-        if (moved.contains(tag) && layoutAnimationsManager_->hasLayoutAnimation(tag, LAYOUT)) {
+        const auto layoutConfig = layoutAnimationsManager_->getLayoutAnimationConfig(tag, LAYOUT);
+        const auto enteringConfig = layoutAnimationsManager_->getLayoutAnimationConfig(tag, ENTERING);
+        if (moved.contains(tag) && layoutConfig) {
           filteredMutations.push_back(
               ShadowViewMutation::InsertMutation(mutation.parentTag, node->previous, hostIndex));
-        } else if (layoutAnimationsManager_->hasLayoutAnimation(tag, ENTERING)) {
-          entering_.push_back(node);
+        } else if (enteringConfig) {
+          transaction.entering.push_back({node, enteringConfig});
           filteredMutations.push_back(
               ShadowViewMutation::InsertMutation(mutation.parentTag, mutation.newChildShadowView, hostIndex));
           auto hiddenView = cloneViewWithoutOpacity(mutation.newChildShadowView, propsParserContext);
@@ -347,7 +330,7 @@ void LayoutAnimationsProxy_Experimental::updateLightTree(
               ShadowViewMutation::RemoveMutation(parentTag, mutation.oldChildShadowView, hostIndex));
           parent->children.erase(parent->children.begin() + hostIndex);
         } else if (!deleted.contains(parentTag)) {
-          handleSubtreeRemoval(node, parent, hostIndex, filteredMutations, teardownMutations);
+          handleSubtreeRemoval(node, parent, hostIndex, transaction);
         }
         break;
       }
@@ -445,37 +428,6 @@ void LayoutAnimationsProxy_Experimental::initializeLightTree(const ShadowTreeRev
   topScreen_ = findActiveBoundary(lightNodes_.at(surfaceId_));
 }
 
-// MARK: Layout Animation Updates
-
-std::optional<SurfaceId> LayoutAnimationsProxy_Experimental::progressLayoutAnimation(
-    int tag,
-    const jsi::Object &newStyle) {
-  ReanimatedSystraceSection s("progressLayoutAnimation");
-  const auto lock = std::unique_lock<std::recursive_mutex>(mutex);
-  const auto layoutAnimationIt = layoutAnimations_.find(tag);
-
-  if (layoutAnimationIt == layoutAnimations_.end()) {
-    return {};
-  }
-
-  auto &layoutAnimation = layoutAnimationIt->second;
-
-  maybeRestoreOpacity(layoutAnimation, newStyle);
-
-  auto rawProps = std::make_shared<RawProps>(uiRuntime_, jsi::Value(uiRuntime_, newStyle));
-
-  const PropsParserContext propsParserContext{layoutAnimation.finalView.surfaceId, *contextContainer_};
-#ifdef RN_SERIALIZABLE_STATE
-  rawProps = std::make_shared<RawProps>(
-      folly::dynamic::merge(layoutAnimation.finalView.props->rawProps, (folly::dynamic)*rawProps));
-#endif
-  auto newProps = getComponentDescriptorForShadowView(layoutAnimation.finalView)
-                      .cloneProps(propsParserContext, layoutAnimation.finalView.props, std::move(*rawProps));
-  updateMap_.insert_or_assign(tag, UpdateValues{newProps, Frame(uiRuntime_, newStyle)});
-
-  return layoutAnimation.finalView.surfaceId;
-}
-
 std::optional<SurfaceId> LayoutAnimationsProxy_Experimental::endLayoutAnimation(int tag, bool shouldRemove) {
   auto lock = std::unique_lock<std::recursive_mutex>(mutex);
   auto layoutAnimationIt = layoutAnimations_.find(tag);
@@ -484,34 +436,11 @@ std::optional<SurfaceId> LayoutAnimationsProxy_Experimental::endLayoutAnimation(
     return {};
   }
 
-  auto &layoutAnimation = layoutAnimationIt->second;
+  const auto surfaceId = layoutAnimationIt->second.finalView.surfaceId;
+  completedAnimations_.insert_or_assign(
+      tag, CompletedLayoutAnimation{.animation = layoutAnimationIt->second, .shouldRemove = shouldRemove});
+  layoutAnimations_.erase(layoutAnimationIt);
 
-  // multiple layout animations can be triggered for a view
-  // one after the other, so we need to keep count of how many
-  // were actually triggered, so that we don't cleanup necessary
-  // structures too early
-  if (--layoutAnimation.count > 0) {
-    return {};
-  }
-  layoutAnimation.isExitingWhenSettled = shouldRemove;
-  maybeSettledAnimationTags_.insert(tag);
-  auto surfaceId = layoutAnimation.finalView.surfaceId;
-
-  std::optional<SharedTag> sharedTag;
-  {
-    auto sharedTransitionLock = std::unique_lock<std::mutex>(sharedTransitionManager_->mutex_);
-    const auto it = sharedTransitionManager_->tagToName_.find(tag);
-    if (it != sharedTransitionManager_->tagToName_.end()) {
-      sharedTag = it->second;
-    }
-  }
-  if (sharedTag) {
-    containerTags_.erase(*sharedTag);
-
-    sharedContainersToRemove_.push_back(tag);
-    tagsToRestore_.push_back(restoreMap_[tag][1]);
-    transformForNode_.clear();
-  }
   if (!shouldRemove) {
     return surfaceId;
   }
@@ -524,11 +453,7 @@ std::optional<SurfaceId> LayoutAnimationsProxy_Experimental::endLayoutAnimation(
     react_native_assert(false && "LightNode not found");
     return surfaceId;
   }
-  auto node = nodeIt->second;
-
-  node->setExitingState(DEAD);
-  lightNodes_.erase(nodeIt);
-  deadNodes.insert(node);
+  nodeIt->second->setExitingState(DEAD);
 
   return surfaceId;
 }
@@ -540,38 +465,54 @@ void LayoutAnimationsProxy_Experimental::handleSubtreeRemoval(
     const std::shared_ptr<LightNode> &node,
     const std::shared_ptr<LightNode> &parent,
     const int hostIndex,
-    ShadowViewMutationList &filteredMutations,
-    ShadowViewMutationList &teardownMutations) const {
+    TransactionMeta &transaction) const {
   ReanimatedSystraceSection s("handleSubtreeRemoval");
   const StartAnimationsRecursivelyConfig config = {
       .shouldRemoveSubviewsWithoutAnimations = true,
       .shouldAnimate = true,
       .isScreenPop = false,
   };
-  if (startAnimationsRecursively(node, teardownMutations, config)) {
+  if (startAnimationsRecursively(node, transaction, config)) {
     return;
   }
   react_native_assert(!node->isExiting() && "A subtree that does not animate must stay UNDEFINED");
   maybeCancelAnimation(node->current.tag);
-  filteredMutations.push_back(ShadowViewMutation::RemoveMutation(parent->current.tag, node->current, hostIndex));
-  teardownMutations.push_back(ShadowViewMutation::DeleteMutation(node->current));
+  transaction.filteredMutations.push_back(
+      ShadowViewMutation::RemoveMutation(parent->current.tag, node->current, hostIndex));
+  transaction.teardownMutations.push_back(ShadowViewMutation::DeleteMutation(node->current));
   parent->children.erase(parent->children.begin() + hostIndex);
 }
 
-void LayoutAnimationsProxy_Experimental::flushDeadNodes(ShadowViewMutationList &filteredMutations) const {
-  ReanimatedSystraceSection s("flushDeadNodes");
-  for (const auto &node : deadNodes) {
-    if (node->state != DELETED) {
-      auto parent = node->parent.lock();
-      react_native_assert(parent && "Parent node is nullptr");
-      auto index = parent->removeChild(node);
-      react_native_assert(index != -1 && "Dead node not found");
-
-      endAnimationsRecursively(node, index, filteredMutations);
-      maybeDropAncestors(parent, filteredMutations);
+void LayoutAnimationsProxy_Experimental::handleRemovals(ShadowViewMutationList &filteredMutations) const {
+  ReanimatedSystraceSection s("handleRemovals");
+  std::vector<Tag> completedRemovalTags;
+  completedRemovalTags.reserve(completedAnimations_.size());
+  for (const auto &[tag, completedAnimation] : completedAnimations_) {
+    if (hasPendingLayoutAnimation(tag) || !completedAnimation.shouldRemove) {
+      continue;
     }
+    completedRemovalTags.push_back(tag);
   }
-  deadNodes.clear();
+
+  for (const auto tag : completedRemovalTags) {
+    const auto completedAnimationIt = completedAnimations_.find(tag);
+    if (completedAnimationIt == completedAnimations_.end() || hasPendingLayoutAnimation(tag) ||
+        !completedAnimationIt->second.shouldRemove) {
+      continue;
+    }
+    const auto nodeIt = lightNodes_.find(tag);
+    if (nodeIt == lightNodes_.end() || nodeIt->second->state != DEAD) {
+      continue;
+    }
+    const auto node = nodeIt->second;
+    auto parent = node->parent.lock();
+    react_native_assert(parent && "Parent node is nullptr");
+    auto index = parent->removeChild(node);
+    react_native_assert(index != -1 && "Dead node not found");
+
+    endAnimationsRecursively(node, index, filteredMutations);
+    maybeDropAncestors(parent, filteredMutations);
+  }
 }
 
 void LayoutAnimationsProxy_Experimental::addOngoingAnimations(ShadowViewMutationList &mutations) const {
@@ -607,15 +548,15 @@ void LayoutAnimationsProxy_Experimental::addOngoingAnimations(ShadowViewMutation
     }
 #endif
 
-    const auto layoutAnimationIt = layoutAnimations_.find(tag);
-
-    if (layoutAnimationIt == layoutAnimations_.end() ||
-        (layoutAnimationIt->second.isSettled() && layoutAnimationIt->second.isExitingWhenSettled)) {
+    auto layoutAnimationIt = layoutAnimations_.find(tag);
+    auto completedAnimationIt = completedAnimations_.find(tag);
+    if (layoutAnimationIt == layoutAnimations_.end() &&
+        (completedAnimationIt == completedAnimations_.end() || completedAnimationIt->second.shouldRemove)) {
       continue;
     }
 
-    auto &layoutAnimation = layoutAnimationIt->second;
-    layoutAnimation.isViewAlreadyMounted = true;
+    auto &layoutAnimation = layoutAnimationIt != layoutAnimations_.end() ? layoutAnimationIt->second
+                                                                         : completedAnimationIt->second.animation;
     auto newView = layoutAnimation.finalView;
     if (updateValues.newProps) {
       newView.props = updateValues.newProps;
@@ -625,6 +566,9 @@ void LayoutAnimationsProxy_Experimental::addOngoingAnimations(ShadowViewMutation
     mutations.push_back(
         ShadowViewMutation::UpdateMutation(layoutAnimation.currentView, newView, layoutAnimation.parentTag));
     layoutAnimation.currentView = newView;
+    if (layoutAnimation.opacity && static_cast<const ViewProps &>(*newView.props).opacity == *layoutAnimation.opacity) {
+      layoutAnimation.opacity.reset();
+    }
   }
   updateMap_.clear();
 }
@@ -633,10 +577,11 @@ void LayoutAnimationsProxy_Experimental::endAnimationsRecursively(
     const std::shared_ptr<LightNode> &node,
     int index,
     ShadowViewMutationList &mutations) const {
-  maybeCancelAnimation(node->current.tag);
+  const auto tag = node->current.tag;
+  maybeCancelAnimation(tag);
   node->setExitingState(DELETED);
   // drop the tag mapping unless it was already re-registered for a new node
-  if (const auto it = lightNodes_.find(node->current.tag); it != lightNodes_.end() && it->second == node) {
+  if (const auto it = lightNodes_.find(tag); it != lightNodes_.end() && it->second == node) {
     lightNodes_.erase(it);
   }
   // iterate from the end, so that children
@@ -686,8 +631,9 @@ const ComponentDescriptor &LayoutAnimationsProxy_Experimental::getComponentDescr
 
 bool LayoutAnimationsProxy_Experimental::startAnimationsRecursively(
     const std::shared_ptr<LightNode> &node,
-    ShadowViewMutationList &mutations,
+    TransactionMeta &transaction,
     StartAnimationsRecursivelyConfig config) const {
+  auto &mutations = transaction.teardownMutations;
   auto &[shouldRemoveSubviewsWithoutAnimations, shouldAnimate, isScreenPop] = config;
   if (isRNSScreenOrStack(node)) {
     isScreenPop = true;
@@ -695,8 +641,9 @@ bool LayoutAnimationsProxy_Experimental::startAnimationsRecursively(
 
   shouldAnimate = !isScreenPop && layoutAnimationsManager_->shouldAnimateExiting(node->current.tag, shouldAnimate);
 
-  const bool hasExitAnimation =
-      shouldAnimate && layoutAnimationsManager_->hasLayoutAnimation(node->current.tag, LayoutAnimationType::EXITING);
+  const auto exitConfig =
+      shouldAnimate ? layoutAnimationsManager_->takeExitingAnimationConfigAndClearTag(node->current.tag) : nullptr;
+  const bool hasExitAnimation = exitConfig != nullptr;
   bool hasAnimatedChildren = false;
 
   shouldRemoveSubviewsWithoutAnimations = shouldRemoveSubviewsWithoutAnimations && !hasExitAnimation;
@@ -715,7 +662,7 @@ bool LayoutAnimationsProxy_Experimental::startAnimationsRecursively(
         endAnimationsRecursively(subNode, index, mutations);
         toBeRemoved.push_back(subNode);
       }
-    } else if (startAnimationsRecursively(subNode, mutations, config)) {
+    } else if (startAnimationsRecursively(subNode, transaction, config)) {
       hasAnimatedChildren = true;
     } else if (shouldRemoveSubviewsWithoutAnimations) {
       maybeCancelAnimation(subNode->current.tag);
@@ -740,9 +687,11 @@ bool LayoutAnimationsProxy_Experimental::startAnimationsRecursively(
   if (hasExitAnimation) {
     node->setExitingState(ANIMATING);
     lightNodes_[node->current.tag] = node;
-    exiting_.push_back(node);
+    transaction.exiting.push_back({node, exitConfig});
   } else {
-    layoutAnimationsManager_->clearLayoutAnimationConfig(node->current.tag);
+    if (!shouldAnimate) {
+      layoutAnimationsManager_->clearLayoutAnimationConfig(node->current.tag);
+    }
     if (hasAnimatedChildren) {
       node->setExitingState(WAITING);
       lightNodes_[node->current.tag] = node;
@@ -752,48 +701,18 @@ bool LayoutAnimationsProxy_Experimental::startAnimationsRecursively(
   return wantAnimateExit;
 }
 
-void LayoutAnimationsProxy_Experimental::updateOngoingAnimationTarget(const int tag, const ShadowViewMutation &mutation)
-    const {
-  layoutAnimations_[tag].finalView = mutation.newChildShadowView;
-}
-
 void LayoutAnimationsProxy_Experimental::maybeCancelAnimation(const int tag) const {
-#ifdef ANDROID
-  // also invalidate animation starts that are scheduled but haven't run yet,
-  // so they don't re-create the animation after this cancellation
-  if (const auto it = pendingStarts_.find(tag); it != pendingStarts_.end()) {
-    it->second.handle++;
-  }
-#endif
-  const auto layoutAnimationIt = layoutAnimations_.find(tag);
-  if (layoutAnimationIt == layoutAnimations_.end()) {
-    return;
-  }
-  if (layoutAnimationIt->second.isSettled()) {
-    // Already settled - cleanupAnimations will erase it together with its updateMap entry.
-    // Mark it as exiting so addOngoingAnimations doesn't flush a pending Update
-    // after the caller has queued this view for removal.
-    layoutAnimationIt->second.isExitingWhenSettled = true;
-    return;
-  }
-  layoutAnimations_.erase(layoutAnimationIt);
-  scheduleOnUI(uiScheduler_, [weakThis = weak_from_this(), tag]() {
-    auto strongThis = weakThis.lock();
-    if (!strongThis) {
-      return;
-    }
-
-    auto &uiRuntime = strongThis->uiRuntime_;
-    strongThis->layoutAnimationsManager_->cancelLayoutAnimation(uiRuntime, tag);
-  });
+  cancelLayoutAnimation(tag);
 }
 
 void LayoutAnimationsProxy_Experimental::surfaceDidUnmount() {
   LayoutAnimationsProxyCommon::surfaceDidUnmount();
-  auto lock = std::unique_lock<std::recursive_mutex>(mutex);
-  auto sharedTransitionLock = std::unique_lock<std::mutex>(sharedTransitionManager_->mutex_);
-  for (const auto &[_, containerTag] : containerTags_) {
-    sharedTransitionManager_->tagToName_.erase(containerTag);
+  {
+    auto lock = std::unique_lock<std::recursive_mutex>(mutex);
+    auto sharedTransitionLock = std::unique_lock<std::mutex>(sharedTransitionManager_->mutex_);
+    for (const auto &[_, containerTag] : containerTags_) {
+      sharedTransitionManager_->tagToName_.erase(containerTag);
+    }
   }
 }
 
@@ -813,316 +732,93 @@ ShadowView LayoutAnimationsProxy_Experimental::cloneViewWithoutOpacity(
   return newView;
 }
 
-ShadowView LayoutAnimationsProxy_Experimental::cloneViewWithOpacity(
-    const ShadowView &shadowView,
-    const PropsParserContext &propsParserContext) const {
-  auto newView = shadowView;
-  const auto &props = static_cast<const ViewProps &>(*newView.props);
-  const folly::dynamic opacity = folly::dynamic::object("opacity", props.opacity);
-  auto newProps =
-      getComponentDescriptorForShadowView(newView).cloneProps(propsParserContext, newView.props, RawProps(opacity));
-  newView.props = newProps;
-  return newView;
-}
-
-void LayoutAnimationsProxy_Experimental::maybeRestoreOpacity(
-    reanimated::LayoutAnimation &layoutAnimation,
-    const jsi::Object &newStyle) const {
-  if (layoutAnimation.opacity && !newStyle.hasProperty(uiRuntime_, "opacity")) {
-    newStyle.setProperty(uiRuntime_, "opacity", jsi::Value(*layoutAnimation.opacity));
-    if (layoutAnimation.isViewAlreadyMounted) {
-      // We want to reset opacity only when we are sure that this update will be
-      // applied to the native view. Otherwise, we want to update opacity using
-      // the `restoreOpacityInCaseOfFlakyEnteringAnimation` method.
-      layoutAnimation.opacity.reset();
-    }
-  }
-}
-
 void LayoutAnimationsProxy_Experimental::cleanupAnimations(
-    ShadowViewMutationList &filteredMutations,
+    TransactionMeta &transaction,
     const PropsParserContext &propsParserContext) const {
   ReanimatedSystraceSection s("cleanupAnimations");
-  cleanupSharedTransitions(filteredMutations, propsParserContext);
-
-#ifdef ANDROID
-  restoreOpacityInCaseOfFlakyEnteringAnimation();
-#endif // ANDROID
-  for (const auto tag : maybeSettledAnimationTags_) {
-    // Skip tags re-animated since they settled (count back above 0).
-    const auto layoutAnimationIt = layoutAnimations_.find(tag);
-    if (layoutAnimationIt == layoutAnimations_.end() || !layoutAnimationIt->second.isSettled()) {
+  for (const auto &[tag, completedAnimation] : completedAnimations_) {
+    if (hasPendingLayoutAnimation(tag)) {
       continue;
     }
-    layoutAnimations_.erase(layoutAnimationIt);
-    updateMap_.erase(tag);
+    const auto restoreIt = restoreMap_.find(tag);
+    if (restoreIt == restoreMap_.end()) {
+      continue;
+    }
+    transaction.tagsToRestore.push_back(restoreIt->second[AFTER]);
+    removeSharedContainer(tag, transaction);
   }
-  maybeSettledAnimationTags_.clear();
+
+  cleanupSharedTransitions(transaction, propsParserContext);
+  cleanupCompletedAnimations(transaction.filteredMutations, propsParserContext, true);
 }
 
 // MARK: Start Animation
 
-ShadowView LayoutAnimationsProxy_Experimental::maybeCreateLayoutAnimation(
-    ShadowView &before,
-    const ShadowView &after,
-    const Tag parentTag) const {
-  auto count = 1;
-  const auto tag = after.tag;
-  auto layoutAnimationIt = layoutAnimations_.find(tag);
-  auto &oldView = before;
-
-  if (layoutAnimationIt != layoutAnimations_.end()) {
-    auto &layoutAnimation = layoutAnimationIt->second;
-    oldView = layoutAnimation.currentView;
-    count = layoutAnimation.count + 1;
-  }
-
-  auto finalView = after;
-  auto currentView = oldView;
-  auto startView = oldView;
-
-  layoutAnimations_[tag] = {
-      .finalView = finalView,
-      .currentView = currentView,
-      .startView = startView,
-      .parentTag = parentTag,
-      .count = count,
-  };
-
-  return oldView;
-}
-
-void LayoutAnimationsProxy_Experimental::startEnteringAnimation(const std::shared_ptr<LightNode> &node) const {
-  auto newChildShadowView = node->current;
-  const auto &finalView = newChildShadowView;
-  const auto &currentView = newChildShadowView;
-
+void LayoutAnimationsProxy_Experimental::startEnteringAnimation(
+    const std::shared_ptr<LightNode> &node,
+    const std::shared_ptr<Serializable> &config) const {
+  const auto &newChildShadowView = node->current;
   const auto &props = newChildShadowView.props;
   auto &viewProps = static_cast<const ViewProps &>(*props);
   const auto opacity = viewProps.opacity;
   const auto &parent = node->parent.lock();
   react_native_assert(parent && "Parent node is nullptr");
-  const auto parentTag = parent->current.tag;
-#ifdef ANDROID
-  const auto handle = pendingStarts_[newChildShadowView.tag].handle;
-  pendingStarts_[newChildShadowView.tag].count++;
-#endif
-
-  scheduleOnUI(
-      uiScheduler_,
-      [weakThis = weak_from_this(),
-       finalView,
-       currentView,
-       newChildShadowView,
-       parentTag,
-       opacity
-#ifdef ANDROID
-       ,
-       handle
-#endif
-  ]() {
-        auto strongThis = weakThis.lock();
-        if (!strongThis) {
-          return;
-        }
-
-        Rect window;
-        const auto tag = newChildShadowView.tag;
-        {
-          auto lock = std::unique_lock<std::recursive_mutex>(strongThis->mutex);
-#ifdef ANDROID
-          if (consumeIsCancelled(strongThis->pendingStarts_, tag, handle)) {
-            // the view was removed before this start could run
-            return;
-          }
-#endif
-          strongThis->layoutAnimations_[tag] = {
-              .finalView = newChildShadowView,
-              .currentView = newChildShadowView,
-              .startView = newChildShadowView,
-              .parentTag = parentTag,
-              .opacity = opacity,
-          };
-          window = strongThis->window_;
-        }
-
-        const Snapshot values(newChildShadowView, window);
-        auto &uiRuntime = strongThis->uiRuntime_;
-        const jsi::Object yogaValues(uiRuntime);
-        yogaValues.setProperty(uiRuntime, "targetOriginX", values.x);
-        yogaValues.setProperty(uiRuntime, "targetGlobalOriginX", values.x);
-        yogaValues.setProperty(uiRuntime, "targetOriginY", values.y);
-        yogaValues.setProperty(uiRuntime, "targetGlobalOriginY", values.y);
-        yogaValues.setProperty(uiRuntime, "targetWidth", values.width);
-        yogaValues.setProperty(uiRuntime, "targetHeight", values.height);
-        yogaValues.setProperty(uiRuntime, "windowWidth", values.windowWidth);
-        yogaValues.setProperty(uiRuntime, "windowHeight", values.windowHeight);
-        strongThis->layoutAnimationsManager_->startLayoutAnimation(
-            uiRuntime, tag, LayoutAnimationType::ENTERING, yogaValues);
-      });
+  enqueueLayoutAnimation(ManagedLayoutAnimationStart{
+      .tag = newChildShadowView.tag,
+      .type = LayoutAnimationType::ENTERING,
+      .before = newChildShadowView,
+      .after = newChildShadowView,
+      .parentTag = parent->current.tag,
+      .opacity = opacity,
+      .config = config,
+  });
 }
 
-void LayoutAnimationsProxy_Experimental::startExitingAnimation(const std::shared_ptr<LightNode> &node) const {
-  auto &oldChildShadowView = node->current;
-  const auto tag = oldChildShadowView.tag;
+void LayoutAnimationsProxy_Experimental::startExitingAnimation(
+    const std::shared_ptr<LightNode> &node,
+    const std::shared_ptr<Serializable> &config) const {
+  const auto &oldChildShadowView = node->current;
   const auto &parent = node->parent.lock();
   react_native_assert(parent && "Parent node is nullptr");
-  const auto parentTag = parent->current.tag;
-#ifdef ANDROID
-  const auto handle = pendingStarts_[tag].handle;
-  pendingStarts_[tag].count++;
-#endif
-
-  scheduleOnUI(
-      uiScheduler_,
-      [weakThis = weak_from_this(),
-       tag,
-       parentTag,
-       oldChildShadowView
-#ifdef ANDROID
-       ,
-       handle
-#endif
-  ]() {
-        auto strongThis = weakThis.lock();
-        if (!strongThis) {
-          return;
-        }
-
-        auto oldView = oldChildShadowView;
-        Rect window{};
-        {
-          auto &mutex = strongThis->mutex;
-          auto lock = std::unique_lock<std::recursive_mutex>(mutex);
-#ifdef ANDROID
-          if (consumeIsCancelled(strongThis->pendingStarts_, tag, handle)) {
-            // the view was removed (e.g. its subtree was force-ended by a screen
-            // pop) before this start could run — its Remove+Delete are already on
-            // their way to the mounting layer, so starting the animation now
-            // would emit updates for a view that's about to be deleted
-            strongThis->layoutAnimationsManager_->clearLayoutAnimationConfig(tag);
-            return;
-          }
-#endif
-          oldView = strongThis->maybeCreateLayoutAnimation(oldView, oldView, parentTag);
-          window = strongThis->window_;
-        }
-
-        const Snapshot values(oldView, window);
-
-        auto &uiRuntime = strongThis->uiRuntime_;
-        const jsi::Object yogaValues(uiRuntime);
-        yogaValues.setProperty(uiRuntime, "currentOriginX", values.x);
-        yogaValues.setProperty(uiRuntime, "currentGlobalOriginX", values.x);
-        yogaValues.setProperty(uiRuntime, "currentOriginY", values.y);
-        yogaValues.setProperty(uiRuntime, "currentGlobalOriginY", values.y);
-        yogaValues.setProperty(uiRuntime, "currentWidth", values.width);
-        yogaValues.setProperty(uiRuntime, "currentHeight", values.height);
-        yogaValues.setProperty(uiRuntime, "windowWidth", values.windowWidth);
-        yogaValues.setProperty(uiRuntime, "windowHeight", values.windowHeight);
-        strongThis->layoutAnimationsManager_->startLayoutAnimation(
-            uiRuntime, tag, LayoutAnimationType::EXITING, yogaValues);
-        strongThis->layoutAnimationsManager_->clearLayoutAnimationConfig(tag);
-      });
+  enqueueLayoutAnimation(ManagedLayoutAnimationStart{
+      .tag = oldChildShadowView.tag,
+      .type = LayoutAnimationType::EXITING,
+      .before = oldChildShadowView,
+      .after = oldChildShadowView,
+      .parentTag = parent->current.tag,
+      .config = config,
+  });
 }
 
-void LayoutAnimationsProxy_Experimental::startLayoutAnimation(const std::shared_ptr<LightNode> &node) const {
-  auto oldChildShadowView = node->previous;
-  auto newChildShadowView = node->current;
-  const auto tag = oldChildShadowView.tag;
+void LayoutAnimationsProxy_Experimental::startLayoutAnimation(
+    const std::shared_ptr<LightNode> &node,
+    const std::shared_ptr<Serializable> &config) const {
+  const auto &oldChildShadowView = node->previous;
+  const auto &newChildShadowView = node->current;
   const auto &parent = node->parent.lock();
   react_native_assert(parent && "Parent node is nullptr");
-  const auto parentTag = parent->current.tag;
-#ifdef ANDROID
-  const auto handle = pendingStarts_[tag].handle;
-  pendingStarts_[tag].count++;
-#endif
-
-  scheduleOnUI(
-      uiScheduler_,
-      [weakThis = weak_from_this(),
-       oldChildShadowView,
-       newChildShadowView,
-       parentTag,
-       tag
-#ifdef ANDROID
-       ,
-       handle
-#endif
-  ]() {
-        auto strongThis = weakThis.lock();
-        if (!strongThis) {
-          return;
-        }
-
-        auto oldView = oldChildShadowView;
-        Rect window{};
-        {
-          auto &mutex = strongThis->mutex;
-          auto lock = std::unique_lock<std::recursive_mutex>(mutex);
-#ifdef ANDROID
-          if (consumeIsCancelled(strongThis->pendingStarts_, tag, handle)) {
-            // the view was removed before this start could run
-            return;
-          }
-#endif
-          oldView = strongThis->maybeCreateLayoutAnimation(oldView, newChildShadowView, parentTag);
-          window = strongThis->window_;
-        }
-
-        const Snapshot currentValues(oldView, window);
-        const Snapshot targetValues(newChildShadowView, window);
-
-        auto &uiRuntime = strongThis->uiRuntime_;
-        const jsi::Object yogaValues(uiRuntime);
-        yogaValues.setProperty(uiRuntime, "currentOriginX", currentValues.x);
-        yogaValues.setProperty(uiRuntime, "currentGlobalOriginX", currentValues.x);
-        yogaValues.setProperty(uiRuntime, "currentOriginY", currentValues.y);
-        yogaValues.setProperty(uiRuntime, "currentGlobalOriginY", currentValues.y);
-        yogaValues.setProperty(uiRuntime, "currentWidth", currentValues.width);
-        yogaValues.setProperty(uiRuntime, "currentHeight", currentValues.height);
-        yogaValues.setProperty(uiRuntime, "targetOriginX", targetValues.x);
-        yogaValues.setProperty(uiRuntime, "targetGlobalOriginX", targetValues.x);
-        yogaValues.setProperty(uiRuntime, "targetOriginY", targetValues.y);
-        yogaValues.setProperty(uiRuntime, "targetGlobalOriginY", targetValues.y);
-        yogaValues.setProperty(uiRuntime, "targetWidth", targetValues.width);
-        yogaValues.setProperty(uiRuntime, "targetHeight", targetValues.height);
-        yogaValues.setProperty(uiRuntime, "windowWidth", targetValues.windowWidth);
-        yogaValues.setProperty(uiRuntime, "windowHeight", targetValues.windowHeight);
-        strongThis->layoutAnimationsManager_->startLayoutAnimation(
-            uiRuntime, tag, LayoutAnimationType::LAYOUT, yogaValues);
-      });
+  enqueueLayoutAnimation(ManagedLayoutAnimationStart{
+      .tag = oldChildShadowView.tag,
+      .type = LayoutAnimationType::LAYOUT,
+      .before = oldChildShadowView,
+      .after = newChildShadowView,
+      .parentTag = parent->current.tag,
+      .config = config,
+  });
 }
 
 void LayoutAnimationsProxy_Experimental::startSharedTransition(
     const int tag,
     const ShadowView &before,
-    const ShadowView &after) const {
-  scheduleOnUI(uiScheduler_, [weakThis = weak_from_this(), before, after, tag]() {
-    auto strongThis = weakThis.lock();
-    if (!strongThis) {
-      return;
-    }
-
-    auto oldView = before;
-    Rect window{};
-    {
-      auto &mutex = strongThis->mutex;
-      auto lock = std::unique_lock<std::recursive_mutex>(mutex);
-      oldView = strongThis->maybeCreateLayoutAnimation(oldView, after, strongThis->surfaceId_);
-      window = strongThis->window_;
-    }
-
-    auto &uiRuntime = strongThis->uiRuntime_;
-    auto propsDiffer = PropsDiffer(uiRuntime, oldView, after);
-
-    const auto &propsDiff = propsDiffer.computeDiff(uiRuntime);
-
-    propsDiff.setProperty(uiRuntime, "windowWidth", window.width);
-    propsDiff.setProperty(uiRuntime, "windowHeight", window.height);
-
-    strongThis->layoutAnimationsManager_->startLayoutAnimation(
-        uiRuntime, tag, LayoutAnimationType::SHARED_ELEMENT_TRANSITION, propsDiff);
+    const ShadowView &after,
+    const std::shared_ptr<Serializable> &config) const {
+  enqueueLayoutAnimation(ManagedLayoutAnimationStart{
+      .tag = tag,
+      .type = LayoutAnimationType::SHARED_ELEMENT_TRANSITION,
+      .before = before,
+      .after = after,
+      .parentTag = surfaceId_,
+      .config = config,
   });
 }
 
@@ -1130,20 +826,11 @@ void LayoutAnimationsProxy_Experimental::startProgressTransition(
     const int tag,
     const ShadowView &before,
     const ShadowView &after) const {
-  scheduleOnUI(uiScheduler_, [weakThis = weak_from_this(), before, after]() {
-    auto strongThis = weakThis.lock();
-    if (!strongThis) {
-      return;
-    }
-
-    auto oldView = before;
-    Rect window{};
-    {
-      auto &mutex = strongThis->mutex;
-      auto lock = std::unique_lock<std::recursive_mutex>(mutex);
-      oldView = strongThis->maybeCreateLayoutAnimation(oldView, after, strongThis->surfaceId_);
-      window = strongThis->window_;
-    }
+  enqueueLayoutAnimation(ProgressLayoutAnimationStart{
+      .tag = tag,
+      .before = before,
+      .after = after,
+      .parentTag = surfaceId_,
   });
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
@@ -124,7 +124,7 @@ std::optional<MountingTransaction> LayoutAnimationsProxy_Experimental::pullTrans
   filteredMutations.insert(
       filteredMutations.end(), transaction.teardownMutations.begin(), transaction.teardownMutations.end());
 
-  handleRemovals(filteredMutations);
+  flushCompletedRemovals(filteredMutations);
 
   flushLayoutAnimationOperations(lock);
 
@@ -483,8 +483,8 @@ void LayoutAnimationsProxy_Experimental::handleSubtreeRemoval(
   parent->children.erase(parent->children.begin() + hostIndex);
 }
 
-void LayoutAnimationsProxy_Experimental::handleRemovals(ShadowViewMutationList &filteredMutations) const {
-  ReanimatedSystraceSection s("handleRemovals");
+void LayoutAnimationsProxy_Experimental::flushCompletedRemovals(ShadowViewMutationList &filteredMutations) const {
+  ReanimatedSystraceSection s("flushCompletedRemovals");
   std::vector<Tag> completedRemovalTags;
   completedRemovalTags.reserve(completedAnimations_.size());
   for (const auto &[tag, completedAnimation] : completedAnimations_) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.h
@@ -18,7 +18,6 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
-#include <utility>
 #include <vector>
 
 namespace reanimated {
@@ -35,50 +34,61 @@ struct StartAnimationsRecursivelyConfig {
   bool isScreenPop;
 };
 
-struct LayoutAnimationsProxy_Experimental : public LayoutAnimationsProxyCommon,
-                                            public std::enable_shared_from_this<LayoutAnimationsProxy_Experimental> {
-  mutable std::unordered_set<std::shared_ptr<LightNode>> deadNodes;
-  mutable std::unordered_map<Tag, int> leastRemoved;
+struct PendingNodeAnimation {
+  std::shared_ptr<LightNode> node;
+  std::shared_ptr<Serializable> config;
+};
+
+struct TransactionMeta {
+  ShadowViewMutationList filteredMutations;
+  ShadowViewMutationList teardownMutations;
+  TransitionMap transitionMap;
+  Transitions transitions;
+  std::vector<PendingNodeAnimation> entering, layout;
+  std::vector<PendingNodeAnimation> exiting;
+  std::vector<std::shared_ptr<LightNode>> containersToInsert;
+  std::vector<Tag> tagsToRestore;
+  std::vector<Tag> sharedContainersToRemove;
+};
+
+struct LayoutAnimationsProxy_Experimental : public LayoutAnimationsProxyCommon {
   mutable std::unordered_set<Tag> activeTransitions_;
   mutable Tag transitionTag_;
   mutable double transitionProgress_;
   mutable bool transitionUpdated_;
   mutable TransitionState transitionState_ = TransitionState::NONE;
   mutable std::shared_ptr<LightNode> topScreen_;
-  mutable std::vector<Tag> sharedContainersToRemove_;
   mutable std::unordered_map<Tag, Tag[2]> restoreMap_;
   mutable std::unordered_map<std::string, Tag> containerTags_;
-  mutable std::vector<Tag> tagsToRestore_;
-  mutable TransitionMap transitionMap_;
-  mutable Transitions transitions_;
   mutable bool synchronized_ = true;
   mutable Tag closingScreenTag_ = -1;
-  mutable std::vector<std::shared_ptr<LightNode>> entering_, layout_, exiting_;
   std::shared_ptr<SharedTransitionManager> sharedTransitionManager_;
   mutable std::unordered_map<Tag, std::shared_ptr<LightNode>> lightNodes_;
   mutable std::vector<std::pair<ShadowTreeRevision::Number, ShadowViewMutationList>> pendingTransactions_;
-  mutable std::vector<std::shared_ptr<LightNode>> containersToInsert_;
-  mutable std::unordered_map<Tag, react::Transform> transformForNode_;
 
   mutable ForceScreenSnapshotFunction forceScreenSnapshot_;
 
   LayoutAnimationsProxy_Experimental(SurfaceId surfaceId, const LayoutAnimationsProxyDependencies &dependencies);
 
-  void startEnteringAnimation(const std::shared_ptr<LightNode> &node) const;
-  void startExitingAnimation(const std::shared_ptr<LightNode> &node) const;
-  void startLayoutAnimation(const std::shared_ptr<LightNode> &node) const;
-  void startSharedTransition(const int tag, const ShadowView &before, const ShadowView &after) const;
+  void startEnteringAnimation(const std::shared_ptr<LightNode> &node, const std::shared_ptr<Serializable> &config)
+      const;
+  void startExitingAnimation(const std::shared_ptr<LightNode> &node, const std::shared_ptr<Serializable> &config) const;
+  void startLayoutAnimation(const std::shared_ptr<LightNode> &node, const std::shared_ptr<Serializable> &config) const;
+  void startSharedTransition(
+      int tag,
+      const ShadowView &before,
+      const ShadowView &after,
+      const std::shared_ptr<Serializable> &config) const;
   void startProgressTransition(const int tag, const ShadowView &before, const ShadowView &after) const;
   void handleProgressTransition(
-      ShadowViewMutationList &filteredMutations,
+      TransactionMeta &transaction,
       const ShadowViewMutationList &mutations,
       const PropsParserContext &propsParserContext) const;
 
   void updateLightTree(
       const PropsParserContext &propsParserContext,
       const ShadowViewMutationList &mutations,
-      ShadowViewMutationList &filteredMutations,
-      ShadowViewMutationList &teardownMutations) const;
+      TransactionMeta &transaction) const;
 
   void applyInitialMutationsToLightTree(const ShadowViewMutationList &mutations) const;
   void initializeLightTree(const ShadowTreeRevision &baseRevision);
@@ -92,20 +102,19 @@ struct LayoutAnimationsProxy_Experimental : public LayoutAnimationsProxyCommon,
   void handleSharedTransitionsStart(
       const std::shared_ptr<LightNode> &afterTopScreen,
       const std::shared_ptr<LightNode> &beforeTopScreen,
-      ShadowViewMutationList &filteredMutations,
+      TransactionMeta &transaction,
       const ShadowViewMutationList &mutations,
       const PropsParserContext &propsParserContext) const;
 
-  void cleanupAnimations(ShadowViewMutationList &filteredMutations, const PropsParserContext &propsParserContext) const;
-  void cleanupSharedTransitions(ShadowViewMutationList &filteredMutations, const PropsParserContext &propsParserContext)
-      const;
+  void cleanupAnimations(TransactionMeta &transaction, const PropsParserContext &propsParserContext) const;
+  void cleanupSharedTransitions(TransactionMeta &transaction, const PropsParserContext &propsParserContext) const;
 
   void hideTransitioningViews(
       BeforeOrAfter index,
-      ShadowViewMutationList &filteredMutations,
+      const Transitions &transitions,
+      ShadowViewMutationList &mutations,
       const PropsParserContext &propsParserContext) const;
 
-  std::optional<SurfaceId> progressLayoutAnimation(int tag, const jsi::Object &newStyle) override;
   std::optional<SurfaceId> endLayoutAnimation(int tag, bool shouldRemove) override;
   void startSurface(
       const facebook::react::ShadowTree &shadowTree,
@@ -122,18 +131,16 @@ struct LayoutAnimationsProxy_Experimental : public LayoutAnimationsProxyCommon,
   void findSharedElementsOnScreen(
       const std::shared_ptr<LightNode> &node,
       BeforeOrAfter index,
-      const PropsParserContext &propsParserContext) const;
+      const PropsParserContext &propsParserContext,
+      TransactionMeta &transaction) const;
 
-  void insertContainers(ShadowViewMutationList &filteredMutations, int &rootChildCount) const;
+  void insertContainers(TransactionMeta &transaction, int &rootChildCount) const;
+
+  void removeSharedContainer(Tag containerTag, TransactionMeta &transaction) const;
 
   std::vector<react::Point> getAbsolutePositionsForRootPathView(const std::shared_ptr<LightNode> &node) const;
 
-  void transferConfigToContainer(Tag containerTag, Tag beforeTag) const;
-
-  Tag getOrCreateContainer(
-      const ShadowView &before,
-      const SharedTag &sharedTag,
-      ShadowViewMutationList &filteredMutations) const;
+  Tag getOrCreateContainer(const ShadowView &before, const SharedTag &sharedTag, TransactionMeta &transaction) const;
 
   void overrideTransform(
       ShadowView &shadowView,
@@ -154,21 +161,15 @@ struct LayoutAnimationsProxy_Experimental : public LayoutAnimationsProxyCommon,
       const std::shared_ptr<LightNode> &node,
       const std::shared_ptr<LightNode> &parent,
       int hostIndex,
-      ShadowViewMutationList &filteredMutations,
-      ShadowViewMutationList &teardownMutations) const;
-  void flushDeadNodes(ShadowViewMutationList &filteredMutations) const;
+      TransactionMeta &transaction) const;
+  void handleRemovals(ShadowViewMutationList &filteredMutations) const;
 
   void addOngoingAnimations(ShadowViewMutationList &mutations) const;
-  void updateOngoingAnimationTarget(const int tag, const ShadowViewMutation &mutation) const;
   ShadowView cloneViewWithoutOpacity(const ShadowView &shadowView, const PropsParserContext &propsParserContext) const;
-
-  ShadowView cloneViewWithOpacity(const ShadowView &shadowView, const PropsParserContext &propsParserContext) const;
-  void maybeRestoreOpacity(reanimated::LayoutAnimation &layoutAnimation, const jsi::Object &newStyle) const;
-  ShadowView maybeCreateLayoutAnimation(ShadowView &before, const ShadowView &after, const Tag parentTag) const;
 
   bool startAnimationsRecursively(
       const std::shared_ptr<LightNode> &node,
-      ShadowViewMutationList &mutations,
+      TransactionMeta &transaction,
       StartAnimationsRecursivelyConfig config) const;
   void endAnimationsRecursively(const std::shared_ptr<LightNode> &node, int index, ShadowViewMutationList &mutations)
       const;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.h
@@ -44,7 +44,8 @@ struct TransactionMeta {
   ShadowViewMutationList teardownMutations;
   TransitionMap transitionMap;
   Transitions transitions;
-  std::vector<PendingNodeAnimation> entering, layout;
+  std::vector<PendingNodeAnimation> layout;
+  std::vector<PendingNodeAnimation> entering;
   std::vector<PendingNodeAnimation> exiting;
   std::vector<std::shared_ptr<LightNode>> containersToInsert;
   std::vector<Tag> tagsToRestore;
@@ -162,7 +163,7 @@ struct LayoutAnimationsProxy_Experimental : public LayoutAnimationsProxyCommon {
       const std::shared_ptr<LightNode> &parent,
       int hostIndex,
       TransactionMeta &transaction) const;
-  void handleRemovals(ShadowViewMutationList &filteredMutations) const;
+  void flushCompletedRemovals(ShadowViewMutationList &filteredMutations) const;
 
   void addOngoingAnimations(ShadowViewMutationList &mutations) const;
   ShadowView cloneViewWithoutOpacity(const ShadowView &shadowView, const PropsParserContext &propsParserContext) const;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
@@ -2,7 +2,6 @@
 #include <reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.h>
 #include <worklets/Compat/StableApi.h>
 
-#include <ReactCommon/CallInvoker.h>
 #include <react/debug/react_native_assert.h>
 #include <react/renderer/mounting/ShadowTree.h>
 #include <react/renderer/mounting/ShadowViewMutation.h>
@@ -37,7 +36,7 @@ std::optional<MountingTransaction> LayoutAnimationsProxy_Legacy::pullTransaction
 #endif
   react_native_assert(surfaceId == surfaceId_ && "pull routed to the wrong surface's proxy");
   auto lock = std::unique_lock<std::recursive_mutex>(mutex);
-  PropsParserContext propsParserContext{surfaceId, *contextContainer_};
+  PropsParserContext propsParserContext{surfaceId_, *contextContainer_};
   ShadowViewMutationList filteredMutations;
 
   std::vector<std::shared_ptr<MutationNode>> roots;
@@ -46,21 +45,6 @@ std::optional<MountingTransaction> LayoutAnimationsProxy_Legacy::pullTransaction
   reconcileContradictedRemovals(mutations, filteredMutations);
 
   addOngoingAnimations(filteredMutations);
-
-#ifdef ANDROID
-  restoreOpacityInCaseOfFlakyEnteringAnimation();
-#endif // ANDROID
-  for (const auto tag : maybeSettledAnimationTags_) {
-    const auto layoutAnimationIt = layoutAnimations_.find(tag);
-    if (layoutAnimationIt == layoutAnimations_.end() || !layoutAnimationIt->second.isSettled()) {
-      continue;
-    }
-    layoutAnimations_.erase(layoutAnimationIt);
-    updateMap_.erase(tag);
-  }
-  maybeSettledAnimationTags_.clear();
-  // Past this point no animation can be settled - we hold the mutex for the whole
-  // transaction, so no end callback can run until we return.
 
   parseRemoveMutations(movedViews, mutations, roots);
 
@@ -75,14 +59,17 @@ std::optional<MountingTransaction> LayoutAnimationsProxy_Legacy::pullTransaction
     surfaceToRemove_ = false;
   }
   const bool flushDeadNodes = shouldFlushDeadNodes(surfaceDropped);
-  handleRemovals(filteredMutations, roots, deadNodes_, surfaceDropped, flushDeadNodes);
+  handleRemovals(filteredMutations, roots, surfaceDropped, flushDeadNodes);
 #ifdef ANDROID
   maybeScheduleCleanupPull(flushDeadNodes);
 #endif // ANDROID
 
   handleUpdatesAndEnterings(filteredMutations, movedViews, mutations, propsParserContext);
 
+  flushLayoutAnimationOperations(lock);
+
   addOngoingAnimations(filteredMutations);
+  cleanupCompletedAnimations(filteredMutations, propsParserContext);
 
   dropUpdatesForDeletedViews(filteredMutations);
 
@@ -129,6 +116,8 @@ void LayoutAnimationsProxy_Legacy::reconcileContradictedRemovals(
       continue;
     }
     auto node = std::static_pointer_cast<MutationNode>(it->second);
+    completedAnimations_.erase(tag);
+    updateMap_.erase(tag);
     // Flush the withheld Remove/Delete for this tag (and its withheld subtree)
     // right now, mirroring the deadNodes cleanup in handleRemovals. This removes
     // the stale view before React's Create/Insert re-registers the same tag.
@@ -157,51 +146,10 @@ void LayoutAnimationsProxy_Legacy::maybeScheduleCleanupPull(const bool flushedDe
     cleanupPullScheduled_ = false;
   } else if (!deadNodes_.empty() && !cleanupPullScheduled_) {
     cleanupPullScheduled_ = true;
-    scheduleDeferredCleanupPull();
+    scheduleCleanupPull();
   }
 }
-
-void LayoutAnimationsProxy_Legacy::scheduleDeferredCleanupPull() const {
-  const std::weak_ptr<UIManager> weakUiManager = uiManager_;
-  jsInvoker_->invokeAsync([weakUiManager, surfaceId = surfaceId_](jsi::Runtime &) {
-    auto uiManager = weakUiManager.lock();
-    if (!uiManager) {
-      return;
-    }
-    uiManager->getShadowTreeRegistry().visit(
-        surfaceId, [](ShadowTree const &shadowTree) { shadowTree.notifyDelegatesOfUpdates(); });
-  });
-}
 #endif
-
-std::optional<SurfaceId> LayoutAnimationsProxy_Legacy::progressLayoutAnimation(int tag, const jsi::Object &newStyle) {
-#ifdef LAYOUT_ANIMATIONS_LOGS
-  LOG(INFO) << "progress layout animation for tag " << tag << std::endl;
-#endif
-  auto lock = std::unique_lock<std::recursive_mutex>(mutex);
-  auto layoutAnimationIt = layoutAnimations_.find(tag);
-
-  if (layoutAnimationIt == layoutAnimations_.end()) {
-    return {};
-  }
-
-  auto &layoutAnimation = layoutAnimationIt->second;
-
-  maybeRestoreOpacity(layoutAnimation, newStyle);
-
-  auto rawProps = std::make_shared<RawProps>(uiRuntime_, jsi::Value(uiRuntime_, newStyle));
-
-  PropsParserContext propsParserContext{layoutAnimation.finalView.surfaceId, *contextContainer_};
-#ifdef RN_SERIALIZABLE_STATE
-  rawProps = std::make_shared<RawProps>(
-      folly::dynamic::merge(layoutAnimation.finalView.props->rawProps, (folly::dynamic)*rawProps));
-#endif
-  auto newProps = getComponentDescriptorForShadowView(layoutAnimation.finalView)
-                      .cloneProps(propsParserContext, layoutAnimation.finalView.props, std::move(*rawProps));
-  updateMap_.insert_or_assign(tag, UpdateValues{newProps, Frame(uiRuntime_, newStyle)});
-
-  return layoutAnimation.finalView.surfaceId;
-}
 
 std::optional<SurfaceId> LayoutAnimationsProxy_Legacy::endLayoutAnimation(int tag, bool shouldRemove) {
 #ifdef LAYOUT_ANIMATIONS_LOGS
@@ -214,21 +162,12 @@ std::optional<SurfaceId> LayoutAnimationsProxy_Legacy::endLayoutAnimation(int ta
     return {};
   }
 
-  auto &layoutAnimation = layoutAnimationIt->second;
-
-  // multiple layout animations can be triggered for a view
-  // one after the other, so we need to keep count of how many
-  // were actually triggered, so that we don't cleanup necessary
-  // structures too early
-  if (--layoutAnimation.count > 0) {
-    return {};
-  }
-  layoutAnimation.isExitingWhenSettled = shouldRemove;
-  maybeSettledAnimationTags_.insert(tag);
-  auto surfaceId = layoutAnimation.finalView.surfaceId;
+  completedAnimations_.insert_or_assign(
+      tag, CompletedLayoutAnimation{.animation = layoutAnimationIt->second, .shouldRemove = shouldRemove});
+  layoutAnimations_.erase(layoutAnimationIt);
 
   if (!shouldRemove || !nodeForTag_.contains(tag)) {
-    return {};
+    return surfaceId_;
   }
 
   auto node = nodeForTag_[tag];
@@ -240,7 +179,7 @@ std::optional<SurfaceId> LayoutAnimationsProxy_Legacy::endLayoutAnimation(int ta
   mutationNode->state = ExitingState_Legacy::DEAD;
   deadNodes_.insert(mutationNode);
 
-  return surfaceId;
+  return surfaceId_;
 }
 
 /**
@@ -266,11 +205,9 @@ void LayoutAnimationsProxy_Legacy::parseRemoveMutations(
       updateIndexForMutation(mutation);
       auto tag = mutation.oldChildShadowView.tag;
       auto parentTag = mutation.parentTag;
-      auto unflattenedParentTag = parentTag; // temporary
 
       std::shared_ptr<MutationNode> mutationNode;
-      std::shared_ptr<Node> node = nodeForTag_[tag], parent = nodeForTag_[parentTag],
-                            unflattenedParent = nodeForTag_[unflattenedParentTag];
+      std::shared_ptr<Node> node = nodeForTag_[tag], parent = nodeForTag_[parentTag];
 
       if (!node) {
         mutationNode = std::make_shared<MutationNode>(mutation);
@@ -294,21 +231,12 @@ void LayoutAnimationsProxy_Legacy::parseRemoveMutations(
         nodeForTag_[parentTag] = parent;
       }
 
-      if (!unflattenedParent) {
-        if (parentTag == unflattenedParentTag) {
-          unflattenedParent = parent;
-        } else {
-          unflattenedParent = std::make_shared<Node>(unflattenedParentTag);
-          nodeForTag_[unflattenedParentTag] = unflattenedParent;
-        }
-      }
-
       mutationNodes.push_back(mutationNode);
 
       childrenForTag[parentTag].push_back(mutationNode);
-      unflattenedChildrenForTag[unflattenedParentTag].push_back(mutationNode);
+      unflattenedChildrenForTag[parentTag].push_back(mutationNode);
       mutationNode->parent = parent;
-      mutationNode->unflattenedParent = unflattenedParent;
+      mutationNode->unflattenedParent = parent;
     }
     if (mutation.type == ShadowViewMutation::Update && movedViews.contains(mutation.newChildShadowView.tag)) {
       auto node = nodeForTag_[mutation.newChildShadowView.tag];
@@ -348,7 +276,6 @@ void LayoutAnimationsProxy_Legacy::parseRemoveMutations(
 void LayoutAnimationsProxy_Legacy::handleRemovals(
     ShadowViewMutationList &filteredMutations,
     std::vector<std::shared_ptr<MutationNode>> &roots,
-    std::unordered_set<std::shared_ptr<MutationNode>> &deadNodes,
     bool surfaceDropped,
     bool flushDeadNodes) const {
   // iterate from the end, so that children
@@ -359,7 +286,7 @@ void LayoutAnimationsProxy_Legacy::handleRemovals(
       filteredMutations.push_back(node->mutation);
       node->unflattenedParent->removeChildFromUnflattenedTree(node); //???
       if (node->state != ExitingState_Legacy::MOVED) {
-        maybeCancelAnimation(node->tag);
+        cancelLayoutAnimation(node->tag);
         filteredMutations.push_back(ShadowViewMutation::DeleteMutation(node->mutation.oldChildShadowView));
         nodeForTag_.erase(node->tag);
         node->state = ExitingState_Legacy::DELETED;
@@ -374,13 +301,13 @@ void LayoutAnimationsProxy_Legacy::handleRemovals(
     // Deferred - the host still has these views mounted, bookkeeping stays.
     return;
   }
-  for (const auto &node : deadNodes) {
+  for (const auto &node : deadNodes_) {
     if (node->state != ExitingState_Legacy::DELETED) {
       endAnimationsRecursively(node, filteredMutations);
       maybeDropAncestors(node->unflattenedParent, node, filteredMutations);
     }
   }
-  deadNodes.clear();
+  deadNodes_.clear();
 }
 
 void LayoutAnimationsProxy_Legacy::handleUpdatesAndEnterings(
@@ -405,52 +332,45 @@ void LayoutAnimationsProxy_Legacy::handleUpdatesAndEnterings(
         updateIndexForMutation(mutation);
 
         const auto parentTag = mutation.parentTag;
-        const auto mutationParent = parentTag;
         if (nodeForTag_.contains(parentTag)) {
           nodeForTag_[parentTag]->applyMutationToIndices(mutation);
         }
 
         if (movedViews.contains(tag)) {
-          auto layoutAnimationIt = layoutAnimations_.find(tag);
-          if (layoutAnimationIt == layoutAnimations_.end()) {
-            if (oldShadowViewsForReparentings.contains(tag)) {
-              filteredMutations.push_back(ShadowViewMutation::InsertMutation(
-                  mutationParent, oldShadowViewsForReparentings[tag], mutation.index));
-            } else {
-              filteredMutations.push_back(mutation);
-            }
-            continue;
-          }
-
-          auto oldView = layoutAnimationIt->second.currentView;
-          filteredMutations.push_back(ShadowViewMutation::InsertMutation(mutationParent, oldView, mutation.index));
-          if (movedViews.contains(tag)) {
-            layoutAnimationIt->second.parentTag = movedViews.at(tag);
+          if (const auto currentView = reparentLayoutAnimation(tag, movedViews.at(tag))) {
+            filteredMutations.push_back(ShadowViewMutation::InsertMutation(parentTag, *currentView, mutation.index));
+          } else if (oldShadowViewsForReparentings.contains(tag)) {
+            filteredMutations.push_back(
+                ShadowViewMutation::InsertMutation(parentTag, oldShadowViewsForReparentings[tag], mutation.index));
+          } else {
+            filteredMutations.push_back(mutation);
           }
           continue;
         }
 
         transferConfigFromNativeID(mutation.newChildShadowView.props->nativeId, mutation.newChildShadowView.tag);
-        if (!layoutAnimationsManager_->hasLayoutAnimation(tag, LayoutAnimationType::ENTERING)) {
+        const auto enteringConfig =
+            layoutAnimationsManager_->getLayoutAnimationConfig(tag, LayoutAnimationType::ENTERING);
+        if (!enteringConfig) {
           filteredMutations.push_back(mutation);
           continue;
         }
 
-        startEnteringAnimation(tag, mutation);
+        startEnteringAnimation(tag, mutation, enteringConfig);
         filteredMutations.push_back(mutation);
 
         // temporarily set opacity to 0 to prevent flickering on android
         std::shared_ptr<ShadowView> newView = cloneViewWithoutOpacity(mutation, propsParserContext);
 
         filteredMutations.push_back(
-            ShadowViewMutation::UpdateMutation(mutation.newChildShadowView, *newView, mutationParent));
+            ShadowViewMutation::UpdateMutation(mutation.newChildShadowView, *newView, parentTag));
         break;
       }
 
       case ShadowViewMutation::Type::Update: {
         auto shouldAnimate = hasLayoutChanged(mutation);
-        if (!layoutAnimationsManager_->hasLayoutAnimation(tag, LayoutAnimationType::LAYOUT) ||
-            (!shouldAnimate && !layoutAnimations_.contains(tag))) {
+        const auto layoutConfig = layoutAnimationsManager_->getLayoutAnimationConfig(tag, LayoutAnimationType::LAYOUT);
+        if (!layoutConfig || (!shouldAnimate && !layoutAnimations_.contains(tag) && !hasPendingLayoutAnimation(tag))) {
           // We should cancel any ongoing animation here to ensure that the
           // proper final state is reached for this view However, due to how
           // RNSScreens handle adding headers (a second commit is triggered to
@@ -461,7 +381,7 @@ void LayoutAnimationsProxy_Legacy::handleUpdatesAndEnterings(
           filteredMutations.push_back(mutation);
           continue;
         } else if (!shouldAnimate) {
-          updateOngoingAnimationTarget(tag, mutation);
+          updateLayoutAnimationTarget(tag, mutation.newChildShadowView);
           continue;
         }
 
@@ -472,7 +392,7 @@ void LayoutAnimationsProxy_Legacy::handleUpdatesAndEnterings(
           mutation.parentTag = movedViews.at(tag);
         }
         if (mutation.parentTag != -1) {
-          startLayoutAnimation(tag, mutation);
+          startLayoutAnimation(tag, mutation, layoutConfig);
         }
         break;
       }
@@ -522,14 +442,14 @@ void LayoutAnimationsProxy_Legacy::addOngoingAnimations(ShadowViewMutationList &
 #endif
 
     auto layoutAnimationIt = layoutAnimations_.find(tag);
-
-    if (layoutAnimationIt == layoutAnimations_.end() ||
-        (layoutAnimationIt->second.isSettled() && layoutAnimationIt->second.isExitingWhenSettled)) {
+    auto completedAnimationIt = completedAnimations_.find(tag);
+    if (layoutAnimationIt == layoutAnimations_.end() &&
+        (completedAnimationIt == completedAnimations_.end() || completedAnimationIt->second.shouldRemove)) {
       continue;
     }
 
-    auto &layoutAnimation = layoutAnimationIt->second;
-    layoutAnimation.isViewAlreadyMounted = true;
+    auto &layoutAnimation = layoutAnimationIt != layoutAnimations_.end() ? layoutAnimationIt->second
+                                                                         : completedAnimationIt->second.animation;
     auto newView = layoutAnimation.finalView;
     newView.props = updateValues.newProps;
     updateLayoutMetrics(newView.layoutMetrics, updateValues.frame);
@@ -537,6 +457,9 @@ void LayoutAnimationsProxy_Legacy::addOngoingAnimations(ShadowViewMutationList &
     mutations.push_back(
         ShadowViewMutation::UpdateMutation(layoutAnimation.currentView, newView, layoutAnimation.parentTag));
     layoutAnimation.currentView = newView;
+    if (layoutAnimation.opacity && static_cast<const ViewProps &>(*newView.props).opacity == *layoutAnimation.opacity) {
+      layoutAnimation.opacity.reset();
+    }
   }
   updateMap_.clear();
 }
@@ -544,7 +467,7 @@ void LayoutAnimationsProxy_Legacy::addOngoingAnimations(ShadowViewMutationList &
 void LayoutAnimationsProxy_Legacy::endAnimationsRecursively(
     const std::shared_ptr<MutationNode> &node,
     ShadowViewMutationList &mutations) const {
-  maybeCancelAnimation(node->tag);
+  cancelLayoutAnimation(node->tag);
   node->state = ExitingState_Legacy::DELETED;
   // iterate from the end, so that children
   // with higher indices appear first in the mutations list
@@ -576,7 +499,7 @@ void LayoutAnimationsProxy_Legacy::maybeDropAncestors(
   if (node->children.size() == 0 && node->state != ExitingState_Legacy::ANIMATING) {
     nodeForTag_.erase(node->tag);
     cleanupMutations.push_back(node->mutation);
-    maybeCancelAnimation(node->tag);
+    cancelLayoutAnimation(node->tag);
     node->state = ExitingState_Legacy::DELETED;
 #ifdef LAYOUT_ANIMATIONS_LOGS
     LOG(INFO) << "delete " << node->tag << std::endl;
@@ -584,11 +507,6 @@ void LayoutAnimationsProxy_Legacy::maybeDropAncestors(
     cleanupMutations.push_back(ShadowViewMutation::DeleteMutation(node->mutation.oldChildShadowView));
     maybeDropAncestors(node->unflattenedParent, node, cleanupMutations);
   }
-}
-
-const ComponentDescriptor &LayoutAnimationsProxy_Legacy::getComponentDescriptorForShadowView(
-    const ShadowView &shadowView) const {
-  return componentDescriptorRegistry_->at(shadowView.componentHandle);
 }
 
 bool LayoutAnimationsProxy_Legacy::startAnimationsRecursively(
@@ -603,8 +521,10 @@ bool LayoutAnimationsProxy_Legacy::startAnimationsRecursively(
 
   shouldAnimate = !isScreenPop && layoutAnimationsManager_->shouldAnimateExiting(node->tag, shouldAnimate);
 
-  bool hasExitAnimation =
-      shouldAnimate && layoutAnimationsManager_->hasLayoutAnimation(node->tag, LayoutAnimationType::EXITING);
+  const auto exitConfig = shouldAnimate && node->state != ExitingState_Legacy::MOVED
+      ? layoutAnimationsManager_->takeExitingAnimationConfigAndClearTag(node->tag)
+      : nullptr;
+  const bool hasExitAnimation = exitConfig != nullptr;
   bool hasAnimatedChildren = false;
 
   shouldRemoveSubviewsWithoutAnimations =
@@ -636,7 +556,7 @@ bool LayoutAnimationsProxy_Legacy::startAnimationsRecursively(
       mutations.push_back(subNode->mutation);
       toBeRemoved.push_back(subNode);
     } else if (shouldRemoveSubviewsWithoutAnimations) {
-      maybeCancelAnimation(subNode->tag);
+      cancelLayoutAnimation(subNode->tag);
       mutations.push_back(subNode->mutation);
       toBeRemoved.push_back(subNode);
       subNode->state = ExitingState_Legacy::DELETED;
@@ -670,8 +590,8 @@ bool LayoutAnimationsProxy_Legacy::startAnimationsRecursively(
 
   if (hasExitAnimation) {
     node->state = ExitingState_Legacy::ANIMATING;
-    startExitingAnimation(node->tag, node->mutation);
-  } else {
+    startExitingAnimation(node->tag, node->mutation, exitConfig);
+  } else if (!shouldAnimate) {
     layoutAnimationsManager_->clearLayoutAnimationConfig(node->tag);
   }
 
@@ -713,248 +633,56 @@ bool LayoutAnimationsProxy_Legacy::shouldOverridePullTransaction() const {
   return true;
 }
 
-void LayoutAnimationsProxy_Legacy::createLayoutAnimation(
-    const ShadowViewMutation &mutation,
-    ShadowView &oldView,
-    const int tag) const {
-  int count = 1;
-  auto layoutAnimationIt = layoutAnimations_.find(tag);
-
-  if (layoutAnimationIt != layoutAnimations_.end()) {
-    auto &layoutAnimation = layoutAnimationIt->second;
-    oldView = layoutAnimation.currentView;
-    count = layoutAnimation.count + 1;
-  }
-
-  auto finalView =
-      mutation.type == ShadowViewMutation::Remove ? mutation.oldChildShadowView : mutation.newChildShadowView;
-  auto currentView = oldView;
-
-  layoutAnimations_.insert_or_assign(
-      tag,
-      LayoutAnimation{
-          .finalView = finalView,
-          .currentView = currentView,
-          .parentTag = mutation.parentTag,
-          .opacity = {},
-          .isViewAlreadyMounted = false,
-          .count = count});
-}
-
-void LayoutAnimationsProxy_Legacy::startEnteringAnimation(const int tag, ShadowViewMutation &mutation) const {
+void LayoutAnimationsProxy_Legacy::startEnteringAnimation(
+    const int tag,
+    ShadowViewMutation &mutation,
+    const std::shared_ptr<Serializable> &config) const {
 #ifdef LAYOUT_ANIMATIONS_LOGS
   LOG(INFO) << "start entering animation for tag " << tag << std::endl;
 #endif
-  auto finalView = mutation.newChildShadowView;
-  auto current = mutation.newChildShadowView;
-
   auto &viewProps = static_cast<const ViewProps &>(*mutation.newChildShadowView.props);
-  auto opacity = viewProps.opacity;
-#ifdef ANDROID
-  const auto handle = pendingStarts_[tag].handle;
-  pendingStarts_[tag].count++;
-#endif
-
-  scheduleOnUI(
-      uiScheduler_,
-      [weakThis = weak_from_this(),
-       finalView,
-       current,
-       mutation,
-       opacity,
-       tag
-#ifdef ANDROID
-       ,
-       handle
-#endif
-  ]() {
-        auto strongThis = weakThis.lock();
-        if (!strongThis) {
-          return;
-        }
-
-        Rect window{};
-        {
-          auto &mutex = strongThis->mutex;
-          auto lock = std::unique_lock<std::recursive_mutex>(mutex);
-#ifdef ANDROID
-          if (consumeIsCancelled(strongThis->pendingStarts_, tag, handle)) {
-            // the view was removed before this start could run
-            return;
-          }
-#endif
-          strongThis->layoutAnimations_.insert_or_assign(
-              tag,
-              LayoutAnimation{
-                  .finalView = finalView, .currentView = current, .parentTag = mutation.parentTag, .opacity = opacity});
-          window = strongThis->window_;
-        }
-
-        Snapshot values(mutation.newChildShadowView, window);
-        auto &uiRuntime = strongThis->uiRuntime_;
-        jsi::Object yogaValues(uiRuntime);
-        yogaValues.setProperty(uiRuntime, "targetOriginX", values.x);
-        yogaValues.setProperty(uiRuntime, "targetGlobalOriginX", values.x);
-        yogaValues.setProperty(uiRuntime, "targetOriginY", values.y);
-        yogaValues.setProperty(uiRuntime, "targetGlobalOriginY", values.y);
-        yogaValues.setProperty(uiRuntime, "targetWidth", values.width);
-        yogaValues.setProperty(uiRuntime, "targetHeight", values.height);
-        yogaValues.setProperty(uiRuntime, "windowWidth", values.windowWidth);
-        yogaValues.setProperty(uiRuntime, "windowHeight", values.windowHeight);
-        strongThis->layoutAnimationsManager_->startLayoutAnimation(
-            uiRuntime, tag, LayoutAnimationType::ENTERING, yogaValues);
-      });
+  enqueueLayoutAnimation(ManagedLayoutAnimationStart{
+      .tag = tag,
+      .type = LayoutAnimationType::ENTERING,
+      .before = mutation.newChildShadowView,
+      .after = mutation.newChildShadowView,
+      .parentTag = mutation.parentTag,
+      .opacity = viewProps.opacity,
+      .config = config,
+  });
 }
 
-void LayoutAnimationsProxy_Legacy::startExitingAnimation(const int tag, ShadowViewMutation &mutation) const {
+void LayoutAnimationsProxy_Legacy::startExitingAnimation(
+    const int tag,
+    ShadowViewMutation &mutation,
+    const std::shared_ptr<Serializable> &config) const {
 #ifdef LAYOUT_ANIMATIONS_LOGS
   LOG(INFO) << "start exiting animation for tag " << tag << std::endl;
 #endif
-#ifdef ANDROID
-  const auto handle = pendingStarts_[tag].handle;
-  pendingStarts_[tag].count++;
-#endif
-
-  scheduleOnUI(
-      uiScheduler_,
-      [weakThis = weak_from_this(),
-       tag,
-       mutation
-#ifdef ANDROID
-       ,
-       handle
-#endif
-  ]() {
-        auto strongThis = weakThis.lock();
-        if (!strongThis) {
-          return;
-        }
-
-        auto oldView = mutation.oldChildShadowView;
-        Rect window{};
-        {
-          auto &mutex = strongThis->mutex;
-          auto lock = std::unique_lock<std::recursive_mutex>(mutex);
-#ifdef ANDROID
-          if (consumeIsCancelled(strongThis->pendingStarts_, tag, handle)) {
-            // The view was removed before this start could run. Deliberately no
-            // clearLayoutAnimationConfig: with tag reuse the config maps already
-            // describe the re-created view, and wiping them would leave it mounted
-            // at opacity 0. A dead tag's stale configs can never fire again.
-            return;
-          }
-#endif
-          strongThis->createLayoutAnimation(mutation, oldView, tag);
-          window = strongThis->window_;
-        }
-
-        Snapshot values(oldView, window);
-
-        auto &uiRuntime = strongThis->uiRuntime_;
-        jsi::Object yogaValues(uiRuntime);
-        yogaValues.setProperty(uiRuntime, "currentOriginX", values.x);
-        yogaValues.setProperty(uiRuntime, "currentGlobalOriginX", values.x);
-        yogaValues.setProperty(uiRuntime, "currentOriginY", values.y);
-        yogaValues.setProperty(uiRuntime, "currentGlobalOriginY", values.y);
-        yogaValues.setProperty(uiRuntime, "currentWidth", values.width);
-        yogaValues.setProperty(uiRuntime, "currentHeight", values.height);
-        yogaValues.setProperty(uiRuntime, "windowWidth", values.windowWidth);
-        yogaValues.setProperty(uiRuntime, "windowHeight", values.windowHeight);
-        strongThis->layoutAnimationsManager_->startLayoutAnimation(
-            uiRuntime, tag, LayoutAnimationType::EXITING, yogaValues);
-        strongThis->layoutAnimationsManager_->clearLayoutAnimationConfig(tag);
-      });
+  enqueueLayoutAnimation(ManagedLayoutAnimationStart{
+      .tag = tag,
+      .type = LayoutAnimationType::EXITING,
+      .before = mutation.oldChildShadowView,
+      .after = mutation.oldChildShadowView,
+      .parentTag = mutation.parentTag,
+      .config = config,
+  });
 }
 
-void LayoutAnimationsProxy_Legacy::startLayoutAnimation(const int tag, const ShadowViewMutation &mutation) const {
+void LayoutAnimationsProxy_Legacy::startLayoutAnimation(
+    const int tag,
+    const ShadowViewMutation &mutation,
+    const std::shared_ptr<Serializable> &config) const {
 #ifdef LAYOUT_ANIMATIONS_LOGS
   LOG(INFO) << "start layout animation for tag " << tag << std::endl;
 #endif
-#ifdef ANDROID
-  const auto handle = pendingStarts_[tag].handle;
-  pendingStarts_[tag].count++;
-#endif
-
-  scheduleOnUI(
-      uiScheduler_,
-      [weakThis = weak_from_this(),
-       mutation,
-       tag
-#ifdef ANDROID
-       ,
-       handle
-#endif
-  ]() {
-        auto strongThis = weakThis.lock();
-        if (!strongThis) {
-          return;
-        }
-
-        auto oldView = mutation.oldChildShadowView;
-        Rect window{};
-        {
-          auto &mutex = strongThis->mutex;
-          auto lock = std::unique_lock<std::recursive_mutex>(mutex);
-#ifdef ANDROID
-          if (consumeIsCancelled(strongThis->pendingStarts_, tag, handle)) {
-            // the view was removed before this start could run
-            return;
-          }
-#endif
-          strongThis->createLayoutAnimation(mutation, oldView, tag);
-          window = strongThis->window_;
-        }
-
-        Snapshot currentValues(oldView, window);
-        Snapshot targetValues(mutation.newChildShadowView, window);
-
-        auto &uiRuntime = strongThis->uiRuntime_;
-        jsi::Object yogaValues(uiRuntime);
-        yogaValues.setProperty(uiRuntime, "currentOriginX", currentValues.x);
-        yogaValues.setProperty(uiRuntime, "currentGlobalOriginX", currentValues.x);
-        yogaValues.setProperty(uiRuntime, "currentOriginY", currentValues.y);
-        yogaValues.setProperty(uiRuntime, "currentGlobalOriginY", currentValues.y);
-        yogaValues.setProperty(uiRuntime, "currentWidth", currentValues.width);
-        yogaValues.setProperty(uiRuntime, "currentHeight", currentValues.height);
-        yogaValues.setProperty(uiRuntime, "targetOriginX", targetValues.x);
-        yogaValues.setProperty(uiRuntime, "targetGlobalOriginX", targetValues.x);
-        yogaValues.setProperty(uiRuntime, "targetOriginY", targetValues.y);
-        yogaValues.setProperty(uiRuntime, "targetGlobalOriginY", targetValues.y);
-        yogaValues.setProperty(uiRuntime, "targetWidth", targetValues.width);
-        yogaValues.setProperty(uiRuntime, "targetHeight", targetValues.height);
-        yogaValues.setProperty(uiRuntime, "windowWidth", targetValues.windowWidth);
-        yogaValues.setProperty(uiRuntime, "windowHeight", targetValues.windowHeight);
-        strongThis->layoutAnimationsManager_->startLayoutAnimation(
-            uiRuntime, tag, LayoutAnimationType::LAYOUT, yogaValues);
-      });
-}
-
-void LayoutAnimationsProxy_Legacy::updateOngoingAnimationTarget(const int tag, const ShadowViewMutation &mutation)
-    const {
-  auto copy = mutation.newChildShadowView;
-  layoutAnimations_[tag].finalView = copy;
-}
-
-void LayoutAnimationsProxy_Legacy::maybeCancelAnimation(const int tag) const {
-#ifdef ANDROID
-  // invalidate animation starts that are scheduled but haven't run yet
-  if (const auto it = pendingStarts_.find(tag); it != pendingStarts_.end()) {
-    it->second.handle++;
-  }
-#endif
-  const auto layoutAnimationIt = layoutAnimations_.find(tag);
-  if (layoutAnimationIt == layoutAnimations_.end()) {
-    return;
-  }
-  layoutAnimations_.erase(layoutAnimationIt);
-  scheduleOnUI(uiScheduler_, [weakThis = weak_from_this(), tag]() {
-    auto strongThis = weakThis.lock();
-    if (!strongThis) {
-      return;
-    }
-
-    auto &uiRuntime = strongThis->uiRuntime_;
-    strongThis->layoutAnimationsManager_->cancelLayoutAnimation(uiRuntime, tag);
+  enqueueLayoutAnimation(ManagedLayoutAnimationStart{
+      .tag = tag,
+      .type = LayoutAnimationType::LAYOUT,
+      .before = mutation.oldChildShadowView,
+      .after = mutation.newChildShadowView,
+      .parentTag = mutation.parentTag,
+      .config = config,
   });
 }
 
@@ -966,23 +694,10 @@ std::shared_ptr<ShadowView> LayoutAnimationsProxy_Legacy::cloneViewWithoutOpacit
     const PropsParserContext &propsParserContext) const {
   auto newView = std::make_shared<ShadowView>(mutation.newChildShadowView);
   folly::dynamic opacity = folly::dynamic::object("opacity", 0);
-  auto newProps =
-      getComponentDescriptorForShadowView(*newView).cloneProps(propsParserContext, newView->props, RawProps(opacity));
+  auto newProps = componentDescriptorRegistry_->at(newView->componentHandle)
+                      .cloneProps(propsParserContext, newView->props, RawProps(opacity));
   newView->props = newProps;
   return newView;
-}
-
-void LayoutAnimationsProxy_Legacy::maybeRestoreOpacity(LayoutAnimation &layoutAnimation, const jsi::Object &newStyle)
-    const {
-  if (layoutAnimation.opacity && !newStyle.hasProperty(uiRuntime_, "opacity")) {
-    newStyle.setProperty(uiRuntime_, "opacity", jsi::Value(*layoutAnimation.opacity));
-    if (layoutAnimation.isViewAlreadyMounted) {
-      // We want to reset opacity only when we are sure that this update will be
-      // applied to the native view. Otherwise, we want to update opacity using
-      // the `restoreOpacityInCaseOfFlakyEnteringAnimation` method.
-      layoutAnimation.opacity.reset();
-    }
-  }
 }
 
 void Node::applyMutationToIndices(const ShadowViewMutation &mutation) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.h
@@ -11,6 +11,7 @@
 #include <reanimated/Tools/PlatformDepMethodsHolder.h>
 
 #include <memory>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -19,7 +20,6 @@
 
 namespace reanimated {
 
-class ReanimatedModuleProxy;
 class LayoutAnimationsProxyRegistry;
 
 using namespace facebook;
@@ -97,32 +97,31 @@ static inline void mergeAndSwap(
   std::swap(A, merged);
 }
 
-struct LayoutAnimationsProxy_Legacy : public LayoutAnimationsProxyCommon,
-                                      public std::enable_shared_from_this<LayoutAnimationsProxy_Legacy> {
+struct LayoutAnimationsProxy_Legacy : public LayoutAnimationsProxyCommon {
   mutable std::unordered_map<Tag, std::shared_ptr<Node>> nodeForTag_;
   mutable std::unordered_set<std::shared_ptr<MutationNode>> deadNodes_;
-  mutable std::unordered_map<Tag, int> leastRemoved;
   mutable bool surfaceToRemove_ = false;
   bool shouldFlushDeadNodes(bool surfaceDropped) const;
 #ifdef ANDROID
   mutable bool cleanupPullScheduled_ = false;
 
   void maybeScheduleCleanupPull(bool flushedDeadNodes) const;
-  void scheduleDeferredCleanupPull() const;
 #endif
 
   LayoutAnimationsProxy_Legacy(const SurfaceId surfaceId, const LayoutAnimationsProxyDependencies &dependencies)
       : LayoutAnimationsProxyCommon(surfaceId, dependencies) {}
 
-  void startEnteringAnimation(const int tag, ShadowViewMutation &mutation) const;
-  void startExitingAnimation(const int tag, ShadowViewMutation &mutation) const;
-  void startLayoutAnimation(const int tag, const ShadowViewMutation &mutation) const;
+  void startEnteringAnimation(const int tag, ShadowViewMutation &mutation, const std::shared_ptr<Serializable> &config)
+      const;
+  void startExitingAnimation(const int tag, ShadowViewMutation &mutation, const std::shared_ptr<Serializable> &config)
+      const;
+  void startLayoutAnimation(
+      const int tag,
+      const ShadowViewMutation &mutation,
+      const std::shared_ptr<Serializable> &config) const;
 
-  std::optional<SurfaceId> progressLayoutAnimation(int tag, const jsi::Object &newStyle) override;
   std::optional<SurfaceId> endLayoutAnimation(int tag, bool shouldRemove) override;
   void shadowTreeWillCommit(bool isSurfaceRemoval) override;
-  void maybeCancelAnimation(const int tag) const;
-
   void reconcileContradictedRemovals(ShadowViewMutationList &mutations, ShadowViewMutationList &filteredMutations)
       const;
   void parseRemoveMutations(
@@ -132,7 +131,6 @@ struct LayoutAnimationsProxy_Legacy : public LayoutAnimationsProxyCommon,
   void handleRemovals(
       ShadowViewMutationList &filteredMutations,
       std::vector<std::shared_ptr<MutationNode>> &roots,
-      std::unordered_set<std::shared_ptr<MutationNode>> &deadNodes,
       bool surfaceDropped,
       bool flushDeadNodes) const;
 
@@ -143,16 +141,11 @@ struct LayoutAnimationsProxy_Legacy : public LayoutAnimationsProxyCommon,
       const PropsParserContext &propsParserContext) const;
   void addOngoingAnimations(ShadowViewMutationList &mutations) const;
   void dropUpdatesForDeletedViews(ShadowViewMutationList &filteredMutations) const;
-  void updateOngoingAnimationTarget(const int tag, const ShadowViewMutation &mutation) const;
   std::shared_ptr<ShadowView> cloneViewWithoutOpacity(
       facebook::react::ShadowViewMutation &mutation,
       const PropsParserContext &propsParserContext) const;
-  void maybeRestoreOpacity(LayoutAnimation &layoutAnimation, const jsi::Object &newStyle) const;
-  void createLayoutAnimation(const ShadowViewMutation &mutation, ShadowView &oldView, const int tag) const;
-
   void updateIndexForMutation(ShadowViewMutation &mutation) const;
 
-  void removeRecursively(std::shared_ptr<MutationNode> node, ShadowViewMutationList &mutations) const;
   bool startAnimationsRecursively(
       const std::shared_ptr<MutationNode> &node,
       bool shouldRemoveSubviewsWithoutAnimations,
@@ -165,7 +158,6 @@ struct LayoutAnimationsProxy_Legacy : public LayoutAnimationsProxyCommon,
       const std::shared_ptr<MutationNode> &child,
       ShadowViewMutationList &cleanupMutations) const;
 
-  const ComponentDescriptor &getComponentDescriptorForShadowView(const ShadowView &shadowView) const;
   // MountingOverrideDelegate
 
   bool shouldOverridePullTransaction() const override;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsUtils.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsUtils.h
@@ -1,15 +1,15 @@
 #pragma once
 
+#include <react/debug/react_native_assert.h>
 #include <react/renderer/components/rnreanimated/Props.h>
 #include <react/renderer/mounting/MountingOverrideDelegate.h>
 #include <react/renderer/mounting/ShadowView.h>
 #include <reanimated/LayoutAnimations/LayoutAnimationsManager.h>
 
 #include <algorithm>
+#include <cstring>
 #include <memory>
-#include <unordered_map>
-#include <unordered_set>
-#include <utility>
+#include <optional>
 #include <vector>
 
 namespace reanimated {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/SharedTransitions.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/SharedTransitions.cpp
@@ -55,7 +55,8 @@ std::shared_ptr<LightNode> LayoutAnimationsProxy_Experimental::findBoundaryGuess
 void LayoutAnimationsProxy_Experimental::findSharedElementsOnScreen(
     const std::shared_ptr<LightNode> &node,
     BeforeOrAfter index,
-    const PropsParserContext &propsParserContext) const {
+    const PropsParserContext &propsParserContext,
+    TransactionMeta &transaction) const {
   if (node->isExiting()) {
     return;
   }
@@ -73,7 +74,7 @@ void LayoutAnimationsProxy_Experimental::findSharedElementsOnScreen(
     absolutePositions = getAbsolutePositionsForRootPathView(node);
     copy.layoutMetrics.frame.origin = absolutePositions[0];
 
-    auto &transition = transitionMap_[*sharedTag];
+    auto &transition = transaction.transitionMap[*sharedTag];
     auto &[snapshot, parentTag, transform] = transition;
     auto newTransform = parseParentTransforms(node, absolutePositions);
     const auto &parent = node->parent.lock();
@@ -85,21 +86,22 @@ void LayoutAnimationsProxy_Experimental::findSharedElementsOnScreen(
     parentTag[indexNum] = parent->current.tag;
 
     if (parentTag[BEFORE] && parentTag[AFTER]) {
-      transitions_.emplace_back(*sharedTag, transition);
+      transaction.transitions.emplace_back(*sharedTag, transition);
     } else if (parentTag[AFTER]) {
       // TODO (future): this is adding unnecessary views to the list
-      tagsToRestore_.push_back(snapshot[AFTER].tag);
+      transaction.tagsToRestore.push_back(snapshot[AFTER].tag);
     }
   }
   for (auto &child : node->children) {
-    findSharedElementsOnScreen(child, index, propsParserContext);
+    findSharedElementsOnScreen(child, index, propsParserContext, transaction);
   }
 }
 
 void LayoutAnimationsProxy_Experimental::handleProgressTransition(
-    ShadowViewMutationList &filteredMutations,
+    TransactionMeta &transaction,
     const ShadowViewMutationList &mutations,
     const PropsParserContext &propsParserContext) const {
+  auto &filteredMutations = transaction.filteredMutations;
   if (!transitionUpdated_) {
     return;
   }
@@ -113,18 +115,17 @@ void LayoutAnimationsProxy_Experimental::handleProgressTransition(
     auto beforeTopScreen = topScreen_;
     auto afterTopScreen = findBoundaryGuess(lightNodes_[transitionTag_]);
     if (beforeTopScreen && afterTopScreen && beforeTopScreen != afterTopScreen) {
-      findSharedElementsOnScreen(beforeTopScreen, BEFORE, propsParserContext);
-      findSharedElementsOnScreen(afterTopScreen, AFTER, propsParserContext);
-      hideTransitioningViews(BEFORE, filteredMutations, propsParserContext);
-      hideTransitioningViews(AFTER, filteredMutations, propsParserContext);
+      findSharedElementsOnScreen(beforeTopScreen, BEFORE, propsParserContext, transaction);
+      findSharedElementsOnScreen(afterTopScreen, AFTER, propsParserContext, transaction);
+      hideTransitioningViews(BEFORE, transaction.transitions, filteredMutations, propsParserContext);
+      hideTransitioningViews(AFTER, transaction.transitions, filteredMutations, propsParserContext);
 
-      for (auto &[sharedTag, transition] : transitions_) {
+      for (auto &[sharedTag, transition] : transaction.transitions) {
         auto &[before, after] = transition.snapshot;
         const auto &transform = transition.transform;
         overrideTransform(before, transform[BEFORE], propsParserContext);
         overrideTransform(after, transform[AFTER], propsParserContext);
-        auto containerTag = getOrCreateContainer(before, sharedTag, filteredMutations);
-        transferConfigToContainer(containerTag, before.tag);
+        auto containerTag = getOrCreateContainer(before, sharedTag, transaction);
 
         restoreMap_[containerTag][BEFORE] = before.tag;
         restoreMap_[containerTag][AFTER] = after.tag;
@@ -137,7 +138,15 @@ void LayoutAnimationsProxy_Experimental::handleProgressTransition(
     }
   } else if (transitionState_ == TransitionState::ACTIVE) {
     for (auto tag : activeTransitions_) {
-      auto layoutAnimation = layoutAnimations_[tag];
+      if (hasPendingLayoutAnimation(tag)) {
+        continue;
+      }
+      const auto layoutAnimationIt = layoutAnimations_.find(tag);
+      if (layoutAnimationIt == layoutAnimations_.end()) {
+        react_native_assert(false && "Shared transition animation not found");
+        continue;
+      }
+      const auto &layoutAnimation = layoutAnimationIt->second;
       auto before = layoutAnimation.startView.layoutMetrics.frame;
       auto after = layoutAnimation.finalView.layoutMetrics.frame;
       auto x = before.origin.x + transitionProgress_ * (after.origin.x - before.origin.x);
@@ -172,16 +181,16 @@ void LayoutAnimationsProxy_Experimental::handleProgressTransition(
     transitionState_ = TransitionState::ACTIVE;
   } else if (transitionState_ == TransitionState::END || transitionState_ == TransitionState::CANCELLED) {
     for (auto tag : activeTransitions_) {
-      sharedContainersToRemove_.push_back(tag);
-      tagsToRestore_.push_back(restoreMap_[tag][AFTER]);
+      transaction.tagsToRestore.push_back(restoreMap_[tag][AFTER]);
       if (transitionState_ == TransitionState::CANCELLED) {
-        tagsToRestore_.push_back(restoreMap_[tag][BEFORE]);
+        transaction.tagsToRestore.push_back(restoreMap_[tag][BEFORE]);
       }
+      removeSharedContainer(tag, transaction);
+      maybeCancelAnimation(tag);
     }
     if (transitionState_ == TransitionState::END) {
       synchronized_ = false;
     }
-    containerTags_.clear();
     activeTransitions_.clear();
     transitionState_ = TransitionState::NONE;
   }
@@ -210,20 +219,14 @@ void LayoutAnimationsProxy_Experimental::overrideTransform(
   shadowView.props = newProps;
 }
 
-void LayoutAnimationsProxy_Experimental::transferConfigToContainer(Tag containerTag, Tag beforeTag) const {
-  layoutAnimationsManager_->transferSharedConfig(beforeTag, containerTag);
-}
-
 Tag LayoutAnimationsProxy_Experimental::getOrCreateContainer(
     const ShadowView &before,
     const SharedTag &sharedTag,
-    ShadowViewMutationList &filteredMutations) const {
-  auto containerTag = containerTags_[sharedTag];
-  auto shouldCreateContainer = true;
-  if (containerTag != -1) {
-    const auto layoutAnimationIt = layoutAnimations_.find(containerTag);
-    shouldCreateContainer = layoutAnimationIt == layoutAnimations_.end() || layoutAnimationIt->second.isSettled();
-  }
+    TransactionMeta &transaction) const {
+  const auto containerIt = containerTags_.find(sharedTag);
+  auto containerTag = containerIt == containerTags_.end() ? -1 : containerIt->second;
+  const auto shouldCreateContainer =
+      containerTag == -1 || (!layoutAnimations_.contains(containerTag) && !hasPendingLayoutAnimation(containerTag));
 
   if (shouldCreateContainer) {
     {
@@ -239,7 +242,7 @@ Tag LayoutAnimationsProxy_Experimental::getOrCreateContainer(
     auto node = std::make_shared<LightNode>();
     node->current = std::move(container);
     root->children.push_back(node);
-    containersToInsert_.push_back(node);
+    transaction.containersToInsert.push_back(node);
     lightNodes_[containerTag] = std::move(node);
 
     containerTags_[sharedTag] = containerTag;
@@ -250,7 +253,7 @@ Tag LayoutAnimationsProxy_Experimental::getOrCreateContainer(
 void LayoutAnimationsProxy_Experimental::handleSharedTransitionsStart(
     const std::shared_ptr<LightNode> &afterTopScreen,
     const std::shared_ptr<LightNode> &beforeTopScreen,
-    ShadowViewMutationList &filteredMutations,
+    TransactionMeta &transaction,
     const ShadowViewMutationList &mutations,
     const PropsParserContext &propsParserContext) const {
   ReanimatedSystraceSection s1("LayoutAnimationsProxy_Experimental::handleSharedTransitionsStart");
@@ -260,34 +263,58 @@ void LayoutAnimationsProxy_Experimental::handleSharedTransitionsStart(
   }
 
   if (beforeTopScreen != afterTopScreen) {
-    for (auto &[sharedTag, transition] : transitions_) {
+    for (auto &[sharedTag, transition] : transaction.transitions) {
       auto &[before, after] = transition.snapshot;
       const auto &transform = transition.transform;
       overrideTransform(before, transform[BEFORE], propsParserContext);
       overrideTransform(after, transform[AFTER], propsParserContext);
-      auto containerTag = getOrCreateContainer(before, sharedTag, filteredMutations);
+      const auto config = layoutAnimationsManager_->getLayoutAnimationConfig(
+          before.tag, LayoutAnimationType::SHARED_ELEMENT_TRANSITION);
+      if (!config) {
+        continue;
+      }
+      auto containerTag = getOrCreateContainer(before, sharedTag, transaction);
 
-      transferConfigToContainer(containerTag, before.tag);
-      restoreMap_[containerTag][1] = after.tag;
+      restoreMap_[containerTag][AFTER] = after.tag;
       before.tag = containerTag;
       after.tag = containerTag;
 
-      startSharedTransition(containerTag, before, after);
+      startSharedTransition(containerTag, before, after, config);
     }
   } else if (!mutations.empty()) {
-    for (auto &[sharedTag, transition] : transitions_) {
-      auto &[_, after] = transition.snapshot;
+    for (auto &[sharedTag, transition] : transaction.transitions) {
+      auto &[before, after] = transition.snapshot;
 
-      auto containerTag = containerTags_[sharedTag];
-      const auto layoutAnimationIt = layoutAnimations_.find(containerTag);
-      if (layoutAnimationIt == layoutAnimations_.end() || layoutAnimationIt->second.isSettled()) {
+      const auto containerIt = containerTags_.find(sharedTag);
+      if (containerIt == containerTags_.end()) {
         continue;
       }
-      after.tag = containerTag;
+      const auto containerTag = containerIt->second;
+      if (hasPendingLayoutAnimation(containerTag)) {
+        const auto config = layoutAnimationsManager_->getLayoutAnimationConfig(
+            before.tag, LayoutAnimationType::SHARED_ELEMENT_TRANSITION);
+        if (!config) {
+          continue;
+        }
+        overrideTransform(after, transition.transform[AFTER], propsParserContext);
+        after.tag = containerTag;
+        updateLayoutAnimationTarget(containerTag, after, config);
+        continue;
+      }
+      const auto layoutAnimationIt = layoutAnimations_.find(containerTag);
+      if (layoutAnimationIt == layoutAnimations_.end()) {
+        continue;
+      }
       const auto &la = layoutAnimationIt->second;
       if (la.finalView.layoutMetrics != after.layoutMetrics) {
+        const auto config = layoutAnimationsManager_->getLayoutAnimationConfig(
+            before.tag, LayoutAnimationType::SHARED_ELEMENT_TRANSITION);
+        if (!config) {
+          continue;
+        }
         overrideTransform(after, transition.transform[AFTER], propsParserContext);
-        startSharedTransition(containerTag, la.currentView, after);
+        after.tag = containerTag;
+        startSharedTransition(containerTag, la.currentView, after, config);
       }
     }
   }
@@ -295,15 +322,16 @@ void LayoutAnimationsProxy_Experimental::handleSharedTransitionsStart(
 
 void LayoutAnimationsProxy_Experimental::hideTransitioningViews(
     BeforeOrAfter index,
-    ShadowViewMutationList &filteredMutations,
+    const Transitions &transitions,
+    ShadowViewMutationList &mutations,
     const PropsParserContext &propsParserContext) const {
-  for (auto &[sharedTag, transition] : transitions_) {
+  for (auto &[sharedTag, transition] : transitions) {
     int indexNum = static_cast<int>(index);
     const auto &shadowView = transition.snapshot[indexNum];
     const auto &parentTag = transition.parentTag[indexNum];
     auto m = ShadowViewMutation::UpdateMutation(
         shadowView, cloneViewWithoutOpacity(shadowView, propsParserContext), parentTag);
-    filteredMutations.push_back(m);
+    mutations.push_back(m);
   }
 }
 
@@ -356,26 +384,30 @@ std::optional<SurfaceId> LayoutAnimationsProxy_Experimental::onGestureCancel(int
   return {};
 }
 
-void LayoutAnimationsProxy_Experimental::insertContainers(
-    ShadowViewMutationList &filteredMutations,
-    int &rootChildCount) const {
+void LayoutAnimationsProxy_Experimental::insertContainers(TransactionMeta &transaction, int &rootChildCount) const {
+  auto &filteredMutations = transaction.filteredMutations;
   ShadowViewMutationList currentMutations;
   std::swap(currentMutations, filteredMutations);
-  filteredMutations.reserve(containersToInsert_.size() * 2);
+  filteredMutations.reserve(transaction.containersToInsert.size() * 2);
   auto root = lightNodes_[surfaceId_];
-  for (auto &node : containersToInsert_) {
+  for (auto &node : transaction.containersToInsert) {
     filteredMutations.push_back(ShadowViewMutation::CreateMutation(node->current));
     filteredMutations.push_back(ShadowViewMutation::InsertMutation(surfaceId_, node->current, rootChildCount++));
   }
   filteredMutations.insert(filteredMutations.end(), currentMutations.begin(), currentMutations.end());
-  containersToInsert_.clear();
+}
+
+void LayoutAnimationsProxy_Experimental::removeSharedContainer(Tag containerTag, TransactionMeta &transaction) const {
+  transaction.sharedContainersToRemove.push_back(containerTag);
+  std::erase_if(containerTags_, [containerTag](const auto &entry) { return entry.second == containerTag; });
 }
 
 void LayoutAnimationsProxy_Experimental::cleanupSharedTransitions(
-    ShadowViewMutationList &filteredMutations,
+    TransactionMeta &transaction,
     const PropsParserContext &propsParserContext) const {
   ReanimatedSystraceSection s1("cleanupSharedTransitions");
-  for (auto &tag : tagsToRestore_) {
+  auto &filteredMutations = transaction.filteredMutations;
+  for (auto &tag : transaction.tagsToRestore) {
     ReanimatedSystraceSection s("Restore tag");
     auto &node = lightNodes_[tag];
     if (node) {
@@ -383,15 +415,17 @@ void LayoutAnimationsProxy_Experimental::cleanupSharedTransitions(
       const auto &parent = node->parent.lock();
       react_native_assert(parent && "Parent node is nullptr");
       auto parentTag = parent->current.tag;
+      const auto opacity = static_cast<const ViewProps &>(*view.props).opacity;
       auto m = ShadowViewMutation::UpdateMutation(
-          cloneViewWithoutOpacity(view, propsParserContext), cloneViewWithOpacity(view, propsParserContext), parentTag);
+          cloneViewWithoutOpacity(view, propsParserContext),
+          cloneViewWithOpacity(view, opacity, propsParserContext),
+          parentTag);
       filteredMutations.push_back(m);
     }
   }
-  tagsToRestore_.clear();
 
   ReanimatedSystraceSection s2("remove shared containers");
-  for (auto &tag : sharedContainersToRemove_) {
+  for (auto &tag : transaction.sharedContainersToRemove) {
     auto root = lightNodes_[surfaceId_];
     for (int i = 0; i < root->children.size(); i++) {
       auto &child = root->children[i];
@@ -402,7 +436,6 @@ void LayoutAnimationsProxy_Experimental::cleanupSharedTransitions(
       }
     }
   }
-  sharedContainersToRemove_.clear();
 }
 
 // MARK: Position Calculation

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -779,6 +779,12 @@ bool ReanimatedModuleProxy::handleRawEvent(const RawEvent &rawEvent, double curr
   return res;
 }
 
+void ReanimatedModuleProxy::flushLayoutAnimationOperations() {
+  if (layoutAnimationsProxyRegistry_) {
+    layoutAnimationsProxyRegistry_->flushLayoutAnimationOperations();
+  }
+}
+
 void ReanimatedModuleProxy::executeLayoutAnimationsRequests() {
   std::set<SurfaceId> flushRequestsCopy = std::move(layoutAnimationFlushRequests_);
   for (const auto surfaceId : flushRequestsCopy) {
@@ -796,6 +802,7 @@ void ReanimatedModuleProxy::performOperations() {
 
   ReanimatedSystraceSection s("ReanimatedModuleProxy::performOperations");
 
+  flushLayoutAnimationOperations();
   executeLayoutAnimationsRequests();
 
   jsi::Runtime &uiRuntime = getJSIRuntimeFromWorkletRuntime(uiRuntime_);
@@ -945,6 +952,7 @@ AnimationMutations ReanimatedModuleProxy::runGrandCallback(
       // lock: they touch only UI-thread state and may re-enter the proxy (via
       // requestAnimationFrame or the commit hook).
       executeWorkletsForFrame(timestamp);
+      flushLayoutAnimationOperations();
       executeLayoutAnimationsRequests();
 
       AnimationMutations mutations;
@@ -958,6 +966,7 @@ AnimationMutations ReanimatedModuleProxy::runGrandCallback(
     }
 
     case GrandCallbackSource::Event: {
+      flushLayoutAnimationOperations();
       executeLayoutAnimationsRequests();
       return collectEventUpdates();
     }
@@ -1247,6 +1256,22 @@ void ReanimatedModuleProxy::initializeLayoutAnimationsProxyRegistry() {
   // relies on the proxy registry being non-null.
   react_native_assert(componentDescriptorRegistry && "ComponentDescriptorRegistry must be alive during initialization");
 
+  const auto requestLayoutAnimationFlush = [weakThis = weak_from_this()](const SurfaceId surfaceId) {
+    const auto strongThis = weakThis.lock();
+    if (!strongThis) {
+      return;
+    }
+    scheduleOnUI(strongThis->uiScheduler_, [weakThis, surfaceId] {
+      if (const auto strongThis = weakThis.lock()) {
+        strongThis->requestRender_([weakThis, surfaceId](const double) {
+          if (const auto strongThis = weakThis.lock()) {
+            strongThis->layoutAnimationFlushRequests_.insert(surfaceId);
+          }
+        });
+      }
+    });
+  };
+
   const LayoutAnimationsProxyDependencies dependencies{
       layoutAnimationsManager_,
       componentDescriptorRegistry,
@@ -1254,6 +1279,7 @@ void ReanimatedModuleProxy::initializeLayoutAnimationsProxyRegistry() {
       getJSIRuntimeFromWorkletRuntime(uiRuntime_),
       uiScheduler_,
       uiManager_,
+      requestLayoutAnimationFlush,
 #ifdef ANDROID
       filterUnmountedTagsFunction_,
       jsInvoker_,

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
@@ -111,6 +111,7 @@ class ReanimatedModuleProxy : public std::enable_shared_from_this<ReanimatedModu
 
   void performOperations();
   void performNonLayoutOperations();
+  void flushLayoutAnimationOperations();
   void executeLayoutAnimationsRequests();
 
   bool handleEventAndFlush(

--- a/packages/react-native-reanimated/__tests__/layoutAnimationsManager.test.ts
+++ b/packages/react-native-reanimated/__tests__/layoutAnimationsManager.test.ts
@@ -49,6 +49,22 @@ function makeConfig(startTimestamps: number[]) {
   };
 }
 
+function makePendingConfig(callback: jest.Mock) {
+  return (): LayoutAnimation => ({
+    initialValues: { originX: 0 },
+    animations: {
+      originX: {
+        current: 0,
+        onStart: jest.fn(),
+        onFrame() {
+          return false;
+        },
+      } as unknown as number,
+    },
+    callback,
+  });
+}
+
 describe('LayoutAnimationsManager', () => {
   let frameFinalizers: Array<() => void>;
   let getAnimationTimestamp: jest.Mock;
@@ -109,5 +125,67 @@ describe('LayoutAnimationsManager', () => {
     expect(startTimestamps).toEqual([300, 300]);
     expect(getAnimationTimestamp).not.toHaveBeenCalled();
     expect(globalThis.__frameTimestamp).toBe(300);
+  });
+
+  test('does not report native ends across three replacements', () => {
+    const callbacks = [jest.fn(), jest.fn(), jest.fn(), jest.fn()];
+
+    callbacks.forEach((callback) => {
+      manager.start(
+        6,
+        LayoutAnimationType.LAYOUT,
+        {},
+        makePendingConfig(callback)
+      );
+    });
+
+    callbacks.slice(0, -1).forEach((callback) => {
+      expect(callback).toHaveBeenCalledWith(false);
+    });
+    expect(callbacks.at(-1)).not.toHaveBeenCalled();
+    expect(globalThis._notifyAboutEnd).not.toHaveBeenCalled();
+
+    manager.stop(6);
+  });
+
+  test('does not report a native end when stopping a replacement', () => {
+    const previousCallback = jest.fn();
+    const replacementCallback = jest.fn();
+
+    manager.start(
+      8,
+      LayoutAnimationType.LAYOUT,
+      {},
+      makePendingConfig(previousCallback)
+    );
+    manager.start(
+      8,
+      LayoutAnimationType.LAYOUT,
+      {},
+      makePendingConfig(replacementCallback)
+    );
+    manager.stop(8);
+
+    expect(previousCallback).toHaveBeenCalledWith(false);
+    expect(replacementCallback).toHaveBeenCalledWith(false);
+    expect(globalThis._notifyAboutEnd).not.toHaveBeenCalled();
+  });
+
+  test('reports exactly one native end when an animation finishes', () => {
+    manager.start(7, LayoutAnimationType.EXITING, {}, makeConfig([]));
+
+    expect(globalThis._notifyAboutEnd).toHaveBeenCalledTimes(1);
+    expect(globalThis._notifyAboutEnd).toHaveBeenCalledWith(7, true);
+  });
+
+  test('reports both completions when a tag restarts before a pull', () => {
+    const config = makeConfig([]);
+
+    manager.start(9, LayoutAnimationType.LAYOUT, {}, config);
+    manager.start(9, LayoutAnimationType.LAYOUT, {}, config);
+
+    expect(globalThis._notifyAboutEnd).toHaveBeenCalledTimes(2);
+    expect(globalThis._notifyAboutEnd).toHaveBeenNthCalledWith(1, 9, false);
+    expect(globalThis._notifyAboutEnd).toHaveBeenNthCalledWith(2, 9, false);
   });
 });

--- a/packages/react-native-reanimated/src/layoutReanimation/animationsManager.native.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/animationsManager.native.ts
@@ -38,12 +38,24 @@ function startObservingProgress(
   });
 }
 
-function stopObservingProgress(
+function removeProgressListener(
   tag: number,
   sharedValue: SharedValue<number>
 ): void {
   'worklet';
   sharedValue.removeListener(tag + TAG_OFFSET);
+}
+
+function stopObservingProgress(
+  tag: number,
+  sharedValue: SharedValue<number>,
+  scheduleFlush: () => void,
+  removeView = false
+): void {
+  'worklet';
+  removeProgressListener(tag, sharedValue);
+  global._notifyAboutEnd(tag, removeView);
+  scheduleFlush();
 }
 
 function createLayoutAnimationManager(): LayoutAnimationsManager {
@@ -115,7 +127,7 @@ function createLayoutAnimationManager(): LayoutAnimationsManager {
         value = makeMutableUI(style.initialValues);
         mutableValuesForTag.set(tag, value);
       } else {
-        stopObservingProgress(tag, value);
+        removeProgressListener(tag, value);
         value._value = style.initialValues;
       }
 
@@ -124,9 +136,7 @@ function createLayoutAnimationManager(): LayoutAnimationsManager {
           currentAnimationForTag.delete(tag);
           mutableValuesForTag.delete(tag);
           const shouldRemoveView = type === LayoutAnimationType.EXITING;
-          stopObservingProgress(tag, value);
-          global._notifyAboutEnd(tag, shouldRemoveView);
-          scheduleFlush();
+          stopObservingProgress(tag, value, scheduleFlush, shouldRemoveView);
         }
         if (style.callback) {
           style.callback(finished);

--- a/packages/react-native-reanimated/src/layoutReanimation/animationsManager.native.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/animationsManager.native.ts
@@ -40,14 +40,10 @@ function startObservingProgress(
 
 function stopObservingProgress(
   tag: number,
-  sharedValue: SharedValue<number>,
-  scheduleFlush: () => void,
-  removeView = false
+  sharedValue: SharedValue<number>
 ): void {
   'worklet';
   sharedValue.removeListener(tag + TAG_OFFSET);
-  global._notifyAboutEnd(tag, removeView);
-  scheduleFlush();
 }
 
 function createLayoutAnimationManager(): LayoutAnimationsManager {
@@ -119,7 +115,7 @@ function createLayoutAnimationManager(): LayoutAnimationsManager {
         value = makeMutableUI(style.initialValues);
         mutableValuesForTag.set(tag, value);
       } else {
-        stopObservingProgress(tag, value, scheduleFlush);
+        stopObservingProgress(tag, value);
         value._value = style.initialValues;
       }
 
@@ -128,7 +124,9 @@ function createLayoutAnimationManager(): LayoutAnimationsManager {
           currentAnimationForTag.delete(tag);
           mutableValuesForTag.delete(tag);
           const shouldRemoveView = type === LayoutAnimationType.EXITING;
-          stopObservingProgress(tag, value, scheduleFlush, shouldRemoveView);
+          stopObservingProgress(tag, value);
+          global._notifyAboutEnd(tag, shouldRemoveView);
+          scheduleFlush();
         }
         if (style.callback) {
           style.callback(finished);


### PR DESCRIPTION
Before this change, each animation start and cancellation scheduled its own `scheduleOnUI` callback. These callbacks reached the UI queue separately and could run around pulls, completions, and newer animation requests. The Legacy and Experimental proxies also handled parts of this flow independently. We could not inspect or reason about the full set of operations as one unit.

Now `enqueueLayoutAnimation` records starts and cancellations in a common queue. `flushLayoutAnimationOperations` reconciles and executes the queue as one batch at a defined point in `performOperations`. This gives us a clear boundary where pending operations become UI work. It also lets us enforce cancellation, replacement, and completion rules before anything reaches `LayoutAnimationsManager`.

#### Threading analysis

[Full AI diagram](https://github.com/user-attachments/files/31315023/commit-02-centralize-layout-animation-operations.html)

#### Test Plan

- Run `layoutAnimationsManager.test.ts`.
- Verify starting, replacing, and cancelling layout animations in FabricExample.
