### PR TITLE
fix(LayoutAnimations): walk web keyframe offsets in order when shifting easings

### DIFF
--- a/packages/react-native-reanimated/CHANGELOG.md
+++ b/packages/react-native-reanimated/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix `Keyframe` easings on web being dropped or applied to the wrong keyframe when the definitions use the `from`/`to` aliases or fractional offsets. ([#10386](https://github.com/software-mansion/react-native-reanimated/pull/10386) by [@dennytosp](https://github.com/dennytosp))
 - Fix `getViewProp` and the runtime-tests prop snapshotting crashing (segfault on style props, unhandled error on layout props) when the view is no longer mounted. ([#10443](https://github.com/software-mansion/react-native-reanimated/pull/10443) by [@tjzel](https://github.com/tjzel))
 - Ship the Jest resolver (`react-native-reanimated/jest/resolver`) in the npm package, so consumer projects can run Jest against Reanimated: the modules that require a real native module are resolved to their web implementations. ([#10377](https://github.com/software-mansion/react-native-reanimated/pull/10377) by [@huextrat](https://github.com/huextrat))
 - Fix mounting an animated component with attached event handlers (e.g. `useAnimatedScrollHandler`) under Jest crashing with `[Reanimated] registerEventHandler is not available in JSReanimated.` - `WorkletEventHandler` now resolves to its web variant in Jest. ([#10377](https://github.com/software-mansion/react-native-reanimated/pull/10377) by [@huextrat](https://github.com/huextrat))

--- a/packages/react-native-reanimated/src/layoutReanimation/web/__tests__/createAnimation.web.test.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/web/__tests__/createAnimation.web.test.ts
@@ -23,8 +23,8 @@ describe(createCustomKeyFrameAnimation, () => {
 
     createCustomKeyFrameAnimation(definitions, LayoutAnimationType.ENTERING);
 
-    expect(definitions[0].easing).toBe(EASING);
-    expect(definitions[100].easing).toBeUndefined();
+    expect(definitions['0'].easing).toBe(EASING);
+    expect(definitions['100'].easing).toBeUndefined();
   });
 
   test("treats 'from' as the offset it aliases", () => {
@@ -36,7 +36,7 @@ describe(createCustomKeyFrameAnimation, () => {
     createCustomKeyFrameAnimation(definitions, LayoutAnimationType.ENTERING);
 
     expect(definitions.from.easing).toBe(EASING);
-    expect(definitions[100].easing).toBeUndefined();
+    expect(definitions['100'].easing).toBeUndefined();
   });
 
   test('shifts the easing off a fractional offset', () => {
@@ -48,8 +48,8 @@ describe(createCustomKeyFrameAnimation, () => {
 
     createCustomKeyFrameAnimation(definitions, LayoutAnimationType.ENTERING);
 
-    expect(definitions[0].easing).toBe(EASING);
-    expect(definitions[33.3].easing).toBeUndefined();
-    expect(definitions[100].easing).toBeUndefined();
+    expect(definitions['0'].easing).toBe(EASING);
+    expect(definitions['33.3'].easing).toBeUndefined();
+    expect(definitions['100'].easing).toBeUndefined();
   });
 });

--- a/packages/react-native-reanimated/src/layoutReanimation/web/__tests__/createAnimation.web.test.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/web/__tests__/createAnimation.web.test.ts
@@ -1,0 +1,55 @@
+'use strict';
+import { LayoutAnimationType } from '../../../commonTypes';
+import type { KeyframeDefinitions } from '../config';
+import { createCustomKeyFrameAnimation } from '../createAnimation';
+
+const EASING = 'cubic-bezier(0.7,0,0.84,0)';
+
+beforeAll(() => {
+  // insertWebAnimation writes into this tag, which the runtime creates on load.
+  const styleTag = document.createElement('style');
+  styleTag.id = 'ReanimatedCustomWebAnimationsStyle';
+  document.head.appendChild(styleTag);
+});
+
+// The easing is moved one keyframe up, so it has to end up on the keyframe that
+// precedes the one it was written on.
+describe(createCustomKeyFrameAnimation, () => {
+  test('shifts the easing off a numeric offset', () => {
+    const definitions = {
+      0: { opacity: 0 },
+      100: { opacity: 1, easing: EASING },
+    } as unknown as KeyframeDefinitions;
+
+    createCustomKeyFrameAnimation(definitions, LayoutAnimationType.ENTERING);
+
+    expect(definitions[0].easing).toBe(EASING);
+    expect(definitions[100].easing).toBeUndefined();
+  });
+
+  test("treats 'from' as the offset it aliases", () => {
+    const definitions = {
+      from: { opacity: 0 },
+      100: { opacity: 1, easing: EASING },
+    } as unknown as KeyframeDefinitions;
+
+    createCustomKeyFrameAnimation(definitions, LayoutAnimationType.ENTERING);
+
+    expect(definitions.from.easing).toBe(EASING);
+    expect(definitions[100].easing).toBeUndefined();
+  });
+
+  test('shifts the easing off a fractional offset', () => {
+    const definitions = {
+      0: { opacity: 0 },
+      33.3: { opacity: 0.5, easing: EASING },
+      100: { opacity: 1 },
+    } as unknown as KeyframeDefinitions;
+
+    createCustomKeyFrameAnimation(definitions, LayoutAnimationType.ENTERING);
+
+    expect(definitions[0].easing).toBe(EASING);
+    expect(definitions[33.3].easing).toBeUndefined();
+    expect(definitions[100].easing).toBeUndefined();
+  });
+});

--- a/packages/react-native-reanimated/src/layoutReanimation/web/createAnimation.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/web/createAnimation.ts
@@ -89,9 +89,16 @@ export function createCustomKeyFrameAnimation(
   // Move keyframe easings one keyframe up (our LA Keyframe definition is different
   // from the CSS keyframes and expects easing to be present in the keyframe to which
   // we animate instead of the keyframe we animate from)
-  const offsets = Object.keys(
-    keyframeDefinitions
-  ) as (keyof KeyframeDefinitions)[];
+  // `Object.keys` lists integer-like keys first, in ascending order, and every
+  // other key after them in insertion order. That is not the order the
+  // keyframes run in once 'from'/'to' aliases or fractional offsets are used,
+  // so the offsets have to be sorted before the easings can be shifted.
+  const toOffset = (offset: keyof KeyframeDefinitions) =>
+    offset === 'from' ? 0 : offset === 'to' ? 100 : Number(offset);
+
+  const offsets = (
+    Object.keys(keyframeDefinitions) as (keyof KeyframeDefinitions)[]
+  ).sort((a, b) => toOffset(a) - toOffset(b));
 
   for (let i = 1; i < offsets.length; i++) {
     const style = keyframeDefinitions[offsets[i]];

--- a/packages/react-native-reanimated/src/layoutReanimation/web/createAnimation.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/web/createAnimation.ts
@@ -90,6 +90,16 @@ export function createCustomKeyFrameAnimation(
   // from the CSS keyframes and expects easing to be present in the keyframe to which
   // we animate instead of the keyframe we animate from)
   // `Object.keys` puts integer-like keys first, so the offsets must be sorted.
+  const toOffset = (offset: keyof KeyframeDefinitions) => {
+    if (offset === 'from') {
+      return 0;
+    }
+    if (offset === 'to') {
+      return 100;
+    }
+    return Number(offset);
+  };
+
   const offsets = (
     Object.keys(keyframeDefinitions) as (keyof KeyframeDefinitions)[]
   ).sort((a, b) => toOffset(a) - toOffset(b));
@@ -107,16 +117,6 @@ export function createCustomKeyFrameAnimation(
   insertWebAnimation(animationData.name, parsedKeyframe);
 
   return animationData.name;
-}
-
-function toOffset(offset: keyof KeyframeDefinitions): number {
-  if (offset === 'from') {
-    return 0;
-  }
-  if (offset === 'to') {
-    return 100;
-  }
-  return Number(offset);
 }
 
 export function createAnimationWithInitialValues(

--- a/packages/react-native-reanimated/src/layoutReanimation/web/createAnimation.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/web/createAnimation.ts
@@ -90,9 +90,6 @@ export function createCustomKeyFrameAnimation(
   // from the CSS keyframes and expects easing to be present in the keyframe to which
   // we animate instead of the keyframe we animate from)
   // `Object.keys` puts integer-like keys first, so the offsets must be sorted.
-  const toOffset = (offset: keyof KeyframeDefinitions) =>
-    offset === 'from' ? 0 : offset === 'to' ? 100 : Number(offset);
-
   const offsets = (
     Object.keys(keyframeDefinitions) as (keyof KeyframeDefinitions)[]
   ).sort((a, b) => toOffset(a) - toOffset(b));
@@ -110,6 +107,16 @@ export function createCustomKeyFrameAnimation(
   insertWebAnimation(animationData.name, parsedKeyframe);
 
   return animationData.name;
+}
+
+function toOffset(offset: keyof KeyframeDefinitions): number {
+  if (offset === 'from') {
+    return 0;
+  }
+  if (offset === 'to') {
+    return 100;
+  }
+  return Number(offset);
 }
 
 export function createAnimationWithInitialValues(

--- a/packages/react-native-reanimated/src/layoutReanimation/web/createAnimation.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/web/createAnimation.ts
@@ -89,10 +89,7 @@ export function createCustomKeyFrameAnimation(
   // Move keyframe easings one keyframe up (our LA Keyframe definition is different
   // from the CSS keyframes and expects easing to be present in the keyframe to which
   // we animate instead of the keyframe we animate from)
-  // `Object.keys` lists integer-like keys first, in ascending order, and every
-  // other key after them in insertion order. That is not the order the
-  // keyframes run in once 'from'/'to' aliases or fractional offsets are used,
-  // so the offsets have to be sorted before the easings can be shifted.
+  // `Object.keys` puts integer-like keys first, so the offsets must be sorted.
   const toOffset = (offset: keyof KeyframeDefinitions) =>
     offset === 'from' ? 0 : offset === 'to' ? 100 : Number(offset);
 


### PR DESCRIPTION
> [!NOTE]
> This pull request was authored by AI on behalf of @dennytosp.

## Summary

`createCustomKeyFrameAnimation` moves each keyframe's easing one keyframe up — a Reanimated `Keyframe` puts the easing on the keyframe it animates *to*, while CSS puts it on the one it animates *from*. The walk uses `Object.keys(keyframeDefinitions)` as the running order:

```ts
const offsets = Object.keys(keyframeDefinitions) as (keyof KeyframeDefinitions)[];

for (let i = 1; i < offsets.length; i++) {
  const style = keyframeDefinitions[offsets[i]];
  if (style.easing) {
    keyframeDefinitions[offsets[i - 1]].easing = style.easing;
    delete style.easing;
  }
}
```

`Object.keys` lists integer-like keys first, in ascending numeric order, and every other key after them in insertion order — which is not the order the keyframes run in. `KeyframeDefinitions` is typed as ``Record<`${number}` | 'from' | 'to', AnimationStyle>``, so both keys that break this are legal input:

| definitions | `Object.keys` | result |
|---|---|---|
| `{ from: …, 100: { easing } }` | `['100', 'from']` | easing **never moved**, stays on 100% |
| `{ 0: …, 33.3: { easing }, 100: … }` | `['0', '100', '33.3']` | easing moved from 33.3% onto **100%** |
| `{ 0: …, 100: { easing } }` | `['0', '100']` | correct |

Probed directly (the function mutates its input, so the shift is observable):

```
KEYS from,100    -> ["100","from"]
AFTER from/100   -> {"100":{"opacity":1,"easing":"cubic-bezier(0.7,0,0.84,0)"},"from":{"opacity":0}}
AFTER 0/100      -> {"0":{"opacity":0,"easing":"cubic-bezier(0.7,0,0.84,0)"},"100":{"opacity":1}}

KEYS 0,33.3,100  -> ["0","100","33.3"]
AFTER 0/33.3/100 -> {"0":{...},"100":{"opacity":1,"easing":"cubic-bezier(...)"},"33.3":{"opacity":0.5}}
```

An `animation-timing-function` left on the 100% keyframe has no following segment to apply to, so in the first row the custom easing is silently dropped and the animation runs with the default. The second row is worse: the easing lands on a keyframe it was never written for.

`from` and `to` are documented aliases — `InnerKeyframe.parseDefinitions` normalizes `from` to `'0'` and `to` to `'100'` and throws if you supply both spellings. But that method is private and only runs from `build()` on the native path; the web path reads `config.definitions` straight off the instance (`animationsManager.ts:135`), so the aliases arrive here un-normalized.

### Fix

Sort the offsets numerically, mapping the two aliases onto the offsets they name, before shifting. This also fixes the fractional case, since `'33.3'` is not an integer-like key and was being enumerated after `'100'`.

## Test plan

New tests in `src/layoutReanimation/web/__tests__/createAnimation.web.test.ts`, including the plain-numeric case as a control so the test file also pins the behavior that already worked. The two affected cases **fail on `main`**:

```console
$ git stash push src/layoutReanimation/web/createAnimation.ts
$ yarn jest src/layoutReanimation/web/__tests__/createAnimation.web.test.ts
  ✓ shifts the easing off a numeric offset
  ✕ treats 'from' as the offset it aliases
  ✕ shifts the easing off a fractional offset
Tests: 2 failed, 1 passed, 3 total
```

With the fix applied:

```console
$ yarn jest
Test Suites: 104 passed, 104 total
Tests:       1559 passed, 1559 total
```

CSS emission order is untouched — only the array the shift loop walks is sorted, and `convertAnimationObjectToKeyframes` still reads `animationData.style`. `yarn eslint` and `oxfmt --check` are clean on both files.

## Changelog

- [x] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.
