### PR TITLE
fix: newer LLVM failing lint on CI

### DIFF
--- a/.github/workflows/example-ios-build-check.yml
+++ b/.github/workflows/example-ios-build-check.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Install LLVM tools (xcode-build-server + llvm clang-tidy)
         if: steps.result-cache.outputs.cache-hit != 'true'
-        run: brew install xcode-build-server llvm
+        run: brew install xcode-build-server llvm@22
 
       - name: Use Node.js
         if: steps.result-cache.outputs.cache-hit != 'true'

--- a/apps/fabric-example/ios/Podfile.lock
+++ b/apps/fabric-example/ios/Podfile.lock
@@ -2441,7 +2441,7 @@ SPEC CHECKSUMS:
   RNCClipboard: f2c861be2669e65f3efa4618c22c95ba1b6dadda
   RNCMaskedView: d4884d6b3b256bd1830a211db3d5f551def82e36
   RNGestureHandler: c8fffb73e8ae9a97a217ab38e0d6f5f9ded7ffc8
-  RNReanimated: 963b366a5daa827aa7c78d6340afe470b2d6db8d
+  RNReanimated: f619e3dfb0b2365b6f37d12f5ff2b1273dbd12c1
   RNScreens: a2103f13fa603c405092daf70ca4eb3a6291fd6d
   RNSVG: 6c9bcbf53822153be6f6c1484f6b0b57c0040d21
   RNWorklets: da0d13711190e9ecee4d78b1f16790502ccb5ba3

--- a/scripts/llvm-tools/clang-tidy-lint.sh
+++ b/scripts/llvm-tools/clang-tidy-lint.sh
@@ -108,12 +108,26 @@ clang_tidy_binary="${clang_tidy_binary:-clang-tidy}"
 run_clang_tidy="${run_clang_tidy:-run-clang-tidy}"
 
 # `command -v` only checks $PATH. Apple Silicon shells often don't include
-# `/usr/local/bin`, and Homebrew's `llvm` formula isn't auto-symlinked. Search
-# common install locations explicitly so the script works without the user
-# having to fiddle with their shell rc.
+# `/usr/local/bin`, and Homebrew's `llvm` formulae are keg-only, so none of
+# them is auto-symlinked into `<prefix>/bin`. Search common install locations
+# explicitly so the script works without the user having to fiddle with their
+# shell rc. Versioned formulae (`llvm@22`, `llvm@21`, ...) live next to the
+# unversioned one under `<prefix>/opt`; they are appended newest major first,
+# after the unversioned `llvm` and within their own Homebrew prefix.
 LLVM_FALLBACKS=(
   "/opt/homebrew/opt/llvm/bin"
   "/usr/local/opt/llvm/bin"
+)
+for llvm_prefix in /opt/homebrew/opt /usr/local/opt; do
+  while IFS= read -r llvm_dir; do
+    LLVM_FALLBACKS+=("$llvm_dir")
+  done < <(
+    for llvm_candidate in "$llvm_prefix"/llvm@*/bin; do
+      if [ -d "$llvm_candidate" ]; then printf '%s\n' "$llvm_candidate"; fi
+    done | sort -t@ -k2,2nr
+  )
+done
+LLVM_FALLBACKS+=(
   "/opt/homebrew/bin"
   "/usr/local/bin"
 )

--- a/scripts/llvm-tools/generate-xcode-metadata.sh
+++ b/scripts/llvm-tools/generate-xcode-metadata.sh
@@ -58,11 +58,14 @@ fi
 echo "info: workspace is $workspace_path" >&2
 
 # Resolve the per-workspace DerivedData folder by checking every plausible
-# DerivedData base for a `${project}-<hash>` folder whose info.plist's
-# WorkspacePath matches the workspace we're building. This is necessary
-# because Xcode disambiguates concurrent workspaces (e.g. git worktrees with
-# the same project name) only by the hash suffix; a naive `${project}-*`
-# glob would also match the other worktrees' folders.
+# DerivedData base for a `${project}` or `${project}-<hash>` folder whose
+# info.plist's WorkspacePath matches the workspace we're building. The match
+# on WorkspacePath is necessary because in the default DerivedData layout
+# Xcode disambiguates concurrent workspaces (e.g. git worktrees with the same
+# project name) only by the hash suffix; a naive `${project}-*` glob would
+# also match the other worktrees' folders. The unsuffixed name is used when
+# Xcode's Derived Data location is relative to the workspace, where the
+# containing path is already unique and no hash is appended.
 #
 # Searched bases, in order:
 #   1. Custom DerivedData location set in Xcode → Preferences → Locations.
@@ -77,7 +80,7 @@ dd_bases=()
 
 dd_proj=""
 for base in "${dd_bases[@]:+${dd_bases[@]}}"; do
-  for candidate in "$base"/"${project}"-*; do
+  for candidate in "$base"/"${project}" "$base"/"${project}"-*; do
     [ -d "$candidate" ] || continue
     plist="$candidate/info.plist"
     [ -f "$plist" ] || continue


### PR DESCRIPTION
## Summary

I fixed CI error during clang-tidy lint step. https://github.com/software-mansion/react-native-reanimated/actions/runs/33768911099

llvm@23 is now installed by default with `brew install llvm` and newer clang-tidy has new rules that break in our repo. I pinned version 22 for the time being.

## Test plan

CI

## Changelog

- [x] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.
