### PR TITLE
fix(LayoutAnimations): exclude animated views from removeClippedSubviews clipping on Android

### DIFF
--- a/.yarn/patches/react-native-npm-0.87.0-5a4de924a2.patch
+++ b/.yarn/patches/react-native-npm-0.87.0-5a4de924a2.patch
@@ -1,0 +1,94 @@
+diff --git a/ReactAndroid/api/ReactAndroid.api b/ReactAndroid/api/ReactAndroid.api
+index 57ed2ec2aa73cba0483e8a86370dd91cb2b7b52c..ab818d0012106395d6e82722a2171a4d71ad745b 100644
+--- a/ReactAndroid/api/ReactAndroid.api
++++ b/ReactAndroid/api/ReactAndroid.api
+@@ -3767,6 +3767,8 @@ public final class com/facebook/react/uimanager/ReactClippingViewGroupHelper {
+ 	public static final field INSTANCE Lcom/facebook/react/uimanager/ReactClippingViewGroupHelper;
+ 	public static final field PROP_REMOVE_CLIPPED_SUBVIEWS Ljava/lang/String;
+ 	public static final fun calculateClippingRect (Landroid/view/View;Landroid/graphics/Rect;)V
++	public static final fun isExcludedFromClipping (Landroid/view/View;)Z
++	public static final fun setExcludedFromClipping (Landroid/view/View;Z)V
+ }
+ 
+ public abstract interface class com/facebook/react/uimanager/ReactCompoundView {
+diff --git a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactClippingViewGroupHelper.kt b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactClippingViewGroupHelper.kt
+index ecc935ac5d1fddf0c2b1ec4bbbe8a84edb2b0c1a..0b768939bfaf737ae04befe79a7d97c494b31d80 100644
+--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactClippingViewGroupHelper.kt
++++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactClippingViewGroupHelper.kt
+@@ -9,6 +9,7 @@ package com.facebook.react.uimanager
+ 
+ import android.graphics.Rect
+ import android.view.View
++import com.facebook.react.R
+ import javax.annotation.concurrent.NotThreadSafe
+ 
+ /**
+@@ -22,6 +23,24 @@ public object ReactClippingViewGroupHelper {
+ 
+   private val helperRect: Rect = Rect()
+ 
++  /**
++   * Excludes [view] from subview clipping. A parent with
++   * [com.facebook.react.uimanager.ReactClippingViewGroup.removeClippedSubviews] keeps an excluded
++   * child attached while the child's bounds are outside the clipping rect, in the same way it keeps
++   * a child with a running [android.view.animation.Animation]. Use it for a child whose layout is
++   * animated through mount updates, so the child is not detached before it reaches its final
++   * position. Clear it when the animation ends. The parent applies normal clipping to the child
++   * again on its next clipping pass.
++   */
++  @JvmStatic
++  public fun setExcludedFromClipping(view: View, excluded: Boolean) {
++    view.setTag(R.id.excluded_from_clipping, if (excluded) true else null)
++  }
++
++  @JvmStatic
++  public fun isExcludedFromClipping(view: View): Boolean =
++      view.getTag(R.id.excluded_from_clipping) == true
++
+   /**
+    * Can be used by view that support
+    * [com.facebook.react.uimanager.ReactClippingViewGroup.removeClippedSubviews] property to
+diff --git a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
+index 24009633c75910e2a32281a1fa46217998961117..18c02fe299ce0088967401dcf841633953733f15 100644
+--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
++++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
+@@ -58,6 +58,7 @@ import com.facebook.react.uimanager.ReactAxOrderHelper
+ import com.facebook.react.uimanager.ReactClippingProhibitedView
+ import com.facebook.react.uimanager.ReactClippingViewGroup
+ import com.facebook.react.uimanager.ReactClippingViewGroupHelper.calculateClippingRect
++import com.facebook.react.uimanager.ReactClippingViewGroupHelper.isExcludedFromClipping
+ import com.facebook.react.uimanager.ReactOverflowViewWithInset
+ import com.facebook.react.uimanager.ReactPointerEventsView
+ import com.facebook.react.uimanager.style.BorderRadiusProp
+@@ -516,14 +517,17 @@ public open class ReactViewGroup public constructor(context: Context?) :
+             !isViewClipped(child, idx) &&
+             !isAnimating &&
+             child !== focusedChild &&
+-            !shouldSkipView
++            !shouldSkipView &&
++            !isExcludedFromClipping(child)
+     ) {
+       setViewClipped(child, true)
+       // We can try saving on invalidate call here as the view that we remove is out of visible area
+       // therefore invalidation is not necessary.
+       removeViewInLayout(child)
+       needUpdateClippingRecursive = true
+-    } else if ((shouldSkipView || intersects) && isViewClipped(child, idx)) {
++    } else if (
++        (shouldSkipView || intersects || isExcludedFromClipping(child)) && isViewClipped(child, idx)
++    ) {
+       val adjustedIdx = idx - clippedSoFar
+       check(adjustedIdx >= 0)
+       setViewClipped(child, false)
+diff --git a/ReactAndroid/src/main/res/views/uimanager/values/ids.xml b/ReactAndroid/src/main/res/views/uimanager/values/ids.xml
+index 0e51a358eb77e9b1ff77ab8e64039ccc306ed0a8..722b0c76fcfd36050c59c4f67912b62143be1c4e 100644
+--- a/ReactAndroid/src/main/res/views/uimanager/values/ids.xml
++++ b/ReactAndroid/src/main/res/views/uimanager/values/ids.xml
+@@ -82,4 +82,7 @@
+ 
+   <!-- tag is used to store important_for_interaction state -->
+   <item type="id" name="important_for_interaction"/>
++
++  <!-- tag is used to keep a view attached to a parent that removes clipped subviews -->
++  <item type="id" name="excluded_from_clipping"/>
+ </resources>

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
   },
   "resolutions": {
     "metro": "patch:metro@npm%3A0.87.0#~/.yarn/patches/metro-npm-0.87.0-1c5c005545.patch",
-    "metro-runtime": "patch:metro-runtime@npm%3A0.87.0#~/.yarn/patches/metro-runtime-npm-0.87.0-2e4e60a54a.patch"
+    "metro-runtime": "patch:metro-runtime@npm%3A0.87.0#~/.yarn/patches/metro-runtime-npm-0.87.0-2e4e60a54a.patch",
+    "react-native@npm:0.87.0": "patch:react-native@npm%3A0.87.0#~/.yarn/patches/react-native-npm-0.87.0-5a4de924a2.patch"
   }
 }

--- a/packages/react-native-reanimated/CHANGELOG.md
+++ b/packages/react-native-reanimated/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix the last `FlatList` item disappearing for one frame during an item-removal layout animation on Android. Views with an active layout animation are now excluded from `removeClippedSubviews` clipping until the animation ends. Requires the React Native change that adds `ReactClippingViewGroupHelper.setExcludedFromClipping`. ([#10487](https://github.com/software-mansion/react-native-reanimated/pull/10487) by [@pawicao](https://github.com/pawicao))
 - Fix `Keyframe` easings on web being dropped or applied to the wrong keyframe when the definitions use the `from`/`to` aliases or fractional offsets. ([#10386](https://github.com/software-mansion/react-native-reanimated/pull/10386) by [@dennytosp](https://github.com/dennytosp))
 - Fix `getViewProp` and the runtime-tests prop snapshotting crashing (segfault on style props, unhandled error on layout props) when the view is no longer mounted. ([#10443](https://github.com/software-mansion/react-native-reanimated/pull/10443) by [@tjzel](https://github.com/tjzel))
 - Ship the Jest resolver (`react-native-reanimated/jest/resolver`) in the npm package, so consumer projects can run Jest against Reanimated: the modules that require a real native module are resolved to their web implementations. ([#10377](https://github.com/software-mansion/react-native-reanimated/pull/10377) by [@huextrat](https://github.com/huextrat))

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.cpp
@@ -7,11 +7,13 @@
 #include <reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.h>
 #include <reanimated/LayoutAnimations/PropsDiffer.h>
 
+#include <algorithm>
 #include <cstring>
 #include <memory>
 #include <optional>
 #include <unordered_set>
 #include <utility>
+#include <vector>
 
 namespace reanimated {
 
@@ -58,6 +60,9 @@ void LayoutAnimationsProxyCommon::startSurface(
 
 void LayoutAnimationsProxyCommon::surfaceDidUnmount() {
   cancelAllLayoutAnimations();
+#ifdef ANDROID
+  publishClippingExclusions();
+#endif
 }
 
 std::optional<SurfaceId> LayoutAnimationsProxyCommon::progressLayoutAnimation(
@@ -472,6 +477,25 @@ void LayoutAnimationsProxyCommon::maybeUpdateWindowDimensions(const ShadowViewMu
 }
 
 #ifdef ANDROID
+void LayoutAnimationsProxyCommon::publishClippingExclusions() const {
+  auto lock = std::unique_lock<std::recursive_mutex>(mutex);
+  std::vector<Tag> excludedTags;
+  for (const auto &[tag, animation] : layoutAnimations_) {
+    excludedTags.push_back(tag);
+  }
+  for (const auto &[tag, pending] : pendingLayoutAnimations_) {
+    excludedTags.push_back(tag);
+  }
+  std::ranges::sort(excludedTags);
+  const auto duplicates = std::ranges::unique(excludedTags);
+  excludedTags.erase(duplicates.begin(), duplicates.end());
+  if (excludedTags == publishedClippingExclusions_) {
+    return;
+  }
+  publishedClippingExclusions_ = std::move(excludedTags);
+  updateClippingExclusions_(surfaceId_, publishedClippingExclusions_);
+}
+
 void LayoutAnimationsProxyCommon::scheduleCleanupPull() const {
   const std::weak_ptr<UIManager> weakUiManager = uiManager_;
   jsInvoker_->invokeAsync([weakUiManager, surfaceId = surfaceId_](jsi::Runtime &) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.h
@@ -67,6 +67,7 @@ struct LayoutAnimationsProxyDependencies {
   std::function<void(SurfaceId)> requestLayoutAnimationFlush;
 #ifdef ANDROID
   PreserveMountedTagsFunction filterUnmountedTagsFunction;
+  UpdateClippingExclusionsFunction updateClippingExclusions;
   std::shared_ptr<facebook::react::CallInvoker> jsInvoker;
 #endif
 #ifdef __APPLE__
@@ -89,6 +90,7 @@ class LayoutAnimationsProxyCommon : public facebook::react::MountingOverrideDele
 #ifdef ANDROID
         ,
         preserveMountedTags_(dependencies.filterUnmountedTagsFunction),
+        updateClippingExclusions_(dependencies.updateClippingExclusions),
         jsInvoker_(dependencies.jsInvoker)
 #endif
   {
@@ -132,6 +134,7 @@ class LayoutAnimationsProxyCommon : public facebook::react::MountingOverrideDele
       const PropsParserContext &propsParserContext) const;
 #ifdef ANDROID
   void scheduleCleanupPull() const;
+  void publishClippingExclusions() const;
 #endif
 
   const SurfaceId surfaceId_;
@@ -151,7 +154,9 @@ class LayoutAnimationsProxyCommon : public facebook::react::MountingOverrideDele
   std::function<void(SurfaceId)> requestLayoutAnimationFlush_;
 #ifdef ANDROID
   PreserveMountedTagsFunction preserveMountedTags_;
+  UpdateClippingExclusionsFunction updateClippingExclusions_;
   std::shared_ptr<facebook::react::CallInvoker> jsInvoker_;
+  mutable std::vector<Tag> publishedClippingExclusions_;
 #endif
 
  private:

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
@@ -134,6 +134,10 @@ std::optional<MountingTransaction> LayoutAnimationsProxy_Experimental::pullTrans
 
   insertContainers(transaction, rootChildCount);
 
+#ifdef ANDROID
+  publishClippingExclusions();
+#endif
+
   return MountingTransaction{surfaceId, transactionNumber, std::move(filteredMutations), telemetry};
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
@@ -73,6 +73,10 @@ std::optional<MountingTransaction> LayoutAnimationsProxy_Legacy::pullTransaction
 
   dropUpdatesForDeletedViews(filteredMutations);
 
+#ifdef ANDROID
+  publishClippingExclusions();
+#endif
+
   return MountingTransaction{surfaceId, transactionNumber, std::move(filteredMutations), telemetry};
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -242,6 +242,7 @@ ReanimatedModuleProxy::ReanimatedModuleProxy(
       synchronouslyUpdateUIPropsFunction_(platformDepMethodsHolder.synchronouslyUpdateUIPropsFunction),
 #ifdef ANDROID
       filterUnmountedTagsFunction_(platformDepMethodsHolder.filterUnmountedTagsFunction),
+      updateClippingExclusions_(platformDepMethodsHolder.updateClippingExclusions),
 #endif // ANDROID
       subscribeForKeyboardEventsFunction_(platformDepMethodsHolder.subscribeForKeyboardEvents),
       unsubscribeFromKeyboardEventsFunction_(platformDepMethodsHolder.unsubscribeFromKeyboardEvents) {
@@ -1287,6 +1288,7 @@ void ReanimatedModuleProxy::initializeLayoutAnimationsProxyRegistry() {
       requestLayoutAnimationFlush,
 #ifdef ANDROID
       filterUnmountedTagsFunction_,
+      updateClippingExclusions_,
       jsInvoker_,
 #endif
 #ifdef __APPLE__

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
@@ -262,6 +262,8 @@ class ReanimatedModuleProxy : public std::enable_shared_from_this<ReanimatedModu
   const PreserveMountedTagsFunction filterUnmountedTagsFunction_;
 
 #ifdef ANDROID
+  const UpdateClippingExclusionsFunction updateClippingExclusions_;
+
   // Reused across `applySynchronousUpdates` calls to avoid per-frame heap
   // allocations. Access only on the UI thread.
   std::vector<int> synchronousPropsIntBuffer_;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Tools/PlatformDepMethodsHolder.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Tools/PlatformDepMethodsHolder.h
@@ -35,6 +35,7 @@ using SynchronouslyUpdateUIPropsFunction = std::function<void(const std::vector<
 using SynchronouslyUpdateUIPropsFunction = std::function<void(const int, const folly::dynamic &)>;
 #endif // ANDROID
 using PreserveMountedTagsFunction = std::function<std::optional<std::unique_ptr<int[]>>(std::vector<int> &)>;
+using UpdateClippingExclusionsFunction = std::function<void(SurfaceId surfaceId, const std::vector<int> &tags)>;
 using GetAnimationTimestampFunction = std::function<double(void)>;
 
 using ProgressLayoutAnimationFunction = std::function<void(jsi::Runtime &, int, jsi::Object)>;
@@ -56,6 +57,7 @@ struct PlatformDepMethodsHolder {
   RequestRenderFunction requestRender;
 #ifdef ANDROID
   PreserveMountedTagsFunction filterUnmountedTagsFunction;
+  UpdateClippingExclusionsFunction updateClippingExclusions;
 #endif // ANDROID
 #ifdef __APPLE__
   ForceScreenSnapshotFunction forceScreenSnapshotFunction;

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
@@ -196,6 +196,13 @@ std::optional<std::unique_ptr<int[]>> NativeProxy::preserveMountedTags(std::vect
   return region;
 }
 
+void NativeProxy::updateClippingExclusions(SurfaceId surfaceId, const std::vector<int> &tags) {
+  static const auto method = getJniMethod<void(jint, jni::alias_ref<jni::JArrayInt>)>("updateClippingExclusions");
+  auto jTags = jni::JArrayInt::newArray(tags.size());
+  jTags->setRegion(0, tags.size(), tags.data());
+  method(javaPart_.get(), surfaceId, jTags);
+}
+
 void NativeProxy::synchronouslyUpdateUIProps(
     const std::vector<int> &intBuffer,
     const std::vector<double> &doubleBuffer) {
@@ -361,6 +368,8 @@ PlatformDepMethodsHolder NativeProxy::getPlatformDependentMethods() {
 
   auto preserveMountedTags = bindThis(&NativeProxy::preserveMountedTags);
 
+  auto updateClippingExclusions = bindThis(&NativeProxy::updateClippingExclusions);
+
   auto synchronouslyUpdateUIPropsFunction = bindThis(&NativeProxy::synchronouslyUpdateUIProps);
 
   auto registerSensorFunction = bindThis(&NativeProxy::registerSensor);
@@ -406,6 +415,7 @@ PlatformDepMethodsHolder NativeProxy::getPlatformDependentMethods() {
   return {
       requestRender,
       preserveMountedTags,
+      updateClippingExclusions,
       synchronouslyUpdateUIPropsFunction,
       getAnimationTimestamp,
       registerSensorFunction,

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
@@ -48,6 +48,7 @@ class NativeProxy : public jni::HybridClass<NativeProxy>, std::enable_shared_fro
   // std::shared_ptr<EventListener> eventListener_;
   void installJSIBindings();
   std::optional<std::unique_ptr<int[]>> preserveMountedTags(std::vector<int> &tags);
+  void updateClippingExclusions(SurfaceId surfaceId, const std::vector<int> &tags);
   void synchronouslyUpdateUIProps(const std::vector<int> &intBuffer, const std::vector<double> &doubleBuffer);
   PlatformDepMethodsHolder getPlatformDependentMethods();
 

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
@@ -20,6 +20,7 @@ import com.swmansion.common.GestureHandlerStateManager
 import com.swmansion.reanimated.css.CSSPlatformTransitionsManager
 import com.swmansion.reanimated.keyboard.KeyboardAnimationManager
 import com.swmansion.reanimated.keyboard.KeyboardWorkletWrapper
+import com.swmansion.reanimated.layoutAnimations.SubviewClippingGuard
 import com.swmansion.reanimated.nativeProxy.AnimationFrameCallback
 import com.swmansion.reanimated.nativeProxy.EventHandler
 import com.swmansion.reanimated.nativeProxy.PseudoSelectorCallback
@@ -48,6 +49,7 @@ open class NativeProxy {
     private val keyboardAnimationManager: KeyboardAnimationManager
     private val pseudoSelectorManager: PseudoSelectorManager
     private val cssPlatformTransitionsManager: CSSPlatformTransitionsManager
+    private val subviewClippingGuard: SubviewClippingGuard
     private var firstUptime: Long = SystemClock.uptimeMillis()
     private var slowAnimationsEnabled = false
     private val animationsDragFactor = 10
@@ -98,6 +100,7 @@ open class NativeProxy {
         pseudoSelectorManager = PseudoSelectorManager(mFabricUIManager, mContext)
         cssPlatformTransitionsManager =
             CSSPlatformTransitionsManager(mFabricUIManager, mContext, ::getAnimationTimestamp)
+        subviewClippingGuard = SubviewClippingGuard(mFabricUIManager)
 
         val callInvokerHolder = context.jsCallInvokerHolder as CallInvokerHolderImpl
         mHybridData =
@@ -140,6 +143,7 @@ open class NativeProxy {
         }
         pseudoSelectorManager.invalidate()
         cssPlatformTransitionsManager.invalidate()
+        subviewClippingGuard.invalidate()
         if (mHybridData.isValid) {
             invalidateCpp()
         }
@@ -227,6 +231,14 @@ open class NativeProxy {
         }
 
         return true
+    }
+
+    @DoNotStrip
+    fun updateClippingExclusions(
+        surfaceId: Int,
+        tags: IntArray,
+    ) {
+        subviewClippingGuard.updateClippingExclusions(surfaceId, tags)
     }
 
     // TODO(#9681): Temporary workaround for RN >= 0.86. Since RN 0.86,

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/layoutAnimations/SubviewClippingGuard.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/layoutAnimations/SubviewClippingGuard.kt
@@ -1,0 +1,90 @@
+package com.swmansion.reanimated.layoutAnimations
+
+import android.view.View
+import com.facebook.react.bridge.UIManager
+import com.facebook.react.bridge.UIManagerListener
+import com.facebook.react.common.annotations.UnstableReactNativeAPI
+import com.facebook.react.fabric.FabricUIManager
+import com.facebook.react.uimanager.IllegalViewOperationException
+import com.facebook.react.uimanager.ReactClippingViewGroupHelper
+
+/**
+ * Excludes views with an active layout animation from subview clipping, so a parent
+ * with `removeClippedSubviews` keeps them attached until the animation ends.
+ */
+internal class SubviewClippingGuard(
+    private val fabricUIManager: FabricUIManager,
+) {
+    private val lock = Any()
+    private var invalidated = false
+
+    /** Per surface: tags of the views with an active or pending layout animation. */
+    private val excludedTagsBySurface = HashMap<Int, IntArray>()
+
+    /** Views that currently carry the exclusion flag. UI thread only. */
+    private val excludedViews = HashMap<Int, View>()
+
+    @OptIn(UnstableReactNativeAPI::class)
+    private val mountListener =
+        object : UIManagerListener {
+            override fun willDispatchViewUpdates(uiManager: UIManager) = Unit
+
+            override fun willMountItems(uiManager: UIManager) = applyExclusions()
+
+            override fun didMountItems(uiManager: UIManager) = Unit
+
+            override fun didDispatchMountItems(uiManager: UIManager) = Unit
+
+            override fun didScheduleMountItems(uiManager: UIManager) = Unit
+        }
+
+    init {
+        @OptIn(UnstableReactNativeAPI::class)
+        fabricUIManager.addUIManagerEventListener(mountListener)
+    }
+
+    /** Called on the JS or the UI thread. */
+    fun updateClippingExclusions(
+        surfaceId: Int,
+        tags: IntArray,
+    ) {
+        synchronized(lock) {
+            if (invalidated) return
+            if (tags.isEmpty()) excludedTagsBySurface.remove(surfaceId) else excludedTagsBySurface[surfaceId] = tags
+        }
+    }
+
+    fun invalidate() {
+        @OptIn(UnstableReactNativeAPI::class)
+        fabricUIManager.removeUIManagerEventListener(mountListener)
+        synchronized(lock) {
+            invalidated = true
+            excludedTagsBySurface.clear()
+        }
+    }
+
+    private fun applyExclusions() {
+        val excludedTags = synchronized(lock) { excludedTagsBySurface.values.flatMap { it.asIterable() }.toHashSet() }
+        if (excludedTags.isEmpty() && excludedViews.isEmpty()) return
+        val stale = excludedViews.entries.iterator()
+        while (stale.hasNext()) {
+            val (tag, view) = stale.next()
+            if (tag in excludedTags) continue
+            ReactClippingViewGroupHelper.setExcludedFromClipping(view, false)
+            stale.remove()
+        }
+        for (tag in excludedTags) {
+            if (tag in excludedViews) continue
+            val view = viewForTag(tag) ?: continue
+            ReactClippingViewGroupHelper.setExcludedFromClipping(view, true)
+            excludedViews[tag] = view
+        }
+    }
+
+    private fun viewForTag(tag: Int): View? =
+        try {
+            fabricUIManager.resolveView(tag)
+        } catch (e: IllegalViewOperationException) {
+            null
+        }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -29522,6 +29522,52 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-native@patch:react-native@npm%3A0.87.0#~/.yarn/patches/react-native-npm-0.87.0-5a4de924a2.patch":
+  version: 0.87.0
+  resolution: "react-native@patch:react-native@npm%3A0.87.0#~/.yarn/patches/react-native-npm-0.87.0-5a4de924a2.patch::version=0.87.0&hash=a2685a"
+  dependencies:
+    "@react-native/asset-utils": "npm:0.87.0"
+    "@react-native/codegen": "npm:0.87.0"
+    "@react-native/community-cli-plugin": "npm:0.87.0"
+    "@react-native/gradle-plugin": "npm:0.87.0"
+    "@react-native/normalize-colors": "npm:0.87.0"
+    "@react-native/virtualized-lists": "npm:0.87.0"
+    anser: "npm:^1.4.9"
+    ansi-regex: "npm:^5.0.0"
+    babel-plugin-syntax-hermes-parser: "npm:0.36.1"
+    base64-js: "npm:^1.5.1"
+    commander: "npm:^12.0.0"
+    flow-enums-runtime: "npm:^0.0.6"
+    hermes-compiler: "npm:250829098.0.16"
+    invariant: "npm:^2.2.4"
+    memoize-one: "npm:^5.0.0"
+    metro-runtime: "npm:^0.87.0"
+    metro-source-map: "npm:^0.87.0"
+    nullthrows: "npm:^1.1.1"
+    pretty-format: "npm:^29.7.0"
+    promise: "npm:^8.3.0"
+    react-devtools-core: "npm:^6.1.5"
+    react-refresh: "npm:^0.14.0"
+    regenerator-runtime: "npm:^0.13.2"
+    scheduler: "npm:0.27.0"
+    semver: "npm:^7.1.3"
+    stacktrace-parser: "npm:^0.1.10"
+    tinyglobby: "npm:^0.2.15"
+    whatwg-fetch: "npm:^3.0.0"
+    ws: "npm:^7.5.10"
+    yargs: "npm:^17.6.2"
+  peerDependencies:
+    "@types/react": ^19.1.1
+    react: ^19.2.3
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  bin:
+    react-native: cli.js
+  checksum: 10/179c826909ae62ba300031cef94f092e203a63f8b49656236a812a8987ecaa270339e859176b3459377e20b3871ec8a7763933f04939cd7eff180b148f0c620a
+  languageName: node
+  linkType: hard
+
 "react-proxy@npm:^1.1.7":
   version: 1.1.8
   resolution: "react-proxy@npm:1.1.8"


### PR DESCRIPTION
> [!WARNING]
> This is just a local proof of concept on how issues with layout animations could be fixed for virtualized lists with `removeClippedSubviews`. Going with this solution would require a change upstream in RN.

> [!NOTE]
> This pull request was authored by AI on behalf of @pawicao.

## Summary

Fixes #10202.

On Android, `FlatList` sets `removeClippedSubviews`. When React removes an item, the content container gets its smaller height in the same transaction, while a cell with a `layout` animation stays at its old position until its first animated frame. `ReactViewGroup` clips a child by its raw bounds and spares only a child with a running legacy `android.view.Animation`. So it detaches the last cell for the frames the cell spends outside the new bounds, then attaches it again when the animation moves it back inside. In the `[LA] List item layout animation` example that is one frame. With a larger gap between the old and the new bounds it is more.

This is a draft for discussion. It depends on a React Native change that does not exist upstream yet. See "How the React Native change is carried" below.

## How it works

1. React Native gets one new public helper, `ReactClippingViewGroupHelper.setExcludedFromClipping(view, excluded)`, backed by a view tag. `ReactViewGroup.updateSubviewClipStatus` reads the tag next to its existing `View.animation` check, so an excluded child stays attached while its bounds are outside the clipping rect, and comes back if it was clipped before. The tag is read only for a child that would otherwise be clipped or is clipped, so the common case never touches it.
2. Both Reanimated proxies publish the tags of the views with an active or pending layout animation at the end of each Android `pullTransaction`, and when the surface unmounts. The list is sent through a new platform function only when it changed.
3. `SubviewClippingGuard` keeps that list per surface and sets the flag in `willMountItems`, before the mount that shrinks the parent, on every newly listed view. It clears the flag when a tag leaves the list. Pending starts are in the list too, because a JS-thread pull cannot start the animation, so the first transaction only queues it.

## Why this shape

The root cause is geometry, not timing. At frame zero a layout animation is at its old layout, and the parent already has its new bounds. Any per-view animation of a child under a parent that does not animate has this property. The three ways out:

- Animate the parent too. That is how React Native's own `LayoutAnimation` avoids the problem: its driver animates every view whose layout changed, the container included. It changes what every existing Reanimated app shows, because today only views with a `layout` config move.
- Hold the parent's shrink until the children finish. Visibly wrong for a parent with a background, and it delays everything below the list.
- Tell clipping to leave the animating child alone. This PR. It matches how React Native already treats a legacy `View.animation`, and it does not depend on geometry or timing.

## The alternative that was here before (https://github.com/software-mansion/react-native-reanimated/pull/10487)

The first version of this PR did the same from the Reanimated side only. It listened to `didMountItems`, after the mount, found each animated child that React Native had detached, and called `parent.updateClippingRect(excludedViews)` to re-attach it before the frame drew. That hid the blink, but React Native does not remember the exclusion. Every animation frame detached the cell again and the guard re-attached it again: one `removeViewInLayout`, one `addViewInLayout`, one `invalidate`, and one walk over all children of the container per frame. A scroll during the animation dropped the exclusion until the next mount. The flag prevents the detach instead of repairing it, and costs one tag read per candidate child.

## How the React Native change is carried

The React Native side is a Yarn patch on `react-native@0.87.0` in `.yarn/patches`. It changes Kotlin sources only. It takes effect in a build of React Native from source; the prebuilt `react-android` artifact does not have it, so the Android build of `react-native-reanimated` is red on CI until the change ships in React Native. The upstream pull request comes next. Until then this draft shows the whole picture in one place.

## Limits

- A view that was clipped before its animation starts stays detached until the parent's next full clipping pass, on scroll or resize. It is outside the viewport, so nothing shows.
- The flag has no owner. If another library sets it on the same view, the last write wins.

## Before vs. After recording

In this example we are pressing on the second element of the list. That press removes this element and the rest of the list is moving with a layout animation. Nothing else should happen. In the "before" section the last element of the lists blinks, in "after" all is clean

https://github.com/user-attachments/assets/b8145f9c-043b-4d42-85eb-e81b1eb22c4f

## Test plan

Physical Pixel 9a, API 36, `apps/fabric-example` built with React Native compiled from source from a 0.87.1 checkout with the same change, `[LA] List item layout animation`, `LinearTransition`, tap the second item, 30 fps recording, frame analysis of the purple item bands.

| Build | Blinks / removals |
|---|---|
| main (e4a098bad6) | 2 / 8 |
| this change | 0 / 8 |

- [x] React Native `ReactViewGroupTest`, with a new test for the exclusion: 3 / 3 pass, `ktfmtCheck` clean
- [x] `spotlessCheck` and `clang-format` on the Reanimated changes
- [x] Experimental proxy on device. Legacy proxy: same shared code path, not measured on device

## Changelog

- [x] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.
