### PR TITLE
fix: treat an empty animationName array as no animation

### DIFF
--- a/packages/react-native-reanimated/CHANGELOG.md
+++ b/packages/react-native-reanimated/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### 🐛 Bug fixes
 
+- Treat `animationName: []` as no animation, so the view is detached instead of running its previous animation forever. ([#10432](https://github.com/software-mansion/react-native-reanimated/pull/10432) by [@MatiPl01](https://github.com/MatiPl01))
 - Fix `SequencedTransition` on web scaling the wrong axis in its midpoint keyframe, so the axis that has already finished no longer collapses while the other one waits. ([#10384](https://github.com/software-mansion/react-native-reanimated/pull/10384) by [@dennytosp](https://github.com/dennytosp))
 - Fix `normalizeColor` resolving `Object.prototype` members such as `'constructor'` and `'toString'` as color names and returning a function instead of `null`. ([#10387](https://github.com/software-mansion/react-native-reanimated/pull/10387) by [@dennytosp](https://github.com/dennytosp))
 - Fix `transform` and `transformOrigin` strings padded with whitespace throwing instead of parsing. ([#10388](https://github.com/software-mansion/react-native-reanimated/pull/10388) by [@dennytosp](https://github.com/dennytosp))

--- a/packages/react-native-reanimated/src/css/utils/props.ts
+++ b/packages/react-native-reanimated/src/css/utils/props.ts
@@ -98,13 +98,17 @@ export function filterCSSAndStyleProperties<S extends object>(
   // Return animationProperties only if at least one animationName contains
   // valid keyframes
   const animationName = animationProperties.animationName;
+  const animationNames = animationName
+    ? Array.isArray(animationName)
+      ? animationName
+      : [animationName]
+    : [];
   const hasAnimationName =
-    !!animationName &&
-    (Array.isArray(animationName) ? animationName : [animationName]).every(
-      (keyframes) =>
-        keyframes === 'none'
-          ? false
-          : isCSSKeyframesRule(keyframes) || isCSSKeyframesObject(keyframes)
+    animationNames.length > 0 &&
+    animationNames.every((keyframes) =>
+      keyframes === 'none'
+        ? false
+        : isCSSKeyframesRule(keyframes) || isCSSKeyframesObject(keyframes)
     );
   const finalAnimationConfig = hasAnimationName
     ? ({


### PR DESCRIPTION
> [!NOTE]
> This pull request was authored by AI on behalf of @MatiPl01.

## Summary

`animationName: []` is treated as a real animation config, so the view is never detached and keeps running its previous animation.

`filterCSSAndStyleProperties` validates `animationName` with `Array.every`, which is vacuously `true` for an empty array. The guard whose comment reads *"only if at least one animationName contains valid keyframes"* therefore lets an empty list through:

```
no animationName at all   -> null
animationName: 'none'     -> null
animationName: undefined  -> null
animationName: []         -> { animationName: [] }   <-- reaches CSSAnimationsManager
```

Every other "no animation" shape becomes `null` and routes to `update(null)`, which detaches correctly. The empty array takes a path that is broken twice:

```ts
this.attachedAnimations = processedAnimations; // [] - cleared here
if (animationUpdates) {
  if (animationUpdates.animationNames?.length === 0) {
    this.detach();                              // guards on length > 0 -> no-op
```

`detach()` is the only caller of `unregisterCSSAnimations`, so `cssAnimationsRegistry_` keeps the view's entry. Its keyframes *are* released, but `CSSAnimation` holds `shared_ptr` copies of the interpolator and easing functions, so that does not stop a running animation, and `handleNodeRemovals` skips nodes still in the shadow tree.

Reachable from ordinary code, e.g. `animationName: isActive ? [fadeIn] : []`.

The fix builds the candidate list once and requires it to be non-empty, which is what the existing comment already describes. No behaviour change for any other input and no extra allocation.

## Test plan

Two views with the same animation, stopped two ways after 5s. Before this change the red box keeps spinning; the green control stops. After it, both stop. (left recording is before, right is after).

- `animationName: []` - we set the `animationName` to an empty array after 5s
- `prop removed` - we just drop the `animationName` prop

Both should behave in the same way.

https://github.com/user-attachments/assets/a9682e3d-f348-45ed-999b-a28955c8a1b7



<details>
<summary>Source code</summary>

```tsx
import React, { useEffect, useState } from 'react';
import { StyleSheet, Text, View } from 'react-native';
import Animated, { css } from 'react-native-reanimated';

const SPIN = css.keyframes({
  from: { transform: [{ rotate: '0deg' }] },
  to: { transform: [{ rotate: '360deg' }] },
});

const spinStyle = {
  animationDuration: 2000,
  animationIterationCount: 'infinite' as const,
  animationTimingFunction: 'linear' as const,
};

export default function App() {
  const [stopped, setStopped] = useState(false);

  useEffect(() => {
    const id = setTimeout(() => setStopped(true), 5000);
    return () => clearTimeout(id);
  }, []);

  return (
    <View style={styles.root}>
      <Animated.View
        style={[styles.box, styles.bad, { ...spinStyle, animationName: stopped ? [] : [SPIN] }]}
      />
      <Animated.View
        style={[styles.box, styles.good, { ...spinStyle, animationName: stopped ? undefined : [SPIN] }]}
      />
      <Text style={styles.label}>
        {stopped ? 'both expected: stopped' : 'both animating'}
      </Text>
    </View>
  );
}

const styles = StyleSheet.create({
  root: { flex: 1, backgroundColor: '#111', alignItems: 'center', justifyContent: 'center', gap: 30 },
  box: { width: 92, height: 92, borderRadius: 12 },
  bad: { backgroundColor: '#e24b4a' },
  good: { backgroundColor: '#1baf7a' },
  label: { color: '#fab219', fontSize: 15, fontWeight: '600' },
});
```

</details>
