### PR TITLE
fix(LayoutAnimations): restore entering animations after Activity reactivation on iOS

### DIFF
--- a/apps/common-app/runtime-tests/reanimated/suites.ts
+++ b/apps/common-app/runtime-tests/reanimated/suites.ts
@@ -78,6 +78,12 @@ export const REANIMATED_TEST_SUITES: RuntimeTestSuite[] = [
     },
   },
   {
+    testSuiteName: 'Activity entering animation',
+    importTest: () => {
+      require('./tests/layoutAnimations/activityEntering.test');
+    },
+  },
+  {
     testSuiteName: 'entering and exiting',
     importTest: () => {
       require('./tests/layoutAnimations/entering/enteringColors.test');

--- a/apps/common-app/runtime-tests/reanimated/tests/layoutAnimations/activityEntering.test.tsx
+++ b/apps/common-app/runtime-tests/reanimated/tests/layoutAnimations/activityEntering.test.tsx
@@ -1,0 +1,94 @@
+import React, { Activity } from 'react';
+import { Platform, StyleSheet } from 'react-native';
+import Animated, {
+  FadeIn,
+  FadeOut,
+  ReduceMotion,
+} from 'react-native-reanimated';
+
+import {
+  callTracker,
+  describe,
+  expect,
+  expectEventually,
+  getTestComponent,
+  getTrackerCallCount,
+  render,
+  test,
+  useTestRef,
+} from '../../../ReJest/RuntimeTestsApi';
+
+const TARGET_REF = 'activity-entering-target';
+const DURATION_MS = 80;
+
+enum Tracker {
+  EnteringFinished = 'activity-entering-finished',
+  ExitingFinished = 'activity-exiting-finished',
+}
+
+const entering = FadeIn.duration(DURATION_MS)
+  .reduceMotion(ReduceMotion.Never)
+  .withCallback((finished) => {
+    'worklet';
+    if (finished) {
+      callTracker(Tracker.EnteringFinished);
+    }
+  });
+
+const exiting = FadeOut.duration(DURATION_MS)
+  .reduceMotion(ReduceMotion.Never)
+  .withCallback((finished) => {
+    'worklet';
+    if (finished) {
+      callTracker(Tracker.ExitingFinished);
+    }
+  });
+
+function Fixture({ visible }: { visible: boolean }) {
+  const ref = useTestRef(TARGET_REF);
+
+  return (
+    <Activity mode={visible ? 'visible' : 'hidden'}>
+      <Animated.View
+        entering={entering}
+        exiting={exiting}
+        ref={ref}
+        style={styles.box}
+      />
+    </Activity>
+  );
+}
+
+async function expectUICalls(tracker: Tracker, count: number) {
+  await expectEventually(() => getTrackerCallCount(tracker)).toBeCalledUI(
+    count
+  );
+}
+
+describe('Activity entering animation', () => {
+  test('runs when Activity restores a hidden view', async () => {
+    await render(<Fixture visible />);
+    await expectUICalls(Tracker.EnteringFinished, 1);
+    const tag = getTestComponent(TARGET_REF).getTag();
+
+    await render(<Fixture visible={false} />);
+    if (Platform.OS === 'ios') {
+      await expectUICalls(Tracker.ExitingFinished, 1);
+    }
+
+    await render(<Fixture visible />);
+    await expectUICalls(
+      Tracker.EnteringFinished,
+      Platform.OS === 'ios' ? 2 : 1
+    );
+    expect(getTestComponent(TARGET_REF).getTag()).toBe(tag);
+  });
+});
+
+const styles = StyleSheet.create({
+  box: {
+    width: 100,
+    height: 100,
+    backgroundColor: 'royalblue',
+  },
+});

--- a/packages/react-native-reanimated/CHANGELOG.md
+++ b/packages/react-native-reanimated/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 🐛 Bug fixes
 
+- Restore entering animations when React reactivates a hidden Activity.
+
 ### 💡 Others
 
 - Add `fontVariationSettings` to the style properties config, so the package type-checks against React Native 0.88 ([#10239](https://github.com/software-mansion/react-native-reanimated/pull/10239) by [@tjzel](https://github.com/tjzel))

--- a/packages/react-native-reanimated/src/createAnimatedComponent/AnimatedComponent.native.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/AnimatedComponent.native.tsx
@@ -3,7 +3,7 @@ import type React from 'react';
 import { Fragment } from 'react';
 
 import { checkStyleOverwriting, maybeBuild } from '../animationBuilder';
-import { IS_JEST, logger } from '../common';
+import { IS_IOS, IS_JEST, logger } from '../common';
 import type { StyleProps } from '../commonTypes';
 import { LayoutAnimationType } from '../commonTypes';
 import { SkipEnteringContext } from '../component/LayoutAnimationConfig';
@@ -113,6 +113,12 @@ export default class AnimatedComponent
       jsPropsUpdater.registerComponent(this, this._options.jsProps);
     }
 
+    if (IS_IOS && !this._isFirstRender && !this.context?.current) {
+      this._configureLayoutAnimation(
+        LayoutAnimationType.ENTERING,
+        this.props.entering
+      );
+    }
     this._configureLayoutAnimation(
       LayoutAnimationType.LAYOUT,
       this.props.layout


### PR DESCRIPTION
## Summary

On iOS, React can deactivate an `Activity` subtree without destroying its component instances. Fabric removes the hidden native view and later recreates it with the same tag, while React re-runs class layout lifecycles.

`AnimatedComponent.componentDidMount` already restores layout and exiting configurations on reactivation. Entering was configured only in the constructor, so the recreated view no longer had an entering configuration after its first exit cleared the native state.

This change configures entering again on subsequent iOS `componentDidMount` calls. It uses the existing native-ID path and continues to honor `LayoutAnimationConfig skipEntering`.

Android intentionally remains unchanged. `Activity` hides its child with `display: 'none'`, but Android retains the native view and emits a Fabric `Update` that switches its layout display type between none and visible. It emits no `Remove/Delete` or `Create/Insert`, so hiding runs no exiting animation and restoring runs no second entering animation. Any visible motion after restore is the configured layout transition, not `FadeIn`.

The broader platform-dependent behavior around `display: 'none'` is intentionally tracked separately in [#10396](https://github.com/software-mansion/react-native-reanimated/issues/10396).

## Test plan

The new enabled runtime test keeps one `Animated.View` inside `Activity`, hides and restores it, and verifies that:

- the initial entering animation finishes on both platforms;
- iOS runs exiting while hidden and entering again after restore;
- Android runs neither exiting nor a second entering animation; and
- the Fabric tag remains unchanged.

Before this change, iOS stops at one entering callback. With this change it reaches two. Android remains at one before and after the change.

## Recordings

Each recording begins before the view is mounted. **Add view** shows the initial entering animation; **Hide Activity** and **Restore Activity** then deactivate and restore that same `Animated.View`. The screen shows the callback counts and Fabric tag throughout.

### iOS

<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><video src="https://github.com/user-attachments/assets/caf7bced-16dd-4715-9bfe-03f51a78550c" controls width="100%"></video></td>
      <td><video src="https://github.com/user-attachments/assets/d856e385-7155-4522-bed2-cfab57e11483" controls width="100%"></video></td>
    </tr>
  </tbody>
</table>

### Android (nothing changed)

<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><video src="https://github.com/user-attachments/assets/15d06748-027a-4425-a559-8617fa92565e" controls width="100%"></video></td>
      <td><video src="https://github.com/user-attachments/assets/0a8f73f9-1eac-442d-905c-02a82f1c4ea5" controls width="100%"></video></td>
    </tr>
  </tbody>
</table>

Device runs:

- iPhone 17 Pro, iOS 26.3.1: before the change, entering remains at 1 after restore; after the change, it reaches 2. Exiting reaches 1 and the tag remains stable in both runs.
- Android emulator, API 35: before and after the change, entering remains at 1, exiting remains at 0, and the tag remains stable because the native view stays mounted. Motion after **Restore Activity** is `LinearTransition`, not entering.

Static verification:

- Reanimated native source typecheck
- common-app native typecheck
- focused ESLint and formatting
- changelog Markdown validation

## Changelog

- [x] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.
