### PR TITLE
fix(metro-config): import MetroConfig from public export path

### DIFF
--- a/packages/react-native-reanimated/metro-config/index.d.ts
+++ b/packages/react-native-reanimated/metro-config/index.d.ts
@@ -1,4 +1,4 @@
-import type { MetroConfig } from '@react-native/metro-config/dist';
+import type { MetroConfig } from '@react-native/metro-config';
 
 export declare function wrapWithReanimatedMetroConfig(
   config: MetroConfig


### PR DESCRIPTION
## Summary

The declaration file `packages/react-native-reanimated/metro-config/index.d.ts` imported `MetroConfig` from `@react-native/metro-config/dist`.

In modern versions of `@react-native/metro-config` (such as `0.86.2`), `/dist` is an internal path and is not exported in `package.json`. When TypeScript compiles with bundler/nodenext resolution (`--moduleResolution bundler`), it reports:
`error TS2307: Cannot find module '@react-native/metro-config/dist' or its corresponding type declarations.`

This PR fixes the import path to consume `MetroConfig` directly from the public export `@react-native/metro-config`.

## Test plan

1. In TypeScript with `--moduleResolution bundler`:
```ts
import { wrapWithReanimatedMetroConfig } from 'react-native-reanimated/metro-config';
```
2. Verify TypeScript compiles without `TS2307` declaration error.

## Changelog

- [x] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.