### PR TITLE
fix(Worklets): stop AnimationFrameQueue dispatch on reentrant invalidate

### DIFF
--- a/packages/react-native-worklets/CHANGELOG.md
+++ b/packages/react-native-worklets/CHANGELOG.md
@@ -25,6 +25,7 @@
 ### 🐛 Bug fixes
 
 - Fix a crash on Android when the React instance is recreated while animations are running - `AnimationFrameQueue` kept delivering frames after `WorkletsModule` was invalidated. ([#10278](https://github.com/software-mansion/react-native-reanimated/pull/10278) by [@shubhamdeol](https://github.com/shubhamdeol))
+- Stop `AnimationFrameQueue` from dispatching the rest of a frame batch when `WorkletsModule` is invalidated from inside a frame callback. ([#10464](https://github.com/software-mansion/react-native-reanimated/pull/10464) by [@tjzel](https://github.com/tjzel))
 - Fix a data race between `getDirty` and `setBlocking` on a Synchronizable - the pointer holding the value is now read and written atomically. ([#10292](https://github.com/software-mansion/react-native-reanimated/pull/10292) by [@tjzel](https://github.com/tjzel))
 - Fix `setBlocking` leaving a Synchronizable locked forever in development builds when the updater function or the serializer throws. ([#10331](https://github.com/software-mansion/react-native-reanimated/pull/10331) by [@tjzel](https://github.com/tjzel))
 - Compare the Synchronizable's imperative lock owner with `std::thread::id` instead of comparing `pthread_t` with `==`, which POSIX doesn't define. ([#10349](https://github.com/software-mansion/react-native-reanimated/pull/10349) by [@tjzel](https://github.com/tjzel))

--- a/packages/react-native-worklets/android/src/main/java/com/swmansion/worklets/runloop/AnimationFrameQueue.kt
+++ b/packages/react-native-worklets/android/src/main/java/com/swmansion/worklets/runloop/AnimationFrameQueue.kt
@@ -119,6 +119,9 @@ class AnimationFrameQueue(
 
             lastFrameTimeMs = currentFrameTimeMs
             for (callback in frameCallbacks) {
+                if (mInvalidated.get()) {
+                    break
+                }
                 callback.onAnimationFrame(currentFrameTimeMs)
             }
         }


### PR DESCRIPTION
## Summary

Follow-up hardening for #10278, raised by a review comment on #10461.

It's still not a fool-proof implementation as the currently executed animation frame callback might call an invalidated native binding - but it doesn't hurt to add this safety measure.

## Test plan

CI passes.

## Changelog

- [x] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.
