### PR TITLE
fix(LayoutAnimations): keep animated views attached under removeClippedSubviews on Android

### DIFF
--- a/packages/react-native-reanimated/CHANGELOG.md
+++ b/packages/react-native-reanimated/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix the last `FlatList` item disappearing for one frame during an item-removal layout animation on Android, where `removeClippedSubviews` detached the cell while it still animated to its new position. ([#10487](https://github.com/software-mansion/react-native-reanimated/pull/10487) by [@pawicao](https://github.com/pawicao))
 - Fix `Keyframe` easings on web being dropped or applied to the wrong keyframe when the definitions use the `from`/`to` aliases or fractional offsets. ([#10386](https://github.com/software-mansion/react-native-reanimated/pull/10386) by [@dennytosp](https://github.com/dennytosp))
 - Fix `getViewProp` and the runtime-tests prop snapshotting crashing (segfault on style props, unhandled error on layout props) when the view is no longer mounted. ([#10443](https://github.com/software-mansion/react-native-reanimated/pull/10443) by [@tjzel](https://github.com/tjzel))
 - Ship the Jest resolver (`react-native-reanimated/jest/resolver`) in the npm package, so consumer projects can run Jest against Reanimated: the modules that require a real native module are resolved to their web implementations. ([#10377](https://github.com/software-mansion/react-native-reanimated/pull/10377) by [@huextrat](https://github.com/huextrat))

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.cpp
@@ -472,6 +472,21 @@ void LayoutAnimationsProxyCommon::maybeUpdateWindowDimensions(const ShadowViewMu
 }
 
 #ifdef ANDROID
+void LayoutAnimationsProxyCommon::protectAnimatedViewsFromSubviewClipping() const {
+  if (layoutAnimations_.empty()) {
+    return;
+  }
+  std::vector<int> viewTags;
+  std::vector<int> parentTags;
+  viewTags.reserve(layoutAnimations_.size());
+  parentTags.reserve(layoutAnimations_.size());
+  for (const auto &[tag, animation] : layoutAnimations_) {
+    viewTags.push_back(tag);
+    parentTags.push_back(animation.parentTag);
+  }
+  protectFromSubviewClipping_(viewTags, parentTags);
+}
+
 void LayoutAnimationsProxyCommon::scheduleCleanupPull() const {
   const std::weak_ptr<UIManager> weakUiManager = uiManager_;
   jsInvoker_->invokeAsync([weakUiManager, surfaceId = surfaceId_](jsi::Runtime &) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.cpp
@@ -7,11 +7,14 @@
 #include <reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.h>
 #include <reanimated/LayoutAnimations/PropsDiffer.h>
 
+#include <algorithm>
 #include <cstring>
 #include <memory>
 #include <optional>
 #include <unordered_set>
 #include <utility>
+#include <variant>
+#include <vector>
 
 namespace reanimated {
 
@@ -58,6 +61,9 @@ void LayoutAnimationsProxyCommon::startSurface(
 
 void LayoutAnimationsProxyCommon::surfaceDidUnmount() {
   cancelAllLayoutAnimations();
+#ifdef ANDROID
+  publishClippingProtection();
+#endif
 }
 
 std::optional<SurfaceId> LayoutAnimationsProxyCommon::progressLayoutAnimation(
@@ -472,19 +478,42 @@ void LayoutAnimationsProxyCommon::maybeUpdateWindowDimensions(const ShadowViewMu
 }
 
 #ifdef ANDROID
-void LayoutAnimationsProxyCommon::protectAnimatedViewsFromSubviewClipping() const {
-  if (layoutAnimations_.empty()) {
+void LayoutAnimationsProxyCommon::publishClippingProtection() const {
+  auto lock = std::unique_lock<std::recursive_mutex>(mutex);
+  std::vector<std::pair<Tag, Tag>> protectedViews;
+  protectedViews.reserve(layoutAnimations_.size() + pendingLayoutAnimations_.size());
+  for (const auto &[tag, animation] : layoutAnimations_) {
+    protectedViews.emplace_back(tag, animation.parentTag);
+  }
+  for (const auto &[tag, pending] : pendingLayoutAnimations_) {
+    const auto parentTag = std::visit(
+        [](const auto &operation) -> Tag {
+          if constexpr (requires { operation.parentTag; }) {
+            return operation.parentTag;
+          } else {
+            return -1;
+          }
+        },
+        layoutAnimationOperations_[pending.operationIndex]);
+    if (parentTag != -1) {
+      protectedViews.emplace_back(tag, parentTag);
+    }
+  }
+  std::ranges::sort(protectedViews);
+  const auto duplicates = std::ranges::unique(protectedViews);
+  protectedViews.erase(duplicates.begin(), duplicates.end());
+  if (protectedViews == publishedClippingProtection_) {
     return;
   }
-  std::vector<int> viewTags;
-  std::vector<int> parentTags;
-  viewTags.reserve(layoutAnimations_.size());
-  parentTags.reserve(layoutAnimations_.size());
-  for (const auto &[tag, animation] : layoutAnimations_) {
-    viewTags.push_back(tag);
-    parentTags.push_back(animation.parentTag);
+  publishedClippingProtection_ = std::move(protectedViews);
+
+  std::vector<int> tagPairs;
+  tagPairs.reserve(2 * publishedClippingProtection_.size());
+  for (const auto &[tag, parentTag] : publishedClippingProtection_) {
+    tagPairs.push_back(tag);
+    tagPairs.push_back(parentTag);
   }
-  protectFromSubviewClipping_(viewTags, parentTags);
+  updateClippingProtection_(surfaceId_, tagPairs);
 }
 
 void LayoutAnimationsProxyCommon::scheduleCleanupPull() const {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.h
@@ -67,7 +67,7 @@ struct LayoutAnimationsProxyDependencies {
   std::function<void(SurfaceId)> requestLayoutAnimationFlush;
 #ifdef ANDROID
   PreserveMountedTagsFunction filterUnmountedTagsFunction;
-  ProtectFromSubviewClippingFunction protectFromSubviewClipping;
+  UpdateClippingProtectionFunction updateClippingProtection;
   std::shared_ptr<facebook::react::CallInvoker> jsInvoker;
 #endif
 #ifdef __APPLE__
@@ -90,7 +90,7 @@ class LayoutAnimationsProxyCommon : public facebook::react::MountingOverrideDele
 #ifdef ANDROID
         ,
         preserveMountedTags_(dependencies.filterUnmountedTagsFunction),
-        protectFromSubviewClipping_(dependencies.protectFromSubviewClipping),
+        updateClippingProtection_(dependencies.updateClippingProtection),
         jsInvoker_(dependencies.jsInvoker)
 #endif
   {
@@ -134,7 +134,7 @@ class LayoutAnimationsProxyCommon : public facebook::react::MountingOverrideDele
       const PropsParserContext &propsParserContext) const;
 #ifdef ANDROID
   void scheduleCleanupPull() const;
-  void protectAnimatedViewsFromSubviewClipping() const;
+  void publishClippingProtection() const;
 #endif
 
   const SurfaceId surfaceId_;
@@ -154,8 +154,9 @@ class LayoutAnimationsProxyCommon : public facebook::react::MountingOverrideDele
   std::function<void(SurfaceId)> requestLayoutAnimationFlush_;
 #ifdef ANDROID
   PreserveMountedTagsFunction preserveMountedTags_;
-  ProtectFromSubviewClippingFunction protectFromSubviewClipping_;
+  UpdateClippingProtectionFunction updateClippingProtection_;
   std::shared_ptr<facebook::react::CallInvoker> jsInvoker_;
+  mutable std::vector<std::pair<Tag, Tag>> publishedClippingProtection_;
 #endif
 
  private:

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.h
@@ -67,6 +67,7 @@ struct LayoutAnimationsProxyDependencies {
   std::function<void(SurfaceId)> requestLayoutAnimationFlush;
 #ifdef ANDROID
   PreserveMountedTagsFunction filterUnmountedTagsFunction;
+  ProtectFromSubviewClippingFunction protectFromSubviewClipping;
   std::shared_ptr<facebook::react::CallInvoker> jsInvoker;
 #endif
 #ifdef __APPLE__
@@ -89,6 +90,7 @@ class LayoutAnimationsProxyCommon : public facebook::react::MountingOverrideDele
 #ifdef ANDROID
         ,
         preserveMountedTags_(dependencies.filterUnmountedTagsFunction),
+        protectFromSubviewClipping_(dependencies.protectFromSubviewClipping),
         jsInvoker_(dependencies.jsInvoker)
 #endif
   {
@@ -132,6 +134,7 @@ class LayoutAnimationsProxyCommon : public facebook::react::MountingOverrideDele
       const PropsParserContext &propsParserContext) const;
 #ifdef ANDROID
   void scheduleCleanupPull() const;
+  void protectAnimatedViewsFromSubviewClipping() const;
 #endif
 
   const SurfaceId surfaceId_;
@@ -151,6 +154,7 @@ class LayoutAnimationsProxyCommon : public facebook::react::MountingOverrideDele
   std::function<void(SurfaceId)> requestLayoutAnimationFlush_;
 #ifdef ANDROID
   PreserveMountedTagsFunction preserveMountedTags_;
+  ProtectFromSubviewClippingFunction protectFromSubviewClipping_;
   std::shared_ptr<facebook::react::CallInvoker> jsInvoker_;
 #endif
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
@@ -134,6 +134,10 @@ std::optional<MountingTransaction> LayoutAnimationsProxy_Experimental::pullTrans
 
   insertContainers(transaction, rootChildCount);
 
+#ifdef ANDROID
+  protectAnimatedViewsFromSubviewClipping();
+#endif
+
   return MountingTransaction{surfaceId, transactionNumber, std::move(filteredMutations), telemetry};
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
@@ -135,7 +135,7 @@ std::optional<MountingTransaction> LayoutAnimationsProxy_Experimental::pullTrans
   insertContainers(transaction, rootChildCount);
 
 #ifdef ANDROID
-  protectAnimatedViewsFromSubviewClipping();
+  publishClippingProtection();
 #endif
 
   return MountingTransaction{surfaceId, transactionNumber, std::move(filteredMutations), telemetry};

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
@@ -74,7 +74,7 @@ std::optional<MountingTransaction> LayoutAnimationsProxy_Legacy::pullTransaction
   dropUpdatesForDeletedViews(filteredMutations);
 
 #ifdef ANDROID
-  protectAnimatedViewsFromSubviewClipping();
+  publishClippingProtection();
 #endif
 
   return MountingTransaction{surfaceId, transactionNumber, std::move(filteredMutations), telemetry};

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
@@ -73,6 +73,10 @@ std::optional<MountingTransaction> LayoutAnimationsProxy_Legacy::pullTransaction
 
   dropUpdatesForDeletedViews(filteredMutations);
 
+#ifdef ANDROID
+  protectAnimatedViewsFromSubviewClipping();
+#endif
+
   return MountingTransaction{surfaceId, transactionNumber, std::move(filteredMutations), telemetry};
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -242,6 +242,7 @@ ReanimatedModuleProxy::ReanimatedModuleProxy(
       synchronouslyUpdateUIPropsFunction_(platformDepMethodsHolder.synchronouslyUpdateUIPropsFunction),
 #ifdef ANDROID
       filterUnmountedTagsFunction_(platformDepMethodsHolder.filterUnmountedTagsFunction),
+      protectFromSubviewClipping_(platformDepMethodsHolder.protectFromSubviewClipping),
 #endif // ANDROID
       subscribeForKeyboardEventsFunction_(platformDepMethodsHolder.subscribeForKeyboardEvents),
       unsubscribeFromKeyboardEventsFunction_(platformDepMethodsHolder.unsubscribeFromKeyboardEvents) {
@@ -1287,6 +1288,7 @@ void ReanimatedModuleProxy::initializeLayoutAnimationsProxyRegistry() {
       requestLayoutAnimationFlush,
 #ifdef ANDROID
       filterUnmountedTagsFunction_,
+      protectFromSubviewClipping_,
       jsInvoker_,
 #endif
 #ifdef __APPLE__

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -242,7 +242,7 @@ ReanimatedModuleProxy::ReanimatedModuleProxy(
       synchronouslyUpdateUIPropsFunction_(platformDepMethodsHolder.synchronouslyUpdateUIPropsFunction),
 #ifdef ANDROID
       filterUnmountedTagsFunction_(platformDepMethodsHolder.filterUnmountedTagsFunction),
-      protectFromSubviewClipping_(platformDepMethodsHolder.protectFromSubviewClipping),
+      updateClippingProtection_(platformDepMethodsHolder.updateClippingProtection),
 #endif // ANDROID
       subscribeForKeyboardEventsFunction_(platformDepMethodsHolder.subscribeForKeyboardEvents),
       unsubscribeFromKeyboardEventsFunction_(platformDepMethodsHolder.unsubscribeFromKeyboardEvents) {
@@ -1288,7 +1288,7 @@ void ReanimatedModuleProxy::initializeLayoutAnimationsProxyRegistry() {
       requestLayoutAnimationFlush,
 #ifdef ANDROID
       filterUnmountedTagsFunction_,
-      protectFromSubviewClipping_,
+      updateClippingProtection_,
       jsInvoker_,
 #endif
 #ifdef __APPLE__

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
@@ -260,6 +260,9 @@ class ReanimatedModuleProxy : public std::enable_shared_from_this<ReanimatedModu
 
   const SynchronouslyUpdateUIPropsFunction synchronouslyUpdateUIPropsFunction_;
   const PreserveMountedTagsFunction filterUnmountedTagsFunction_;
+#ifdef ANDROID
+  const ProtectFromSubviewClippingFunction protectFromSubviewClipping_;
+#endif // ANDROID
 
 #ifdef ANDROID
   // Reused across `applySynchronousUpdates` calls to avoid per-frame heap

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
@@ -261,7 +261,7 @@ class ReanimatedModuleProxy : public std::enable_shared_from_this<ReanimatedModu
   const SynchronouslyUpdateUIPropsFunction synchronouslyUpdateUIPropsFunction_;
   const PreserveMountedTagsFunction filterUnmountedTagsFunction_;
 #ifdef ANDROID
-  const ProtectFromSubviewClippingFunction protectFromSubviewClipping_;
+  const UpdateClippingProtectionFunction updateClippingProtection_;
 #endif // ANDROID
 
 #ifdef ANDROID

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Tools/PlatformDepMethodsHolder.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Tools/PlatformDepMethodsHolder.h
@@ -35,8 +35,7 @@ using SynchronouslyUpdateUIPropsFunction = std::function<void(const std::vector<
 using SynchronouslyUpdateUIPropsFunction = std::function<void(const int, const folly::dynamic &)>;
 #endif // ANDROID
 using PreserveMountedTagsFunction = std::function<std::optional<std::unique_ptr<int[]>>(std::vector<int> &)>;
-using ProtectFromSubviewClippingFunction =
-    std::function<void(const std::vector<int> &viewTags, const std::vector<int> &parentTags)>;
+using UpdateClippingProtectionFunction = std::function<void(SurfaceId surfaceId, const std::vector<int> &tagPairs)>;
 using GetAnimationTimestampFunction = std::function<double(void)>;
 
 using ProgressLayoutAnimationFunction = std::function<void(jsi::Runtime &, int, jsi::Object)>;
@@ -58,7 +57,7 @@ struct PlatformDepMethodsHolder {
   RequestRenderFunction requestRender;
 #ifdef ANDROID
   PreserveMountedTagsFunction filterUnmountedTagsFunction;
-  ProtectFromSubviewClippingFunction protectFromSubviewClipping;
+  UpdateClippingProtectionFunction updateClippingProtection;
 #endif // ANDROID
 #ifdef __APPLE__
   ForceScreenSnapshotFunction forceScreenSnapshotFunction;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Tools/PlatformDepMethodsHolder.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Tools/PlatformDepMethodsHolder.h
@@ -35,6 +35,8 @@ using SynchronouslyUpdateUIPropsFunction = std::function<void(const std::vector<
 using SynchronouslyUpdateUIPropsFunction = std::function<void(const int, const folly::dynamic &)>;
 #endif // ANDROID
 using PreserveMountedTagsFunction = std::function<std::optional<std::unique_ptr<int[]>>(std::vector<int> &)>;
+using ProtectFromSubviewClippingFunction =
+    std::function<void(const std::vector<int> &viewTags, const std::vector<int> &parentTags)>;
 using GetAnimationTimestampFunction = std::function<double(void)>;
 
 using ProgressLayoutAnimationFunction = std::function<void(jsi::Runtime &, int, jsi::Object)>;
@@ -56,6 +58,7 @@ struct PlatformDepMethodsHolder {
   RequestRenderFunction requestRender;
 #ifdef ANDROID
   PreserveMountedTagsFunction filterUnmountedTagsFunction;
+  ProtectFromSubviewClippingFunction protectFromSubviewClipping;
 #endif // ANDROID
 #ifdef __APPLE__
   ForceScreenSnapshotFunction forceScreenSnapshotFunction;

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
@@ -196,6 +196,16 @@ std::optional<std::unique_ptr<int[]>> NativeProxy::preserveMountedTags(std::vect
   return region;
 }
 
+void NativeProxy::protectFromSubviewClipping(const std::vector<int> &viewTags, const std::vector<int> &parentTags) {
+  static const auto method =
+      getJniMethod<void(jni::alias_ref<jni::JArrayInt>, jni::alias_ref<jni::JArrayInt>)>("protectFromSubviewClipping");
+  auto jViewTags = jni::JArrayInt::newArray(viewTags.size());
+  jViewTags->setRegion(0, viewTags.size(), viewTags.data());
+  auto jParentTags = jni::JArrayInt::newArray(parentTags.size());
+  jParentTags->setRegion(0, parentTags.size(), parentTags.data());
+  method(javaPart_.get(), jViewTags, jParentTags);
+}
+
 void NativeProxy::synchronouslyUpdateUIProps(
     const std::vector<int> &intBuffer,
     const std::vector<double> &doubleBuffer) {
@@ -361,6 +371,8 @@ PlatformDepMethodsHolder NativeProxy::getPlatformDependentMethods() {
 
   auto preserveMountedTags = bindThis(&NativeProxy::preserveMountedTags);
 
+  auto protectFromSubviewClipping = bindThis(&NativeProxy::protectFromSubviewClipping);
+
   auto synchronouslyUpdateUIPropsFunction = bindThis(&NativeProxy::synchronouslyUpdateUIProps);
 
   auto registerSensorFunction = bindThis(&NativeProxy::registerSensor);
@@ -406,6 +418,7 @@ PlatformDepMethodsHolder NativeProxy::getPlatformDependentMethods() {
   return {
       requestRender,
       preserveMountedTags,
+      protectFromSubviewClipping,
       synchronouslyUpdateUIPropsFunction,
       getAnimationTimestamp,
       registerSensorFunction,

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
@@ -196,14 +196,11 @@ std::optional<std::unique_ptr<int[]>> NativeProxy::preserveMountedTags(std::vect
   return region;
 }
 
-void NativeProxy::protectFromSubviewClipping(const std::vector<int> &viewTags, const std::vector<int> &parentTags) {
-  static const auto method =
-      getJniMethod<void(jni::alias_ref<jni::JArrayInt>, jni::alias_ref<jni::JArrayInt>)>("protectFromSubviewClipping");
-  auto jViewTags = jni::JArrayInt::newArray(viewTags.size());
-  jViewTags->setRegion(0, viewTags.size(), viewTags.data());
-  auto jParentTags = jni::JArrayInt::newArray(parentTags.size());
-  jParentTags->setRegion(0, parentTags.size(), parentTags.data());
-  method(javaPart_.get(), jViewTags, jParentTags);
+void NativeProxy::updateClippingProtection(SurfaceId surfaceId, const std::vector<int> &tagPairs) {
+  static const auto method = getJniMethod<void(jint, jni::alias_ref<jni::JArrayInt>)>("updateClippingProtection");
+  auto jTagPairs = jni::JArrayInt::newArray(tagPairs.size());
+  jTagPairs->setRegion(0, tagPairs.size(), tagPairs.data());
+  method(javaPart_.get(), surfaceId, jTagPairs);
 }
 
 void NativeProxy::synchronouslyUpdateUIProps(
@@ -371,7 +368,7 @@ PlatformDepMethodsHolder NativeProxy::getPlatformDependentMethods() {
 
   auto preserveMountedTags = bindThis(&NativeProxy::preserveMountedTags);
 
-  auto protectFromSubviewClipping = bindThis(&NativeProxy::protectFromSubviewClipping);
+  auto updateClippingProtection = bindThis(&NativeProxy::updateClippingProtection);
 
   auto synchronouslyUpdateUIPropsFunction = bindThis(&NativeProxy::synchronouslyUpdateUIProps);
 
@@ -418,7 +415,7 @@ PlatformDepMethodsHolder NativeProxy::getPlatformDependentMethods() {
   return {
       requestRender,
       preserveMountedTags,
-      protectFromSubviewClipping,
+      updateClippingProtection,
       synchronouslyUpdateUIPropsFunction,
       getAnimationTimestamp,
       registerSensorFunction,

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
@@ -48,7 +48,7 @@ class NativeProxy : public jni::HybridClass<NativeProxy>, std::enable_shared_fro
   // std::shared_ptr<EventListener> eventListener_;
   void installJSIBindings();
   std::optional<std::unique_ptr<int[]>> preserveMountedTags(std::vector<int> &tags);
-  void protectFromSubviewClipping(const std::vector<int> &viewTags, const std::vector<int> &parentTags);
+  void updateClippingProtection(SurfaceId surfaceId, const std::vector<int> &tagPairs);
   void synchronouslyUpdateUIProps(const std::vector<int> &intBuffer, const std::vector<double> &doubleBuffer);
   PlatformDepMethodsHolder getPlatformDependentMethods();
 

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
@@ -48,6 +48,7 @@ class NativeProxy : public jni::HybridClass<NativeProxy>, std::enable_shared_fro
   // std::shared_ptr<EventListener> eventListener_;
   void installJSIBindings();
   std::optional<std::unique_ptr<int[]>> preserveMountedTags(std::vector<int> &tags);
+  void protectFromSubviewClipping(const std::vector<int> &viewTags, const std::vector<int> &parentTags);
   void synchronouslyUpdateUIProps(const std::vector<int> &intBuffer, const std::vector<double> &doubleBuffer);
   PlatformDepMethodsHolder getPlatformDependentMethods();
 

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
@@ -234,11 +234,11 @@ open class NativeProxy {
     }
 
     @DoNotStrip
-    fun protectFromSubviewClipping(
-        viewTags: IntArray,
-        parentTags: IntArray,
+    fun updateClippingProtection(
+        surfaceId: Int,
+        tagPairs: IntArray,
     ) {
-        subviewClippingGuard.protect(viewTags, parentTags)
+        subviewClippingGuard.updateClippingProtection(surfaceId, tagPairs)
     }
 
     // TODO(#9681): Temporary workaround for RN >= 0.86. Since RN 0.86,

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
@@ -20,6 +20,7 @@ import com.swmansion.common.GestureHandlerStateManager
 import com.swmansion.reanimated.css.CSSPlatformTransitionsManager
 import com.swmansion.reanimated.keyboard.KeyboardAnimationManager
 import com.swmansion.reanimated.keyboard.KeyboardWorkletWrapper
+import com.swmansion.reanimated.layoutAnimations.SubviewClippingGuard
 import com.swmansion.reanimated.nativeProxy.AnimationFrameCallback
 import com.swmansion.reanimated.nativeProxy.EventHandler
 import com.swmansion.reanimated.nativeProxy.PseudoSelectorCallback
@@ -48,6 +49,7 @@ open class NativeProxy {
     private val keyboardAnimationManager: KeyboardAnimationManager
     private val pseudoSelectorManager: PseudoSelectorManager
     private val cssPlatformTransitionsManager: CSSPlatformTransitionsManager
+    private val subviewClippingGuard: SubviewClippingGuard
     private var firstUptime: Long = SystemClock.uptimeMillis()
     private var slowAnimationsEnabled = false
     private val animationsDragFactor = 10
@@ -98,6 +100,7 @@ open class NativeProxy {
         pseudoSelectorManager = PseudoSelectorManager(mFabricUIManager, mContext)
         cssPlatformTransitionsManager =
             CSSPlatformTransitionsManager(mFabricUIManager, mContext, ::getAnimationTimestamp)
+        subviewClippingGuard = SubviewClippingGuard(mFabricUIManager)
 
         val callInvokerHolder = context.jsCallInvokerHolder as CallInvokerHolderImpl
         mHybridData =
@@ -140,6 +143,7 @@ open class NativeProxy {
         }
         pseudoSelectorManager.invalidate()
         cssPlatformTransitionsManager.invalidate()
+        subviewClippingGuard.invalidate()
         if (mHybridData.isValid) {
             invalidateCpp()
         }
@@ -227,6 +231,14 @@ open class NativeProxy {
         }
 
         return true
+    }
+
+    @DoNotStrip
+    fun protectFromSubviewClipping(
+        viewTags: IntArray,
+        parentTags: IntArray,
+    ) {
+        subviewClippingGuard.protect(viewTags, parentTags)
     }
 
     // TODO(#9681): Temporary workaround for RN >= 0.86. Since RN 0.86,

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/layoutAnimations/SubviewClippingGuard.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/layoutAnimations/SubviewClippingGuard.kt
@@ -1,0 +1,82 @@
+package com.swmansion.reanimated.layoutAnimations
+
+import android.view.View
+import com.facebook.react.bridge.UIManager
+import com.facebook.react.bridge.UIManagerListener
+import com.facebook.react.common.annotations.UnstableReactNativeAPI
+import com.facebook.react.fabric.FabricUIManager
+import com.facebook.react.uimanager.IllegalViewOperationException
+import com.facebook.react.uimanager.ReactClippingViewGroup
+
+/**
+ * A parent with `removeClippedSubviews` detaches a child that lies outside its bounds. A layout
+ * animation moves the child over many frames, so the child can leave the bounds before it
+ * arrives at its target. This class attaches such children again after each mount, until the
+ * animation ends and React Native clips them with their final layout.
+ */
+internal class SubviewClippingGuard(
+    private val fabricUIManager: FabricUIManager,
+) {
+    private val lock = Any()
+    private var animatedChildrenByParent = HashMap<Int, MutableSet<Int>>()
+
+    @OptIn(UnstableReactNativeAPI::class)
+    private val mountListener =
+        object : UIManagerListener {
+            override fun willDispatchViewUpdates(uiManager: UIManager) = Unit
+
+            override fun willMountItems(uiManager: UIManager) = Unit
+
+            override fun didMountItems(uiManager: UIManager) = restoreClippedChildren()
+
+            override fun didDispatchMountItems(uiManager: UIManager) = Unit
+
+            override fun didScheduleMountItems(uiManager: UIManager) = Unit
+        }
+
+    init {
+        @OptIn(UnstableReactNativeAPI::class)
+        fabricUIManager.addUIManagerEventListener(mountListener)
+    }
+
+    /** Called from the pull that emits the transaction, on the JS or the UI thread. */
+    fun protect(
+        viewTags: IntArray,
+        parentTags: IntArray,
+    ) {
+        synchronized(lock) {
+            for (i in viewTags.indices) {
+                animatedChildrenByParent.getOrPut(parentTags[i]) { HashSet() }.add(viewTags[i])
+            }
+        }
+    }
+
+    fun invalidate() {
+        @OptIn(UnstableReactNativeAPI::class)
+        fabricUIManager.removeUIManagerEventListener(mountListener)
+        synchronized(lock) { animatedChildrenByParent.clear() }
+    }
+
+    private fun restoreClippedChildren() {
+        val byParent =
+            synchronized(lock) {
+                if (animatedChildrenByParent.isEmpty()) return
+                animatedChildrenByParent.also { animatedChildrenByParent = HashMap() }
+            }
+        for ((parentTag, childTags) in byParent) {
+            val parent = viewForTag(parentTag) as? ReactClippingViewGroup ?: continue
+            if (!parent.removeClippedSubviews) continue
+            if (childTags.none { isDetached(it) }) continue
+            parent.updateClippingRect(childTags)
+        }
+    }
+
+    private fun isDetached(tag: Int): Boolean = viewForTag(tag)?.let { it.parent == null } ?: false
+
+    private fun viewForTag(tag: Int): View? =
+        try {
+            fabricUIManager.resolveView(tag)
+        } catch (e: IllegalViewOperationException) {
+            null
+        }
+}

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/layoutAnimations/SubviewClippingGuard.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/layoutAnimations/SubviewClippingGuard.kt
@@ -9,16 +9,17 @@ import com.facebook.react.uimanager.IllegalViewOperationException
 import com.facebook.react.uimanager.ReactClippingViewGroup
 
 /**
- * A parent with `removeClippedSubviews` detaches a child that lies outside its bounds. A layout
- * animation moves the child over many frames, so the child can leave the bounds before it
- * arrives at its target. This class attaches such children again after each mount, until the
- * animation ends and React Native clips them with their final layout.
+ * Keeps views with an active layout animation attached to a parent that has
+ * `removeClippedSubviews`, until the animation ends and the final layout mounts.
  */
 internal class SubviewClippingGuard(
     private val fabricUIManager: FabricUIManager,
 ) {
     private val lock = Any()
-    private var animatedChildrenByParent = HashMap<Int, MutableSet<Int>>()
+    private var invalidated = false
+
+    /** Per surface: flat `[tag, parentTag, ...]` pairs of the animated views. */
+    private val tagPairsBySurface = HashMap<Int, IntArray>()
 
     @OptIn(UnstableReactNativeAPI::class)
     private val mountListener =
@@ -39,35 +40,42 @@ internal class SubviewClippingGuard(
         fabricUIManager.addUIManagerEventListener(mountListener)
     }
 
-    /** Called from the pull that emits the transaction, on the JS or the UI thread. */
-    fun protect(
-        viewTags: IntArray,
-        parentTags: IntArray,
+    /** Called on the JS or the UI thread. */
+    fun updateClippingProtection(
+        surfaceId: Int,
+        tagPairs: IntArray,
     ) {
         synchronized(lock) {
-            for (i in viewTags.indices) {
-                animatedChildrenByParent.getOrPut(parentTags[i]) { HashSet() }.add(viewTags[i])
-            }
+            if (invalidated) return
+            if (tagPairs.isEmpty()) tagPairsBySurface.remove(surfaceId) else tagPairsBySurface[surfaceId] = tagPairs
         }
     }
 
     fun invalidate() {
         @OptIn(UnstableReactNativeAPI::class)
         fabricUIManager.removeUIManagerEventListener(mountListener)
-        synchronized(lock) { animatedChildrenByParent.clear() }
+        synchronized(lock) {
+            invalidated = true
+            tagPairsBySurface.clear()
+        }
     }
 
     private fun restoreClippedChildren() {
-        val byParent =
-            synchronized(lock) {
-                if (animatedChildrenByParent.isEmpty()) return
-                animatedChildrenByParent.also { animatedChildrenByParent = HashMap() }
+        val surfaces = synchronized(lock) { tagPairsBySurface.values.toList() }
+        if (surfaces.isEmpty()) return
+        val protectedTags = HashSet<Int>()
+        val childrenByParent = HashMap<Int, MutableList<Int>>()
+        for (tagPairs in surfaces) {
+            for (i in tagPairs.indices step 2) {
+                protectedTags.add(tagPairs[i])
+                childrenByParent.getOrPut(tagPairs[i + 1]) { ArrayList() }.add(tagPairs[i])
             }
-        for ((parentTag, childTags) in byParent) {
+        }
+        for ((parentTag, children) in childrenByParent) {
             val parent = viewForTag(parentTag) as? ReactClippingViewGroup ?: continue
             if (!parent.removeClippedSubviews) continue
-            if (childTags.none { isDetached(it) }) continue
-            parent.updateClippingRect(childTags)
+            if (children.none { isDetached(it) }) continue
+            parent.updateClippingRect(protectedTags)
         }
     }
 


### PR DESCRIPTION
> [!NOTE]
> This pull request was authored by AI on behalf of @pawicao.

## Summary

Fixes #10202.

On Android, `FlatList` sets `removeClippedSubviews` by default. When React removes an item, the content container gets its smaller height in the same transaction, while the cells that have a `layout` animation stay at their old positions until their first animated frame. `ReactViewGroup` clips a child by its raw bounds (`child.left/top/right/bottom`) and only spares a child with a running legacy `android.view.Animation`. So it detaches the last cell for one frame and re-attaches it when the animated position enters the new bounds.

This change keeps a view with an active layout animation attached to its clipping parent until the animation ends.

## How it works

- Both proxies publish the clipping protection of their surface at the end of each `pullTransaction` on Android and when the surface unmounts: the tag and parent tag of every active layout animation and of every pending start (a JS-thread pull cannot start the animation yet, so the first transaction only queues it). The proxy sends the set only when it changed, through the new platform function `updateClippingProtection`.
- `SubviewClippingGuard` keeps that set per surface and listens to `didMountItems`. After each mount it looks at each parent in the set that has `removeClippedSubviews`. If one of its animated children is detached, it calls `ReactClippingViewGroup.updateClippingRect(excludedViews)` on the parent with the tags of all protected views, so a nested clipping parent keeps its own exclusions. React Native re-attaches the excluded children in the same UI-thread pass, before the frame draws.
- When the animation ends, the proxy publishes the smaller set, the final layout update mounts, and normal clipping applies again.

The state lives in Kotlin for as long as the animation lives in the proxy. The guard calls into React Native only when a parent has clipped one of the protected children.

## Limits

- A scroll during the animation recomputes clipping without the exclusion set. The next mount restores the child.
- A child whose final layout is outside the parent bounds and equal to its last animated layout stays attached until the parent recomputes clipping. React Native's own animation exemption has the same property.

## Recordings

Before/After

https://github.com/user-attachments/assets/b8145f9c-043b-4d42-85eb-e81b1eb22c4f


## Test plan

Physical Pixel 9a, API 36, 30 fps screen recordings, `[LA] List item layout animation` example, `LinearTransition`, tap the second item, frame analysis of the purple item bands.

| Build | Blinks / trials |
|---|---|
| main (e4a098bad6) | 2 / 8 |
| this change, first revision | 0 / 12 |
| this change, after review fixes | 0 / 12 |

- [x] Android: `[LA] List item layout animation` remove (0/12 blinks), add (clean)
- [x] Android: Experimental proxy (default flags). Legacy proxy: code path added, not measured on device
- [x] `lint:android`, `lint:clang-tidy:android --strict`, `lint:clang-tidy:ios --strict`: 0 warnings

## Changelog

- [x] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.

