### PR TITLE
test(Worklets): cover serializing an undecorated Shareable by reference

### DIFF
--- a/apps/common-app/runtime-tests/worklets/tests/memory/shareable.test.tsx
+++ b/apps/common-app/runtime-tests/worklets/tests/memory/shareable.test.tsx
@@ -1,4 +1,5 @@
 import {
+  createSerializable,
   createShareable,
   runOnUISync,
   runOnRuntimeSync,
@@ -10,6 +11,7 @@ import {
   scheduleOnRuntime,
   UIRuntimeId,
   isShareable,
+  serializableMappingCache,
   type ShareableHost,
 } from 'react-native-worklets';
 import {
@@ -282,6 +284,31 @@ describe('Shareable hosted on UI', () => {
       const value = await (shareable as ShareableGuest<number>).getAsync();
 
       expect(value).toBe(42);
+    }
+  );
+
+  test.each(initModes)(
+    'undecorated guest is serialized by reference (%s)',
+    (initMode) => {
+      const shareable = createShareable(
+        UIRuntimeId,
+        0,
+        getInitOptions(initMode)
+      );
+      const carrier = {};
+      serializableMappingCache.set(carrier, createSerializable(shareable));
+
+      const readBack = runOnUISync(() => {
+        'worklet';
+        return (carrier as unknown as ShareableHost<number>).value;
+      });
+      expect(readBack).toBe(0);
+
+      runOnUISync(() => {
+        'worklet';
+        (carrier as unknown as ShareableHost<number>).value = 42;
+      });
+      expect((shareable as ShareableGuest<number>).getSync()).toBe(42);
     }
   );
 


### PR DESCRIPTION
> [!NOTE]
> This pull request was authored by AI on behalf of @tjzel.

## Summary

`createSerializable` returns a Shareable's existing ref instead of cloning the guest because `shareableGuestUnpacker` memoizes every guest into `serializableMappingCache`, decorated or not. Callers can rely on that to reach a Shareable through an unrelated object - #10413 does exactly this, mapping an `AnimatedRef` onto the Shareable that holds its shadow node wrapper.

Nothing guarded that. Move the `memoize` call inside the `if (guestDecorator)` block above it and an undecorated Shareable would be structurally cloned instead, so worklets would receive a detached copy of the guest with no `value` at all - a silent wrong answer, not a crash.

The existing undecorated tests all close over the Shareable directly, which never exercises the mapping cache. This one routes through it and then writes back through the host to prove the worklet got the same host, not a copy.

## Test plan

Worklets runtime tests pass.

## Changelog

- [x] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.
