### PR TITLE
fix(animation): expose reduceMotion in withClamp's public type

### DIFF
--- a/docs/docs-reanimated/docs/animations/withClamp.mdx
+++ b/docs/docs-reanimated/docs/animations/withClamp.mdx
@@ -32,6 +32,7 @@ function App() {
     config: {
       min?: T;
       max?: T;
+      reduceMotion?: ReduceMotion;
     },
     clampedAnimation: T
   ): T;
@@ -50,10 +51,11 @@ function App() {
 
 An object with following properties:
 
-| Name             | Type Description |
-| ---------------- | ---------------- | ------------------------------------------------ |
-| min <Optional/> | `number`         | The lowest value your animation can ever reach   |
-| max <Optional/> | `number`         | The greatest value your animation can ever reach |
+| Name                      | Type           | Default               | Description                                                                                                  |
+| ------------------------- | -------------- | --------------------- | ------------------------------------------------------------------------------------------------------------ |
+| min <Optional/>          | `number`       | `undefined`           | The lowest value your animation can ever reach                                                               |
+| max <Optional/>          | `number`       | `undefined`           | The greatest value your animation can ever reach                                                             |
+| reduceMotion <Optional/> | `ReduceMotion` | `ReduceMotion.System` | A parameter that determines how the animation responds to the device's reduced motion accessibility setting. |
 
 #### `animation`
 

--- a/packages/react-native-reanimated/CHANGELOG.md
+++ b/packages/react-native-reanimated/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### 🐛 Bug fixes
 
+- Add the missing `reduceMotion` option to `withClamp`'s public type. The implementation already read it and honoured it at runtime, but the exported signature omitted it, so passing it failed to type-check. (by [@dennytosp](https://github.com/dennytosp))
 - Reset `IN_STYLE_UPDATER` even when an initial style updater throws, so a single updater error no longer leaves all animations returning raw values until reload. ([#10445](https://github.com/software-mansion/react-native-reanimated/pull/10445) by [@alexey-khatskelevich](https://github.com/alexey-khatskelevich))
 - Fix `./gradlew app:build` failing on `:lintAnalyzeDebug` with a K2 UAST crash on `.gradle.kts` build scripts - all lint tasks are now skipped, not only `lintVital*`. ([#10448](https://github.com/software-mansion/react-native-reanimated/pull/10448) by [@tshmieldev](https://github.com/tshmieldev))
 - Treat `animationName: []` as no animation, so the view is detached instead of running its previous animation forever. ([#10432](https://github.com/software-mansion/react-native-reanimated/pull/10432) by [@MatiPl01](https://github.com/MatiPl01))

--- a/packages/react-native-reanimated/__typetests__/withClampTest.tst.ts
+++ b/packages/react-native-reanimated/__typetests__/withClampTest.tst.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from 'tstyche';
+
+import { ReduceMotion, useAnimatedStyle, withClamp, withSpring } from '..';
+
+describe('withClamp', () => {
+  test('requires both a config and an animation to clamp', () => {
+    expect(withClamp).type.not.toBeCallableWith();
+    expect(withClamp).type.not.toBeCallableWith({ min: 0, max: 100 });
+    expect(withClamp).type.toBeCallableWith(
+      { min: 0, max: 100 },
+      withSpring(50)
+    );
+  });
+
+  test('min and max are both optional', () => {
+    expect(withClamp).type.toBeCallableWith({}, withSpring(50));
+    expect(withClamp).type.toBeCallableWith({ min: 0 }, withSpring(50));
+    expect(withClamp).type.toBeCallableWith({ max: 100 }, withSpring(50));
+  });
+
+  test('accepts reduceMotion, like every other animation modifier', () => {
+    expect(withClamp).type.toBeCallableWith(
+      { min: 0, max: 100, reduceMotion: ReduceMotion.Never },
+      withSpring(50)
+    );
+    expect(withClamp).type.toBeCallableWith(
+      { min: 0, max: 100, reduceMotion: ReduceMotion.Always },
+      withSpring(50)
+    );
+    expect(withClamp).type.toBeCallableWith(
+      { min: 0, max: 100, reduceMotion: ReduceMotion.System },
+      withSpring(50)
+    );
+    expect(withClamp).type.toBeCallableWith(
+      { reduceMotion: ReduceMotion.Never },
+      withSpring(50)
+    );
+  });
+
+  test('rejects a reduceMotion that is not a ReduceMotion member', () => {
+    expect(withClamp).type.not.toBeCallableWith(
+      { min: 0, max: 100, reduceMotion: 'never' },
+      withSpring(50)
+    );
+    expect(withClamp).type.not.toBeCallableWith(
+      { min: 0, max: 100, reduceMotion: true },
+      withSpring(50)
+    );
+  });
+
+  test('rejects unknown config properties', () => {
+    expect(withClamp).type.not.toBeCallableWith(
+      { min: 0, max: 100, duration: 500 },
+      withSpring(50)
+    );
+  });
+
+  test('clamps a string animation', () => {
+    expect(withClamp).type.toBeCallableWith(
+      { min: '0deg', max: '90deg', reduceMotion: ReduceMotion.Never },
+      withSpring('45deg')
+    );
+  });
+
+  test('min and max must match the clamped animation', () => {
+    expect(withClamp).type.not.toBeCallableWith(
+      { min: '0deg', max: '90deg' },
+      withSpring(50)
+    );
+  });
+
+  test('clamps width inside useAnimatedStyle', () => {
+    expect(useAnimatedStyle).type.toBeCallableWith(() => ({
+      width: withClamp(
+        { min: 0, max: 100, reduceMotion: ReduceMotion.Never },
+        withSpring(50)
+      ),
+    }));
+  });
+});

--- a/packages/react-native-reanimated/src/animation/clamp.ts
+++ b/packages/react-native-reanimated/src/animation/clamp.ts
@@ -18,6 +18,7 @@ type withClampType = <T extends number | string>(
   config: {
     min?: T;
     max?: T;
+    reduceMotion?: ReduceMotion;
   },
   clampedAnimation: T
 ) => T;


### PR DESCRIPTION
## Description

`withClamp` accepts and honours `reduceMotion` at runtime — `clamp.ts:26` takes it in the config and `clamp.ts:132` passes it through `getReduceMotionForAnimation(config.reduceMotion)` — but the implementation is cast `as withClampType`, and that type declares only `{ min?, max? }`. So the option works and TypeScript rejects it:

```tsx
withClamp({ min: 0, max: 100, reduceMotion: ReduceMotion.Never }, withSpring(50))
//                            ~~~~~~~~~~~~ Object literal may only specify known properties
```

Every other animation modifier — `withSpring`, `withTiming`, `withDecay`, `withDelay`, `withSequence`, `withRepeat` — exposes it, so `withClamp` is the odd one out.

Adding it to `withClampType` is the whole fix. The docs table is updated to match, and while there it also gets the `Default` column the other animation pages have; the existing table's header row was malformed (two header cells, three separator cells), which is why it rendered without one.



## Test plan

Added `__typetests__/withClampTest.tst.ts`, covering that the config is required, that `min`/`max` stay optional, that all three `ReduceMotion` members are accepted, and that a bare string or boolean is still rejected.

```
yarn type:check:tests
  pass ./__typetests__/withClampTest.tst.ts
  Test files: 14 passed, 14 total
  Tests:      62 passed, 62 total
  Assertions: 96 passed, 96 total

yarn tsc --noEmit     clean
```

Red check — removing `reduceMotion?: ReduceMotion;` again fails exactly the new assertions:

```
fail ./__typetests__/withClampTest.tst.ts
  at ./__typetests__/withClampTest.tst.ts:23:27 ❭ withClamp ❭ accepts reduceMotion, like every other animation modifier
  at ./__typetests__/withClampTest.tst.ts:27:27 ❭ withClamp ❭ accepts reduceMotion, like every other animation modifier
```