### PR TITLE
docs(Worklets): explain how mergeConfig treats polyfillModuleNames

### DIFF
--- a/docs/docs-worklets/docs/bundleMode/setup.mdx
+++ b/docs/docs-worklets/docs/bundleMode/setup.mdx
@@ -77,6 +77,14 @@ To use `react-native-worklets`'s Bundle Mode feature, you need to make the follo
   </TabItem>
 </Tabs>
 
+`bundleModeMetroConfig` sets `serializer.polyfillModuleNames`. `mergeConfig` replaces this array, it does not concatenate it. If your Metro config sets `serializer.polyfillModuleNames` too, use `getBundleModeMetroConfig`, which appends to your list:
+
+```javascript
+module.exports = getBundleModeMetroConfig(
+  mergeConfig(getDefaultConfig(__dirname), config)
+);
+```
+
 ## Enable seamless Metro bundling
 
 _This step is optional but highly recommended._

--- a/packages/react-native-worklets/CHANGELOG.md
+++ b/packages/react-native-worklets/CHANGELOG.md
@@ -40,6 +40,7 @@
 
 ### 💡 Others
 
+- Create the native side of `WorkletsModule` on a background thread as soon as the module is created, so `installTurboModule` only attaches it to the RN Runtime. ([#10489](https://github.com/software-mansion/react-native-reanimated/pull/10489) by [@tjzel](https://github.com/tjzel))
 - Build `nativeLoggingHook` for Worklet Runtimes natively instead of reading React Native's host function from the RN Runtime. ([#10488](https://github.com/software-mansion/react-native-reanimated/pull/10488) by [@tjzel](https://github.com/tjzel))
 - Drop the `RCTEventEmitter` base class from `WorkletsModule` on iOS. The module never emitted events, so it now inherits from `NSObject` and declares the `bridge` property itself. ([#10485](https://github.com/software-mansion/react-native-reanimated/pull/10485) by [@tjzel](https://github.com/tjzel))
 - Pass arguments to batched UI worklets separately instead of capturing them in wrapper worklets, reducing worklet serialization. ([#10466](https://github.com/software-mansion/react-native-reanimated/pull/10466) by [@tshmieldev](https://github.com/tshmieldev))

--- a/packages/react-native-worklets/CHANGELOG.md
+++ b/packages/react-native-worklets/CHANGELOG.md
@@ -40,6 +40,7 @@
 
 ### 💡 Others
 
+- In Bundle Mode, evaluate the bundle on the UI Worklet Runtime on a background thread while the RN Runtime evaluates it, instead of on the JS thread in `start`. `bundleModeMetroConfig` prepends a polyfill that triggers it. ([#10490](https://github.com/software-mansion/react-native-reanimated/pull/10490) by [@tjzel](https://github.com/tjzel))
 - Create the native side of `WorkletsModule` on a background thread as soon as the module is created, so `installTurboModule` only attaches it to the RN Runtime. ([#10489](https://github.com/software-mansion/react-native-reanimated/pull/10489) by [@tjzel](https://github.com/tjzel))
 - Build `nativeLoggingHook` for Worklet Runtimes natively instead of reading React Native's host function from the RN Runtime. ([#10488](https://github.com/software-mansion/react-native-reanimated/pull/10488) by [@tjzel](https://github.com/tjzel))
 - Drop the `RCTEventEmitter` base class from `WorkletsModule` on iOS. The module never emitted events, so it now inherits from `NSObject` and declares the `bridge` property itself. ([#10485](https://github.com/software-mansion/react-native-reanimated/pull/10485) by [@tjzel](https://github.com/tjzel))

--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.cpp
@@ -6,8 +6,10 @@
 #include <worklets/WorkletRuntime/RuntimeData.h>
 #include <worklets/WorkletRuntime/UIRuntimeDecorator.h>
 
+#include <react/debug/react_native_assert.h>
+
 #include <memory>
-#include <utility>
+#include <stdexcept>
 
 using namespace facebook;
 
@@ -18,17 +20,15 @@ bool isDevBundleFromRNRuntime(jsi::Runtime &rnRuntime) {
   return rtDev.isBool() && rtDev.asBool();
 }
 
-/**
- * This method is required outside of Bundle Mode to make sure we start creating
- * Worklet Runtimes only after unpackers code was loaded from the RN Runtime.
- *
- * In Bundle Mode unpackers are installed during bundle evaluation instead.
- */
 void WorkletsModuleProxy::start() {
-  /**
-   * We call additional `init` method here because
-   * JSIWorkletsModuleProxy needs a weak_ptr to the UI Runtime.
-   */
+  react_native_assert(jsScheduler_->canInvokeSyncOnJS() && "start must be called on the JS thread");
+  if (!rnRuntimeProxy_) [[unlikely]] {
+    throw std::runtime_error("[Worklets] WorkletsModuleProxy must be attached to the RN runtime before start.");
+  }
+  if (animationFrameBatchinator_) [[unlikely]] {
+    throw std::runtime_error("[Worklets] WorkletsModuleProxy was already started.");
+  }
+
   const auto uiRuntimeProxy = JSIWorkletsModuleProxy::createForNewRuntime(rnRuntimeProxy_, RuntimeData::uiRuntimeId);
   uiWorkletRuntime_->init(uiRuntimeProxy);
 
@@ -40,36 +40,42 @@ void WorkletsModuleProxy::start() {
 }
 
 WorkletsModuleProxy::WorkletsModuleProxy(
-    jsi::Runtime &rnRuntime,
-    const std::shared_ptr<CallInvoker> &jsCallInvoker,
+    const std::shared_ptr<JSScheduler> &jsScheduler,
     const std::shared_ptr<UIScheduler> &uiScheduler,
-    std::function<bool()> &&isJavaScriptThread,
     const std::shared_ptr<RuntimeBindings> &runtimeBindings,
-    const BundleModeConfig &bundleModeConfig,
     const std::shared_ptr<RNRuntimeStatus> &rnRuntimeStatus)
-    : isDevBundle_(isDevBundleFromRNRuntime(rnRuntime)),
-      jsScheduler_(std::make_shared<JSScheduler>(rnRuntime, jsCallInvoker, std::move(isJavaScriptThread))),
+    : isDevBundle_(false),
+      jsScheduler_(jsScheduler),
       uiScheduler_(uiScheduler),
       jsLogger_(std::make_shared<JSLogger>(jsScheduler_)),
       runtimeBindings_(runtimeBindings),
-      bundleModeConfig_(bundleModeConfig),
+      bundleModeConfig_{.enabled = false},
       memoryManager_(std::make_shared<MemoryManager>()),
       runtimeManager_(std::make_shared<RuntimeManager>()),
       unpackerLoader_(std::make_shared<UnpackerLoader>()),
       rnRuntimeStatus_(rnRuntimeStatus),
-      uiWorkletRuntime_(runtimeManager_->createUninitializedUIRuntime(std::make_shared<AsyncQueueUI>(uiScheduler_))),
-      rnRuntimeProxy_(std::make_shared<JSIWorkletsModuleProxy>(
-          isDevBundle_,
-          jsScheduler_,
-          uiScheduler_,
-          memoryManager_,
-          runtimeManager_,
-          uiWorkletRuntime_,
-          runtimeBindings_,
-          bundleModeConfig_,
-          unpackerLoader_,
-          rnRuntimeStatus_,
-          RuntimeData::rnRuntimeId)) {
+      uiWorkletRuntime_(runtimeManager_->createUninitializedUIRuntime(std::make_shared<AsyncQueueUI>(uiScheduler_))) {}
+
+void WorkletsModuleProxy::attachToRNRuntime(jsi::Runtime &rnRuntime, const BundleModeConfig &bundleModeConfig) {
+  react_native_assert(jsScheduler_->canInvokeSyncOnJS() && "attachToRNRuntime must be called on the JS thread");
+  if (rnRuntimeProxy_) [[unlikely]] {
+    throw std::runtime_error("[Worklets] WorkletsModuleProxy is already attached to the RN runtime.");
+  }
+
+  isDevBundle_ = isDevBundleFromRNRuntime(rnRuntime);
+  bundleModeConfig_ = bundleModeConfig;
+  rnRuntimeProxy_ = std::make_shared<JSIWorkletsModuleProxy>(
+      isDevBundle_,
+      jsScheduler_,
+      uiScheduler_,
+      memoryManager_,
+      runtimeManager_,
+      uiWorkletRuntime_,
+      runtimeBindings_,
+      bundleModeConfig_,
+      unpackerLoader_,
+      rnRuntimeStatus_,
+      RuntimeData::rnRuntimeId);
   RNRuntimeWorkletDecorator::decorate(rnRuntime, rnRuntimeProxy_->toOptimizedObject(rnRuntime), jsLogger_);
 }
 

--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.cpp
@@ -25,18 +25,11 @@ void WorkletsModuleProxy::start() {
   if (!rnRuntimeProxy_) [[unlikely]] {
     throw std::runtime_error("[Worklets] WorkletsModuleProxy must be attached to the RN runtime before start.");
   }
-  if (animationFrameBatchinator_) [[unlikely]] {
-    throw std::runtime_error("[Worklets] WorkletsModuleProxy was already started.");
+  if (uiRuntimeStarted_) {
+    return;
   }
 
-  const auto uiRuntimeProxy = JSIWorkletsModuleProxy::createForNewRuntime(rnRuntimeProxy_, RuntimeData::uiRuntimeId);
-  uiWorkletRuntime_->init(uiRuntimeProxy);
-
-  animationFrameBatchinator_ =
-      std::make_shared<AnimationFrameBatchinator>(uiWorkletRuntime_, runtimeBindings_->requestAnimationFrame);
-
-  UIRuntimeDecorator::decorate(
-      uiWorkletRuntime_->getJSIRuntime(), animationFrameBatchinator_->getJsiRequestAnimationFrame());
+  startUIRuntime(JSIWorkletsModuleProxy::createForNewRuntime(rnRuntimeProxy_, RuntimeData::uiRuntimeId));
 }
 
 WorkletsModuleProxy::WorkletsModuleProxy(
@@ -54,16 +47,54 @@ WorkletsModuleProxy::WorkletsModuleProxy(
       runtimeManager_(std::make_shared<RuntimeManager>()),
       unpackerLoader_(std::make_shared<UnpackerLoader>()),
       rnRuntimeStatus_(rnRuntimeStatus),
-      uiWorkletRuntime_(runtimeManager_->createUninitializedUIRuntime(std::make_shared<AsyncQueueUI>(uiScheduler_))) {}
+      uiWorkletRuntime_(runtimeManager_->createUninitializedUIRuntime(std::make_shared<AsyncQueueUI>(uiScheduler_))),
+      uiRuntimeStarted_(false) {}
 
-void WorkletsModuleProxy::attachToRNRuntime(jsi::Runtime &rnRuntime, const BundleModeConfig &bundleModeConfig) {
+void WorkletsModuleProxy::startUIRuntimeInBundleMode(const BundleModeConfig &bundleModeConfig) {
+  if (!bundleModeConfig.enabled) [[unlikely]] {
+    throw std::runtime_error("[Worklets] startUIRuntimeInBundleMode requires Bundle Mode.");
+  }
+  if (rnRuntimeProxy_) [[unlikely]] {
+    throw std::runtime_error("[Worklets] startUIRuntimeInBundleMode must be called before attachToRNRuntime.");
+  }
+  if (uiRuntimeStarted_) [[unlikely]] {
+    throw std::runtime_error("[Worklets] The UI Worklet Runtime was already started.");
+  }
+
+  bundleModeConfig_ = bundleModeConfig;
+  startUIRuntime(std::make_shared<JSIWorkletsModuleProxy>(
+      false, /* isDevBundle_ */
+      jsScheduler_,
+      uiScheduler_,
+      memoryManager_,
+      runtimeManager_,
+      uiWorkletRuntime_,
+      runtimeBindings_,
+      bundleModeConfig_,
+      unpackerLoader_,
+      rnRuntimeStatus_,
+      RuntimeData::uiRuntimeId));
+}
+
+void WorkletsModuleProxy::attachToRNRuntime(
+    jsi::Runtime &rnRuntime,
+    const std::optional<BundleModeConfig> &bundleModeConfig) {
   react_native_assert(jsScheduler_->canInvokeSyncOnJS() && "attachToRNRuntime must be called on the JS thread");
   if (rnRuntimeProxy_) [[unlikely]] {
     throw std::runtime_error("[Worklets] WorkletsModuleProxy is already attached to the RN runtime.");
   }
+  if (uiRuntimeStarted_ && bundleModeConfig.has_value()) [[unlikely]] {
+    throw std::runtime_error("[Worklets] The Bundle Mode config was already set by startUIRuntimeInBundleMode.");
+  }
+  if (!uiRuntimeStarted_ && !bundleModeConfig.has_value()) [[unlikely]] {
+    throw std::runtime_error(
+        "[Worklets] attachToRNRuntime requires a Bundle Mode config unless startUIRuntimeInBundleMode was called.");
+  }
 
   isDevBundle_ = isDevBundleFromRNRuntime(rnRuntime);
-  bundleModeConfig_ = bundleModeConfig;
+  if (bundleModeConfig.has_value()) {
+    bundleModeConfig_ = *bundleModeConfig;
+  }
   rnRuntimeProxy_ = std::make_shared<JSIWorkletsModuleProxy>(
       isDevBundle_,
       jsScheduler_,
@@ -82,6 +113,18 @@ void WorkletsModuleProxy::attachToRNRuntime(jsi::Runtime &rnRuntime, const Bundl
 WorkletsModuleProxy::~WorkletsModuleProxy() {
   animationFrameBatchinator_.reset();
   uiWorkletRuntime_.reset();
+}
+
+void WorkletsModuleProxy::startUIRuntime(const std::shared_ptr<JSIWorkletsModuleProxy> &uiRuntimeProxy) {
+  uiWorkletRuntime_->init(uiRuntimeProxy);
+
+  animationFrameBatchinator_ =
+      std::make_shared<AnimationFrameBatchinator>(uiWorkletRuntime_, runtimeBindings_->requestAnimationFrame);
+
+  UIRuntimeDecorator::decorate(
+      uiWorkletRuntime_->getJSIRuntime(), animationFrameBatchinator_->getJsiRequestAnimationFrame());
+
+  uiRuntimeStarted_ = true;
 }
 
 } // namespace worklets

--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.h
@@ -21,15 +21,14 @@ namespace worklets {
 
 class WorkletsModuleProxy : public std::enable_shared_from_this<WorkletsModuleProxy> {
  public:
+  void attachToRNRuntime(jsi::Runtime &rnRuntime, const BundleModeConfig &bundleModeConfig);
+
   void start();
 
   explicit WorkletsModuleProxy(
-      jsi::Runtime &rnRuntime,
-      const std::shared_ptr<CallInvoker> &jsCallInvoker,
+      const std::shared_ptr<JSScheduler> &jsScheduler,
       const std::shared_ptr<UIScheduler> &uiScheduler,
-      std::function<bool()> &&isJavaScriptQueue,
       const std::shared_ptr<RuntimeBindings> &runtimeBindings,
-      const BundleModeConfig &bundleModeConfig,
       const std::shared_ptr<RNRuntimeStatus> &rnRuntimeStatus);
 
   ~WorkletsModuleProxy();
@@ -55,18 +54,18 @@ class WorkletsModuleProxy : public std::enable_shared_from_this<WorkletsModulePr
   }
 
  private:
-  const bool isDevBundle_;
+  bool isDevBundle_;
   const std::shared_ptr<JSScheduler> jsScheduler_;
   const std::shared_ptr<UIScheduler> uiScheduler_;
   const std::shared_ptr<JSLogger> jsLogger_;
   const std::shared_ptr<RuntimeBindings> runtimeBindings_;
-  const BundleModeConfig bundleModeConfig_;
+  BundleModeConfig bundleModeConfig_;
   const std::shared_ptr<MemoryManager> memoryManager_;
   const std::shared_ptr<RuntimeManager> runtimeManager_;
   const std::shared_ptr<UnpackerLoader> unpackerLoader_;
   const std::shared_ptr<RNRuntimeStatus> rnRuntimeStatus_;
   std::shared_ptr<WorkletRuntime> uiWorkletRuntime_;
-  const std::shared_ptr<JSIWorkletsModuleProxy> rnRuntimeProxy_;
+  std::shared_ptr<JSIWorkletsModuleProxy> rnRuntimeProxy_;
   std::shared_ptr<AnimationFrameBatchinator> animationFrameBatchinator_;
 #ifndef NDEBUG
   SingleInstanceChecker<WorkletsModuleProxy> singleInstanceChecker_;

--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.h
@@ -16,12 +16,58 @@
 #include <worklets/WorkletRuntime/WorkletRuntime.h>
 
 #include <memory>
+#include <optional>
 
 namespace worklets {
 
+/**
+ * The initialization is a sequence of steps. The steps which do not need the RN Runtime run on background threads
+ * before the bundle asks for the module. The steps which need the RN Runtime run on the JS thread.
+ *
+ * Every mode starts the same way:
+ *
+ *   1. Native module creation: the platform creates the native module before the bundle runs. The module creates a
+ *      `WorkletsModuleProxyInitializer` and dispatches `WorkletsModuleProxyInitializer::prepareProxy` to a
+ *      background thread.
+ *   2. Background thread: `prepareProxy` calls the constructor of this class. The constructor creates the UI Worklet
+ *      Runtime, but does not initialize it.
+ *
+ * Legacy Mode continues with:
+ *
+ *   3. JS thread: the bundle evaluates `NativeWorklets`, which calls `installTurboModule(false)`. The native module
+ *      calls `WorkletsModuleProxyInitializer::finalize`. It waits for step 2 and calls `attachToRNRuntime` with a
+ *      disabled Bundle Mode config. `attachToRNRuntime` creates the JSI proxy for the RN Runtime and installs it on
+ *      the RN Runtime.
+ *   4. JS thread: `NativeWorklets` hands the unpacker code to the JSI proxy.
+ *   5. JS thread: `NativeWorklets` calls `start`. It initializes the UI Worklet Runtime and evaluates the unpacker
+ *      code on it.
+ *
+ * Bundle Mode continues with:
+ *
+ *   3. JS thread: the `prepareBundleMode` polyfill runs before the first module of the bundle. The Worklets plugin
+ *      enables the polyfill only when Bundle Mode is on. The polyfill calls `prepareBundleMode` on the native
+ *      module. The module calls `WorkletsModuleProxyInitializer::beginBundleMode` and dispatches
+ *      `WorkletsModuleProxyInitializer::prepareBundleMode` to a background thread.
+ *   4. Background thread: `prepareBundleMode` waits for step 2, loads the bundle and calls
+ *      `startUIRuntimeInBundleMode`. It stores the Bundle Mode config, initializes the UI Worklet Runtime and
+ *      evaluates the bundle on it. This runs in parallel with the JS thread, which evaluates the bundle on the RN
+ *      Runtime.
+ *   5. JS thread: the bundle evaluates `NativeWorklets`, which calls `installTurboModule(true)`. The native module
+ *      calls `WorkletsModuleProxyInitializer::finalize`. It waits for step 4 and calls `attachToRNRuntime` without
+ *      a Bundle Mode config, because step 4 already stored it. `attachToRNRuntime` creates the JSI proxy for the RN
+ *      Runtime and installs it on the RN Runtime.
+ *   6. JS thread: `NativeWorklets` calls `start`. It returns immediately, because step 4 already initialized the UI
+ *      Worklet Runtime.
+ *
+ * When Bundle Mode is enabled but the polyfill did not run, steps 3 and 4 are skipped. Step 5 then loads the bundle
+ * and passes the Bundle Mode config to `attachToRNRuntime`, and step 6 initializes the UI Worklet Runtime by
+ * evaluating the bundle on it, both on the JS thread.
+ */
 class WorkletsModuleProxy : public std::enable_shared_from_this<WorkletsModuleProxy> {
  public:
-  void attachToRNRuntime(jsi::Runtime &rnRuntime, const BundleModeConfig &bundleModeConfig);
+  void startUIRuntimeInBundleMode(const BundleModeConfig &bundleModeConfig);
+
+  void attachToRNRuntime(jsi::Runtime &rnRuntime, const std::optional<BundleModeConfig> &bundleModeConfig);
 
   void start();
 
@@ -54,6 +100,8 @@ class WorkletsModuleProxy : public std::enable_shared_from_this<WorkletsModulePr
   }
 
  private:
+  void startUIRuntime(const std::shared_ptr<JSIWorkletsModuleProxy> &uiRuntimeProxy);
+
   bool isDevBundle_;
   const std::shared_ptr<JSScheduler> jsScheduler_;
   const std::shared_ptr<UIScheduler> uiScheduler_;
@@ -67,6 +115,7 @@ class WorkletsModuleProxy : public std::enable_shared_from_this<WorkletsModulePr
   std::shared_ptr<WorkletRuntime> uiWorkletRuntime_;
   std::shared_ptr<JSIWorkletsModuleProxy> rnRuntimeProxy_;
   std::shared_ptr<AnimationFrameBatchinator> animationFrameBatchinator_;
+  bool uiRuntimeStarted_;
 #ifndef NDEBUG
   SingleInstanceChecker<WorkletsModuleProxy> singleInstanceChecker_;
 #endif // NDEBUG

--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxyInitializer.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxyInitializer.cpp
@@ -1,0 +1,63 @@
+#include <worklets/NativeModules/WorkletsModuleProxyInitializer.h>
+
+#include <react/debug/react_native_assert.h>
+
+#include <exception>
+#include <stdexcept>
+#include <utility>
+
+namespace worklets {
+
+WorkletsModuleProxyInitializer::WorkletsModuleProxyInitializer(
+    const std::shared_ptr<JSScheduler> &jsScheduler,
+    const std::shared_ptr<UIScheduler> &uiScheduler,
+    const std::shared_ptr<RuntimeBindings> &runtimeBindings,
+    const std::shared_ptr<RNRuntimeStatus> &rnRuntimeStatus)
+    : jsScheduler_(jsScheduler),
+      uiScheduler_(uiScheduler),
+      runtimeBindings_(runtimeBindings),
+      rnRuntimeStatus_(rnRuntimeStatus),
+      preparedProxyPromise_(std::make_shared<std::promise<std::shared_ptr<WorkletsModuleProxy>>>()),
+      preparedProxy_(preparedProxyPromise_->get_future()) {}
+
+void WorkletsModuleProxyInitializer::prepareProxy() {
+  if (prepared_.exchange(true)) {
+    throw std::runtime_error("[Worklets] prepareProxy must be called exactly once.");
+  }
+  try {
+    preparedProxyPromise_->set_value(
+        std::make_shared<WorkletsModuleProxy>(jsScheduler_, uiScheduler_, runtimeBindings_, rnRuntimeStatus_));
+  } catch (...) {
+    preparedProxyPromise_->set_exception(std::current_exception());
+  }
+}
+
+std::shared_ptr<WorkletsModuleProxy> WorkletsModuleProxyInitializer::finalize(
+    jsi::Runtime &rnRuntime,
+    const BundleModeConfig &bundleModeConfig) {
+  react_native_assert(jsScheduler_->canInvokeSyncOnJS() && "finalize must be called on the JS thread");
+  ProxyFuture preparedProxy;
+  {
+    std::lock_guard lock(mutex_);
+    preparedProxy = std::move(preparedProxy_);
+  }
+  if (!preparedProxy.valid()) {
+    throw std::runtime_error("[Worklets] finalize was called after the prepared proxy was already taken.");
+  }
+  auto proxy = preparedProxy.get();
+  proxy->attachToRNRuntime(rnRuntime, bundleModeConfig);
+  return proxy;
+}
+
+void WorkletsModuleProxyInitializer::invalidate() {
+  ProxyFuture preparedProxy;
+  {
+    std::lock_guard lock(mutex_);
+    preparedProxy = std::move(preparedProxy_);
+  }
+  if (preparedProxy.valid()) {
+    preparedProxy.wait();
+  }
+}
+
+} // namespace worklets

--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxyInitializer.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxyInitializer.cpp
@@ -32,28 +32,81 @@ void WorkletsModuleProxyInitializer::prepareProxy() {
   }
 }
 
-std::shared_ptr<WorkletsModuleProxy> WorkletsModuleProxyInitializer::finalize(
-    jsi::Runtime &rnRuntime,
-    const BundleModeConfig &bundleModeConfig) {
-  react_native_assert(jsScheduler_->canInvokeSyncOnJS() && "finalize must be called on the JS thread");
+void WorkletsModuleProxyInitializer::beginBundleMode() {
+  react_native_assert(jsScheduler_->canInvokeSyncOnJS() && "beginBundleMode must be called on the JS thread");
+  std::lock_guard lock(mutex_);
+  if (startedProxy_.valid()) [[unlikely]] {
+    throw std::runtime_error("[Worklets] beginBundleMode must be called at most once.");
+  }
+  if (!preparedProxy_.valid()) [[unlikely]] {
+    throw std::runtime_error("[Worklets] beginBundleMode must be called before finalize.");
+  }
+  startedProxyPromise_ = std::make_shared<std::promise<std::shared_ptr<WorkletsModuleProxy>>>();
+  startedProxy_ = startedProxyPromise_->get_future();
+}
+
+void WorkletsModuleProxyInitializer::prepareBundleMode(const BundleModeConfigLoader &loadBundleModeConfig) {
+  ProxyPromise startedProxyPromise;
   ProxyFuture preparedProxy;
   {
     std::lock_guard lock(mutex_);
+    startedProxyPromise = std::move(startedProxyPromise_);
     preparedProxy = std::move(preparedProxy_);
   }
-  if (!preparedProxy.valid()) {
+  if (!startedProxyPromise) [[unlikely]] {
+    throw std::runtime_error("[Worklets] prepareBundleMode must be called exactly once after beginBundleMode.");
+  }
+  try {
+    if (!preparedProxy.valid()) [[unlikely]] {
+      throw std::runtime_error("[Worklets] prepareBundleMode was called after the prepared proxy was already taken.");
+    }
+    auto proxy = preparedProxy.get();
+    proxy->startUIRuntimeInBundleMode(loadBundleModeConfig());
+    startedProxyPromise->set_value(std::move(proxy));
+  } catch (...) {
+    startedProxyPromise->set_exception(std::current_exception());
+  }
+}
+
+std::shared_ptr<WorkletsModuleProxy> WorkletsModuleProxyInitializer::finalize(
+    jsi::Runtime &rnRuntime,
+    const bool bundleModeEnabled,
+    const BundleModeConfigLoader &loadBundleModeConfig) {
+  react_native_assert(jsScheduler_->canInvokeSyncOnJS() && "finalize must be called on the JS thread");
+  bool startedAheadOfTime = false;
+  ProxyFuture proxyFuture;
+  {
+    std::lock_guard lock(mutex_);
+    startedAheadOfTime = startedProxy_.valid();
+    proxyFuture = std::move(startedAheadOfTime ? startedProxy_ : preparedProxy_);
+  }
+  if (!proxyFuture.valid()) [[unlikely]] {
     throw std::runtime_error("[Worklets] finalize was called after the prepared proxy was already taken.");
   }
-  auto proxy = preparedProxy.get();
-  proxy->attachToRNRuntime(rnRuntime, bundleModeConfig);
+  if (startedAheadOfTime && !bundleModeEnabled) [[unlikely]] {
+    throw std::runtime_error(
+        "[Worklets] prepareBundleMode was called, but installTurboModule was called with Bundle Mode disabled.");
+  }
+  auto proxy = proxyFuture.get();
+  if (startedAheadOfTime) {
+    proxy->attachToRNRuntime(rnRuntime, std::nullopt);
+  } else {
+    proxy->attachToRNRuntime(
+        rnRuntime, bundleModeEnabled ? loadBundleModeConfig() : BundleModeConfig{.enabled = false});
+  }
   return proxy;
 }
 
 void WorkletsModuleProxyInitializer::invalidate() {
+  ProxyFuture startedProxy;
   ProxyFuture preparedProxy;
   {
     std::lock_guard lock(mutex_);
+    startedProxy = std::move(startedProxy_);
     preparedProxy = std::move(preparedProxy_);
+  }
+  if (startedProxy.valid()) {
+    startedProxy.wait();
   }
   if (preparedProxy.valid()) {
     preparedProxy.wait();

--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxyInitializer.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxyInitializer.cpp
@@ -83,10 +83,6 @@ std::shared_ptr<WorkletsModuleProxy> WorkletsModuleProxyInitializer::finalize(
   if (!proxyFuture.valid()) [[unlikely]] {
     throw std::runtime_error("[Worklets] finalize was called after the prepared proxy was already taken.");
   }
-  if (startedAheadOfTime && !bundleModeEnabled) [[unlikely]] {
-    throw std::runtime_error(
-        "[Worklets] prepareBundleMode was called, but installTurboModule was called with Bundle Mode disabled.");
-  }
   auto proxy = proxyFuture.get();
   if (startedAheadOfTime) {
     proxy->attachToRNRuntime(rnRuntime, std::nullopt);

--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxyInitializer.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxyInitializer.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <jsi/jsi.h>
+#include <worklets/NativeModules/WorkletsModuleProxy.h>
+#include <worklets/Tools/JSScheduler.h>
+#include <worklets/Tools/RNRuntimeStatus.h>
+#include <worklets/Tools/UIScheduler.h>
+#include <worklets/WorkletRuntime/BundleModeConfig.h>
+#include <worklets/WorkletRuntime/RuntimeBindings.h>
+
+#include <atomic>
+#include <future>
+#include <memory>
+#include <mutex>
+
+namespace worklets {
+
+class WorkletsModuleProxyInitializer {
+ public:
+  WorkletsModuleProxyInitializer(
+      const std::shared_ptr<JSScheduler> &jsScheduler,
+      const std::shared_ptr<UIScheduler> &uiScheduler,
+      const std::shared_ptr<RuntimeBindings> &runtimeBindings,
+      const std::shared_ptr<RNRuntimeStatus> &rnRuntimeStatus);
+
+  void prepareProxy();
+
+  std::shared_ptr<WorkletsModuleProxy> finalize(jsi::Runtime &rnRuntime, const BundleModeConfig &bundleModeConfig);
+
+  void invalidate();
+
+ private:
+  using ProxyFuture = std::future<std::shared_ptr<WorkletsModuleProxy>>;
+
+  const std::shared_ptr<JSScheduler> jsScheduler_;
+  const std::shared_ptr<UIScheduler> uiScheduler_;
+  const std::shared_ptr<RuntimeBindings> runtimeBindings_;
+  const std::shared_ptr<RNRuntimeStatus> rnRuntimeStatus_;
+
+  std::atomic<bool> prepared_{false};
+  std::mutex mutex_;
+  const std::shared_ptr<std::promise<std::shared_ptr<WorkletsModuleProxy>>> preparedProxyPromise_;
+  ProxyFuture preparedProxy_;
+};
+
+} // namespace worklets

--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxyInitializer.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxyInitializer.h
@@ -9,6 +9,7 @@
 #include <worklets/WorkletRuntime/RuntimeBindings.h>
 
 #include <atomic>
+#include <functional>
 #include <future>
 #include <memory>
 #include <mutex>
@@ -17,6 +18,8 @@ namespace worklets {
 
 class WorkletsModuleProxyInitializer {
  public:
+  using BundleModeConfigLoader = std::function<BundleModeConfig()>;
+
   WorkletsModuleProxyInitializer(
       const std::shared_ptr<JSScheduler> &jsScheduler,
       const std::shared_ptr<UIScheduler> &uiScheduler,
@@ -25,11 +28,17 @@ class WorkletsModuleProxyInitializer {
 
   void prepareProxy();
 
-  std::shared_ptr<WorkletsModuleProxy> finalize(jsi::Runtime &rnRuntime, const BundleModeConfig &bundleModeConfig);
+  void beginBundleMode();
+
+  void prepareBundleMode(const BundleModeConfigLoader &loadBundleModeConfig);
+
+  std::shared_ptr<WorkletsModuleProxy>
+  finalize(jsi::Runtime &rnRuntime, bool bundleModeEnabled, const BundleModeConfigLoader &loadBundleModeConfig);
 
   void invalidate();
 
  private:
+  using ProxyPromise = std::shared_ptr<std::promise<std::shared_ptr<WorkletsModuleProxy>>>;
   using ProxyFuture = std::future<std::shared_ptr<WorkletsModuleProxy>>;
 
   const std::shared_ptr<JSScheduler> jsScheduler_;
@@ -39,8 +48,10 @@ class WorkletsModuleProxyInitializer {
 
   std::atomic<bool> prepared_{false};
   std::mutex mutex_;
-  const std::shared_ptr<std::promise<std::shared_ptr<WorkletsModuleProxy>>> preparedProxyPromise_;
+  const ProxyPromise preparedProxyPromise_;
   ProxyFuture preparedProxy_;
+  ProxyPromise startedProxyPromise_;
+  ProxyFuture startedProxy_;
 };
 
 } // namespace worklets

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.cpp
@@ -99,7 +99,8 @@ void WorkletRuntime::init(const std::shared_ptr<JSIWorkletsModuleProxy> &jsiWork
   const auto runtimeBindings = jsiWorkletsModuleProxy->getRuntimeBindings();
   const auto bundleModeEnabled = jsiWorkletsModuleProxy->isBundleModeEnabled();
   const auto unpackerLoader = jsiWorkletsModuleProxy->getUnpackerLoader();
-  const auto &nativeLoggingHook = runtimeBindings->nativeLoggingHook;
+  const auto nativeLoggingHook =
+      bundleModeEnabled ? runtimeBindings->nativeLoggingHook : RuntimeBindings::NativeLoggingHook{};
 
   WorkletRuntimeDecorator::decorate(
       rt,

--- a/packages/react-native-worklets/__tests__/bundleMode.test.ts
+++ b/packages/react-native-worklets/__tests__/bundleMode.test.ts
@@ -70,4 +70,22 @@ describe('bundle mode Metro config', () => {
     expect(result.filePath.endsWith(path.join('.worklets', '1.js'))).toBe(true);
     expect(resolveRequest).not.toHaveBeenCalled();
   });
+
+  test('keeps existing polyfills and appends the prepareBundleMode polyfill', () => {
+    const config = getBundleModeMetroConfig({
+      resolver: {},
+      serializer: { polyfillModuleNames: ['/custom/polyfill.js'] },
+      transformer: {},
+    });
+
+    expect(config.serializer.polyfillModuleNames).toHaveLength(2);
+    expect(config.serializer.polyfillModuleNames[0]).toBe(
+      '/custom/polyfill.js'
+    );
+    expect(
+      config.serializer.polyfillModuleNames[1].endsWith(
+        path.join('bundleMode', 'polyfills', 'prepareBundleMode.js')
+      )
+    ).toBe(true);
+  });
 });

--- a/packages/react-native-worklets/android/src/main/cpp/worklets/android/WorkletsModule.cpp
+++ b/packages/react-native-worklets/android/src/main/cpp/worklets/android/WorkletsModule.cpp
@@ -1,3 +1,4 @@
+#include <worklets/Tools/JSScheduler.h>
 #include <worklets/Tools/ScriptBuffer.h>
 #include <worklets/WorkletRuntime/BundleModeConfig.h>
 #include <worklets/WorkletRuntime/RuntimeBindings.h>
@@ -26,63 +27,62 @@ namespace worklets {
 using namespace facebook;
 using namespace react;
 
+namespace {
+
+BundleModeConfig bundleModeConfigFromWrapper(
+    const jni::alias_ref<JScriptBufferWrapper::javaobject> &jScriptBufferWrapper) {
+  if (!jScriptBufferWrapper) {
+    return BundleModeConfig{.enabled = false};
+  }
+  auto cxxWrapper = jScriptBufferWrapper->cthis();
+  return BundleModeConfig{.enabled = true, .script = cxxWrapper->getScript(), .sourceURL = cxxWrapper->getSourceUrl()};
+}
+
+} // namespace
+
 WorkletsModule::WorkletsModule(
     jni::alias_ref<jhybridobject> jThis, // NOLINT //(performance-unnecessary-value-param)
-    const BundleModeConfig &bundleModeConfig,
     jsi::Runtime *rnRuntime,
     const std::shared_ptr<facebook::react::CallInvoker> &jsCallInvoker,
     const std::shared_ptr<UIScheduler> &uiScheduler)
     : javaPart_(jni::make_global(jThis)),
       rnRuntime_(rnRuntime),
       rnRuntimeStatus_(std::make_shared<RNRuntimeStatus>()),
-      workletsModuleProxy_(std::make_shared<WorkletsModuleProxy>(
-          *rnRuntime,
-          jsCallInvoker,
+      initializer_(std::make_shared<WorkletsModuleProxyInitializer>(
+          std::make_shared<JSScheduler>(*rnRuntime, jsCallInvoker, getIsOnJSQueueThread()),
           uiScheduler,
-          getIsOnJSQueueThread(),
-          getRuntimeBindings(bundleModeConfig.enabled),
-          bundleModeConfig,
+          getRuntimeBindings(),
           rnRuntimeStatus_)) {}
 
 jni::local_ref<WorkletsModule::jhybriddata> WorkletsModule::initHybrid(
     jni::alias_ref<jhybridobject> jThis, // NOLINT //(performance-unnecessary-value-param)
-    jboolean bundleModeEnabled,
     jlong jsContext,
     jni::alias_ref<facebook::react::CallInvokerHolder::javaobject> jsCallInvokerHolder,
-    jni::alias_ref<worklets::AndroidUIScheduler::javaobject> androidUIScheduler,
-    jni::alias_ref<JScriptBufferWrapper::javaobject>
-        jScriptBufferWrapper // NOLINT //(performance-unnecessary-value-param)
-) {
+    jni::alias_ref<worklets::AndroidUIScheduler::javaobject> androidUIScheduler) {
   auto jsCallInvoker = jsCallInvokerHolder->cthis()->getCallInvoker();
   auto rnRuntime = reinterpret_cast<jsi::Runtime *>(jsContext); // NOLINT //(performance-no-int-to-ptr)
   auto uiScheduler = androidUIScheduler->cthis()->getUIScheduler();
-
-  std::shared_ptr<const ScriptBuffer> script = nullptr;
-  std::string sourceURL;
-  if (bundleModeEnabled) {
-    auto cxxWrapper = jScriptBufferWrapper->cthis();
-    script = cxxWrapper->getScript();
-    sourceURL = cxxWrapper->getSourceUrl();
-  }
-
-  return makeCxxInstance(
-      jThis,
-      BundleModeConfig{
-          .enabled = static_cast<bool>(bundleModeEnabled),
-          .script = script,
-          .sourceURL = sourceURL,
-      },
-      rnRuntime,
-      jsCallInvoker,
-      uiScheduler);
+  return makeCxxInstance(jThis, rnRuntime, jsCallInvoker, uiScheduler);
 }
 
-std::shared_ptr<RuntimeBindings> WorkletsModule::getRuntimeBindings(const bool bundleModeEnabled) {
+void WorkletsModule::prepareProxyCpp() {
+  initializer_->prepareProxy();
+}
+
+void WorkletsModule::installTurboModuleCpp(
+    jboolean bundleModeEnabled,
+    jni::alias_ref<JScriptBufferWrapper::javaobject>
+        jScriptBufferWrapper // NOLINT //(performance-unnecessary-value-param)
+) {
+  workletsModuleProxy_ = initializer_->finalize(*rnRuntime_, bundleModeConfigFromWrapper(jScriptBufferWrapper));
+}
+
+std::shared_ptr<RuntimeBindings> WorkletsModule::getRuntimeBindings() {
   return std::make_shared<RuntimeBindings>(RuntimeBindings{
       .requestAnimationFrame = getRequestAnimationFrame(),
-      .nativeLoggingHook = bundleModeEnabled ? makeNativeLoggingHook() : RuntimeBindings::NativeLoggingHook{}
+      .nativeLoggingHook = makeNativeLoggingHook()
 #ifdef WORKLETS_FETCH_PREVIEW_ENABLED
-      ,
+          ,
       .abortRequest = getAbortRequest(),
       .clearCookies = getClearCookies(),
       .sendRequest = getSendRequest()
@@ -181,6 +181,7 @@ std::function<bool()> WorkletsModule::getIsOnJSQueueThread() {
 
 void WorkletsModule::invalidateCpp() {
   rnRuntimeStatus_->setDead();
+  initializer_->invalidate();
   javaPart_.reset();
   workletsModuleProxy_.reset();
 }
@@ -192,6 +193,8 @@ void WorkletsModule::startCpp() {
 void WorkletsModule::registerNatives() {
   registerHybrid({
       makeNativeMethod("initHybrid", WorkletsModule::initHybrid),
+      makeNativeMethod("prepareProxyCpp", WorkletsModule::prepareProxyCpp),
+      makeNativeMethod("installTurboModuleCpp", WorkletsModule::installTurboModuleCpp),
       makeNativeMethod("invalidateCpp", WorkletsModule::invalidateCpp),
       makeNativeMethod("startCpp", WorkletsModule::startCpp),
   });

--- a/packages/react-native-worklets/android/src/main/cpp/worklets/android/WorkletsModule.cpp
+++ b/packages/react-native-worklets/android/src/main/cpp/worklets/android/WorkletsModule.cpp
@@ -27,19 +27,6 @@ namespace worklets {
 using namespace facebook;
 using namespace react;
 
-namespace {
-
-BundleModeConfig bundleModeConfigFromWrapper(
-    const jni::alias_ref<JScriptBufferWrapper::javaobject> &jScriptBufferWrapper) {
-  if (!jScriptBufferWrapper) {
-    return BundleModeConfig{.enabled = false};
-  }
-  auto cxxWrapper = jScriptBufferWrapper->cthis();
-  return BundleModeConfig{.enabled = true, .script = cxxWrapper->getScript(), .sourceURL = cxxWrapper->getSourceUrl()};
-}
-
-} // namespace
-
 WorkletsModule::WorkletsModule(
     jni::alias_ref<jhybridobject> jThis, // NOLINT //(performance-unnecessary-value-param)
     jsi::Runtime *rnRuntime,
@@ -69,12 +56,17 @@ void WorkletsModule::prepareProxyCpp() {
   initializer_->prepareProxy();
 }
 
-void WorkletsModule::installTurboModuleCpp(
-    jboolean bundleModeEnabled,
-    jni::alias_ref<JScriptBufferWrapper::javaobject>
-        jScriptBufferWrapper // NOLINT //(performance-unnecessary-value-param)
-) {
-  workletsModuleProxy_ = initializer_->finalize(*rnRuntime_, bundleModeConfigFromWrapper(jScriptBufferWrapper));
+void WorkletsModule::beginBundleModeCpp() {
+  initializer_->beginBundleMode();
+}
+
+void WorkletsModule::prepareBundleModeCpp() {
+  initializer_->prepareBundleMode([this] { return loadBundleModeConfig(); });
+}
+
+void WorkletsModule::installTurboModuleCpp(jboolean bundleModeEnabled) {
+  workletsModuleProxy_ = initializer_->finalize(
+      *rnRuntime_, static_cast<bool>(bundleModeEnabled), [this] { return loadBundleModeConfig(); });
 }
 
 std::shared_ptr<RuntimeBindings> WorkletsModule::getRuntimeBindings() {
@@ -88,6 +80,15 @@ std::shared_ptr<RuntimeBindings> WorkletsModule::getRuntimeBindings() {
       .sendRequest = getSendRequest()
 #endif // WORKLETS_FETCH_PREVIEW_ENABLED
   });
+}
+
+BundleModeConfig WorkletsModule::loadBundleModeConfig() {
+  static const auto jCreateScriptBufferWrapper =
+      getJniMethod<JScriptBufferWrapper::javaobject()>("createScriptBufferWrapper");
+  const auto jScriptBufferWrapper = jCreateScriptBufferWrapper(javaPart_.get());
+  const auto scriptBufferWrapper = jScriptBufferWrapper->cthis();
+  return BundleModeConfig{
+      .enabled = true, .script = scriptBufferWrapper->getScript(), .sourceURL = scriptBufferWrapper->getSourceUrl()};
 }
 
 RuntimeBindings::RequestAnimationFrame WorkletsModule::getRequestAnimationFrame() {
@@ -195,6 +196,8 @@ void WorkletsModule::registerNatives() {
   registerHybrid({
       makeNativeMethod("initHybrid", WorkletsModule::initHybrid),
       makeNativeMethod("prepareProxyCpp", WorkletsModule::prepareProxyCpp),
+      makeNativeMethod("beginBundleModeCpp", WorkletsModule::beginBundleModeCpp),
+      makeNativeMethod("prepareBundleModeCpp", WorkletsModule::prepareBundleModeCpp),
       makeNativeMethod("installTurboModuleCpp", WorkletsModule::installTurboModuleCpp),
       makeNativeMethod("invalidateCpp", WorkletsModule::invalidateCpp),
       makeNativeMethod("startCpp", WorkletsModule::startCpp),

--- a/packages/react-native-worklets/android/src/main/cpp/worklets/android/WorkletsModule.cpp
+++ b/packages/react-native-worklets/android/src/main/cpp/worklets/android/WorkletsModule.cpp
@@ -182,6 +182,7 @@ std::function<bool()> WorkletsModule::getIsOnJSQueueThread() {
 void WorkletsModule::invalidateCpp() {
   rnRuntimeStatus_->setDead();
   initializer_->invalidate();
+  initializer_.reset();
   javaPart_.reset();
   workletsModuleProxy_.reset();
 }

--- a/packages/react-native-worklets/android/src/main/cpp/worklets/android/WorkletsModule.h
+++ b/packages/react-native-worklets/android/src/main/cpp/worklets/android/WorkletsModule.h
@@ -4,6 +4,7 @@
 #include <fbjni/fbjni.h>
 #include <jsi/jsi.h>
 #include <worklets/NativeModules/WorkletsModuleProxy.h>
+#include <worklets/NativeModules/WorkletsModuleProxyInitializer.h>
 #include <worklets/Tools/RNRuntimeStatus.h>
 #include <worklets/Tools/ScriptBuffer.h>
 #include <worklets/WorkletRuntime/BundleModeConfig.h>
@@ -25,11 +26,9 @@ class WorkletsModule : public jni::HybridClass<WorkletsModule> {
 
   static jni::local_ref<jhybriddata> initHybrid(
       jni::alias_ref<jhybridobject> jThis,
-      jboolean bundleModeEnabled,
       jlong jsContext,
       jni::alias_ref<facebook::react::CallInvokerHolder::javaobject> jsCallInvokerHolder,
-      jni::alias_ref<worklets::AndroidUIScheduler::javaobject> androidUIScheduler,
-      jni::alias_ref<JScriptBufferWrapper::javaobject> jScriptBufferWrapper);
+      jni::alias_ref<worklets::AndroidUIScheduler::javaobject> androidUIScheduler);
 
   static void registerNatives();
 
@@ -40,10 +39,15 @@ class WorkletsModule : public jni::HybridClass<WorkletsModule> {
  private:
   explicit WorkletsModule(
       jni::alias_ref<jhybridobject> jThis,
-      const BundleModeConfig &bundleModeConfig,
       jsi::Runtime *rnRuntime,
       const std::shared_ptr<facebook::react::CallInvoker> &jsCallInvoker,
       const std::shared_ptr<UIScheduler> &uiScheduler);
+
+  void prepareProxyCpp();
+
+  void installTurboModuleCpp(
+      jboolean bundleModeEnabled,
+      jni::alias_ref<JScriptBufferWrapper::javaobject> jScriptBufferWrapper);
 
   void startCpp();
 
@@ -54,7 +58,7 @@ class WorkletsModule : public jni::HybridClass<WorkletsModule> {
     return javaPart_->getClass()->getMethod<Signature>(methodName.c_str());
   }
 
-  std::shared_ptr<RuntimeBindings> getRuntimeBindings(bool bundleModeEnabled);
+  std::shared_ptr<RuntimeBindings> getRuntimeBindings();
 
   RuntimeBindings::RequestAnimationFrame getRequestAnimationFrame();
 #ifdef WORKLETS_FETCH_PREVIEW_ENABLED
@@ -69,6 +73,7 @@ class WorkletsModule : public jni::HybridClass<WorkletsModule> {
   jni::global_ref<WorkletsModule::javaobject> javaPart_;
   jsi::Runtime *rnRuntime_;
   std::shared_ptr<RNRuntimeStatus> rnRuntimeStatus_;
+  std::shared_ptr<WorkletsModuleProxyInitializer> initializer_;
   std::shared_ptr<WorkletsModuleProxy> workletsModuleProxy_;
 };
 

--- a/packages/react-native-worklets/android/src/main/cpp/worklets/android/WorkletsModule.h
+++ b/packages/react-native-worklets/android/src/main/cpp/worklets/android/WorkletsModule.h
@@ -45,9 +45,11 @@ class WorkletsModule : public jni::HybridClass<WorkletsModule> {
 
   void prepareProxyCpp();
 
-  void installTurboModuleCpp(
-      jboolean bundleModeEnabled,
-      jni::alias_ref<JScriptBufferWrapper::javaobject> jScriptBufferWrapper);
+  void beginBundleModeCpp();
+
+  void prepareBundleModeCpp();
+
+  void installTurboModuleCpp(jboolean bundleModeEnabled);
 
   void startCpp();
 
@@ -59,6 +61,8 @@ class WorkletsModule : public jni::HybridClass<WorkletsModule> {
   }
 
   std::shared_ptr<RuntimeBindings> getRuntimeBindings();
+
+  BundleModeConfig loadBundleModeConfig();
 
   RuntimeBindings::RequestAnimationFrame getRequestAnimationFrame();
 #ifdef WORKLETS_FETCH_PREVIEW_ENABLED

--- a/packages/react-native-worklets/android/src/networking/com/swmansion/worklets/WorkletsModule.kt
+++ b/packages/react-native-worklets/android/src/networking/com/swmansion/worklets/WorkletsModule.kt
@@ -16,7 +16,7 @@ import com.swmansion.worklets.runloop.AnimationFrameCallback
 import com.swmansion.worklets.runloop.AnimationFrameQueue
 
 @Suppress("KotlinJniMissingFunction")
-@ReactModule(name = WorkletsModule.NAME)
+@ReactModule(name = WorkletsModule.NAME, needsEagerInit = true)
 class WorkletsModule(
     reactContext: ReactApplicationContext,
 ) : NativeWorkletsModuleSpec(reactContext),
@@ -36,10 +36,6 @@ class WorkletsModule(
     @Suppress("unused")
     protected fun getHybridData(): HybridData? = mHybridData
 
-    init {
-        reactContext.assertOnJSQueueThread()
-    }
-
     private val mAndroidUIScheduler = AndroidUIScheduler(reactContext)
     private val mAnimationFrameQueue = AnimationFrameQueue(reactContext)
     private val mWorkletsNetworking = WorkletsNetworking()
@@ -54,12 +50,17 @@ class WorkletsModule(
 
     @OptIn(FrameworkAPI::class)
     private external fun initHybrid(
-        bundleModeEnabled: Boolean,
         jsContext: Long,
         jsCallInvokerHolder: CallInvokerHolderImpl,
         androidUIScheduler: AndroidUIScheduler,
-        scriptBufferWrapper: ScriptBufferWrapper?,
     ): HybridData
+
+    private external fun prepareProxyCpp()
+
+    private external fun installTurboModuleCpp(
+        bundleModeEnabled: Boolean,
+        scriptBufferWrapper: ScriptBufferWrapper?,
+    )
 
     @OptIn(FrameworkAPI::class)
     @ReactMethod(isBlockingSynchronousMethod = true)
@@ -68,9 +69,6 @@ class WorkletsModule(
 
         context.assertOnJSQueueThread()
 
-        val jsContext = checkNotNull(context.javaScriptContextHolder).get()
-        val jsCallInvokerHolder = context.jsCallInvokerHolder as CallInvokerHolderImpl
-
         val scriptBufferWrapper: ScriptBufferWrapper? =
             if (bundleModeEnabled) {
                 ScriptBufferWrapper(context.sourceURL, context)
@@ -78,14 +76,7 @@ class WorkletsModule(
                 null
             }
 
-        mHybridData =
-            initHybrid(
-                bundleModeEnabled,
-                jsContext,
-                jsCallInvokerHolder,
-                mAndroidUIScheduler,
-                scriptBufferWrapper,
-            )
+        installTurboModuleCpp(bundleModeEnabled, scriptBufferWrapper)
         return true
     }
 
@@ -161,6 +152,8 @@ class WorkletsModule(
 
     override fun initialize() {
         reactApplicationContext.addLifecycleEventListener(this)
+        createHybrid()
+        Thread({ prepareProxyCpp() }, "WorkletsProxyPrepare").start()
     }
 
     override fun invalidate() {
@@ -201,4 +194,15 @@ class WorkletsModule(
     }
 
     override fun onHostDestroy() {}
+
+    @OptIn(FrameworkAPI::class)
+    private fun createHybrid() {
+        val context = reactApplicationContext
+        val jsContext =
+            checkNotNull(context.javaScriptContextHolder) {
+                "[Worklets] JavaScript context is not available yet."
+            }.get()
+        val jsCallInvokerHolder = context.jsCallInvokerHolder as CallInvokerHolderImpl
+        mHybridData = initHybrid(jsContext, jsCallInvokerHolder, mAndroidUIScheduler)
+    }
 }

--- a/packages/react-native-worklets/android/src/networking/com/swmansion/worklets/WorkletsModule.kt
+++ b/packages/react-native-worklets/android/src/networking/com/swmansion/worklets/WorkletsModule.kt
@@ -57,26 +57,26 @@ class WorkletsModule(
 
     private external fun prepareProxyCpp()
 
-    private external fun installTurboModuleCpp(
-        bundleModeEnabled: Boolean,
-        scriptBufferWrapper: ScriptBufferWrapper?,
-    )
+    private external fun beginBundleModeCpp()
+
+    private external fun prepareBundleModeCpp()
+
+    private external fun installTurboModuleCpp(bundleModeEnabled: Boolean)
+
+    @OptIn(FrameworkAPI::class)
+    @ReactMethod(isBlockingSynchronousMethod = true)
+    override fun prepareBundleMode(): Boolean {
+        reactApplicationContext.assertOnJSQueueThread()
+        beginBundleModeCpp()
+        Thread({ prepareBundleModeCpp() }, "WorkletsBundleModePrepare").start()
+        return true
+    }
 
     @OptIn(FrameworkAPI::class)
     @ReactMethod(isBlockingSynchronousMethod = true)
     override fun installTurboModule(bundleModeEnabled: Boolean): Boolean {
-        val context = reactApplicationContext
-
-        context.assertOnJSQueueThread()
-
-        val scriptBufferWrapper: ScriptBufferWrapper? =
-            if (bundleModeEnabled) {
-                ScriptBufferWrapper(context.sourceURL, context)
-            } else {
-                null
-            }
-
-        installTurboModuleCpp(bundleModeEnabled, scriptBufferWrapper)
+        reactApplicationContext.assertOnJSQueueThread()
+        installTurboModuleCpp(bundleModeEnabled)
         return true
     }
 
@@ -136,6 +136,10 @@ class WorkletsModule(
     /** @noinspection unused */
     @DoNotStrip
     fun isOnJSQueueThread(): Boolean = reactApplicationContext.isOnJSQueueThread
+
+    /** @noinspection unused */
+    @DoNotStrip
+    fun createScriptBufferWrapper(): ScriptBufferWrapper = ScriptBufferWrapper(reactApplicationContext.sourceURL, reactApplicationContext)
 
     fun toggleSlowAnimations() {
         val animationsDragFactor = 10

--- a/packages/react-native-worklets/android/src/no-networking/com/swmansion/worklets/WorkletsModule.kt
+++ b/packages/react-native-worklets/android/src/no-networking/com/swmansion/worklets/WorkletsModule.kt
@@ -13,7 +13,7 @@ import com.swmansion.worklets.runloop.AnimationFrameCallback
 import com.swmansion.worklets.runloop.AnimationFrameQueue
 
 @Suppress("KotlinJniMissingFunction")
-@ReactModule(name = WorkletsModule.NAME)
+@ReactModule(name = WorkletsModule.NAME, needsEagerInit = true)
 class WorkletsModule(
     reactContext: ReactApplicationContext,
 ) : NativeWorkletsModuleSpec(reactContext),
@@ -33,10 +33,6 @@ class WorkletsModule(
     @Suppress("unused")
     protected fun getHybridData(): HybridData? = mHybridData
 
-    init {
-        reactContext.assertOnJSQueueThread()
-    }
-
     private val mAndroidUIScheduler = AndroidUIScheduler(reactContext)
     private val mAnimationFrameQueue = AnimationFrameQueue(reactContext)
     private var mSlowAnimationsEnabled = false
@@ -50,12 +46,17 @@ class WorkletsModule(
 
     @OptIn(FrameworkAPI::class)
     private external fun initHybrid(
-        bundleModeEnabled: Boolean,
         jsContext: Long,
         jsCallInvokerHolder: CallInvokerHolderImpl,
         androidUIScheduler: AndroidUIScheduler,
-        scriptBufferWrapper: ScriptBufferWrapper?,
     ): HybridData
+
+    private external fun prepareProxyCpp()
+
+    private external fun installTurboModuleCpp(
+        bundleModeEnabled: Boolean,
+        scriptBufferWrapper: ScriptBufferWrapper?,
+    )
 
     @OptIn(FrameworkAPI::class)
     @ReactMethod(isBlockingSynchronousMethod = true)
@@ -64,9 +65,6 @@ class WorkletsModule(
 
         context.assertOnJSQueueThread()
 
-        val jsContext = checkNotNull(context.javaScriptContextHolder).get()
-        val jsCallInvokerHolder = context.jsCallInvokerHolder as CallInvokerHolderImpl
-
         val scriptBufferWrapper: ScriptBufferWrapper? =
             if (bundleModeEnabled) {
                 ScriptBufferWrapper(context.sourceURL, context)
@@ -74,14 +72,7 @@ class WorkletsModule(
                 null
             }
 
-        mHybridData =
-            initHybrid(
-                bundleModeEnabled,
-                jsContext,
-                jsCallInvokerHolder,
-                mAndroidUIScheduler,
-                scriptBufferWrapper,
-            )
+        installTurboModuleCpp(bundleModeEnabled, scriptBufferWrapper)
         return true
     }
 
@@ -117,6 +108,8 @@ class WorkletsModule(
 
     override fun initialize() {
         reactApplicationContext.addLifecycleEventListener(this)
+        createHybrid()
+        Thread({ prepareProxyCpp() }, "WorkletsProxyPrepare").start()
     }
 
     override fun invalidate() {
@@ -157,4 +150,15 @@ class WorkletsModule(
     }
 
     override fun onHostDestroy() {}
+
+    @OptIn(FrameworkAPI::class)
+    private fun createHybrid() {
+        val context = reactApplicationContext
+        val jsContext =
+            checkNotNull(context.javaScriptContextHolder) {
+                "[Worklets] JavaScript context is not available yet."
+            }.get()
+        val jsCallInvokerHolder = context.jsCallInvokerHolder as CallInvokerHolderImpl
+        mHybridData = initHybrid(jsContext, jsCallInvokerHolder, mAndroidUIScheduler)
+    }
 }

--- a/packages/react-native-worklets/android/src/no-networking/com/swmansion/worklets/WorkletsModule.kt
+++ b/packages/react-native-worklets/android/src/no-networking/com/swmansion/worklets/WorkletsModule.kt
@@ -53,26 +53,26 @@ class WorkletsModule(
 
     private external fun prepareProxyCpp()
 
-    private external fun installTurboModuleCpp(
-        bundleModeEnabled: Boolean,
-        scriptBufferWrapper: ScriptBufferWrapper?,
-    )
+    private external fun beginBundleModeCpp()
+
+    private external fun prepareBundleModeCpp()
+
+    private external fun installTurboModuleCpp(bundleModeEnabled: Boolean)
+
+    @OptIn(FrameworkAPI::class)
+    @ReactMethod(isBlockingSynchronousMethod = true)
+    override fun prepareBundleMode(): Boolean {
+        reactApplicationContext.assertOnJSQueueThread()
+        beginBundleModeCpp()
+        Thread({ prepareBundleModeCpp() }, "WorkletsBundleModePrepare").start()
+        return true
+    }
 
     @OptIn(FrameworkAPI::class)
     @ReactMethod(isBlockingSynchronousMethod = true)
     override fun installTurboModule(bundleModeEnabled: Boolean): Boolean {
-        val context = reactApplicationContext
-
-        context.assertOnJSQueueThread()
-
-        val scriptBufferWrapper: ScriptBufferWrapper? =
-            if (bundleModeEnabled) {
-                ScriptBufferWrapper(context.sourceURL, context)
-            } else {
-                null
-            }
-
-        installTurboModuleCpp(bundleModeEnabled, scriptBufferWrapper)
+        reactApplicationContext.assertOnJSQueueThread()
+        installTurboModuleCpp(bundleModeEnabled)
         return true
     }
 
@@ -92,6 +92,10 @@ class WorkletsModule(
     /** @noinspection unused */
     @DoNotStrip
     fun isOnJSQueueThread(): Boolean = reactApplicationContext.isOnJSQueueThread
+
+    /** @noinspection unused */
+    @DoNotStrip
+    fun createScriptBufferWrapper(): ScriptBufferWrapper = ScriptBufferWrapper(reactApplicationContext.sourceURL, reactApplicationContext)
 
     fun toggleSlowAnimations() {
         val animationsDragFactor = 10

--- a/packages/react-native-worklets/apple/worklets/apple/AnimationFrameQueue.mm
+++ b/packages/react-native-worklets/apple/worklets/apple/AnimationFrameQueue.mm
@@ -10,6 +10,7 @@
 #endif // TARGET_OS_OSX
 
 #import <React/RCTAssert.h>
+#import <React/RCTUtils.h>
 
 constexpr auto TIME_SAMPLES_AMOUNT = 4;
 
@@ -36,7 +37,9 @@ typedef void (^AnimationFrameCallback)(WorkletsDisplayLink *displayLink);
 
 - (instancetype)init
 {
-  AssertJavaScriptQueue();
+  react_native_assert(
+      (IsJavaScriptQueue() || RCTIsMainQueue()) &&
+      "AnimationFrameQueue must be created on the JavaScript queue or the main queue");
   if constexpr (worklets::StaticFeatureFlags::getFlag("IOS_DYNAMIC_FRAMERATE_ENABLED")) {
     bool supportsProMotion = false;
 #if !TARGET_OS_OSX

--- a/packages/react-native-worklets/apple/worklets/apple/AssertJavaScriptQueue.h
+++ b/packages/react-native-worklets/apple/worklets/apple/AssertJavaScriptQueue.h
@@ -3,12 +3,12 @@
 // Copied from RCTJSThreadManager.mm
 static NSString *const RCTJSThreadName = @"com.facebook.react.runtime.JavaScript";
 
-static BOOL IsJavaScriptQueue()
+static inline BOOL IsJavaScriptQueue()
 {
   return [NSThread.currentThread.name isEqualToString:RCTJSThreadName];
 }
 
-static void AssertJavaScriptQueue()
+static inline void AssertJavaScriptQueue()
 {
   react_native_assert(IsJavaScriptQueue() && "This function must be called on the JavaScript queue");
 }

--- a/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.h
+++ b/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.h
@@ -1,12 +1,13 @@
 #import <React/RCTBridgeModule.h>
 #import <React/RCTCallInvokerModule.h>
+#import <React/RCTInitializing.h>
 #import <React/RCTInvalidating.h>
 
 #import <rnworklets/rnworklets.h>
 
 #import <worklets/NativeModules/WorkletsModuleProxy.h>
 
-@interface WorkletsModule : NSObject <NativeWorkletsModuleSpec, RCTCallInvokerModule, RCTInvalidating>
+@interface WorkletsModule : NSObject <NativeWorkletsModuleSpec, RCTCallInvokerModule, RCTInitializing, RCTInvalidating>
 
 - (std::shared_ptr<worklets::WorkletsModuleProxy>)getWorkletsModuleProxy;
 

--- a/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.mm
+++ b/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.mm
@@ -1,8 +1,9 @@
-#import <worklets/NativeModules/JSIWorkletsModuleProxy.h>
+#import <worklets/NativeModules/WorkletsModuleProxyInitializer.h>
+#import <worklets/Tools/JSScheduler.h>
 #import <worklets/Tools/RNRuntimeStatus.h>
-#import <worklets/Tools/ScriptBuffer.h>
 #import <worklets/Tools/SingleInstanceChecker.h>
-#import <worklets/WorkletRuntime/RNRuntimeWorkletDecorator.h>
+#import <worklets/WorkletRuntime/BundleModeConfig.h>
+#import <worklets/WorkletRuntime/RuntimeBindings.h>
 #import <worklets/apple/AnimationFrameQueue.h>
 #import <worklets/apple/AssertJavaScriptQueue.h>
 #import <worklets/apple/AssertTurboModuleManagerQueue.h>
@@ -21,16 +22,33 @@
 #import <worklets/apple/Networking/WorkletsNetworking.h>
 #endif // WORKLETS_FETCH_PREVIEW_ENABLED
 
+#import <memory>
+#import <string>
+
 using namespace worklets;
 
 @interface RCTBridge (JSIRuntime)
 - (void *)runtime;
 @end
 
+namespace {
+
+BundleModeConfig makeBundleModeConfig(NSURL *bundleURL)
+{
+  return BundleModeConfig{
+      .enabled = true,
+      .script = getScript(bundleURL),
+      .sourceURL = bundleURL != nil ? std::string([[bundleURL absoluteString] UTF8String]) : std::string{}};
+}
+
+} // namespace
+
 @implementation WorkletsModule {
   AnimationFrameQueue *animationFrameQueue_;
-  std::shared_ptr<WorkletsModuleProxy> workletsModuleProxy_;
+  std::shared_ptr<IOSUIScheduler> uiScheduler_;
   std::shared_ptr<RNRuntimeStatus> rnRuntimeStatus_;
+  std::shared_ptr<WorkletsModuleProxyInitializer> initializer_;
+  std::shared_ptr<WorkletsModuleProxy> workletsModuleProxy_;
 #ifdef WORKLETS_FETCH_PREVIEW_ENABLED
   WorkletsNetworking *workletsNetworking_;
 #endif // WORKLETS_FETCH_PREVIEW_ENABLED
@@ -54,6 +72,15 @@ using namespace worklets;
 
 RCT_EXPORT_MODULE(WorkletsModule);
 
+- (void)initialize
+{
+  [self createPlatformObjects];
+  [self createInitializer];
+
+  const auto initializer = initializer_;
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{ initializer->prepareProxy(); });
+}
+
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule : (BOOL)bundleModeEnabled)
 {
   react_native_assert(self.bridge != nullptr);
@@ -62,39 +89,9 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule : (BOOL)bundleModeEnab
   AssertJavaScriptQueue();
 
   jsi::Runtime &rnRuntime = *reinterpret_cast<facebook::jsi::Runtime *>(self.bridge.runtime);
-
-  std::string sourceURL = "";
-  std::shared_ptr<const ScriptBuffer> script = nullptr;
-
-  if (bundleModeEnabled) {
-    NSURL *url = bundleManager_.bundleURL;
-    script = getScript(url);
-    sourceURL = [[url absoluteString] UTF8String];
-  }
-
-#ifdef WORKLETS_FETCH_PREVIEW_ENABLED
-  id networkingModule = [moduleRegistry_ moduleForClass:RCTNetworking.class];
-  workletsNetworking_ = [[WorkletsNetworking alloc] init:networkingModule];
-#endif // WORKLETS_FETCH_PREVIEW_ENABLED
-
-  auto jsCallInvoker = callInvoker_.callInvoker;
-  auto uiScheduler = std::make_shared<IOSUIScheduler>();
-  auto isJavaScriptQueue = []() -> bool {
-    return IsJavaScriptQueue();
-  };
-  animationFrameQueue_ = [AnimationFrameQueue new];
-  auto runtimeBindings = [self getRuntimeBindings:bundleModeEnabled];
-  rnRuntimeStatus_ = std::make_shared<RNRuntimeStatus>();
-
-  workletsModuleProxy_ = std::make_shared<WorkletsModuleProxy>(
-      rnRuntime,
-      jsCallInvoker,
-      uiScheduler,
-      std::move(isJavaScriptQueue),
-      runtimeBindings,
-      BundleModeConfig{.enabled = static_cast<bool>(bundleModeEnabled), .script = script, .sourceURL = sourceURL},
-      rnRuntimeStatus_);
-
+  const auto bundleModeConfig =
+      bundleModeEnabled ? makeBundleModeConfig(bundleManager_.bundleURL) : BundleModeConfig{.enabled = false};
+  workletsModuleProxy_ = initializer_->finalize(rnRuntime, bundleModeConfig);
   return @YES;
 }
 
@@ -119,6 +116,9 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(toggleSlowAnimationsOnUIRuntime)
   if (rnRuntimeStatus_) {
     rnRuntimeStatus_->setDead();
   }
+  if (initializer_) {
+    initializer_->invalidate();
+  }
   workletsModuleProxy_.reset();
 }
 
@@ -129,16 +129,39 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(toggleSlowAnimationsOnUIRuntime)
   return std::make_shared<facebook::react::NativeWorkletsModuleSpecJSI>(params);
 }
 
-- (std::shared_ptr<RuntimeBindings>)getRuntimeBindings:(BOOL)bundleModeEnabled
+- (void)createPlatformObjects
+{
+  animationFrameQueue_ = [AnimationFrameQueue new];
+  uiScheduler_ = std::make_shared<IOSUIScheduler>();
+  rnRuntimeStatus_ = std::make_shared<RNRuntimeStatus>();
+#ifdef WORKLETS_FETCH_PREVIEW_ENABLED
+  id networkingModule = [moduleRegistry_ moduleForClass:RCTNetworking.class];
+  workletsNetworking_ = [[WorkletsNetworking alloc] init:networkingModule];
+#endif // WORKLETS_FETCH_PREVIEW_ENABLED
+}
+
+- (void)createInitializer
+{
+  react_native_assert(self.bridge != nullptr);
+  react_native_assert(self.bridge.runtime != nullptr);
+
+  jsi::Runtime &rnRuntime = *reinterpret_cast<facebook::jsi::Runtime *>(self.bridge.runtime);
+  const auto jsScheduler =
+      std::make_shared<JSScheduler>(rnRuntime, callInvoker_.callInvoker, []() -> bool { return IsJavaScriptQueue(); });
+  initializer_ = std::make_shared<WorkletsModuleProxyInitializer>(
+      jsScheduler, uiScheduler_, [self getRuntimeBindings], rnRuntimeStatus_);
+}
+
+- (std::shared_ptr<RuntimeBindings>)getRuntimeBindings
 {
   return std::make_shared<RuntimeBindings>(RuntimeBindings{
       .requestAnimationFrame = [animationFrameQueue =
                                     animationFrameQueue_](std::function<void(const double)> &&callback) -> void {
         [animationFrameQueue requestAnimationFrame:callback];
       },
-      .nativeLoggingHook = bundleModeEnabled ? makeNativeLoggingHook() : RuntimeBindings::NativeLoggingHook{}
+      .nativeLoggingHook = makeNativeLoggingHook()
 #ifdef WORKLETS_FETCH_PREVIEW_ENABLED
-      ,
+          ,
       .abortRequest =
           [workletsNetworking = workletsNetworking_](jsi::Runtime &rt, const jsi::Value &requestID) {
             [workletsNetworking jsiAbortRequest:requestID.asNumber()];

--- a/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.mm
+++ b/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.mm
@@ -81,6 +81,20 @@ RCT_EXPORT_MODULE(WorkletsModule);
   dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{ initializer->prepareProxy(); });
 }
 
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(prepareBundleMode)
+{
+  AssertJavaScriptQueue();
+
+  initializer_->beginBundleMode();
+
+  const auto initializer = initializer_;
+  const auto loadBundleModeConfig = [self makeBundleModeConfigLoader];
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    initializer->prepareBundleMode(loadBundleModeConfig);
+  });
+  return @YES;
+}
+
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule : (BOOL)bundleModeEnabled)
 {
   react_native_assert(self.bridge != nullptr);
@@ -89,9 +103,8 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule : (BOOL)bundleModeEnab
   AssertJavaScriptQueue();
 
   jsi::Runtime &rnRuntime = *reinterpret_cast<facebook::jsi::Runtime *>(self.bridge.runtime);
-  const auto bundleModeConfig =
-      bundleModeEnabled ? makeBundleModeConfig(bundleManager_.bundleURL) : BundleModeConfig{.enabled = false};
-  workletsModuleProxy_ = initializer_->finalize(rnRuntime, bundleModeConfig);
+  workletsModuleProxy_ =
+      initializer_->finalize(rnRuntime, static_cast<bool>(bundleModeEnabled), [self makeBundleModeConfigLoader]);
   return @YES;
 }
 
@@ -151,6 +164,14 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(toggleSlowAnimationsOnUIRuntime)
       std::make_shared<JSScheduler>(rnRuntime, callInvoker_.callInvoker, []() -> bool { return IsJavaScriptQueue(); });
   initializer_ = std::make_shared<WorkletsModuleProxyInitializer>(
       jsScheduler, uiScheduler_, [self getRuntimeBindings], rnRuntimeStatus_);
+}
+
+- (WorkletsModuleProxyInitializer::BundleModeConfigLoader)makeBundleModeConfigLoader
+{
+  NSURL *bundleURL = bundleManager_.bundleURL;
+  return [bundleURL] {
+    return makeBundleModeConfig(bundleURL);
+  };
 }
 
 - (std::shared_ptr<RuntimeBindings>)getRuntimeBindings

--- a/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.mm
+++ b/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.mm
@@ -118,6 +118,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(toggleSlowAnimationsOnUIRuntime)
   }
   if (initializer_) {
     initializer_->invalidate();
+    initializer_.reset();
   }
   workletsModuleProxy_.reset();
 }

--- a/packages/react-native-worklets/bundleMode/index.js
+++ b/packages/react-native-worklets/bundleMode/index.js
@@ -7,6 +7,11 @@ const turboModuleRegistryShimPath = path.join(
   'shims',
   'turboModuleRegistryShim.js'
 );
+const prepareBundleModePolyfillPath = path.join(
+  __dirname,
+  'polyfills',
+  'prepareBundleMode.js'
+);
 const turboModuleRegistryModuleName =
   'react-native/Libraries/TurboModule/TurboModuleRegistry';
 const turboModuleRegistryFileSuffix = path.join(
@@ -78,6 +83,7 @@ function bundleModeResolveRequest(
 const bundleModeMetroConfig = {
   serializer: {
     createModuleIdFactory: bundleModeCreateModuleIdFactory,
+    polyfillModuleNames: [prepareBundleModePolyfillPath],
   },
   resolver: {
     resolveRequest: (
@@ -117,6 +123,10 @@ const bundleModeMetroConfig = {
 /** Use in Expo projects. */
 function getBundleModeMetroConfig(/** @type {any} */ config) {
   config.serializer.createModuleIdFactory = bundleModeCreateModuleIdFactory;
+  config.serializer.polyfillModuleNames = [
+    ...(config.serializer.polyfillModuleNames ?? []),
+    prepareBundleModePolyfillPath,
+  ];
 
   const currentResolveRequest = config?.resolver?.resolveRequest;
   config.resolver.resolveRequest = (

--- a/packages/react-native-worklets/bundleMode/polyfills/prepareBundleMode.js
+++ b/packages/react-native-worklets/bundleMode/polyfills/prepareBundleMode.js
@@ -1,0 +1,16 @@
+'use strict';
+
+globalThis._WORKLETS_BUNDLE_MODE_ENABLED = false;
+
+const reactNativeRuntimeKind = 1;
+
+if (
+  globalThis._WORKLETS_BUNDLE_MODE_ENABLED &&
+  (globalThis.__RUNTIME_KIND === undefined ||
+    globalThis.__RUNTIME_KIND === reactNativeRuntimeKind)
+) {
+  const workletsModule = globalThis.__turboModuleProxy
+    ? globalThis.__turboModuleProxy('WorkletsModule')
+    : globalThis.nativeModuleProxy?.WorkletsModule;
+  workletsModule?.prepareBundleMode?.();
+}

--- a/packages/react-native-worklets/package.json
+++ b/packages/react-native-worklets/package.json
@@ -146,6 +146,11 @@
     "jsSrcsDir": "src/specs",
     "android": {
       "javaPackageName": "com.swmansion.worklets"
+    },
+    "ios": {
+      "unstableModulesRequiringMainQueueSetup": [
+        "WorkletsModule"
+      ]
     }
   }
 }

--- a/packages/react-native-worklets/package.json
+++ b/packages/react-native-worklets/package.json
@@ -112,6 +112,7 @@
     "bundleMode/index.js",
     "bundleMode/index.d.ts",
     "bundleMode/shims/*.js",
+    "bundleMode/polyfills/*.js",
     "scripts/worklets_utils.rb",
     "scripts/validate-react-native-version.js",
     "jest",

--- a/packages/react-native-worklets/plugin-oxc/src/bundle_mode.rs
+++ b/packages/react-native-worklets/plugin-oxc/src/bundle_mode.rs
@@ -11,6 +11,7 @@ const TOGGLE_PATHS: &[&str] = &[
     "react-native-worklets/src/debug/bundleMode.native.ts",
     "react-native-worklets/lib/module/index.js",
     "react-native-worklets/lib/module/debug/bundleMode.native.js",
+    "react-native-worklets/bundleMode/polyfills/prepareBundleMode.js",
 ];
 
 pub fn enable_flag<'a>(program: &mut Program<'a>, builder: AstBuilder<'a>, filename: &str) -> bool {

--- a/packages/react-native-worklets/plugin/__tests__/plugin-bundleMode.test.ts
+++ b/packages/react-native-worklets/plugin/__tests__/plugin-bundleMode.test.ts
@@ -54,6 +54,10 @@ const TOGGLE_PATH_CASES: ReadonlyArray<[label: string, filename: string]> = [
     'built mode-check',
     'react-native-worklets/lib/module/debug/bundleMode.native.js',
   ],
+  [
+    'prepareBundleMode polyfill',
+    'react-native-worklets/bundleMode/polyfills/prepareBundleMode.js',
+  ],
 ];
 
 const REQUIRE_PREFIX = 'require("react-native-worklets/.worklets/';

--- a/packages/react-native-worklets/plugin/index.js
+++ b/packages/react-native-worklets/plugin/index.js
@@ -549,7 +549,8 @@ var require_bundleMode = __commonJS({
       (0, path_1.join)(WORKLETS_SRC_DIR, "index.ts"),
       (0, path_1.join)(WORKLETS_SRC_DIR, "debug", "bundleMode.native.ts"),
       (0, path_1.join)(WORKLETS_LIB_DIR, "index.js"),
-      (0, path_1.join)(WORKLETS_LIB_DIR, "debug", "bundleMode.native.js")
+      (0, path_1.join)(WORKLETS_LIB_DIR, "debug", "bundleMode.native.js"),
+      (0, path_1.join)(WORKLETS_PACKAGE, "bundleMode", "polyfills", "prepareBundleMode.js")
     ];
     function toggleBundleMode(path, state) {
       if (!state.opts.bundleMode || !togglePaths.some((togglePath) => {

--- a/packages/react-native-worklets/plugin/src/bundleMode.ts
+++ b/packages/react-native-worklets/plugin/src/bundleMode.ts
@@ -13,6 +13,7 @@ const togglePaths = [
   join(WORKLETS_SRC_DIR, 'debug', 'bundleMode.native.ts'),
   join(WORKLETS_LIB_DIR, 'index.js'),
   join(WORKLETS_LIB_DIR, 'debug', 'bundleMode.native.js'),
+  join(WORKLETS_PACKAGE, 'bundleMode', 'polyfills', 'prepareBundleMode.js'),
 ];
 
 /**

--- a/packages/react-native-worklets/src/specs/NativeWorkletsModule.ts
+++ b/packages/react-native-worklets/src/specs/NativeWorkletsModule.ts
@@ -4,6 +4,7 @@ import { type TurboModule, TurboModuleRegistry } from 'react-native';
 
 export interface Spec extends TurboModule {
   installTurboModule: (bundleModeEnabled: boolean) => boolean;
+  prepareBundleMode: () => boolean;
   toggleSlowAnimationsOnUIRuntime: () => boolean;
   start: () => boolean;
 }


### PR DESCRIPTION
> [!NOTE]
> This pull request was authored by AI on behalf of @tjzel.

Requires #10490 to be merged first.

## Summary

#10490 makes `bundleModeMetroConfig` set `serializer.polyfillModuleNames`. Metro's `mergeConfig` replaces that array instead of concatenating it, so a project that already sets `serializer.polyfillModuleNames` silently loses the Worklets polyfill, or its own polyfills, depending on the merge order. I added a note to the Bundle Mode setup guide that explains this and shows `getBundleModeMetroConfig`, which appends to the existing list, as the form to use in that case.

## Test plan

Docs only. `yarn format:md` leaves the file unchanged.

## Changelog

- [x] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.
