### PR TITLE
fix: restore Jest support in consumer projects

### DIFF
--- a/docs/docs-reanimated/docs/guides/testing-with-jest.mdx
+++ b/docs/docs-reanimated/docs/guides/testing-with-jest.mdx
@@ -33,9 +33,14 @@ test('reference', () => {
 
 ## Setup
 
-:::note
-Before you begin, make sure to follow the respective Jest guide for [React Native Worklets](https://docs.swmansion.com/react-native-worklets/docs/guides/testing).
-:::
+Override Jest resolver to enforce resolving web implementation of Reanimated and React Native Worklets instead of pulling the native one. Modify your `jest.config.js` file to include the following code:
+
+```js
+module.exports = {
+  // ... other configurations
+  resolver: 'react-native-reanimated/jest/resolver',
+};
+```
 
 Add the following line to your `jest-setup.js` file:
 
@@ -50,6 +55,7 @@ To be sure, check if your `jest.config.js` file contains:
 ```js
 ...
 preset: 'react-native',
+resolver: 'react-native-reanimated/jest/resolver',
 setupFilesAfterEnv: ['./jest-setup.js'],
 ...
 ```

--- a/docs/docs-reanimated/docs/guides/testing-with-jest.mdx
+++ b/docs/docs-reanimated/docs/guides/testing-with-jest.mdx
@@ -33,6 +33,10 @@ test('reference', () => {
 
 ## Setup
 
+:::note
+Before you begin, make sure to follow the respective Jest guide for [React Native Worklets](https://docs.swmansion.com/react-native-worklets/docs/guides/testing).
+:::
+
 Override Jest resolver to enforce resolving web implementation of Reanimated and React Native Worklets instead of pulling the native one. Modify your `jest.config.js` file to include the following code:
 
 ```js

--- a/packages/react-native-reanimated/CHANGELOG.md
+++ b/packages/react-native-reanimated/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### 🐛 Bug fixes
 
+- Ship the Jest resolver (`react-native-reanimated/jest/resolver`) in the npm package, so consumer projects can run Jest against Reanimated: the modules that require a real native module are resolved to their web implementations. ([#10377](https://github.com/software-mansion/react-native-reanimated/pull/10377) by [@huextrat](https://github.com/huextrat))
+- Fix mounting an animated component with attached event handlers (e.g. `useAnimatedScrollHandler`) under Jest crashing with `[Reanimated] registerEventHandler is not available in JSReanimated.` - `WorkletEventHandler` now resolves to its web variant in Jest. ([#10377](https://github.com/software-mansion/react-native-reanimated/pull/10377) by [@huextrat](https://github.com/huextrat))
 - Reset `IN_STYLE_UPDATER` even when an initial style updater throws, so a single updater error no longer leaves all animations returning raw values until reload. ([#10445](https://github.com/software-mansion/react-native-reanimated/pull/10445) by [@alexey-khatskelevich](https://github.com/alexey-khatskelevich))
 - Fix `./gradlew app:build` failing on `:lintAnalyzeDebug` with a K2 UAST crash on `.gradle.kts` build scripts - all lint tasks are now skipped, not only `lintVital*`. ([#10448](https://github.com/software-mansion/react-native-reanimated/pull/10448) by [@tshmieldev](https://github.com/tshmieldev))
 - Treat `animationName: []` as no animation, so the view is detached instead of running its previous animation forever. ([#10432](https://github.com/software-mansion/react-native-reanimated/pull/10432) by [@MatiPl01](https://github.com/MatiPl01))

--- a/packages/react-native-reanimated/__tests__/hooks.useAnimatedScrollHandler.test.tsx
+++ b/packages/react-native-reanimated/__tests__/hooks.useAnimatedScrollHandler.test.tsx
@@ -1,0 +1,32 @@
+import { fireEvent, render } from '@testing-library/react-native';
+
+import Animated, { useAnimatedScrollHandler, useSharedValue } from '../src';
+
+describe('useAnimatedScrollHandler', () => {
+  test('a component with an event handler mounts and receives events under Jest', () => {
+    const offsets: number[] = [];
+
+    function ScrollComponent() {
+      const offset = useSharedValue(0);
+      const scrollHandler = useAnimatedScrollHandler((event) => {
+        offset.value = event.contentOffset.y;
+        offsets.push(event.contentOffset.y);
+      });
+      return <Animated.ScrollView testID="scroll" onScroll={scrollHandler} />;
+    }
+
+    const { getByTestId, unmount } = render(<ScrollComponent />);
+
+    fireEvent.scroll(getByTestId('scroll'), {
+      nativeEvent: {
+        contentOffset: { x: 0, y: 42 },
+        contentSize: { height: 500, width: 100 },
+        layoutMeasurement: { height: 100, width: 100 },
+      },
+    });
+
+    expect(offsets).toContain(42);
+
+    unmount();
+  });
+});

--- a/packages/react-native-reanimated/jest/resolver.js
+++ b/packages/react-native-reanimated/jest/resolver.js
@@ -8,6 +8,7 @@ const WEB_ONLY_IN_JEST = new Set([
   'UpdateLayoutAnimations',
   'useAnimatedRef',
   'useAnimatedStyle',
+  'WorkletEventHandler',
   'JSPropsUpdater',
   'updateProps',
   'util',

--- a/packages/react-native-reanimated/package.json
+++ b/packages/react-native-reanimated/package.json
@@ -68,6 +68,7 @@
     "scripts/validate-react-native-version.js",
     "compatibility.json",
     "mock.js",
+    "jest/resolver.js",
     "plugin/index.js",
     "plugin/index.d.ts",
     "metro-config",


### PR DESCRIPTION
> [!NOTE]
> This pull request was authored by AI on behalf of huextrat.

## Summary

Since 4.6.0, running Jest against Reanimated in a consumer project is broken: the shared files that used to branch on `SHOULD_BE_USE_WEB`/`IS_JEST` were split into `.native`/`.web` variants, and under Jest the `.native` ones get resolved. Importing the package crashes at initialization with ``[Reanimated] `setCSSEventHandler` is not available in JSReanimated.`` before `setUpTests()` can even run, and further crashes follow once components render (`mappers.native` has no frame loop on the Jest runtime, `registerEventHandler`, `findHostInstance`, …).

This repo's own Jest config already handles this with `packages/react-native-reanimated/jest/resolver.js`, which resolves the native-module-dependent files to their web variants — but that resolver is not shipped in the npm package, so consumers have no working setup.

This PR:

- **Ships `react-native-reanimated/jest/resolver` in the npm package** (mirroring `react-native-worklets`, which already ships its resolver) and documents it in the testing guide, with the same presentation as the Worklets guide.
- **Adds `WorkletEventHandler` to the resolver's web-only list**: mounting an animated component with attached event handlers (e.g. `useAnimatedScrollHandler`) crashed with ``[Reanimated] registerEventHandler is not available in JSReanimated.`` — the web variant registers plain JS listeners, as the shared file's `SHOULD_BE_USE_WEB` branch did pre-4.6.

The resolver is the only supported Jest setup: it also chains the Worklets resolver, so no `jest.mock('react-native-worklets', …)` is needed.

## Test plan

- `yarn jest` in `packages/react-native-reanimated`: 107 suites / 1598 tests pass, including the new regression test `hooks.useAnimatedScrollHandler.test.tsx` (mount + `fireEvent.scroll` + unmount). It fails with the exact pre-fix `registerEventHandler` error when `WorkletEventHandler` is removed from the resolver list.
- Validated against a real ~1700-test consumer app suite (Expo / jest-expo): with `resolver: 'react-native-reanimated/jest/resolver'`, the full suite passes — it fully crashed before these changes.

## Changelog

- [x] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
