### PR TITLE
fix(SET): ship react-native.config.js in the npm package

### DIFF
--- a/packages/react-native-reanimated/package.json
+++ b/packages/react-native-reanimated/package.json
@@ -67,6 +67,7 @@
     "scripts/worklets-version.json",
     "scripts/validate-react-native-version.js",
     "compatibility.json",
+    "react-native.config.js",
     "mock.js",
     "plugin/index.js",
     "plugin/index.d.ts",


### PR DESCRIPTION
`react-native.config.js` was added in #9435 to register `REASharedTransitionBoundaryComponentDescriptor` and the `Common/NativeView` CMakeLists for Android autolinking, but it was never added to the `files` allowlist in `package.json`, so npm excluded it from the published tarball. Apps installing Reanimated from the registry ended up with no boundary component descriptor on Android, so shared transitions never ran. The monorepo example apps consume the package through a workspace symlink, which is why this wasn't caught in-repo.

#### Test Plan

- `npm pack` — the tarball now contains `react-native.config.js`.
- Fresh out-of-tree RN 0.87 app on Android consuming the packed tarball: without the file shared transitions don't animate, with it they do.