### PR TITLE
refactor(Worklets): build nativeLoggingHook natively

### DIFF
--- a/packages/react-native-worklets/CHANGELOG.md
+++ b/packages/react-native-worklets/CHANGELOG.md
@@ -40,6 +40,7 @@
 
 ### 💡 Others
 
+- Build `nativeLoggingHook` for Worklet Runtimes natively instead of reading React Native's host function from the RN Runtime. ([#10488](https://github.com/software-mansion/react-native-reanimated/pull/10488) by [@tjzel](https://github.com/tjzel))
 - Drop the `RCTEventEmitter` base class from `WorkletsModule` on iOS. The module never emitted events, so it now inherits from `NSObject` and declares the `bridge` property itself. ([#10485](https://github.com/software-mansion/react-native-reanimated/pull/10485) by [@tjzel](https://github.com/tjzel))
 - Pass arguments to batched UI worklets separately instead of capturing them in wrapper worklets, reducing worklet serialization. ([#10466](https://github.com/software-mansion/react-native-reanimated/pull/10466) by [@tshmieldev](https://github.com/tshmieldev))
 - Mark the special-case `__proto__` object reconstruction path as unlikely. ([#10465](https://github.com/software-mansion/react-native-reanimated/pull/10465) by [@tshmieldev](https://github.com/tshmieldev))

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/RuntimeBindings.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/RuntimeBindings.h
@@ -4,6 +4,13 @@
 
 #include <functional>
 #include <stdexcept>
+#include <string>
+
+#if defined(__APPLE__) && defined(__OBJC__)
+#import <React/RCTLog.h>
+#elif defined(ANDROID)
+#include <android/log.h>
+#endif
 
 using namespace facebook;
 
@@ -48,12 +55,23 @@ struct RuntimeBindings {
 #endif // WORKLETS_FETCH_PREVIEW_ENABLED
 };
 
-inline RuntimeBindings::NativeLoggingHook extractNativeLoggingHookFromRNRuntime(jsi::Runtime &rnRuntime) {
-  auto nativeLoggingHookValue = rnRuntime.global().getProperty(rnRuntime, "nativeLoggingHook");
-  if (!nativeLoggingHookValue.isObject() || !nativeLoggingHookValue.asObject(rnRuntime).isFunction(rnRuntime)) {
-    throw std::runtime_error("[Worklets] nativeLoggingHook is missing.");
-  }
-  return nativeLoggingHookValue.asObject(rnRuntime).asFunction(rnRuntime).getHostFunction(rnRuntime);
+#if defined(ANDROID) || (defined(__APPLE__) && defined(__OBJC__))
+inline RuntimeBindings::NativeLoggingHook makeNativeLoggingHook() {
+  return [](jsi::Runtime &rt, const jsi::Value &, const jsi::Value *args, size_t count) -> jsi::Value {
+    if (count != 2) {
+      throw std::invalid_argument("nativeLoggingHook takes 2 arguments");
+    }
+    const auto message = args[0].asString(rt).utf8(rt);
+    const auto logLevel = static_cast<unsigned int>(args[1].asNumber());
+#if defined(__APPLE__)
+    _RCTLogJavaScriptInternal(static_cast<RCTLogLevel>(logLevel), [NSString stringWithUTF8String:message.c_str()]);
+#else
+    __android_log_write(
+        static_cast<android_LogPriority>(logLevel + ANDROID_LOG_DEBUG), "ReactNativeJS", message.c_str());
+#endif
+    return jsi::Value::undefined();
+  };
 }
+#endif // defined(ANDROID) || (defined(__APPLE__) && defined(__OBJC__))
 
 } // namespace worklets

--- a/packages/react-native-worklets/android/src/main/cpp/worklets/android/WorkletsModule.cpp
+++ b/packages/react-native-worklets/android/src/main/cpp/worklets/android/WorkletsModule.cpp
@@ -40,7 +40,7 @@ WorkletsModule::WorkletsModule(
           jsCallInvoker,
           uiScheduler,
           getIsOnJSQueueThread(),
-          getRuntimeBindings(bundleModeConfig.enabled, *rnRuntime),
+          getRuntimeBindings(bundleModeConfig.enabled),
           bundleModeConfig,
           rnRuntimeStatus_)) {}
 
@@ -77,13 +77,10 @@ jni::local_ref<WorkletsModule::jhybriddata> WorkletsModule::initHybrid(
       uiScheduler);
 }
 
-std::shared_ptr<RuntimeBindings> WorkletsModule::getRuntimeBindings(
-    const bool bundleModeEnabled,
-    jsi::Runtime &rnRuntime) {
+std::shared_ptr<RuntimeBindings> WorkletsModule::getRuntimeBindings(const bool bundleModeEnabled) {
   return std::make_shared<RuntimeBindings>(RuntimeBindings{
       .requestAnimationFrame = getRequestAnimationFrame(),
-      .nativeLoggingHook =
-          bundleModeEnabled ? extractNativeLoggingHookFromRNRuntime(rnRuntime) : RuntimeBindings::NativeLoggingHook{}
+      .nativeLoggingHook = bundleModeEnabled ? makeNativeLoggingHook() : RuntimeBindings::NativeLoggingHook{}
 #ifdef WORKLETS_FETCH_PREVIEW_ENABLED
       ,
       .abortRequest = getAbortRequest(),

--- a/packages/react-native-worklets/android/src/main/cpp/worklets/android/WorkletsModule.h
+++ b/packages/react-native-worklets/android/src/main/cpp/worklets/android/WorkletsModule.h
@@ -54,7 +54,7 @@ class WorkletsModule : public jni::HybridClass<WorkletsModule> {
     return javaPart_->getClass()->getMethod<Signature>(methodName.c_str());
   }
 
-  std::shared_ptr<RuntimeBindings> getRuntimeBindings(bool bundleModeEnabled, jsi::Runtime &rnRuntime);
+  std::shared_ptr<RuntimeBindings> getRuntimeBindings(bool bundleModeEnabled);
 
   RuntimeBindings::RequestAnimationFrame getRequestAnimationFrame();
 #ifdef WORKLETS_FETCH_PREVIEW_ENABLED

--- a/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.mm
+++ b/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.mm
@@ -83,7 +83,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule : (BOOL)bundleModeEnab
     return IsJavaScriptQueue();
   };
   animationFrameQueue_ = [AnimationFrameQueue new];
-  auto runtimeBindings = [self getRuntimeBindings:rnRuntime bundleModeEnabled:bundleModeEnabled];
+  auto runtimeBindings = [self getRuntimeBindings:bundleModeEnabled];
   rnRuntimeStatus_ = std::make_shared<RNRuntimeStatus>();
 
   workletsModuleProxy_ = std::make_shared<WorkletsModuleProxy>(
@@ -129,16 +129,14 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(toggleSlowAnimationsOnUIRuntime)
   return std::make_shared<facebook::react::NativeWorkletsModuleSpecJSI>(params);
 }
 
-- (std::shared_ptr<RuntimeBindings>)getRuntimeBindings:(jsi::Runtime &)rnRuntime
-                                     bundleModeEnabled:(BOOL)bundleModeEnabled
+- (std::shared_ptr<RuntimeBindings>)getRuntimeBindings:(BOOL)bundleModeEnabled
 {
   return std::make_shared<RuntimeBindings>(RuntimeBindings{
       .requestAnimationFrame = [animationFrameQueue =
                                     animationFrameQueue_](std::function<void(const double)> &&callback) -> void {
         [animationFrameQueue requestAnimationFrame:callback];
       },
-      .nativeLoggingHook =
-          bundleModeEnabled ? extractNativeLoggingHookFromRNRuntime(rnRuntime) : RuntimeBindings::NativeLoggingHook{}
+      .nativeLoggingHook = bundleModeEnabled ? makeNativeLoggingHook() : RuntimeBindings::NativeLoggingHook{}
 #ifdef WORKLETS_FETCH_PREVIEW_ENABLED
       ,
       .abortRequest =


### PR DESCRIPTION
## Summary

Read #10490 for more context.

I'm making `nativeLoggingHook` to be re-done in the native code rather than acquired from the RN Runtime. This way extra Worklet Runtimes can be initialized in parallel to the RN Runtime, instead of waiting for its initialization to finish and only then acquire the logger.

## Test plan

Logging runtime tests work.

## Changelog

- [x] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.
