### PR TITLE
docs(worklets): sync `isWorkletFunction` type definitions with source

### DIFF
--- a/docs/docs-worklets/docs/utility/isWorkletFunction.mdx
+++ b/docs/docs-worklets/docs/utility/isWorkletFunction.mdx
@@ -42,21 +42,25 @@ console.log(isNonWorkletFunction); // false
   ];
 
   interface WorkletInitData {
-    code: string;
+    /** Only when bytecode isn't toggled. */
+    code?: string;
+    /** Only in production builds and explicitly toggled. */
+    bytecode?: ArrayBuffer;
     /** Only in dev builds. */
     location?: string;
     /** Only in dev builds. */
     sourceMap?: string;
-    /** Only in dev builds. */
-    version?: string;
   }
 
   interface WorkletProps {
     __closure: WorkletClosure;
     __workletHash: number;
-    __initData: WorkletInitData;
+    /** Only in Legacy Eval Mode. */
+    __initData?: WorkletInitData;
     /** `__stackDetails` is removed after parsing. */
     __stackDetails?: WorkletStackDetails;
+    /** Only in dev builds. */
+    __pluginVersion?: string;
   }
 
   type WorkletFunction<


### PR DESCRIPTION
> [!NOTE]
> This pull request was authored by AI on behalf of @tjzel.

Last part of splitting up #10401. Stacked on #10414.

## Summary

The `Type definitions` block on the `isWorkletFunction` page had drifted from `WorkletProps` and `WorkletInitData` in `packages/react-native-worklets/src/types.ts`. I synced it: `code` is optional, `bytecode` exists, `version` does not, `__initData` is optional and only set in Legacy Eval Mode, and `__pluginVersion` was missing.

Documentation only.

## Test plan

Docs lint passes.

## Changelog

- [x] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.
