### PR TITLE
chore: stop oxfmt reformatting code embedded in tagged templates

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -6,6 +6,7 @@
   "trailingComma": "es5",
   "tabWidth": 2,
   "arrowParens": "always",
+  "embeddedLanguageFormatting": "off",
   "sortPackageJson": false,
   "jsdoc": true,
   "ignorePatterns": [


### PR DESCRIPTION
we don't want oxc to format code inside html`<script></script>` tags, as it can break .toInclude() assertions in test cases if for example it changes double quotes to single quotes (true story)

this pr disables that behavior by setting `embeddedLanguageFormatting: false`