### PR TITLE
ci: fix simctl bootstatus argument order in remote runtime tests

### DIFF
--- a/apps/fabric-example/scripts/runtime-tests-remote.mjs
+++ b/apps/fabric-example/scripts/runtime-tests-remote.mjs
@@ -246,7 +246,7 @@ async function install() {
   }
   log(`booting remote simulator ${UDID}`);
   await simRemote(['simctl', 'boot', UDID]).catch(() => {}); // tolerate already-booted
-  await simRemote(['simctl', 'bootstatus', '-b', UDID], { timeout: 300_000 });
+  await simRemote(['simctl', 'bootstatus', UDID, '-b'], { timeout: 300_000 });
   log(`uploading ${APP_PATH} to the orchestrator (QUIC)`);
   await simRemote(['simctl', 'uninstall', UDID, BUNDLE_ID]).catch(() => {});
   await simRemote(['simctl', 'install', UDID, path.resolve(APP_PATH)], {


### PR DESCRIPTION
The remote runtime-test driver calls `sim-remote simctl bootstatus -b <UDID>` with the flag before the device, but `simctl bootstatus` takes the device first (`simctl bootstatus <device> [-bcd]`) and the sim-remote shim enforces that order, failing with `Invalid device: -b`. Every run of the Argent Cloud iOS runtime tests workflow has failed at "Pick remote simulator and install app" since this landed.

Now the device comes first, matching the `simctl` usage and the local `runtime-tests-server.js` call.

#### Test Plan

- The `ios-argent / Remote tests` legs on this PR reach past the bootstatus step.
