### PR TITLE
fix(Worklets): correct `RetainingSerializable.h` include in umbrella `Serializable.h`

### DIFF
--- a/packages/react-native-worklets/CHANGELOG.md
+++ b/packages/react-native-worklets/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Fix `setBlocking` leaving a Synchronizable locked forever in development builds when the updater function or the serializer throws. ([#10331](https://github.com/software-mansion/react-native-reanimated/pull/10331) by [@tjzel](https://github.com/tjzel))
 - Compare the Synchronizable's imperative lock owner with `std::thread::id` instead of comparing `pthread_t` with `==`, which POSIX doesn't define. ([#10349](https://github.com/software-mansion/react-native-reanimated/pull/10349) by [@tjzel](https://github.com/tjzel))
 - Added an umbrella header for removed `Serializable.h` file for backwards compatibility with Expo
+- Fix the umbrella `Serializable.h` header including a non-existent `RetainableSerializable.h` instead of `RetainingSerializable.h`, which made the header fail to compile. ([#10406](https://github.com/software-mansion/react-native-reanimated/pull/10406) by [@tjzel](https://github.com/tjzel))
 
 ### 💡 Others
 

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Serializable.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Serializable.h
@@ -3,7 +3,7 @@
 #warning Do not include this file directly, it will be removed in the future. Prefer including specific Serializable headers.
 
 #include <worklets/SharedItems/Serializable/CustomSerializable.h>
-#include <worklets/SharedItems/Serializable/RetainableSerializable.h>
+#include <worklets/SharedItems/Serializable/RetainingSerializable.h>
 #include <worklets/SharedItems/Serializable/Serializable.h>
 #include <worklets/SharedItems/Serializable/SerializableArray.h>
 #include <worklets/SharedItems/Serializable/SerializableArrayBuffer.h>


### PR DESCRIPTION
> [!NOTE]
> This pull request was authored by AI on behalf of @tjzel.

## Summary

The umbrella `Serializable.h` added in #10345 for backwards compatibility includes `worklets/SharedItems/Serializable/RetainableSerializable.h`, but the file is named `RetainingSerializable.h`. Any translation unit that includes the umbrella fails to compile, which defeats the point of keeping it around. Nothing in this repository includes it, so CI never caught it. I pointed the include at the real filename.

## Test plan

The following no longer fails to compile:

```cpp
#include <worklets/SharedItems/Serializable.h>

int main() {
  return 0;
}
```

Before: `fatal error: 'worklets/SharedItems/Serializable/RetainableSerializable.h' file not found`.

## Changelog

- [x] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.
