### PR TITLE
fix: publish reanimated jest resolver

### DIFF
--- a/packages/react-native-reanimated/package.json
+++ b/packages/react-native-reanimated/package.json
@@ -68,6 +68,7 @@
     "scripts/validate-react-native-version.js",
     "compatibility.json",
     "mock.js",
+    "jest/resolver.js",
     "plugin/index.js",
     "plugin/index.d.ts",
     "metro-config",


### PR DESCRIPTION
## Summary

Include `jest/resolver.js` in the published `react-native-reanimated` package and document its configuration.

Reanimated already uses this resolver for its own tests, but the file is missing from the package's `files` list. Without it, Jest resolves native implementations that do not support the testing environment. Rendering an animated style can then fail with `Cannot set properties of undefined (setting 'current')`.

The resolver implementation remains unchanged.

## Test plan

Verify that `jest/resolver.js` appears in the package contents:

```sh
npm pack --dry-run --ignore-scripts
```

In a React Native app configured for Reanimated Jest testing, add:

```js
// jest.config.js
resolver: 'react-native-reanimated/jest/resolver',
```

Keep the documented Worklets setup and `setUpTests()` initialization. Add this test:

```tsx
import { fireEvent, render } from '@testing-library/react-native';
import React from 'react';
import { Button } from 'react-native';
import Animated, {
  useAnimatedStyle,
  useSharedValue,
  withTiming,
} from 'react-native-reanimated';

function Example() {
  const width = useSharedValue(0);
  const style = useAnimatedStyle(() => ({
    width: withTiming(width.value, { duration: 500 }),
  }));

  return (
    <>
      <Animated.View testID="view" style={style} />
      <Button
        title="Animate"
        onPress={() => {
          width.value = 100;
        }}
      />
    </>
  );
}

test('updates animated styles in Jest', () => {
  jest.useFakeTimers();

  try {
    const { getByTestId, getByText } = render(<Example />);
    const view = getByTestId('view');

    expect(view).toHaveAnimatedStyle({ width: 0 });

    fireEvent.press(getByText('Animate'));
    jest.advanceTimersByTime(600);

    expect(view).toHaveAnimatedStyle({ width: 100 });
  } finally {
    jest.useRealTimers();
  }
});
```

Run `yarn test reanimated-jest.test.tsx --runInBand`. The component should mount successfully and its animated width should reach `100`.

## Changelog

- [ ] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.