### PR TITLE
fix(Worklets): Crash when handling __proto__

### DIFF
--- a/packages/react-native-worklets/CHANGELOG.md
+++ b/packages/react-native-worklets/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Fix build error when Bundle Mode worklet captures JSX name. ([#10409](https://github.com/software-mansion/react-native-reanimated/pull/10409) by [@tshmieldev](https://github.com/tshmieldev))
 - Fix `ReferenceError` when a worklet file assigns to `module.exports`. ([#10408](https://github.com/software-mansion/react-native-reanimated/pull/10408) by [@tshmieldev](https://github.com/tshmieldev))
 - Stop workletizing getters, setters and constructors. ([#10421](https://github.com/software-mansion/react-native-reanimated/pull/10421) by [@tshmieldev](https://github.com/tshmieldev))
+- Fix a crash when serializing objects with a `__proto__` key. ([#10451](https://github.com/software-mansion/react-native-reanimated/pull/10451) by [@tshmieldev](https://github.com/tshmieldev))
 
 ### 💡 Others
 

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Serializable/SerializableObject.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Serializable/SerializableObject.cpp
@@ -3,10 +3,28 @@
 #include <worklets/SharedItems/Serializable/SerializableObject.h>
 
 #include <memory>
+#include <string>
+#include <utility>
 
 using namespace facebook;
 
 namespace worklets {
+
+namespace {
+
+void defineOwnDataProperty(jsi::Runtime &rt, const jsi::Object &target, const std::string &key, jsi::Value value) {
+  jsi::Object descriptor(rt);
+  descriptor.setProperty(rt, "configurable", true);
+  descriptor.setProperty(rt, "enumerable", true);
+  descriptor.setProperty(rt, "writable", true);
+  descriptor.setProperty(rt, "value", std::move(value));
+
+  const auto objectCtor = rt.global().getPropertyAsObject(rt, "Object");
+  const auto defineProperty = objectCtor.getPropertyAsFunction(rt, "defineProperty");
+  defineProperty.call(rt, jsi::Value(rt, target), jsi::String::createFromUtf8(rt, key), std::move(descriptor));
+}
+
+} // namespace
 
 SerializableObject::SerializableObject(jsi::Runtime &rt, const jsi::Object &object)
     : Serializable(ValueType::ObjectType) {
@@ -33,7 +51,11 @@ SerializableObject::SerializableObject(jsi::Runtime &rt, const jsi::Object &obje
 jsi::Value SerializableObject::toJSValue(jsi::Runtime &rt) {
   auto obj = jsi::Object(rt);
   for (const auto &i : data_) {
-    obj.setProperty(rt, jsi::String::createFromUtf8(rt, i.first), i.second->toJSValue(rt));
+    if (i.first == "__proto__") {
+      defineOwnDataProperty(rt, obj, i.first, i.second->toJSValue(rt));
+    } else {
+      obj.setProperty(rt, jsi::String::createFromUtf8(rt, i.first), i.second->toJSValue(rt));
+    }
   }
   if (nativeState_ != nullptr) {
     obj.setNativeState(rt, nativeState_);

--- a/packages/react-native-worklets/__tests__/serializable.native.test.ts
+++ b/packages/react-native-worklets/__tests__/serializable.native.test.ts
@@ -134,3 +134,29 @@ describe('createSerializable unsupported-type warning', () => {
     expect(console.warn).not.toHaveBeenCalled();
   });
 });
+
+describe('createSerializable with `__proto__` key', () => {
+  const globalWithDev = globalThis as unknown as { __DEV__?: boolean };
+
+  beforeEach(() => {
+    globalWithDev.__DEV__ = false;
+  });
+
+  afterEach(() => {
+    delete globalWithDev.__DEV__;
+  });
+
+  test('keeps `__proto__` as an own property of the cloned object', () => {
+    const value = JSON.parse('{"a":{"b":{"__proto__":{}}}}');
+
+    const result = createSerializable(value) as unknown as {
+      value: { a: { value: { b: { value: Record<string, unknown> } } } };
+    };
+    const clonedB = result.value.a.value.b.value;
+
+    expect(Object.prototype.hasOwnProperty.call(clonedB, '__proto__')).toBe(
+      true
+    );
+    expect(clonedB.__proto__).toEqual({ __serializableRef: true, value: {} });
+  });
+});

--- a/packages/react-native-worklets/src/memory/serializable.native.ts
+++ b/packages/react-native-worklets/src/memory/serializable.native.ts
@@ -364,7 +364,7 @@ function cloneObjectProperties<T extends object>(
   shouldPersistRemote: boolean,
   depth: number
 ): Record<string, unknown> {
-  const clonedProps: Record<string, unknown> = {};
+  const clonedProps: Record<string, unknown> = Object.create(null);
   for (const [key, element] of Object.entries(value)) {
     // We don't need to clone __initData field as it contains long strings
     // representing the worklet code, source map, and location, and we will
@@ -840,7 +840,10 @@ function makeShareableCloneOnUIRecursiveLEGACY<TValue>(
           '[Worklets] Promises cannot be converted to serializable.'
         );
       }
-      const toAdapt: Record<string, FlatSerializableRef<TValue>> = {};
+      const toAdapt: Record<
+        string,
+        FlatSerializableRef<TValue>
+      > = Object.create(null);
       for (const [key, element] of Object.entries(value)) {
         toAdapt[key] = cloneRecursive(element);
       }


### PR DESCRIPTION
Fixes https://github.com/software-mansion/react-native-reanimated/issues/10436

2 changes:
Now clonedProps are `Object.create(null)` instead of `{}`, so it does not have a `__proto__` setter; as a consequence assigning a plain property named `__proto__` via `clonedProps["__proto__"]` works as expected.

In the deserialization phase, when we are constructing a new object, there is a special case for `__proto__`, where it is set via `Object.defineProperty()` and not `setProperty()` to avoid going through the default `__proto__` setter present on objects.

A test was added to detect regressions in the future