### PR TITLE
fix: remove flaky WeakRef test

### DIFF
--- a/apps/common-app/runtime-tests/worklets/tests/runtimes/weakRef.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/runtimes/weakRef.test.tsx
@@ -67,30 +67,6 @@ describe('WeakRef on Worklet Runtime', () => {
 
       expect(wasTargetCollected).toBe(true);
     });
-
-    test(`does not release targets after synchronous execution on ${name} Runtime`, () => {
-      runOnRuntimeSyncWithId(runtimeId, () => {
-        'worklet';
-        const target = {};
-        globalThis.weakRefTest = new WeakRef(target);
-      });
-
-      const isTargetAliveBeforeGC = runOnRuntimeSyncWithId(runtimeId, () => {
-        'worklet';
-        return globalThis.weakRefTest?.deref() !== undefined;
-      });
-      expect(isTargetAliveBeforeGC).toBe(true);
-
-      const wasTargetCollected = runOnRuntimeSyncWithId(runtimeId, () => {
-        'worklet';
-        globalThis.gc!();
-        const wasCollected = globalThis.weakRefTest?.deref() === undefined;
-        delete globalThis.weakRefTest;
-        return wasCollected;
-      });
-
-      expect(wasTargetCollected).toBe(false);
-    });
   });
 
   test('is unavailable on a Worker Runtime with the event loop disabled', async () => {


### PR DESCRIPTION
## Summary

Sometimes the event loop can hit the microtask checkpoint in-between the callbacks and clean the WeakRef.

## Test plan

Runtime tests pass

## Changelog

- [x] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.
