### PR TITLE
fix(iOS): report an error on a failed reload instead of installing a dummy proxy

### DIFF
--- a/packages/react-native-reanimated/apple/reanimated/apple/ReanimatedModule.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/ReanimatedModule.mm
@@ -154,34 +154,11 @@ RCT_EXPORT_MODULE(ReanimatedModule);
   }
 }
 
-/**
- * Currently on iOS React Native can go into a non-fatal race condition
- * on a double reload. Double reload can happen during an OTA update,
- * when an app is reloaded immediately after evaluating the bundle.
- * We need to bail on it without throwing exceptions.
- */
-- (BOOL)hasReactNativeFailedReload
-{
-  id workletsModule = [_moduleRegistry moduleForName:"WorkletsModule"];
-  if (![_moduleRegistry moduleIsInitialized:[workletsModule class]]) {
-    return YES;
-  }
-
-  // On a double reload React Native can momentarily leave the surface presenter without
-  // a scheduler. This is another manifestation of the same non-fatal reload race, so we
-  // bail on it here instead of asserting on a nil scheduler later in installTurboModule.
-  if ([_surfacePresenter scheduler] == nil) {
-    return YES;
-  }
-
-  return NO;
-}
-
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule)
 {
   REAAssertJavaScriptQueue();
 
-  if ([self hasReactNativeFailedReload]) {
+  if ([_surfacePresenter scheduler] == nil) {
     return @NO;
   }
 

--- a/packages/react-native-reanimated/src/ReanimatedModule/NativeReanimated.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/NativeReanimated.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-empty-function */
 'use strict';
 
 import type { SerializableRef, WorkletFunction } from 'react-native-worklets';
@@ -64,16 +63,10 @@ class NativeReanimatedModule implements IReanimatedModule {
     }
     global._REANIMATED_VERSION_JS = jsVersion;
 
-    if (ReanimatedTurboModule) {
-      const status = installTurboModule();
-      if (!status) {
-        // This path means that React Native has failed on reload.
-        // We don't want to throw any errors to not mislead the users
-        // that the problem is related to Reanimated.
-        // We install a DummyReanimatedModuleProxy instead.
-        this.#reanimatedModuleProxy = new DummyReanimatedModuleProxy();
-        return;
-      }
+    if (ReanimatedTurboModule && !installTurboModule()) {
+      throw new Error(
+        '[Reanimated] Failed to install the native module because React Native has no active surface on its discarded instance. This happens when the app is reloaded while a previous reload is still in progress, for example during an OTA update immediately upon launch. No action is required; the app will continue to function as usual.'
+      );
     }
 
     if (global.__reanimatedModuleProxy === undefined) {
@@ -261,52 +254,6 @@ See https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooti
   unregisterPseudoStyles(viewTag: number) {
     this.#reanimatedModuleProxy.unregisterPseudoStyles(viewTag);
   }
-}
-
-class DummyReanimatedModuleProxy implements ReanimatedModuleProxy {
-  configureLayoutAnimationBatch(): void {}
-  setShouldAnimateExitingForTag(): void {}
-  getStaticFeatureFlag(): boolean {
-    return false;
-  }
-  setDynamicFeatureFlag(): void {}
-  subscribeForKeyboardEvents(): number {
-    return -1;
-  }
-
-  unsubscribeFromKeyboardEvents(): void {}
-  setViewStyle(): void {}
-  setCSSEventHandler(): void {}
-  markNodeAsRemovable(): void {}
-  unmarkNodeAsRemovable(): void {}
-  registerCSSKeyframes(): void {}
-  unregisterCSSKeyframes(): void {}
-  applyCSSAnimations(): void {}
-  registerCSSAnimations(): void {}
-  updateCSSAnimations(): void {}
-  unregisterCSSAnimations(): void {}
-  runCSSTransition(): void {}
-  unregisterCSSTransition(): void {}
-  registerSensor(): number {
-    return -1;
-  }
-
-  unregisterSensor(): void {}
-  registerEventHandler(): number {
-    return -1;
-  }
-
-  unregisterEventHandler(): void {}
-  getViewProp() {
-    return null!;
-  }
-
-  getSettledUpdates(): SettledUpdate[] {
-    return [];
-  }
-
-  registerPseudoStyles(): void {}
-  unregisterPseudoStyles(): void {}
 }
 
 function installTurboModule() {


### PR DESCRIPTION
## Summary

I removed the legacy code which injected a dummy Reanimated Proxy to silently ignore the case for multiple simultaneous reload on iOS. Instead now we throw a meaningful error, which will be ignored by the app anyway as the respective instance is torn down.

## Test plan

Multiple reloads don't crash the iOS app still (on Reanimated, they may crash on React Native itself)

## Changelog

- [x] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.
