### PR TITLE
ci: collect crash diagnostics when runtime tests die mid-run

### DIFF
--- a/.github/workflows/runtime-tests-android.yml
+++ b/.github/workflows/runtime-tests-android.yml
@@ -158,3 +158,12 @@ jobs:
           disable-animations: false
           working-directory: apps/fabric-example
           script: node scripts/runtime-tests-server.js --launch --platform android --configuration "$CONFIGURATION" --library reanimated --skip-build --connect-timeout 900 --idle-timeout 900 || node scripts/runtime-tests-server.js --launch --platform android --configuration "$CONFIGURATION" --library reanimated --skip-build --connect-timeout 900 --idle-timeout 900
+
+      - name: Upload crash reports
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: android-crash-reports-${{ inputs.configuration || 'DebugRuntimeTests' }}-${{ matrix.bundleMode && 'bundle-mode' || 'legacy-eval' }}
+          path: apps/fabric-example/crash-reports
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/runtime-tests-ios.yml
+++ b/.github/workflows/runtime-tests-ios.yml
@@ -154,6 +154,15 @@ jobs:
           || node scripts/runtime-tests-server.js --launch --library reanimated
           --configuration "$CONFIGURATION" --skip-build --connect-timeout 900 --idle-timeout 900 $SANITIZER_FLAG
 
+      - name: Upload crash reports
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: ios-crash-reports-${{ inputs.configuration || 'DebugRuntimeTests' }}-${{ matrix.bundleMode && 'bundle-mode' || 'legacy-eval' }}${{ inputs.sanitizer && format('-{0}', inputs.sanitizer) || '' }}
+          path: apps/fabric-example/crash-reports
+          if-no-files-found: ignore
+          retention-days: 14
+
       # With halt_on_error=0 a detected race does not fail the tests that
       # triggered it, so the collected reports have to fail the job here.
       - name: Fail on sanitizer reports

--- a/apps/fabric-example/.gitignore
+++ b/apps/fabric-example/.gitignore
@@ -69,5 +69,8 @@ yarn-error.log
 # Sanitizer reports from scripts/runtime-tests-server.js --sanitizer
 sanitizer-reports/
 
+# Crash diagnostics from scripts/runtime-tests-server.js
+crash-reports/
+
 # Packaged app artifacts from scripts/export-runtime-tests-app.js
 dist/

--- a/apps/fabric-example/scripts/runtime-tests-server.js
+++ b/apps/fabric-example/scripts/runtime-tests-server.js
@@ -18,6 +18,7 @@ const projectRoot = path.resolve(__dirname, '..');
 const iosDir = path.join(projectRoot, 'ios');
 const androidDir = path.join(projectRoot, 'android');
 const SANITIZER_REPORT_DIR = path.join(projectRoot, 'sanitizer-reports');
+const CRASH_REPORT_DIR = path.join(projectRoot, 'crash-reports');
 // -enable*Sanitizer alone does not reach the Pods project on CI (the built
 // products carried no -fsanitize flags), so each build setting is also forced
 // as a command-line override, which applies to every target.
@@ -143,6 +144,9 @@ let connectTimer = null;
 let idleTimer = null;
 /** @type {import('child_process').ChildProcess | null} */
 let metroChild = null;
+/** @type {string | null} */
+let androidSerial = null;
+let crashDiagnosticsDone = false;
 
 /**
  * @param {unknown} error
@@ -180,7 +184,7 @@ function armConnectTimer() {
     console.error(
       `[runtime-tests] no device connected within ${CONNECT_TIMEOUT_MS / 1000}s, exiting`
     );
-    shutdown(1);
+    failWithDiagnostics(1);
   }, CONNECT_TIMEOUT_MS);
 }
 
@@ -226,7 +230,7 @@ wss.on('connection', (socket) => {
       );
       if (PLATFORM === 'android') {
         console.error(
-          '[runtime-tests] Check `adb logcat` for crashes (grep AndroidRuntime or ReactNative)'
+          '[runtime-tests] The app most likely crashed — collecting crash diagnostics below.'
         );
       } else {
         console.error(
@@ -237,9 +241,10 @@ wss.on('connection', (socket) => {
         '[runtime-tests] or grep `[remoteReporter]` in Metro output for the WS close reason.'
       );
       console.error('========================================');
-    } else {
-      console.log('[runtime-tests] device disconnected');
+      failWithDiagnostics(exitCode);
+      return;
     }
+    console.log('[runtime-tests] device disconnected');
     shutdown(exitCode);
   });
 
@@ -380,7 +385,7 @@ function resetIdleTimer() {
     console.error(
       `[runtime-tests] no traffic for ${IDLE_TIMEOUT_MS / 1000}s, assuming the run is stuck`
     );
-    shutdown(1);
+    failWithDiagnostics(1);
   }, IDLE_TIMEOUT_MS);
 }
 
@@ -414,6 +419,315 @@ function printSanitizerReports() {
   // step that fails on them, so only point at them here.
   console.error(
     `[runtime-tests] ${files.length} sanitizer report file(s) in ${SANITIZER_REPORT_DIR}: ${files.join(', ')}`
+  );
+}
+
+/** @param {number} code */
+function failWithDiagnostics(code) {
+  clearTimer('connect');
+  clearTimer('idle');
+  dumpAndroidCrashDiagnostics()
+    .catch((error) => {
+      console.error(
+        `[runtime-tests] crash diagnostics failed: ${errorMessage(error)}`
+      );
+    })
+    .finally(() => shutdown(code));
+}
+
+async function dumpAndroidCrashDiagnostics() {
+  if (PLATFORM !== 'android' || BUILD_ONLY || crashDiagnosticsDone) {
+    return;
+  }
+  crashDiagnosticsDone = true;
+  const serial =
+    androidSerial ?? (await listAndroidDevices().catch(() => []))[0];
+  if (!serial) {
+    console.error(
+      '[runtime-tests] no adb device available for crash diagnostics'
+    );
+    return;
+  }
+  console.error(`[runtime-tests] collecting crash diagnostics from ${serial}…`);
+  fs.mkdirSync(CRASH_REPORT_DIR, { recursive: true });
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+
+  let crashLog = '';
+  let hasCrashLog = false;
+  for (let attempt = 0; attempt < 10; attempt++) {
+    await sleep(3000);
+    crashLog = await readCrashBuffer(serial);
+    hasCrashLog = crashBufferHasContent(crashLog);
+    if (hasCrashLog) {
+      await sleep(3000);
+      crashLog = await readCrashBuffer(serial);
+      break;
+    }
+  }
+  if (hasCrashLog) {
+    const file = path.join(CRASH_REPORT_DIR, `logcat-crash-${stamp}.txt`);
+    fs.writeFileSync(file, crashLog);
+    console.error(`[runtime-tests] logcat crash buffer (saved to ${file}):`);
+    console.error(tailLines(crashLog, 400));
+  } else {
+    console.error(
+      '[runtime-tests] logcat crash buffer is empty (no Java or native crash was recorded)'
+    );
+  }
+  await adbDiag(serial, ['logcat', '-b', 'crash', '-c']).catch(() => {});
+
+  const tombstone = await pullLatestTombstone(serial, stamp);
+  if (tombstone) {
+    console.error(
+      `[runtime-tests] tombstone ${tombstone.name} (saved to ${tombstone.file}):`
+    );
+    console.error(headLines(tombstone.text, 200));
+  }
+
+  const nativeReport = tombstone?.text ?? (hasCrashLog ? crashLog : null);
+  if (nativeReport) {
+    await symbolizeNativeCrash(serial, nativeReport, stamp);
+  }
+}
+
+/**
+ * @param {string} serial
+ * @returns {Promise<string>}
+ */
+async function readCrashBuffer(serial) {
+  return adbDiag(serial, ['logcat', '-b', 'crash', '-d']).then(
+    ({ stdout }) => stdout,
+    (error) => {
+      console.error(
+        `[runtime-tests] failed to read logcat crash buffer: ${errorMessage(error)}`
+      );
+      return '';
+    }
+  );
+}
+
+/**
+ * @param {string} crashLog
+ * @returns {boolean}
+ */
+function crashBufferHasContent(crashLog) {
+  return crashLog
+    .split('\n')
+    .some((line) => line.trim() && !line.startsWith('---------'));
+}
+
+/**
+ * @param {string} serial
+ * @param {string} stamp
+ * @returns {Promise<{ name: string; text: string; file: string } | null>}
+ */
+async function pullLatestTombstone(serial, stamp) {
+  const rootOutput = await adbDiag(serial, ['root']).then(
+    ({ stdout, stderr }) => stdout + stderr,
+    (error) => `${errorMessage(error)}`
+  );
+  if (/cannot run as root|error/i.test(rootOutput)) {
+    console.error(
+      `[runtime-tests] adb root unavailable, skipping tombstones: ${rootOutput.trim()}`
+    );
+    return null;
+  }
+  await adbDiag(serial, ['wait-for-device']).catch(() => {});
+  const pullDir = path.join(CRASH_REPORT_DIR, `tombstones-${stamp}`);
+  const pulled = await adbDiag(serial, [
+    'pull',
+    '-a',
+    '/data/tombstones',
+    pullDir,
+  ]).then(
+    () => true,
+    () => false
+  );
+  if (!pulled) {
+    console.error('[runtime-tests] no tombstones directory on the device');
+    return null;
+  }
+  const nestedDir = path.join(pullDir, 'tombstones');
+  const tombstonesDir = fs.existsSync(nestedDir) ? nestedDir : pullDir;
+  /** @type {{ name: string; mtimeMs: number }[]} */
+  let entries = [];
+  try {
+    entries = fs
+      .readdirSync(tombstonesDir)
+      .filter((name) => !name.endsWith('.pb'))
+      .map((name) => ({
+        name,
+        mtimeMs: fs.statSync(path.join(tombstonesDir, name)).mtimeMs,
+      }))
+      .sort((a, b) => b.mtimeMs - a.mtimeMs);
+  } catch {
+    entries = [];
+  }
+  if (entries.length === 0) {
+    console.error('[runtime-tests] no tombstones on the device');
+    return null;
+  }
+  const newest = entries[0];
+  if (runStartedAt > 0 && newest.mtimeMs < runStartedAt - 60_000) {
+    console.error(
+      `[runtime-tests] newest tombstone (${newest.name}) predates this run — the app died without a native crash dump`
+    );
+    return null;
+  }
+  const file = path.join(tombstonesDir, newest.name);
+  const text = fs.readFileSync(file, 'utf8');
+  await adbDiag(serial, ['shell', 'rm', '-f', '/data/tombstones/*']).catch(
+    () => {}
+  );
+  return { name: newest.name, text, file };
+}
+
+/**
+ * @param {string} serial
+ * @param {string} reportText
+ * @param {string} stamp
+ */
+async function symbolizeNativeCrash(serial, reportText, stamp) {
+  if (!reportText.includes('*** ***')) {
+    return;
+  }
+  const ndkStack = findNdkStack();
+  if (!ndkStack) {
+    console.error(
+      '[runtime-tests] ndk-stack not found (looked in ANDROID_NDK_HOME and $ANDROID_HOME/ndk), skipping symbolication'
+    );
+    return;
+  }
+  let symDir = findAndroidSymbolsDir();
+  if (!symDir) {
+    console.error(
+      '[runtime-tests] no unstripped libs under android/app/build/intermediates/merged_native_libs, skipping symbolication'
+    );
+    return;
+  }
+  const abi = await adbDiag(serial, [
+    'shell',
+    'getprop',
+    'ro.product.cpu.abi',
+  ]).then(
+    ({ stdout }) => stdout.trim(),
+    () => null
+  );
+  if (abi && fs.existsSync(path.join(symDir, abi))) {
+    symDir = path.join(symDir, abi);
+  }
+  const dumpFile = path.join(CRASH_REPORT_DIR, `native-crash-${stamp}.txt`);
+  fs.writeFileSync(dumpFile, reportText);
+  const stdout = await run(ndkStack, ['-sym', symDir, '-dump', dumpFile]).then(
+    (result) => result.stdout,
+    (error) => {
+      printCommandFailure(error);
+      return '';
+    }
+  );
+  if (stdout.trim()) {
+    const file = path.join(
+      CRASH_REPORT_DIR,
+      `native-crash-symbolized-${stamp}.txt`
+    );
+    fs.writeFileSync(file, stdout);
+    console.error(
+      `[runtime-tests] symbolized native stack trace (saved to ${file}):`
+    );
+    console.error(headLines(stdout, 250));
+  }
+}
+
+/**
+ * @param {string} serial
+ * @param {string[]} adbArgs
+ * @returns {Promise<{ stdout: string; stderr: string }>}
+ */
+function adbDiag(serial, adbArgs) {
+  return adb(serial, adbArgs, { timeout: 30_000 });
+}
+
+/** @returns {string | null} */
+function findNdkStack() {
+  const bin = process.platform === 'win32' ? 'ndk-stack.cmd' : 'ndk-stack';
+  const candidates = [];
+  if (process.env.ANDROID_NDK_HOME) {
+    candidates.push(path.join(process.env.ANDROID_NDK_HOME, bin));
+  }
+  const sdkRoot = process.env.ANDROID_HOME || process.env.ANDROID_SDK_ROOT;
+  const ndkRoot = sdkRoot ? path.join(sdkRoot, 'ndk') : null;
+  if (ndkRoot && fs.existsSync(ndkRoot)) {
+    const versions = fs.readdirSync(ndkRoot).sort().reverse();
+    for (const version of versions) {
+      candidates.push(path.join(ndkRoot, version, bin));
+    }
+  }
+  return candidates.find((candidate) => fs.existsSync(candidate)) ?? null;
+}
+
+/** @returns {string | null} */
+function findAndroidSymbolsDir() {
+  const buildType = CONFIGURATION[0].toLowerCase() + CONFIGURATION.slice(1);
+  const root = path.join(
+    androidDir,
+    'app',
+    'build',
+    'intermediates',
+    'merged_native_libs',
+    buildType
+  );
+  if (!fs.existsSync(root)) {
+    return null;
+  }
+  const stack = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop();
+    if (!dir) {
+      break;
+    }
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+      const full = path.join(dir, entry.name);
+      if (entry.name === 'lib') {
+        return full;
+      }
+      stack.push(full);
+    }
+  }
+  return null;
+}
+
+/**
+ * @param {string} text
+ * @param {number} count
+ * @returns {string}
+ */
+function headLines(text, count) {
+  const lines = text.split('\n');
+  if (lines.length <= count) {
+    return text;
+  }
+  return (
+    lines.slice(0, count).join('\n') +
+    `\n[runtime-tests] … ${lines.length - count} more lines in the saved file`
+  );
+}
+
+/**
+ * @param {string} text
+ * @param {number} count
+ * @returns {string}
+ */
+function tailLines(text, count) {
+  const lines = text.split('\n');
+  if (lines.length <= count) {
+    return text;
+  }
+  return (
+    `[runtime-tests] … ${lines.length - count} earlier lines in the saved file\n` +
+    lines.slice(-count).join('\n')
   );
 }
 
@@ -894,6 +1208,7 @@ if (SHOULD_LAUNCH) {
     }
     if (PLATFORM === 'android') {
       const serial = await resolveAndroidDevice();
+      androidSerial = serial;
       if (!SKIP_BUILD) {
         await buildAndroidApp(serial);
       }

--- a/apps/fabric-example/scripts/runtime-tests-server.js
+++ b/apps/fabric-example/scripts/runtime-tests-server.js
@@ -546,7 +546,11 @@ function formatIOSCrashReport(text) {
   try {
     payload = JSON.parse(text.slice(newlineIndex + 1));
   } catch {
-    return headLines(text, 200);
+    try {
+      payload = JSON.parse(text);
+    } catch {
+      return headLines(text, 200);
+    }
   }
   const lines = [];
   if (payload.exception) {
@@ -728,7 +732,15 @@ async function pullLatestTombstone(serial, stamp) {
     return null;
   }
   const newest = entries[0];
-  if (newest.mtimeMs < (runStartedAt || serverStartedAt) - 60_000) {
+  const hostBoundary = (runStartedAt || serverStartedAt) - 60_000;
+  const deviceNowMs = await adbDiag(serial, ['shell', 'date', '+%s']).then(
+    ({ stdout }) => Number(stdout.trim()) * 1000,
+    () => NaN
+  );
+  const boundary = Number.isFinite(deviceNowMs)
+    ? deviceNowMs - (Date.now() - hostBoundary)
+    : hostBoundary;
+  if (newest.mtimeMs < boundary) {
     console.error(
       `[runtime-tests] newest tombstone (${newest.name}) predates this run — the app died without a native crash dump`
     );
@@ -893,8 +905,14 @@ function tailLines(text, count) {
   );
 }
 
+let shutdownStarted = false;
+
 /** @param {number} code */
 function shutdown(code) {
+  if (shutdownStarted) {
+    return;
+  }
+  shutdownStarted = true;
   printSanitizerReports();
   clearTimer('connect');
   clearTimer('idle');

--- a/apps/fabric-example/scripts/runtime-tests-server.js
+++ b/apps/fabric-example/scripts/runtime-tests-server.js
@@ -136,6 +136,7 @@ if (BUILD_ONLY && SHOULD_LAUNCH) {
 
 /** @type {import('ws').WebSocket | null} */
 let client = null;
+const serverStartedAt = Date.now();
 let runStartedAt = 0;
 let exitCode = 1;
 let runFinished = false;
@@ -186,7 +187,7 @@ function armConnectTimer() {
     console.error(
       `[runtime-tests] no device connected within ${CONNECT_TIMEOUT_MS / 1000}s, exiting`
     );
-    failWithDiagnostics(1);
+    void failWithDiagnostics(1);
   }, CONNECT_TIMEOUT_MS);
 }
 
@@ -243,7 +244,7 @@ wss.on('connection', (socket) => {
         '[runtime-tests] or grep `[remoteReporter]` in Metro output for the WS close reason.'
       );
       console.error('========================================');
-      failWithDiagnostics(exitCode);
+      void failWithDiagnostics(exitCode);
       return;
     }
     console.log('[runtime-tests] device disconnected');
@@ -387,7 +388,7 @@ function resetIdleTimer() {
     console.error(
       `[runtime-tests] no traffic for ${IDLE_TIMEOUT_MS / 1000}s, assuming the run is stuck`
     );
-    failWithDiagnostics(1);
+    void failWithDiagnostics(1);
   }, IDLE_TIMEOUT_MS);
 }
 
@@ -425,16 +426,18 @@ function printSanitizerReports() {
 }
 
 /** @param {number} code */
-function failWithDiagnostics(code) {
+async function failWithDiagnostics(code) {
   clearTimer('connect');
   clearTimer('idle');
-  dumpCrashDiagnostics()
-    .catch((error) => {
-      console.error(
-        `[runtime-tests] crash diagnostics failed: ${errorMessage(error)}`
-      );
-    })
-    .finally(() => shutdown(code));
+  try {
+    await dumpCrashDiagnostics();
+  } catch (error) {
+    console.error(
+      `[runtime-tests] crash diagnostics failed: ${errorMessage(error)}`
+    );
+  } finally {
+    shutdown(code);
+  }
 }
 
 function dumpCrashDiagnostics() {
@@ -467,6 +470,7 @@ async function dumpIOSCrashDiagnostics() {
   console.error(
     `[runtime-tests] looking for FabricExample crash reports in ${reportsDir}…`
   );
+  /** @type {{ name: string; file: string; mtimeMs: number }[]} */
   let reports = [];
   for (let attempt = 0; attempt < 10; attempt++) {
     await sleep(3000);
@@ -516,11 +520,20 @@ function findFreshIOSCrashReports(reportsDir) {
       const file = path.join(reportsDir, name);
       return { name, file, mtimeMs: fs.statSync(file).mtimeMs };
     })
-    .filter((report) =>
-      runStartedAt > 0 ? report.mtimeMs >= runStartedAt - 60_000 : true
+    .filter(
+      (report) => report.mtimeMs >= (runStartedAt || serverStartedAt) - 60_000
     )
     .sort((a, b) => b.mtimeMs - a.mtimeMs);
 }
+
+/**
+ * @typedef {{
+ *   imageIndex?: number;
+ *   imageOffset?: number;
+ *   symbol?: string;
+ *   symbolLocation?: number;
+ * }} IpsFrame
+ */
 
 /**
  * @param {string} text
@@ -547,12 +560,8 @@ function formatIOSCrashReport(text) {
   }
   const images = payload.usedImages ?? [];
   /**
-   * @param {{
-   *   imageIndex?: number;
-   *   imageOffset?: number;
-   *   symbol?: string;
-   *   symbolLocation?: number;
-   * }} frame
+   * @param {IpsFrame} frame
+   * @returns {string}
    */
   const formatFrame = (frame) => {
     const image = images[frame.imageIndex ?? -1] ?? {};
@@ -561,9 +570,13 @@ function formatIOSCrashReport(text) {
       : `0x${(frame.imageOffset ?? 0).toString(16)}`;
     return `${image.name ?? '?'}  ${location}`;
   };
-  if (Array.isArray(payload.lastExceptionBacktrace)) {
+  /** @type {IpsFrame[]} */
+  const lastExceptionBacktrace = Array.isArray(payload.lastExceptionBacktrace)
+    ? payload.lastExceptionBacktrace
+    : [];
+  if (lastExceptionBacktrace.length > 0) {
     lines.push('last exception backtrace:');
-    payload.lastExceptionBacktrace.forEach((frame, index) => {
+    lastExceptionBacktrace.forEach((frame, index) => {
       lines.push(`  #${String(index).padStart(2)} ${formatFrame(frame)}`);
     });
   }
@@ -574,7 +587,9 @@ function formatIOSCrashReport(text) {
     lines.push(
       `faulting thread ${faultingIndex}${threadName ? ` (${threadName})` : ''}:`
     );
-    (thread.frames ?? []).forEach((frame, index) => {
+    /** @type {IpsFrame[]} */
+    const frames = thread.frames ?? [];
+    frames.forEach((frame, index) => {
       lines.push(`  #${String(index).padStart(2)} ${formatFrame(frame)}`);
     });
   }
@@ -713,7 +728,7 @@ async function pullLatestTombstone(serial, stamp) {
     return null;
   }
   const newest = entries[0];
-  if (runStartedAt > 0 && newest.mtimeMs < runStartedAt - 60_000) {
+  if (newest.mtimeMs < (runStartedAt || serverStartedAt) - 60_000) {
     console.error(
       `[runtime-tests] newest tombstone (${newest.name}) predates this run — the app died without a native crash dump`
     );
@@ -763,7 +778,9 @@ async function symbolizeNativeCrash(serial, reportText, stamp) {
   }
   const dumpFile = path.join(CRASH_REPORT_DIR, `native-crash-${stamp}.txt`);
   fs.writeFileSync(dumpFile, reportText);
-  const stdout = await run(ndkStack, ['-sym', symDir, '-dump', dumpFile]).then(
+  const stdout = await run(ndkStack, ['-sym', symDir, '-dump', dumpFile], {
+    timeout: 60_000,
+  }).then(
     (result) => result.stdout,
     (error) => {
       printCommandFailure(error);

--- a/apps/fabric-example/scripts/runtime-tests-server.js
+++ b/apps/fabric-example/scripts/runtime-tests-server.js
@@ -2,6 +2,7 @@
 
 const path = require('path');
 const fs = require('fs');
+const os = require('os');
 const net = require('net');
 const http = require('http');
 const { spawn, execFile } = require('child_process');
@@ -234,7 +235,7 @@ wss.on('connection', (socket) => {
         );
       } else {
         console.error(
-          '[runtime-tests] Check the iOS simulator log for crashes (Xcode → Devices → View Device Logs)'
+          '[runtime-tests] The app most likely crashed — collecting crash reports below.'
         );
       }
       console.error(
@@ -426,7 +427,7 @@ function printSanitizerReports() {
 function failWithDiagnostics(code) {
   clearTimer('connect');
   clearTimer('idle');
-  dumpAndroidCrashDiagnostics()
+  dumpCrashDiagnostics()
     .catch((error) => {
       console.error(
         `[runtime-tests] crash diagnostics failed: ${errorMessage(error)}`
@@ -435,11 +436,152 @@ function failWithDiagnostics(code) {
     .finally(() => shutdown(code));
 }
 
-async function dumpAndroidCrashDiagnostics() {
-  if (PLATFORM !== 'android' || BUILD_ONLY || crashDiagnosticsDone) {
+async function dumpCrashDiagnostics() {
+  if (BUILD_ONLY || crashDiagnosticsDone) {
     return;
   }
   crashDiagnosticsDone = true;
+  if (PLATFORM === 'android') {
+    await dumpAndroidCrashDiagnostics();
+  } else if (PLATFORM === 'ios') {
+    await dumpIOSCrashDiagnostics();
+  }
+}
+
+async function dumpIOSCrashDiagnostics() {
+  if (process.platform !== 'darwin') {
+    console.error(
+      '[runtime-tests] the simulator runs on a remote host — check its ~/Library/Logs/DiagnosticReports for FabricExample crash reports'
+    );
+    return;
+  }
+  const reportsDir = path.join(
+    os.homedir(),
+    'Library',
+    'Logs',
+    'DiagnosticReports'
+  );
+  console.error(
+    `[runtime-tests] looking for FabricExample crash reports in ${reportsDir}…`
+  );
+  let reports = [];
+  for (let attempt = 0; attempt < 10; attempt++) {
+    await sleep(3000);
+    reports = findFreshIOSCrashReports(reportsDir);
+    if (reports.length > 0) {
+      await sleep(3000);
+      reports = findFreshIOSCrashReports(reportsDir);
+      break;
+    }
+  }
+  if (reports.length === 0) {
+    console.error(
+      '[runtime-tests] no fresh crash reports (the app may have hung or been killed without crashing)'
+    );
+    return;
+  }
+  fs.mkdirSync(CRASH_REPORT_DIR, { recursive: true });
+  for (const report of reports.slice(0, 3)) {
+    const saved = path.join(CRASH_REPORT_DIR, report.name);
+    fs.copyFileSync(report.file, saved);
+    const text = fs.readFileSync(report.file, 'utf8');
+    console.error(
+      `[runtime-tests] crash report ${report.name} (full report saved to ${saved}):`
+    );
+    console.error(formatIOSCrashReport(text));
+  }
+}
+
+/**
+ * @param {string} reportsDir
+ * @returns {{ name: string; file: string; mtimeMs: number }[]}
+ */
+function findFreshIOSCrashReports(reportsDir) {
+  let names = [];
+  try {
+    names = fs.readdirSync(reportsDir);
+  } catch {
+    return [];
+  }
+  return names
+    .filter(
+      (name) =>
+        name.startsWith('FabricExample') &&
+        (name.endsWith('.ips') || name.endsWith('.crash'))
+    )
+    .map((name) => {
+      const file = path.join(reportsDir, name);
+      return { name, file, mtimeMs: fs.statSync(file).mtimeMs };
+    })
+    .filter((report) =>
+      runStartedAt > 0 ? report.mtimeMs >= runStartedAt - 60_000 : true
+    )
+    .sort((a, b) => b.mtimeMs - a.mtimeMs);
+}
+
+/**
+ * @param {string} text
+ * @returns {string}
+ */
+function formatIOSCrashReport(text) {
+  const newlineIndex = text.indexOf('\n');
+  /** @type {any} */
+  let payload;
+  try {
+    payload = JSON.parse(text.slice(newlineIndex + 1));
+  } catch {
+    return headLines(text, 200);
+  }
+  const lines = [];
+  if (payload.exception) {
+    lines.push(`exception: ${JSON.stringify(payload.exception)}`);
+  }
+  if (payload.termination) {
+    lines.push(`termination: ${JSON.stringify(payload.termination)}`);
+  }
+  if (payload.asi) {
+    lines.push(`abort messages: ${JSON.stringify(payload.asi)}`);
+  }
+  const images = payload.usedImages ?? [];
+  /**
+   * @param {{
+   *   imageIndex?: number;
+   *   imageOffset?: number;
+   *   symbol?: string;
+   *   symbolLocation?: number;
+   * }} frame
+   */
+  const formatFrame = (frame) => {
+    const image = images[frame.imageIndex ?? -1] ?? {};
+    const location = frame.symbol
+      ? `${frame.symbol} + ${frame.symbolLocation ?? 0}`
+      : `0x${(frame.imageOffset ?? 0).toString(16)}`;
+    return `${image.name ?? '?'}  ${location}`;
+  };
+  if (Array.isArray(payload.lastExceptionBacktrace)) {
+    lines.push('last exception backtrace:');
+    payload.lastExceptionBacktrace.forEach((frame, index) => {
+      lines.push(`  #${String(index).padStart(2)} ${formatFrame(frame)}`);
+    });
+  }
+  const faultingIndex = payload.faultingThread ?? 0;
+  const thread = (payload.threads ?? [])[faultingIndex];
+  if (thread) {
+    const threadName = thread.name ?? thread.queue ?? '';
+    lines.push(
+      `faulting thread ${faultingIndex}${threadName ? ` (${threadName})` : ''}:`
+    );
+    (thread.frames ?? []).forEach((frame, index) => {
+      lines.push(`  #${String(index).padStart(2)} ${formatFrame(frame)}`);
+    });
+  }
+  if (lines.length === 0) {
+    return headLines(text, 200);
+  }
+  return lines.join('\n');
+}
+
+async function dumpAndroidCrashDiagnostics() {
   const serial =
     androidSerial ?? (await listAndroidDevices().catch(() => []))[0];
   if (!serial) {

--- a/apps/fabric-example/scripts/runtime-tests-server.js
+++ b/apps/fabric-example/scripts/runtime-tests-server.js
@@ -147,7 +147,8 @@ let idleTimer = null;
 let metroChild = null;
 /** @type {string | null} */
 let androidSerial = null;
-let crashDiagnosticsDone = false;
+/** @type {Promise<void> | null} */
+let crashDiagnosticsPromise = null;
 
 /**
  * @param {unknown} error
@@ -436,16 +437,18 @@ function failWithDiagnostics(code) {
     .finally(() => shutdown(code));
 }
 
-async function dumpCrashDiagnostics() {
-  if (BUILD_ONLY || crashDiagnosticsDone) {
-    return;
+function dumpCrashDiagnostics() {
+  if (BUILD_ONLY) {
+    return Promise.resolve();
   }
-  crashDiagnosticsDone = true;
-  if (PLATFORM === 'android') {
-    await dumpAndroidCrashDiagnostics();
-  } else if (PLATFORM === 'ios') {
-    await dumpIOSCrashDiagnostics();
-  }
+  crashDiagnosticsPromise ??= (async () => {
+    if (PLATFORM === 'android') {
+      await dumpAndroidCrashDiagnostics();
+    } else if (PLATFORM === 'ios') {
+      await dumpIOSCrashDiagnostics();
+    }
+  })();
+  return crashDiagnosticsPromise;
 }
 
 async function dumpIOSCrashDiagnostics() {


### PR DESCRIPTION
> [!NOTE]
> This pull request was authored by AI on behalf of @tjzel.

## Summary

The Android Release legs of the [runtime tests nightly](https://github.com/software-mansion/react-native-reanimated/actions/runs/33355451787) have been crashing every other night since at least August 18, and the jobs captured no crash information — by the time anyone looked, the emulator was gone and the logs had expired. I taught `runtime-tests-server.js` to collect diagnostics whenever the app dies mid-run, times out, or never connects: on Android it dumps the logcat crash buffer, pulls tombstones over `adb root`, and symbolizes the stack with `ndk-stack` against the unstripped `merged_native_libs`; on a local macOS host it collects fresh `.ips` crash reports from `~/Library/Logs/DiagnosticReports` and prints the parsed exception, termination reason, and symbolized faulting-thread backtrace. The collection runs inside the emulator-runner step while the device is still alive, retry attempts are kept apart by clearing device-side buffers between them, concurrent failure paths share one memoized diagnostics promise, and every diagnostics `adb` call has a timeout so a dead emulator cannot hang the job. Both the Android and iOS workflows upload the saved reports as an artifact on failure. The remote Argent legs run the collector on a Linux runner, so there the output points at the remote host instead.

## Test plan

I validated the pipeline end to end by sending SIGSEGV to the app mid-run on a local emulator — the job log prints the crash buffer, the tombstone, and the `ndk-stack`-symbolized stack trace; on iOS I verified discovery and `.ips` formatting against a real crash report. The diagnostics found the actual nightly crash, fixed in the stacked follow-up PR.

## Changelog

- [x] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.
