### PR TITLE
fix(metro): use the public MetroConfig type export

### DIFF
--- a/packages/react-native-reanimated/CHANGELOG.md
+++ b/packages/react-native-reanimated/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix the Metro configuration type import to use the public package export. ([#10454](https://github.com/software-mansion/react-native-reanimated/pull/10454) by [@sneakykiwi](https://github.com/sneakykiwi))
 - Skip the Android mounted-tag correction in Layout Animations when React Native's `enableMountingCoordinatorPullModelAndroid` feature flag is on, since the pull model already guarantees that updates can't outrun a view's first mount. ([#10481](https://github.com/software-mansion/react-native-reanimated/pull/10481) by [@piaskowyk](https://github.com/piaskowyk))
 - Fix `Keyframe` easings on web being dropped or applied to the wrong keyframe when the definitions use the `from`/`to` aliases or fractional offsets. ([#10386](https://github.com/software-mansion/react-native-reanimated/pull/10386) by [@dennytosp](https://github.com/dennytosp))
 - Fix `getViewProp` and the runtime-tests prop snapshotting crashing (segfault on style props, unhandled error on layout props) when the view is no longer mounted. ([#10443](https://github.com/software-mansion/react-native-reanimated/pull/10443) by [@tjzel](https://github.com/tjzel))

--- a/packages/react-native-reanimated/metro-config/index.d.ts
+++ b/packages/react-native-reanimated/metro-config/index.d.ts
@@ -1,4 +1,4 @@
-import type { MetroConfig } from '@react-native/metro-config/dist';
+import type { MetroConfig } from '@react-native/metro-config';
 
 export declare function wrapWithReanimatedMetroConfig(
   config: MetroConfig


### PR DESCRIPTION
> [!NOTE]
> This pull request was authored by AI on behalf of @sneakykiwi.

## Summary

Fixes #10453.

Import `MetroConfig` from the public package export instead of `@react-native/metro-config/dist`.

This changes types only. No runtime changes, comments, or test files.

## Test plan

The reproduction in #10453 fails with TS2307 before this change and exits with code 0 after it.

The declaration remains:

```ts
import type { MetroConfig } from '@react-native/metro-config';

export declare function wrapWithReanimatedMetroConfig(
  config: MetroConfig
): MetroConfig;
```

The check uses TypeScript 7.0.2 and `@react-native/metro-config` 0.86.2:

```sh
npx tsc --ignoreConfig --noEmit --moduleResolution bundler --module esnext --target esnext --types node packages/react-native-reanimated/metro-config/index.d.ts
```

The upstream changelog check passes. No native build was run.

## Changelog

- [x] I added an entry to the `Unpublished` section of `react-native-reanimated/CHANGELOG.md`.
