### PR TITLE
fix: look up style keywords as own properties

### DIFF
--- a/packages/react-native-reanimated/CHANGELOG.md
+++ b/packages/react-native-reanimated/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix `transformOrigin` and `fontWeight` resolving `Object.prototype` members such as `'constructor'` and `'toString'` as keywords and returning a function instead of throwing. ([#10454](https://github.com/software-mansion/react-native-reanimated/pull/10454) by [@dennytosp](https://github.com/dennytosp))
 - Reset `IN_STYLE_UPDATER` even when an initial style updater throws, so a single updater error no longer leaves all animations returning raw values until reload. ([#10445](https://github.com/software-mansion/react-native-reanimated/pull/10445) by [@alexey-khatskelevich](https://github.com/alexey-khatskelevich))
 - Fix `./gradlew app:build` failing on `:lintAnalyzeDebug` with a K2 UAST crash on `.gradle.kts` build scripts - all lint tasks are now skipped, not only `lintVital*`. ([#10448](https://github.com/software-mansion/react-native-reanimated/pull/10448) by [@tshmieldev](https://github.com/tshmieldev))
 - Treat `animationName: []` as no animation, so the view is detached instead of running its previous animation forever. ([#10432](https://github.com/software-mansion/react-native-reanimated/pull/10432) by [@MatiPl01](https://github.com/MatiPl01))

--- a/packages/react-native-reanimated/src/common/style/processors/__tests__/font.test.ts
+++ b/packages/react-native-reanimated/src/common/style/processors/__tests__/font.test.ts
@@ -14,13 +14,20 @@ describe(processFontWeight, () => {
   });
 
   describe('throws an error for invalid font weight values', () => {
-    test.each(['unknown-weight', '1000', '0', 505])(
-      'throws an error for %p',
-      (value) => {
-        expect(() => processFontWeight(value)).toThrow(
-          new Error(`[Reanimated] ${ERROR_MESSAGES.invalidFontWeight(value)}`)
-        );
-      }
-    );
+    test.each([
+      'unknown-weight',
+      '1000',
+      '0',
+      505,
+      // Object.prototype members must not resolve as font weight keywords
+      'constructor',
+      'toString',
+      '__proto__',
+      'hasOwnProperty',
+    ])('throws an error for %p', (value) => {
+      expect(() => processFontWeight(value)).toThrow(
+        new Error(`[Reanimated] ${ERROR_MESSAGES.invalidFontWeight(value)}`)
+      );
+    });
   });
 });

--- a/packages/react-native-reanimated/src/common/style/processors/__tests__/transformOrigin.test.ts
+++ b/packages/react-native-reanimated/src/common/style/processors/__tests__/transformOrigin.test.ts
@@ -301,6 +301,79 @@ describe(processTransformOrigin, () => {
         ],
       },
       {
+        name: 'Object.prototype members',
+        cases: [
+          {
+            name: 'invalid',
+            cases: [
+              {
+                input: 'constructor',
+                message: ERROR_MESSAGES.invalidValue(
+                  'constructor',
+                  'x',
+                  'constructor',
+                  false
+                ),
+              },
+              {
+                input: 'toString',
+                message: ERROR_MESSAGES.invalidValue(
+                  'toString',
+                  'x',
+                  'toString',
+                  false
+                ),
+              },
+              {
+                input: '__proto__',
+                message: ERROR_MESSAGES.invalidValue(
+                  '__proto__',
+                  'x',
+                  '__proto__',
+                  false
+                ),
+              },
+              {
+                input: 'hasOwnProperty',
+                message: ERROR_MESSAGES.invalidValue(
+                  'hasOwnProperty',
+                  'x',
+                  'hasOwnProperty',
+                  false
+                ),
+              },
+              {
+                input: 'left toString', // keyword conversion lookup on the y-axis
+                message: ERROR_MESSAGES.invalidValue(
+                  'toString',
+                  'y',
+                  'left toString',
+                  false
+                ),
+              },
+              {
+                input: 'top constructor', // x and y are not swapped
+                message: ERROR_MESSAGES.invalidValue(
+                  'top',
+                  'x',
+                  'top constructor',
+                  false
+                ),
+              },
+              {
+                input: ['constructor'],
+                message: ERROR_MESSAGES.invalidValue(
+                  'constructor',
+                  'x',
+                  ['constructor'],
+                  true
+                ),
+              },
+            ],
+          },
+        ],
+      },
+      {
         name: 'array syntax',
         cases: [
           {

--- a/packages/react-native-reanimated/src/common/style/processors/font.ts
+++ b/packages/react-native-reanimated/src/common/style/processors/font.ts
@@ -21,7 +21,9 @@ export const processFontWeight: ValueProcessor<string | number, string> = (
     return stringValue;
   }
 
-  if (stringValue in FONT_WEIGHT_MAPPINGS) {
+  // `in` walks the prototype chain, so plain `Object` members such as
+  // 'constructor' or 'toString' would resolve to a font weight here.
+  if (Object.prototype.hasOwnProperty.call(FONT_WEIGHT_MAPPINGS, stringValue)) {
     return FONT_WEIGHT_MAPPINGS[
       stringValue as keyof typeof FONT_WEIGHT_MAPPINGS
     ];

--- a/packages/react-native-reanimated/src/common/style/processors/transformOrigin.ts
+++ b/packages/react-native-reanimated/src/common/style/processors/transformOrigin.ts
@@ -73,9 +73,15 @@ export const ERROR_MESSAGES = {
 
 function maybeSwapComponents(components: ReadonlyArray<string | number>) {
   'worklet';
+  // `in` walks the prototype chain, so plain `Object` members such as
+  // 'constructor' or 'toString' would resolve to a keyword here.
   if (
-    components[0] in VERTICAL_CONVERSIONS &&
-    (components[1] === undefined || components[1] in HORIZONTAL_CONVERSIONS)
+    Object.prototype.hasOwnProperty.call(VERTICAL_CONVERSIONS, components[0]) &&
+    (components[1] === undefined ||
+      Object.prototype.hasOwnProperty.call(
+        HORIZONTAL_CONVERSIONS,
+        components[1]
+      ))
   ) {
     const copy = [...components];
     [copy[0], copy[1]] = [copy[1], copy[0]];
@@ -112,7 +118,10 @@ function parseValue(
   if (typeof value === 'number') {
     return value;
   }
-  if (keywordConversions && value in keywordConversions) {
+  if (
+    keywordConversions &&
+    Object.prototype.hasOwnProperty.call(keywordConversions, value)
+  ) {
     return keywordConversions[value];
   }
   if (allowPercentages && value.endsWith('%')) {

--- a/packages/react-native-reanimated/src/common/web/style/processors/__tests__/font.test.ts
+++ b/packages/react-native-reanimated/src/common/web/style/processors/__tests__/font.test.ts
@@ -13,6 +13,13 @@ describe(processFontWeight, () => {
   test('returns undefined for unsupported values', () => {
     expect(processFontWeight('unknown')).toBeUndefined();
   });
+
+  test.each(['constructor', 'toString', '__proto__', 'hasOwnProperty'])(
+    'returns undefined for the Object.prototype member %p',
+    (value) => {
+      expect(processFontWeight(value)).toBeUndefined();
+    }
+  );
 });
 
 describe(processFontVariant, () => {

--- a/packages/react-native-reanimated/src/common/web/style/processors/font.ts
+++ b/packages/react-native-reanimated/src/common/web/style/processors/font.ts
@@ -9,7 +9,9 @@ export const processFontWeight: ValueProcessor<number | string> = (value) => {
     return String(value);
   }
 
-  if (value in FONT_WEIGHT_MAPPINGS) {
+  // `in` walks the prototype chain, so plain `Object` members such as
+  // 'constructor' or 'toString' would resolve to a font weight here.
+  if (Object.prototype.hasOwnProperty.call(FONT_WEIGHT_MAPPINGS, value)) {
     return FONT_WEIGHT_MAPPINGS[value as keyof typeof FONT_WEIGHT_MAPPINGS];
   }
 };


### PR DESCRIPTION
## Description

Same defect as #10387, in three more lookups: `value in MAP` walks the prototype chain, so `Object.prototype` members resolve as if they were valid style keywords.

- `processTransformOrigin('constructor')` returns `['50%', Object, 0]` instead of throwing — `Object` itself ends up in the transform origin.
- `processFontWeight('toString')` returns the function.
- The web `processFontWeight` has the same lookup.

This is reachable from ordinary user code: React Native types `transformOrigin` as `string | (string | number)[]`, so `transformOrigin: 'constructor'` typechecks.

`maybeSwapComponents` had it twice more, where a prototype member on either axis made the parser swap the components before parsing them.

Switched all of them to `Object.prototype.hasOwnProperty.call(...)`, matching what #10387 did for named colors.



## Test plan

Added cases for `constructor`, `toString`, `__proto__` and `hasOwnProperty` to the existing invalid-value tables in `transformOrigin.test.ts` and `font.test.ts`, plus the web `font.test.ts`, including the two-component forms (`'left toString'`, `'top constructor'`) that exercise the swap path.

```
yarn jest src/common/style/processors/__tests__ src/common/web/style/processors/__tests__
  Test Suites: 17 passed, 17 total
  Tests:       309 passed, 309 total
```

Red check — restoring the `in` lookups fails exactly the new cases and nothing else:

```
● fontTs2 › throws an error for invalid font weight values › throws an error for "constructor"
● fontTs2 › throws an error for invalid font weight values › throws an error for "toString"
● fontTs2 › throws an error for invalid font weight values › throws an error for "__proto__"
● transformOriginTs7 › invalid cases › Object.prototype members › ... for input "constructor"
● transformOriginTs7 › invalid cases › Object.prototype members › ... for input "left toString"
● transformOriginTs7 › invalid cases › Object.prototype members › ... for input "top constructor"
● processFontWeight › returns undefined for the Object.prototype member "constructor"
```