### PR TITLE
fix: Serializable umbrella header for expo

### DIFF
--- a/packages/react-native-worklets/CHANGELOG.md
+++ b/packages/react-native-worklets/CHANGELOG.md
@@ -22,15 +22,12 @@
 - Fix a data race between `getDirty` and `setBlocking` on a Synchronizable - the pointer holding the value is now read and written atomically. ([#10292](https://github.com/software-mansion/react-native-reanimated/pull/10292) by [@tjzel](https://github.com/tjzel))
 - Fix `setBlocking` leaving a Synchronizable locked forever in development builds when the updater function or the serializer throws. ([#10331](https://github.com/software-mansion/react-native-reanimated/pull/10331) by [@tjzel](https://github.com/tjzel))
 - Compare the Synchronizable's imperative lock owner with `std::thread::id` instead of comparing `pthread_t` with `==`, which POSIX doesn't define. ([#10349](https://github.com/software-mansion/react-native-reanimated/pull/10349) by [@tjzel](https://github.com/tjzel))
+- Added an umbrella header for removed `Serializable.h` file for backwards compatibility with Expo
 
 ### 💡 Others
 
 - Update the sponsors section in the README. ([#10347](https://github.com/software-mansion/react-native-reanimated/pull/10347) by [@m-bert](https://github.com/m-bert))
-
-\[general] - bump Worklets version to 0.13.0
-
+- bump Worklets version to 0.13.0
 - Split every C++ `Serializable` subclass into a dedicated file under `SharedItems/Serializable/`, with its factory function alongside. No behavior change. ([#10345](https://github.com/software-mansion/react-native-reanimated/pull/10345) by [@tjzel](https://github.com/tjzel))
-
 - Split `Synchronizable` into an interface and a `SynchronizableDynamic` implementation. ([#10293](https://github.com/software-mansion/react-native-reanimated/pull/10293) by [@tjzel](https://github.com/tjzel))
-
 - Remove outdated Worklets Babel plugin README. ([#10350](https://github.com/software-mansion/react-native-reanimated/pull/10350) by [@tjzel](https://github.com/tjzel))

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Serializable.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Serializable.h
@@ -10,6 +10,7 @@
 #include <worklets/SharedItems/Serializable/SerializableBigInt.h>
 #include <worklets/SharedItems/Serializable/SerializableError.h>
 #include <worklets/SharedItems/Serializable/SerializableHostFunction.h>
+#include <worklets/SharedItems/Serializable/SerializableHostObject.h>
 #include <worklets/SharedItems/Serializable/SerializableImport.h>
 #include <worklets/SharedItems/Serializable/SerializableInitializer.h>
 #include <worklets/SharedItems/Serializable/SerializableMap.h>

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Serializable.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Serializable.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#warning Do not include this file directly, it will be removed in the future. Prefer including specific Serializable headers.
+
+#include <worklets/SharedItems/Serializable/CustomSerializable.h>
+#include <worklets/SharedItems/Serializable/RetainableSerializable.h>
+#include <worklets/SharedItems/Serializable/Serializable.h>
+#include <worklets/SharedItems/Serializable/SerializableArray.h>
+#include <worklets/SharedItems/Serializable/SerializableArrayBuffer.h>
+#include <worklets/SharedItems/Serializable/SerializableBigInt.h>
+#include <worklets/SharedItems/Serializable/SerializableError.h>
+#include <worklets/SharedItems/Serializable/SerializableHostFunction.h>
+#include <worklets/SharedItems/Serializable/SerializableImport.h>
+#include <worklets/SharedItems/Serializable/SerializableInitializer.h>
+#include <worklets/SharedItems/Serializable/SerializableMap.h>
+#include <worklets/SharedItems/Serializable/SerializableObject.h>
+#include <worklets/SharedItems/Serializable/SerializableRegExp.h>
+#include <worklets/SharedItems/Serializable/SerializableRemoteFunction.h>
+#include <worklets/SharedItems/Serializable/SerializableScalar.h>
+#include <worklets/SharedItems/Serializable/SerializableSet.h>
+#include <worklets/SharedItems/Serializable/SerializableString.h>
+#include <worklets/SharedItems/Serializable/SerializableTurboModuleLike.h>
+#include <worklets/SharedItems/Serializable/SerializableWorklet.h>


### PR DESCRIPTION
## Summary

Fixing Expo build failure on nightly CI https://github.com/software-mansion/react-native-reanimated/actions/runs/32607491823/job/97114784216

Expo uses `Serializable.h` header which doesn't exist anymore. I added an umbrella header for them with the warning to refrain from further use.

## Test plan

Next CI run will succeed

## Changelog

- [x] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.
