### PR TITLE
ReJest: worklet class members

### DIFF
--- a/apps/common-app/runtime-tests/ReJest/TestRunner/CallTrackerRegistry.ts
+++ b/apps/common-app/runtime-tests/ReJest/TestRunner/CallTrackerRegistry.ts
@@ -15,7 +15,7 @@ function callTrackerJS(name: string) {
 }
 
 export class CallTrackerRegistry {
-  public callTracker(name: string) {
+  public callTracker = (name: string) => {
     'worklet';
     if (_WORKLET) {
       callCallTrackerRegistryUI.setBlocking((prev) => {
@@ -24,7 +24,7 @@ export class CallTrackerRegistry {
     } else {
       callTrackerJS(name);
     }
-  }
+  };
 
   public async getTrackerCallCount(name: string): Promise<TrackerCallCount> {
     const onUI = await runOnUIBlocking(

--- a/apps/common-app/runtime-tests/ReJest/TestRunner/NotificationRegistry.ts
+++ b/apps/common-app/runtime-tests/ReJest/TestRunner/NotificationRegistry.ts
@@ -8,14 +8,14 @@ function notifyJS(name: string) {
 }
 
 export class NotificationRegistry {
-  public notify(name: string) {
+  public notify = (name: string) => {
     'worklet';
     if (globalThis.__RUNTIME_KIND != RuntimeKind.ReactNative) {
       scheduleOnRN(notifyJS, name);
     } else {
       notifyJS(name);
     }
-  }
+  };
 
   public async waitForNotification(name: string, timeout?: number) {
     return this.waitForNotifications([name], timeout);

--- a/apps/common-app/runtime-tests/ReJest/TestRunner/TestRunner.ts
+++ b/apps/common-app/runtime-tests/ReJest/TestRunner/TestRunner.ts
@@ -115,7 +115,6 @@ export class TestRunner {
   }
 
   public createOrderConstraint() {
-    'worklet';
     return this.createTestValue<number>(0, (prev: number, current: number) => {
       'worklet';
       if (prev == current - 1) {

--- a/apps/common-app/runtime-tests/ReJest/TestRunner/ValueRegistry.ts
+++ b/apps/common-app/runtime-tests/ReJest/TestRunner/ValueRegistry.ts
@@ -10,7 +10,6 @@ export class ValueRegistry {
     name: string,
     value: SharedValue<TValue>
   ) {
-    'worklet';
     this._valueRegistry[name] = value as SharedValue;
   }
 


### PR DESCRIPTION
With the new oxc plugin dropping support for class method workletisation, existing code had to be tweaked to work. Where possible, the worklet directive was dropped, and in other cases, methods got changed into properties.