### PR TITLE
fix(SharedElementTransitions): make native gestures work inside SharedTransitionBoundary on Android

### DIFF
--- a/packages/react-native-reanimated/CHANGELOG.md
+++ b/packages/react-native-reanimated/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### 🐛 Bug fixes
 
 - Fix `SequencedTransition` on web scaling the wrong axis in its midpoint keyframe, so the axis that has already finished no longer collapses while the other one waits. ([#10384](https://github.com/software-mansion/react-native-reanimated/pull/10384) by [@dennytosp](https://github.com/dennytosp))
+- Fix native gestures (e.g. scrolling) not working inside `SharedTransitionBoundary` on Android by growing the boundary's zero-sized frame to cover its children. ([#10430](https://github.com/software-mansion/react-native-reanimated/pull/10430) by [@bartlomiejbloniarz](https://github.com/bartlomiejbloniarz))
 - Fix `normalizeColor` resolving `Object.prototype` members such as `'constructor'` and `'toString'` as color names and returning a function instead of `null`. ([#10387](https://github.com/software-mansion/react-native-reanimated/pull/10387) by [@dennytosp](https://github.com/dennytosp))
 - Fix `transform` and `transformOrigin` strings padded with whitespace throwing instead of parsing. ([#10388](https://github.com/software-mansion/react-native-reanimated/pull/10388) by [@dennytosp](https://github.com/dennytosp))
 - Fix `linear()` easing not clamping an out-of-order input progress value on its first or last control point, which left the control points non-monotonic and the resulting curve wrong. ([#10380](https://github.com/software-mansion/react-native-reanimated/pull/10380) by [@dennytosp](https://github.com/dennytosp))

--- a/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/REASharedTransitionBoundaryShadowNode.cpp
+++ b/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/REASharedTransitionBoundaryShadowNode.cpp
@@ -1,5 +1,7 @@
 #include "REASharedTransitionBoundaryShadowNode.h"
 
+#include <algorithm>
+
 namespace facebook::react {
 
 extern const char REASharedTransitionBoundaryComponentName[] = "REASharedTransitionBoundary";
@@ -10,6 +12,22 @@ void REASharedTransitionBoundaryShadowNode::initialize() {
   // the view in the native tree, so it shows up in mutations and can be
   // tracked in the light tree.
   traits_.unset(ShadowNodeTraits::ForceFlattenView);
+}
+
+void REASharedTransitionBoundaryShadowNode::layout(LayoutContext layoutContext) {
+  YogaLayoutableShadowNode::layout(layoutContext);
+
+  // Android only delivers touches within a view's bounds, breaking native
+  // gestures inside a zero-sized `display: contents` frame. The frame and
+  // its children share the parent's origin, so only the size needs to grow.
+  const auto contentBounds = getContentBounds();
+  auto layoutMetrics = getLayoutMetrics();
+  layoutMetrics.frame.size = {contentBounds.getMaxX(), contentBounds.getMaxY()};
+  // The base class derived overflowInset against the old zero frame; only
+  // children at negative coordinates overflow the grown one.
+  layoutMetrics.overflowInset = {
+      std::min(contentBounds.getMinX(), Float{0}), std::min(contentBounds.getMinY(), Float{0}), 0, 0};
+  setLayoutMetrics(layoutMetrics);
 }
 
 } // namespace facebook::react

--- a/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/REASharedTransitionBoundaryShadowNode.h
+++ b/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/REASharedTransitionBoundaryShadowNode.h
@@ -34,6 +34,8 @@ class REASharedTransitionBoundaryShadowNode final : public ConcreteViewShadowNod
     initialize();
   }
 
+  void layout(LayoutContext layoutContext) override;
+
  private:
   void initialize();
 };

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/view/REASharedTransitionBoundaryView.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/view/REASharedTransitionBoundaryView.java
@@ -6,10 +6,9 @@ import android.view.ViewGroup;
 public class REASharedTransitionBoundaryView extends ViewGroup {
   public REASharedTransitionBoundaryView(Context context) {
     super(context);
-    // The boundary uses `display: contents`, so this view has an empty frame
-    // while its children are laid out in the coordinate space of its parent.
-    // Without this, the children would be clipped to the empty bounds.
-    // It only affects children of this view, not the rest of the app.
+    // Children can lie outside the boundary's frame — moved by an animation
+    // without a re-layout, or laid out at negative coordinates — so they
+    // must not be clipped.
     this.setClipChildren(false);
   }
 


### PR DESCRIPTION
`SharedTransitionBoundary` renders a `display: contents` view that we keep in the native tree so the light tree can track it. Yoga zeroes the frame of such nodes, so the boundary mounted as a 0×0 native view. Android delivers native touch events only within a view's bounds, so gestures handled natively — most visibly scrolling — never reached anything inside a boundary. Taps kept working because the JS touch pipeline traverses non-clipping view groups, and iOS was unaffected because its hit test follows `overflowInset`.

Now the boundary's shadow node overrides `layout` and grows its frame to its children's bounds. This mirrors how gesture-handler keeps its unflattened `display: contents` detector views touchable (`RNGestureHandlerDetectorShadowNode`), minus the child shifting: the boundary always sits at its parent's origin, which the children are already positioned relative to, so only the size changes and no coordinates move.

#### Test Plan

- Build FabricExample on Android and iOS.
- Open `[SET] FlatList`, scroll the horizontal lists, tap an item, navigate back.


Fixes #10336.
