### PR TITLE
test(worklets): make the date serialization test timezone-independent

### DIFF
--- a/apps/common-app/runtime-tests/worklets/tests/runtimes/loggingFromWorkletRuntime.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/runtimes/loggingFromWorkletRuntime.test.tsx
@@ -247,13 +247,11 @@ const testCases: Record<string, TestCase> = {
     },
   },
   date: {
-    expected: '1970',
-    bundleMode: 'Thu Jan 01 1970 00:00:00 GMT+0000 (UTC)',
-    noBundleMode: '{}',
+    expected: '2020',
     checkIncludes: { bundleMode: true, noBundleMode: false },
     factory: () => {
       'worklet';
-      return new Date(0);
+      return new Date(Date.UTC(2020, 5, 15));
     },
   },
   regExp: {


### PR DESCRIPTION
> [!NOTE]
> This pull request was authored by AI on behalf of @tjzel.

## Summary

The `date serializes as expected` test failed on every nightly run of the `Remote tests (DebugRuntimeTests, Bundle Mode)` leg since the Argent Cloud legs landed in #10270, e.g. https://github.com/software-mansion/react-native-reanimated/actions/runs/32807785563/job/97687691853. The case logged `new Date(0)` and asserted the captured `nativeLoggingHook` message contains `1970`, but the console polyfill renders a `Date` with `Date.prototype.toString()`, which uses the device timezone — on a remote simulator whose host sits behind UTC, the epoch renders as `Wed Dec 31 1969 …` and the assertion fails. I switched the case to `new Date(Date.UTC(2020, 5, 15))`, so the `2020` needle survives every UTC±14 timezone, while the Legacy Eval expectation is unaffected because the `Date` still loses its type crossing to the UI runtime and logs as `{}`. I also removed the `bundleMode` and `noBundleMode` strings from the entry — the harness resolves `expected ?? entry[modeKey]` and the entry sets `expected`, so they were dead values.

## Test plan

This PR touches `apps/common-app/runtime-tests/**`, so the Argent remote legs run on it — the previously failing `Remote tests (DebugRuntimeTests, Bundle Mode)` leg should now pass.

## Changelog

- [x] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.
