### PR TITLE
fix(CSS): leave the second component at zero for single-argument translate and skew

### DIFF
--- a/packages/react-native-reanimated/CHANGELOG.md
+++ b/packages/react-native-reanimated/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix single-argument `translate()` and `skew()` in transform strings repeating the argument on the Y axis instead of leaving it at zero, so `translate(100px)` no longer also moves the element down. ([#10385](https://github.com/software-mansion/react-native-reanimated/pull/10385) by [@dennytosp](https://github.com/dennytosp))
 - Fix the Metro configuration type import to use the public package export. ([#10454](https://github.com/software-mansion/react-native-reanimated/pull/10454) by [@sneakykiwi](https://github.com/sneakykiwi))
 - Skip the Android mounted-tag correction in Layout Animations when React Native's `enableMountingCoordinatorPullModelAndroid` feature flag is on, since the pull model already guarantees that updates can't outrun a view's first mount. ([#10481](https://github.com/software-mansion/react-native-reanimated/pull/10481) by [@piaskowyk](https://github.com/piaskowyk))
 - Fix `Keyframe` easings on web being dropped or applied to the wrong keyframe when the definitions use the `from`/`to` aliases or fractional offsets. ([#10386](https://github.com/software-mansion/react-native-reanimated/pull/10386) by [@dennytosp](https://github.com/dennytosp))

--- a/packages/react-native-reanimated/src/common/style/processors/__tests__/transform.test.ts
+++ b/packages/react-native-reanimated/src/common/style/processors/__tests__/transform.test.ts
@@ -34,12 +34,13 @@ describe(processTransform, () => {
             output: [{ translateX: '25%' }, { translateY: 25 }],
           },
           {
+            // A single argument leaves the Y axis at zero, it is not repeated.
             input: 'translate(25)',
-            output: [{ translateX: 25 }, { translateY: 25 }],
+            output: [{ translateX: 25 }, { translateY: 0 }],
           },
           {
             input: 'translate(25%)',
-            output: [{ translateX: '25%' }, { translateY: '25%' }],
+            output: [{ translateX: '25%' }, { translateY: 0 }],
           },
         ],
       },
@@ -172,8 +173,9 @@ describe(processTransform, () => {
         name: 'skew',
         cases: [
           {
+            // A single argument leaves the Y axis at zero, it is not repeated.
             input: 'skew(45deg)',
-            output: [{ skewX: '45deg' }, { skewY: '45deg' }],
+            output: [{ skewX: '45deg' }, { skewY: '0deg' }],
           },
           {
             input: 'skew(0)',

--- a/packages/react-native-reanimated/src/common/style/processors/transform.ts
+++ b/packages/react-native-reanimated/src/common/style/processors/transform.ts
@@ -38,8 +38,10 @@ function parseTranslate(values: (number | string)[]): TransformsArray {
   if (values.length > 2) {
     return [];
   }
+  // translate(tx) leaves ty at zero, it does not repeat tx - unlike scale(s),
+  // which is uniform. https://drafts.csswg.org/css-transforms/#funcdef-transform-translate
   const result = parseTranslateX([values[0]]).concat(
-    parseTranslateY([values[1] ?? values[0]])
+    parseTranslateY([values[1] ?? 0])
   );
   return result.length === 2 ? result : [];
 }
@@ -103,9 +105,9 @@ function parseSkew(values: (number | string)[]): TransformsArray {
   if (values.length > 2) {
     return [];
   }
-  const result = parseSkewX([values[0]]).concat(
-    parseSkewY([values[1] ?? values[0]])
-  );
+  // skew(ax) leaves ay at zero, same as translate above.
+  // https://drafts.csswg.org/css-transforms/#funcdef-transform-skew
+  const result = parseSkewX([values[0]]).concat(parseSkewY([values[1] ?? 0]));
   return result.length === 2 ? result : [];
 }
 


### PR DESCRIPTION
> [!NOTE]
> This pull request was authored by AI on behalf of @dennytosp.

## Summary

`parseTranslate` and `parseSkew` fall back to `values[1] ?? values[0]`, which copies the single argument onto the Y axis:

```ts
processTransform('translate(25px)') // -> [{ translateX: 25 }, { translateY: 25 }]
processTransform('skew(30deg)')     // -> [{ skewX: '30deg' }, { skewY: '30deg' }]
```

CSS Transforms Level 1 says the opposite for both:

- [`translate(tx)`](https://drafts.csswg.org/css-transforms/#funcdef-transform-translate) — *"If `<ty>` is not provided, ty has zero value."*
- [`skew(ax)`](https://drafts.csswg.org/css-transforms/#funcdef-transform-skew) — *"If the second parameter is not provided, it has a zero value."*

React Native's own parser agrees. `Libraries/StyleSheet/processTransform.js` pads the list with a literal zero:

```js
if (parsedArgs?.length === 1) {
  parsedArgs.push(0);
}
```

Confirmed by running it directly against this repo's installed React Native:

```
RNCORE translate(25px)  ->  [{"translate":[25,0]}]
```

So `transform: 'translate(100px)'` moves the element 100px **down as well as across** in Reanimated, and a CSS transition animating that value drags it diagonally.

### Why this reads as a copy-paste slip rather than a design choice

`parseScale` uses the same `values[1] ?? values[0]` shape, and there it is correct — `scale(s)` is uniform per spec. But `parseScale` also has an explicit `values.length === 1` branch above it, so by the time that fallback runs `values[1]` is always defined and the `?? values[0]` is dead. `parseTranslate` and `parseSkew` have no such branch, so they inherited a fallback that only made sense for scale.

### Fix

Pass `0` as the missing second component. No guard changes were needed: `parseTranslateY` accepts it as a number, and `parseSkewY` already maps a zero to `'0deg'` (`values[0] === 0 ? '0deg' : values[0]`). Both still emit two entries, so transform lists keep the same length whether or not the second argument was written — which matters for interpolating between two transform strings.

`parseScale` is deliberately left alone.

## Test plan

This changes behavior that three existing assertions in `src/common/style/processors/__tests__/transform.test.ts` had captured, so those three are updated rather than added to. They **fail on `main`** against the spec-correct expectations:

```console
$ git stash push src/common/style/processors/transform.ts
$ yarn jest src/common/style/processors/__tests__/transform.test.ts
  ✕ parses translate(25)     Expected [{translateX:25},{translateY:0}]     Received [{translateX:25},{translateY:25}]
  ✕ parses translate(25%)    Expected [{translateX:'25%'},{translateY:0}]  Received [{translateX:'25%'},{translateY:'25%'}]
  ✕ parses skew(45deg)       Expected [{skewX:'45deg'},{skewY:'0deg'}]     Received [{skewX:'45deg'},{skewY:'45deg'}]
Tests: 3 failed, 61 passed, 64 total
```

With the fix applied:

```console
$ yarn jest
Test Suites: 103 passed, 103 total
Tests:       1556 passed, 1556 total
```

Two-argument forms, `scale()`, `translateX/Y()`, `skewX/Y()`, the array input path, and every error case are untouched. `yarn eslint` and `oxfmt --check` are clean on both files.

If you would rather keep the current behavior for compatibility reasons, I am happy to close this — but then the two spec references above are worth a comment in the source, because the next reader will file the same report.

## Changelog

- [x] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.
