### PR TITLE
refactor(Reanimated): back `AnimatedRef` with a Shareable instead of a handle

### DIFF
--- a/packages/react-native-reanimated/CHANGELOG.md
+++ b/packages/react-native-reanimated/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🛠 Breaking changes
 
+- `AnimatedRefOnUI` is now a `ShareableHost<ShadowNodeWrapper | null>` read with `.value` instead of a callable, and `AnimatedRefOnJS` was renamed to `AnimatedRefOnRN`. `measure` on an unmounted ref now returns `null` and warns instead of calling into `_measure`. ([#10413](https://github.com/software-mansion/react-native-reanimated/pull/10413) by [@tjzel](https://github.com/tjzel))
 - Remove the `USE_SYNCHRONIZABLE_FOR_MUTABLES` feature flag. Mutables always use Synchronizable state now. ([#10298](https://github.com/software-mansion/react-native-reanimated/pull/10298) by [@tjzel](https://github.com/tjzel))
 
 ### 🎉 New features

--- a/packages/react-native-reanimated/src/hook/commonTypes.ts
+++ b/packages/react-native-reanimated/src/hook/commonTypes.ts
@@ -8,7 +8,7 @@ import type {
   TextStyle,
   ViewStyle,
 } from 'react-native';
-import type { WorkletFunction } from 'react-native-worklets';
+import type { ShareableHost, WorkletFunction } from 'react-native-worklets';
 
 import type { Maybe } from '../common';
 import type {
@@ -61,16 +61,9 @@ export type AnimatedRef<TRef extends InstanceOrElement = HostInstance> = {
   getTag?: () => Maybe<number>;
 };
 
-// Might make that type generic if it's ever needed.
-export type AnimatedRefOnJS = AnimatedRef<InternalHostInstance>;
+export type AnimatedRefOnRN = AnimatedRef<InternalHostInstance>;
 
-/**
- * `AnimatedRef` is mapped to this type on the UI thread via a serializable
- * handle.
- */
-export type AnimatedRefOnUI = {
-  (): number | ShadowNodeWrapper | null;
-};
+export type AnimatedRefOnUI = ShareableHost<ShadowNodeWrapper | null>;
 
 type ReanimatedPayload = {
   eventName: string;

--- a/packages/react-native-reanimated/src/hook/useAnimatedRef.native.ts
+++ b/packages/react-native-reanimated/src/hook/useAnimatedRef.native.ts
@@ -3,12 +3,14 @@ import { useState } from 'react';
 import type { HostInstance } from 'react-native';
 import {
   createSerializable,
+  createShareable,
+  scheduleOnUI,
   serializableMappingCache,
+  UIRuntimeId,
 } from 'react-native-worklets';
 
 import type { InstanceOrElement, ShadowNodeWrapper } from '../commonTypes';
 import { getShadowNodeWrapperFromRef } from '../fabricUtils';
-import { makeMutable } from '../mutables';
 import type { AnimatedRef, AnimatedRefOnUI } from './commonTypes';
 import { useAnimatedRefBase } from './useAnimatedRefCommon';
 
@@ -23,25 +25,22 @@ export function useAnimatedRef<
   TRef extends InstanceOrElement = HostInstance,
 >(): AnimatedRef<TRef> {
   const [sharedWrapper] = useState(() =>
-    makeMutable<ShadowNodeWrapper | null>(null)
+    createShareable<ShadowNodeWrapper | null>(UIRuntimeId, null)
   );
 
   const resultRef = useAnimatedRefBase<TRef>((ref) => {
     const currentWrapper = getShadowNodeWrapperFromRef(ref);
 
-    sharedWrapper.value = currentWrapper;
+    scheduleOnUI(() => {
+      (sharedWrapper as AnimatedRefOnUI).value = currentWrapper;
+    });
 
     return currentWrapper;
   });
 
   if (!serializableMappingCache.get(resultRef)) {
-    const animatedRefSerializableHandle = createSerializable({
-      __init: (): AnimatedRefOnUI => {
-        'worklet';
-        return () => sharedWrapper.value;
-      },
-    });
-    serializableMappingCache.set(resultRef, animatedRefSerializableHandle);
+    const animatedRefSerializable = createSerializable(sharedWrapper);
+    serializableMappingCache.set(resultRef, animatedRefSerializable);
   }
 
   return resultRef;

--- a/packages/react-native-reanimated/src/platformFunctions/dispatchCommand.native.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/dispatchCommand.native.ts
@@ -3,8 +3,7 @@
 import { RuntimeKind } from 'react-native-worklets';
 
 import { IS_JEST, logger } from '../common';
-import type { ShadowNodeWrapper } from '../commonTypes';
-import type { AnimatedRefOnJS, AnimatedRefOnUI } from '../hook/commonTypes';
+import type { AnimatedRefOnRN, AnimatedRefOnUI } from '../hook/commonTypes';
 import type { DispatchCommand } from './types';
 
 /**
@@ -21,7 +20,7 @@ import type { DispatchCommand } from './types';
 export let dispatchCommand: DispatchCommand;
 
 function dispatchCommandNative(
-  animatedRef: AnimatedRefOnJS | AnimatedRefOnUI,
+  animatedRef: AnimatedRefOnRN | AnimatedRefOnUI,
   commandName: string,
   args: Array<unknown> = []
 ) {
@@ -30,7 +29,7 @@ function dispatchCommandNative(
     return;
   }
 
-  const shadowNodeWrapper = animatedRef();
+  const shadowNodeWrapper = (animatedRef as AnimatedRefOnUI).value;
 
   // This prevents crashes if ref has not been set yet
   if (!shadowNodeWrapper) {
@@ -40,11 +39,7 @@ function dispatchCommandNative(
     return;
   }
 
-  global._dispatchCommand!(
-    shadowNodeWrapper as ShadowNodeWrapper,
-    commandName,
-    args
-  );
+  global._dispatchCommand!(shadowNodeWrapper, commandName, args);
 }
 
 function dispatchCommandJest() {

--- a/packages/react-native-reanimated/src/platformFunctions/dispatchCommand.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/dispatchCommand.ts
@@ -1,11 +1,11 @@
 'use strict';
 
 import { logger } from '../common';
-import type { AnimatedRefOnJS, AnimatedRefOnUI } from '../hook/commonTypes';
+import type { AnimatedRefOnRN, AnimatedRefOnUI } from '../hook/commonTypes';
 import type { DispatchCommand } from './types';
 
 function dispatchCommandWeb(
-  _animatedRef: AnimatedRefOnJS | AnimatedRefOnUI,
+  _animatedRef: AnimatedRefOnRN | AnimatedRefOnUI,
   _commandName: string,
   _args: Array<unknown> = []
 ) {

--- a/packages/react-native-reanimated/src/platformFunctions/measure.native.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/measure.native.ts
@@ -2,14 +2,10 @@
 import { RuntimeKind } from 'react-native-worklets';
 
 import { IS_JEST, logger } from '../common';
-import type {
-  InstanceOrElement,
-  MeasuredDimensions,
-  ShadowNodeWrapper,
-} from '../commonTypes';
+import type { InstanceOrElement, MeasuredDimensions } from '../commonTypes';
 import type {
   AnimatedRef,
-  AnimatedRefOnJS,
+  AnimatedRefOnRN,
   AnimatedRefOnUI,
 } from '../hook/commonTypes';
 
@@ -30,21 +26,21 @@ type Measure = <TRef extends InstanceOrElement>(
  */
 export let measure: Measure;
 
-function measureNative(animatedRef: AnimatedRefOnJS | AnimatedRefOnUI) {
+function measureNative(animatedRef: AnimatedRefOnRN | AnimatedRefOnUI) {
   'worklet';
   if (globalThis.__RUNTIME_KIND === RuntimeKind.ReactNative) {
     return null;
   }
 
-  const viewTag = animatedRef();
-  if (viewTag === -1) {
+  const viewTag = (animatedRef as AnimatedRefOnUI).value;
+  if (!viewTag) {
     logger.warn(
       `The view with tag ${viewTag} is not a valid argument for measure(). This may be because the view is not currently rendered, which may not be a bug (e.g. an off-screen FlatList item).`
     );
     return null;
   }
 
-  const measured = global._measure!(viewTag as ShadowNodeWrapper);
+  const measured = global._measure!(viewTag);
   if (measured === null) {
     logger.warn(
       `The view has some undefined, not-yet-computed or meaningless value of \`LayoutMetrics\` type. This may be because the view is not currently rendered, which may not be a bug (e.g. an off-screen FlatList item).`

--- a/packages/react-native-reanimated/src/platformFunctions/setNativeProps.native.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/setNativeProps.native.ts
@@ -9,7 +9,7 @@ import type {
 } from '../commonTypes';
 import type {
   AnimatedRef,
-  AnimatedRefOnJS,
+  AnimatedRefOnRN,
   AnimatedRefOnUI,
 } from '../hook/commonTypes';
 
@@ -34,7 +34,7 @@ type SetNativeProps = <TRef extends InstanceOrElement>(
 export let setNativeProps: SetNativeProps;
 
 function setNativePropsNative(
-  animatedRef: AnimatedRefOnJS | AnimatedRefOnUI,
+  animatedRef: AnimatedRefOnRN | AnimatedRefOnUI,
   updates: StyleProps
 ) {
   'worklet';
@@ -42,7 +42,8 @@ function setNativePropsNative(
     logger.warn('setNativeProps() can only be used on the UI runtime.');
     return;
   }
-  const shadowNodeWrapper = animatedRef() as ShadowNodeWrapper;
+  const shadowNodeWrapper = (animatedRef as AnimatedRefOnUI)
+    .value as ShadowNodeWrapper;
   processColorsInProps(updates);
   global._updateProps!([{ shadowNodeWrapper, updates }]);
 }


### PR DESCRIPTION
## Summary

Use plain `Shareable` as internal implementation of `useAnimatedRef`.

## Test plan

Reanimated runtime tests pass.

## Changelog

- [x] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.
