### PR TITLE
chore(Worklets): drop RCTEventEmitter base from WorkletsModule

### DIFF
--- a/packages/react-native-worklets/CHANGELOG.md
+++ b/packages/react-native-worklets/CHANGELOG.md
@@ -39,6 +39,7 @@
 
 ### 💡 Others
 
+- Drop the `RCTEventEmitter` base class from `WorkletsModule` on iOS. The module never emitted events, so it now inherits from `NSObject` and declares the `bridge` property itself. ([#10485](https://github.com/software-mansion/react-native-reanimated/pull/10485) by [@tjzel](https://github.com/tjzel))
 - Pass arguments to batched UI worklets separately instead of capturing them in wrapper worklets, reducing worklet serialization. ([#10466](https://github.com/software-mansion/react-native-reanimated/pull/10466) by [@tshmieldev](https://github.com/tshmieldev))
 - Mark the special-case `__proto__` object reconstruction path as unlikely. ([#10465](https://github.com/software-mansion/react-native-reanimated/pull/10465) by [@tshmieldev](https://github.com/tshmieldev))
 - Update the sponsors section in the README. ([#10347](https://github.com/software-mansion/react-native-reanimated/pull/10347) by [@m-bert](https://github.com/m-bert))

--- a/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.h
+++ b/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.h
@@ -1,12 +1,12 @@
+#import <React/RCTBridgeModule.h>
 #import <React/RCTCallInvokerModule.h>
-#import <React/RCTEventEmitter.h>
 #import <React/RCTInvalidating.h>
 
 #import <rnworklets/rnworklets.h>
 
 #import <worklets/NativeModules/WorkletsModuleProxy.h>
 
-@interface WorkletsModule : RCTEventEmitter <NativeWorkletsModuleSpec, RCTCallInvokerModule, RCTInvalidating>
+@interface WorkletsModule : NSObject <NativeWorkletsModuleSpec, RCTCallInvokerModule, RCTInvalidating>
 
 - (std::shared_ptr<worklets::WorkletsModuleProxy>)getWorkletsModuleProxy;
 

--- a/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.mm
+++ b/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.mm
@@ -45,6 +45,7 @@ using namespace worklets;
   return workletsModuleProxy_;
 }
 
+@synthesize bridge = _bridge;
 @synthesize bundleManager = bundleManager_;
 @synthesize callInvoker = callInvoker_;
 #ifdef WORKLETS_FETCH_PREVIEW_ENABLED
@@ -119,8 +120,6 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(toggleSlowAnimationsOnUIRuntime)
     rnRuntimeStatus_->setDead();
   }
   workletsModuleProxy_.reset();
-
-  [super invalidate];
 }
 
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:


### PR DESCRIPTION
## Summary

`WorkletsModule` on iOS has inherited from `RCTEventEmitter` since the split from Reanimated in #6827, but it's not actually necessary, since we don't emit any events.

I stripped that interface.

## Test plan

CI

## Changelog

- [x] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.

