### PR TITLE
cherry-pick(worklets-0.10-stable): Pass -fno-pch-timestamp so ccache can reuse the Android PCH (#9749)

### DIFF
--- a/packages/react-native-worklets/android/CMakeLists.txt
+++ b/packages/react-native-worklets/android/CMakeLists.txt
@@ -60,6 +60,12 @@ add_library(worklets SHARED ${WORKLETS_COMMON_CPP_SOURCES}
 
 target_precompile_headers(worklets PRIVATE "${ANDROID_CPP_DIR}/WorkletsPCH.h")
 
+# Stop Clang from embedding a build timestamp in the .pch. Without this the PCH
+# is non-reproducible across builds, so ccache can't reuse it and translation
+# units reject a restored PCH as "modified since built".
+target_compile_options(
+  worklets PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:-Xclang;-fno-pch-timestamp>")
+
 if(ReactAndroid_VERSION_MINOR GREATER_EQUAL 80)
   include(
     "${REACT_NATIVE_DIR}/ReactCommon/cmake-utils/react-native-flags.cmake")


### PR DESCRIPTION
> [!NOTE]
> This pull request was authored by AI on behalf of janicduplessis.

## Summary

Cherry-picking #9749 to `worklets-0.10-stable`, the worklets hunk only (the reanimated hunk already reached `4.4-stable` and `4.5-stable` through #9841 and #9808, but `worklets-0.10-stable` never received its half, so every published `react-native-worklets` 0.10.x lacks the flag while `react-native-reanimated` 4.5.x, whose peer range is `0.10.x`, has it).

Without `-Xclang -fno-pch-timestamp`, clang embeds header mtimes in `cmake_pch.hxx.pch`. Any compiler cache keyed on the PCH content (ccache with `sloppiness=pch_defines,time_macros`) sees a different PCH after every fresh install or checkout, logs `Precompiled header includes .../WorkletsPCH.h, which has a new mtime`, rebuilds it, and then misses on all 38 worklets translation units. The flag cannot be added from the app side: with AGP and NDK 27 the legacy toolchain file resets `CMAKE_CXX_FLAGS`, so `CXXFLAGS` never reaches the PCH compile.

The change is byte-identical to `main` (`packages/react-native-worklets/android/CMakeLists.txt` lines 63-67 after #9788's formatting). It is inert without a compiler cache, and clang-only by construction since the NDK only ships clang.

## Test plan

Measured with `react-native-worklets` 0.10.1 (this file is byte-identical on `worklets-0.10-stable`, the 0.10.1 tag, and the published package) in an Expo SDK 57 / React Native 0.86.3 app, `./gradlew assembleDebug -PreactNativeArchitectures=arm64-v8a`, NDK 27.1, CMake 3.22.1, ccache 4.12.3 as `CMAKE_CXX_COMPILER_LAUNCHER` with `CCACHE_NOHASHDIR=true` and `CCACHE_SLOPPINESS=pch_defines,time_macros`:

- Before: after a fresh `git worktree add` plus `npm install`, worklets 0 of 38 objects hit; the `.pch` was rebuilt with the "new mtime" message every time.
- After (this hunk applied to the installed package): fresh checkout plus `npm install`, worklets 40 of 40 (38 objects, 2 CMake probes) direct hits including the `cmake_pch.hxx.pch` compile itself; the restored `.pch` is byte-identical (19,135,628 bytes) across installs. Same result reanimated 4.5.1 already gets with its copy of the flag (108 of 108).
- Freshness: appending a line to `WorkletsPCH.h` still rebuilds the PCH and all 38 dependents (ninja log: 40 new entries), so header edits are not masked.

To reproduce: apply this patch to `node_modules/react-native-worklets/android/CMakeLists.txt` in any app on worklets 0.10.x, build twice from two fresh checkouts with the ccache settings above, and compare `ccache -s` between the builds.

## Changelog

- [x] This PR does not change `react-native-reanimated`; `worklets-0.10-stable` has no `packages/react-native-worklets/CHANGELOG.md` (the file and its check were introduced by #10201 after #9749 merged).
