### PR TITLE
fix(plugin): hoist a worklet parameter that reads its own closure

### DIFF
--- a/packages/react-native-worklets/CHANGELOG.md
+++ b/packages/react-native-worklets/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Stop workletizing getters, setters and constructors. ([#10421](https://github.com/software-mansion/react-native-reanimated/pull/10421) by [@tshmieldev](https://github.com/tshmieldev))
 - Fix a crash when serializing objects with a `__proto__` key. ([#10451](https://github.com/software-mansion/react-native-reanimated/pull/10451) by [@tshmieldev](https://github.com/tshmieldev))
 - Fix `./gradlew app:build` failing on `:lintAnalyzeDebug` with a K2 UAST crash on `.gradle.kts` build scripts - all lint tasks are now skipped, not only `lintVital*`. ([#10448](https://github.com/software-mansion/react-native-reanimated/pull/10448) by [@tshmieldev](https://github.com/tshmieldev))
+- Fix a worklet whose parameter default reads a captured binding throwing `ReferenceError` on the UI thread - the closure destructure lands in the body, which a parameter expression cannot see, so such a parameter is now hoisted into the body after it. (by [@YevheniiKotyrlo](https://github.com/YevheniiKotyrlo))
 
 ### 💡 Others
 

--- a/packages/react-native-worklets/plugin/__tests__/plugin-legacy.test.ts
+++ b/packages/react-native-worklets/plugin/__tests__/plugin-legacy.test.ts
@@ -61,10 +61,479 @@ function runPlugin(
   return transformed;
 }
 
+/**
+ * A worklet the UI runtime would evaluate, as a callable — `this` is its host
+ * object.
+ */
+type EvaluatedWorklet = (this: {
+  __closure: Record<string, unknown>;
+}) => unknown;
+
+/**
+ * The serialized worklet out of the emitted `__initData`, compiled and ready to
+ * call.
+ *
+ * `__initData.code` is the exact string the UI runtime evaluates, and `new
+ * Function` compiles it in the GLOBAL scope — so a captured binding is
+ * reachable through `this.__closure` and through nothing else. That is what
+ * makes a call here mean what a call on the UI thread means: a scope that
+ * already holds the capture cannot observe a worklet that fails to reach it.
+ */
+function evaluateWorkletCode(transformedCode: string): EvaluatedWorklet {
+  const match = /code: (?<literal>"(?:[^"\\]|\\.)*")/u.exec(transformedCode);
+  assert(match?.groups?.literal, 'no worklet `code` in the transformed output');
+  const workletSource: unknown = JSON.parse(match.groups.literal);
+  assert(typeof workletSource === 'string', '`code` is not a string');
+
+  return new Function(`return ${workletSource}`)() as EvaluatedWorklet;
+}
+
 describe('babel plugin', () => {
   beforeEach(() => {
     process.env.WORKLETS_JEST_SHOULD_MOCK_SOURCE_MAP = '1';
     process.env.WORKLETS_JEST_SHOULD_MOCK_VERSION = '1';
+  });
+
+  describe('closure-dependent parameters', () => {
+    test('hoists a default that reads a captured binding into the body', () => {
+      const input = html`<script>
+        const DEFAULTS = { max: 8 };
+
+        function clamp(value, limits = DEFAULTS) {
+          'worklet';
+          return Math.min(value, limits.max);
+        }
+      </script>`;
+
+      const { code } = runPlugin(input);
+
+      // The capture is destructured at the top of the BODY, and a parameter default is evaluated
+      // in the PARAMETER scope, which by specification cannot see a body declaration. Leaving the
+      // default in place emits a function that throws ReferenceError on every call that omits the
+      // argument — on the UI thread, an uncaught C++ exception.
+      // The whole fix, in the emitted body: the parameter carries a placeholder and the default
+      // is resolved AFTER the closure destructure, where the capture actually exists.
+      //
+      // The placeholder carries no digit. `Scope#generateUid` strips trailing digits from the
+      // requested name, so a parameter index cannot reach the output; where a digit DOES appear
+      // it is that function's collision counter, never the position.
+      expect(code).toContain(
+        '(value,_workletParameter){const{DEFAULTS}=this.__closure;let limits=_workletParameter===void 0?DEFAULTS:_workletParameter;'
+      );
+    });
+
+    test('hoists a parameter that depends on an already-hoisted parameter', () => {
+      const input = html`<script>
+        const DEFAULTS = { max: 8 };
+
+        function span(first = DEFAULTS, second = first) {
+          'worklet';
+          return first.max + second.max;
+        }
+      </script>`;
+
+      const { code } = runPlugin(input);
+
+      // Hoisting `first` moves its binding into the body, so `second` is left reading a name
+      // parameter scope no longer has — the same ReferenceError, one parameter over. The rule is
+      // transitive for exactly this reason.
+      // Both parameters land in the body, in declaration order, so `second` resolves `first`
+      // from the body binding rather than from a parameter scope that no longer has it.
+      //
+      // `_workletParameter` then `_workletParameter2` is `generateUid` avoiding a collision with
+      // the name it just handed out — the counter skips 1 — and not the parameter positions,
+      // which are 0 and 1.
+      expect(code).toContain(
+        'let first=_workletParameter===void 0?DEFAULTS:_workletParameter;let second=_workletParameter2===void 0?first:_workletParameter2;'
+      );
+    });
+
+    test('leaves a default that reads an earlier parameter alone', () => {
+      const input = html`<script>
+        function distance(from, to = from) {
+          'worklet';
+          return to - from;
+        }
+      </script>`;
+
+      const { code } = runPlugin(input);
+
+      // Parameter scope can legitimately see an earlier parameter, and this worklet captures
+      // nothing, so rewriting it would be a change with no cause.
+      expect(code).not.toContain('_workletParameter');
+    });
+
+    test('hoists a LATER parameter that captures nothing, so evaluation order is preserved', () => {
+      const input = html`<script>
+        const DEFAULTS = { max: 8 };
+
+        function span(first = DEFAULTS, second = globalThis.fallback()) {
+          'worklet';
+          return first.max + second;
+        }
+      </script>`;
+
+      const { code } = runPlugin(input);
+
+      // `second` reads a global, so it captures nothing and nothing about SCOPE forces it to move.
+      // Order does: every parameter expression runs before the body, so leaving `second` behind
+      // would run it BEFORE `first`, which now lives in the body. The source says `first` then
+      // `second`, and a transform that silently swaps two side effects is a defect no return value
+      // reveals — which is why the assertion is on the emitted order rather than on a result.
+      expect(code).toContain(
+        'let first=_workletParameter===void 0?DEFAULTS:_workletParameter;let second=_workletParameter2===void 0?globalThis.fallback():_workletParameter2;'
+      );
+    });
+
+    test('leaves a plain identifier after a hoisted parameter alone', () => {
+      const input = html`<script>
+        const DEFAULTS = { max: 8 };
+
+        function span(first = DEFAULTS, second) {
+          'worklet';
+          return first.max + second;
+        }
+      </script>`;
+
+      const { code } = runPlugin(input);
+
+      // The order rule is bounded by what a parameter EVALUATES, not by where it sits. An
+      // identifier binds the argument and runs nothing, so it has no side effect to reorder and
+      // moving it would be churn. Its slot stays exactly where it was written.
+      expect(code).toContain('(_workletParameter,second){');
+    });
+
+    test('hoists a DEFAULTLESS pattern after a hoisted parameter — destructuring is observable', () => {
+      const input = html`<script>
+        const DEFAULTS = { max: 8 };
+
+        function span(first = DEFAULTS, { max }) {
+          'worklet';
+          return first.max + max;
+        }
+      </script>`;
+
+      const { code } = runPlugin(input);
+
+      // A pattern with no default still evaluates in the parameter scope: it reads properties and
+      // drives the iterator protocol, both of which can run user code through a getter. So the
+      // order rule keys on "evaluates something", never on "carries a default" — the narrower
+      // reading would leave a getter firing on the wrong side of the hoisted parameter.
+      expect(code).toContain(
+        'let first=_workletParameter===void 0?DEFAULTS:_workletParameter;let{max:max}=_workletParameter2;'
+      );
+    });
+
+    test('hoists a destructuring pattern WHOLE, keeping its nested defaults', () => {
+      const input = html`<script>
+        const DEFAULTS = { max: 8, min: 1 };
+
+        function span({ min, max } = DEFAULTS) {
+          'worklet';
+          return max - min;
+        }
+      </script>`;
+
+      const { code } = runPlugin(input);
+
+      // The pattern moves intact rather than being decomposed, so nested defaults, computed keys
+      // and throw-on-`undefined` destructuring semantics are all unchanged — the only thing that
+      // moves is WHERE the binding happens.
+      expect(code).toContain(
+        // Shorthand properties are expanded by the generator, so the serialized body spells the
+        // pattern `{min:min,max:max}` — asserted as emitted rather than as authored.
+        'let{min:min,max:max}=_workletParameter===void 0?DEFAULTS:_workletParameter;'
+      );
+    });
+
+    test('hoists a pattern whose NESTED default reads a capture', () => {
+      const input = html`<script>
+        const DEFAULTS = { min: 1 };
+
+        function low({ min = DEFAULTS.min }) {
+          'worklet';
+          return min;
+        }
+      </script>`;
+
+      const { code } = runPlugin(input);
+
+      // The parameter itself carries no default; the capture is read from inside the pattern. A
+      // check that only looked at `AssignmentPattern` at the top level would miss it entirely.
+      expect(code).toContain('let{min=DEFAULTS.min}=_workletParameter;');
+    });
+
+    test('replaces a rest element ARGUMENT, so the rest keeps collecting', () => {
+      const input = html`<script>
+        const DEFAULTS = { max: 8 };
+
+        function first(...[limits = DEFAULTS]) {
+          'worklet';
+          return limits.max;
+        }
+      </script>`;
+
+      const { code } = runPlugin(input);
+
+      // `...rest` binds a plain identifier and cannot carry a default, so it has nothing to hoist.
+      // `...[a = CAPTURED]` is a pattern and does — and there the placeholder replaces the rest
+      // ARGUMENT, never the parameter, because the rest element itself has to go on collecting the
+      // remaining arguments. Overwriting the parameter would silently drop every argument past
+      // that position.
+      expect(code).toContain('(..._restPattern){');
+      expect(code).toContain('let[limits=DEFAULTS]=_restPattern;');
+    });
+
+    test('a capture in a non-computed KEY position is not a reference to it', () => {
+      const input = html`<script>
+        const min = 1;
+
+        function rename({ min: renamed }) {
+          'worklet';
+          return renamed + min;
+        }
+      </script>`;
+
+      const { code } = runPlugin(input);
+
+      // `{ min: renamed }` names a property, not the binding `min`. Rewriting on a key match would
+      // hoist a parameter that depends on nothing, which is a behaviour change with no cause.
+      expect(code).toContain('({min:renamed})');
+      expect(code).not.toContain('_workletParameter');
+    });
+
+    test('hoists NOTHING when the body redeclares a hoistable parameter with `var`', () => {
+      const input = html`<script>
+        const DEFAULTS = { max: 8 };
+
+        function shadow(limits = DEFAULTS) {
+          'worklet';
+          var limits;
+          return 1;
+        }
+      </script>`;
+
+      const { code } = runPlugin(input);
+
+      // `var x` may legally redeclare a PARAMETER and may not redeclare a `let`, so hoisting this
+      // one emits `let limits; var limits;` — a SyntaxError, failing on every call rather than only
+      // the defaulting one. That is strictly worse than the defect being fixed, so the whole plan
+      // is refused and the output matches upstream's exactly. The floor for this function is "no
+      // worse than unpatched", never "broken differently".
+      expect(code).toContain('(limits=DEFAULTS){');
+      expect(code).not.toContain('_workletParameter');
+    });
+
+    test('a BLOCKED plan hoists nothing, including the parameters that could have moved', () => {
+      const input = html`<script>
+        const DEFAULTS = { max: 8 };
+
+        function cascade(limits = DEFAULTS, scale = limits.max) {
+          'worklet';
+          var scale;
+          return scale;
+        }
+      </script>`;
+
+      const { code } = runPlugin(input);
+
+      // `limits` alone is hoistable and `scale` is not. Moving only `limits` would leave `scale`
+      // reading a name that is no longer in parameter scope — the original defect at a NEW trigger,
+      // on a call that worked before the patch. All or nothing is what makes that unrepresentable.
+      expect(code).toContain('(limits=DEFAULTS,scale=limits.max){');
+      expect(code).not.toContain('_workletParameter');
+    });
+
+    test("hoists a default that calls the worklet's OWN name, past the recursion binding", () => {
+      const input = html`<script>
+        const DEFAULTS = { max: 8 };
+
+        function walk(depth, next = walk) {
+          'worklet';
+          return depth > 0 ? next(depth - 1) : DEFAULTS.max;
+        }
+      </script>`;
+
+      const { code } = runPlugin(input);
+
+      // `prependRecursiveDeclaration` shadows a self-referencing worklet's own name with
+      // `const <name> = this._recur;` INSIDE the body. A default that calls the worklet therefore
+      // resolves, from parameter scope, to the bare function expression and invokes it with no
+      // `this` — whose body reads `this.__closure` first. The recursion binding counts as body
+      // scope for exactly that reason.
+      expect(code).toContain('=this._recur;');
+      expect(code).toContain('_workletParameter===void 0?');
+    });
+
+    test('the same shape hoists in a worklet that captures NOTHING', () => {
+      const input = html`<script>
+        function walk(depth, next = walk) {
+          'worklet';
+          return depth > 0 ? next(depth - 1) : 0;
+        }
+      </script>`;
+
+      const { code } = runPlugin(input);
+
+      // The recursion binding exists whether or not anything was captured, so gating the hoist on
+      // the closure count made two otherwise-identical worklets differ by one captured constant.
+      expect(code).toContain('=this._recur;');
+      expect(code).toContain('_workletParameter===void 0?');
+    });
+
+    test('the hoisted binding is `let`, so a body may reassign its own parameter', () => {
+      const input = html`<script>
+        const DEFAULTS = { max: 8 };
+
+        function bump(limits = DEFAULTS) {
+          'worklet';
+          limits = { max: limits.max + 1 };
+          return limits.max;
+        }
+      </script>`;
+
+      const { code } = runPlugin(input);
+
+      // A parameter is assignable, so the binding that replaces it must be too. `const` here is
+      // observable only as the "Assignment to constant variable" it throws at call time, which is
+      // why the emitted keyword is asserted rather than inferred.
+      expect(code).toContain(
+        'let limits=_workletParameter===void 0?DEFAULTS:_workletParameter;'
+      );
+    });
+
+    test('the parameter COUNT is preserved — one parameter becomes one placeholder', () => {
+      const input = html`<script>
+        const DEFAULTS = { max: 8 };
+
+        function clamp(value, limits = DEFAULTS) {
+          'worklet';
+          return Math.min(value, limits.max);
+        }
+      </script>`;
+
+      const { code } = runPlugin(input);
+
+      // `arguments` is indexed by position, so a hoisted parameter must leave its slot occupied
+      // rather than vanish from the list.
+      //
+      // `Function.prototype.length` is the one observable this DOES move, and it moves by
+      // construction: it counts the parameters before the first default, so replacing a defaulted
+      // parameter with a plain placeholder raises it — measured 1 -> 2 for this function. Nothing
+      // in this package reads a worklet's arity, and the alternative is the ReferenceError, so the
+      // trade is deliberate rather than overlooked. It is pinned here so a future change to the
+      // placeholder shape cannot move it further without saying so.
+      expect(code).toContain('(value,_workletParameter){');
+      expect(code).not.toContain('(value){');
+    });
+
+    test('the placeholder cannot collide with a name the body already declares', () => {
+      const input = html`<script>
+        const DEFAULTS = { max: 8 };
+
+        function collide(limits = DEFAULTS) {
+          'worklet';
+          const _workletParameter = 7;
+          return limits.max + _workletParameter;
+        }
+      </script>`;
+
+      const { code } = runPlugin(input);
+
+      // A raw identifier would emit two `_workletParameter` bindings in one scope, which does not
+      // parse. `generateUid` re-suffixes until the name is free across the whole program.
+      expect(code).toContain('_workletParameter2');
+    });
+
+    test('a default that CONSTRUCTS a captured worklet class hoists', () => {
+      const input = html`<script>
+        class Limits {
+          constructor() {
+            this.max = 8;
+          }
+        }
+
+        function clamp(scale, limits = new Limits()) {
+          'worklet';
+          return Math.min(limits.max, scale);
+        }
+      </script>`;
+
+      const { code } = runPlugin(input);
+
+      // A captured worklet CLASS never appears in `closureVariables` under its own name —
+      // `buildWorkletString` replaces `Limits` with `Limits<suffix>` and prepends
+      // `const Limits = Limits<suffix>();` to the body. So the constructor name is body-scoped
+      // exactly like a capture, and reading it from a parameter default is the original defect at
+      // a trigger the closure-name scan alone cannot see.
+      expect(code).toContain(
+        'let limits=_workletParameter===void 0?new Limits():_workletParameter'
+      );
+    });
+
+    test('a hoisted initializer lands AFTER the class-factory declaration it reads', () => {
+      const input = html`<script>
+        class Limits {
+          constructor() {
+            this.max = 8;
+          }
+        }
+
+        function clamp(scale, limits = new Limits()) {
+          'worklet';
+          return Math.min(limits.max, scale);
+        }
+      </script>`;
+
+      const { code } = runPlugin(input);
+
+      // Ordering, not merely presence: `const Limits = …` is a `const`, so an initializer placed
+      // above it reads the name in its temporal dead zone and throws just as surely as the
+      // unhoisted version did. The closure destructure stays first because the factory call needs
+      // it.
+      const factoryIndex = code.indexOf('const Limits=');
+      const hoistIndex = code.indexOf('let limits=');
+
+      expect(factoryIndex).toBeGreaterThan(-1);
+      expect(hoistIndex).toBeGreaterThan(factoryIndex);
+    });
+
+    test('the emitted worklet RUNS, and runs its defaults in source order', () => {
+      const input = html`<script>
+        const DEFAULTS = { max: 8 };
+
+        function span(
+          first = (globalThis.trace.push('first'), DEFAULTS),
+          second = globalThis.trace.push('second')
+        ) {
+          'worklet';
+          globalThis.trace.push('body');
+          return first.max + second;
+        }
+      </script>`;
+
+      const { code } = runPlugin(input);
+
+      // Every other test in this block asserts emitted TEXT, which structurally cannot fail for
+      // the reason this defect fails: the emitted function parses fine and throws when it is
+      // CALLED. So this one calls it, in the only scope that matters — `new Function` compiles in
+      // the global scope, so the captured `DEFAULTS` is reachable through `this.__closure` and
+      // through nothing else, which is the UI runtime's shape.
+      const worklet = evaluateWorkletCode(code);
+      const trace: Array<string> = [];
+      // The worklet reaches its recorder off the global, because that is the one thing a bare
+      // `new Function` scope shares with this one.
+      Object.assign(globalThis, { trace });
+
+      const result = worklet.call({ __closure: { DEFAULTS: { max: 8 } } });
+
+      // `Array.prototype.push` returns the new length, so `second` is 2 and the value doubles as
+      // proof that the default ran rather than being dropped: 8 + 2.
+      expect(result).toBe(10);
+      // The ORDER is what the value cannot tell you — leaving `second` in the parameter scope
+      // yields the identical 10 while running the two side effects the other way round.
+      expect(trace).toEqual(['first', 'second', 'body']);
+    });
   });
 
   describe('generally', () => {

--- a/packages/react-native-worklets/plugin/__tests__/plugin-legacy.test.ts
+++ b/packages/react-native-worklets/plugin/__tests__/plugin-legacy.test.ts
@@ -64,10 +64,18 @@ function runPlugin(
 /**
  * A worklet the UI runtime would evaluate, as a callable — `this` is its host
  * object.
+ *
+ * The host carries `__closure` and whatever else a test hands the worklet to
+ * reach. `this` is the one channel into a `new Function` scope that costs
+ * nothing outside the call, which is what keeps a worklet that records its own
+ * evaluation order from writing to a global every later test can see.
  */
-type EvaluatedWorklet = (this: {
+type WorkletHost = {
   __closure: Record<string, unknown>;
-}) => unknown;
+  [property: string]: unknown;
+};
+
+type EvaluatedWorklet = (this: WorkletHost) => unknown;
 
 /**
  * The serialized worklet out of the emitted `__initData`, compiled and ready to
@@ -503,11 +511,11 @@ describe('babel plugin', () => {
         const DEFAULTS = { max: 8 };
 
         function span(
-          first = (globalThis.trace.push('first'), DEFAULTS),
-          second = globalThis.trace.push('second')
+          first = (this.trace.push('first'), DEFAULTS),
+          second = this.trace.push('second')
         ) {
           'worklet';
-          globalThis.trace.push('body');
+          this.trace.push('body');
           return first.max + second;
         }
       </script>`;
@@ -521,11 +529,12 @@ describe('babel plugin', () => {
       // through nothing else, which is the UI runtime's shape.
       const worklet = evaluateWorkletCode(code);
       const trace: Array<string> = [];
-      // The worklet reaches its recorder off the global, because that is the one thing a bare
-      // `new Function` scope shares with this one.
-      Object.assign(globalThis, { trace });
 
-      const result = worklet.call({ __closure: { DEFAULTS: { max: 8 } } });
+      // The recorder rides on the host object, which is the one channel a bare `new Function`
+      // scope has into this one and costs nothing outside the call. A parameter default reads
+      // `this` from the call receiver in either arm — the hoisted one and the one this patch
+      // would leave in parameter scope — so the counterfactual is still observable.
+      const result = worklet.call({ __closure: { DEFAULTS: { max: 8 } }, trace });
 
       // `Array.prototype.push` returns the new length, so `second` is 2 and the value doubles as
       // proof that the default ran rather than being dropped: 8 + 2.
@@ -533,6 +542,64 @@ describe('babel plugin', () => {
       // The ORDER is what the value cannot tell you — leaving `second` in the parameter scope
       // yields the identical 10 while running the two side effects the other way round.
       expect(trace).toEqual(['first', 'second', 'body']);
+    });
+
+    test('a body statement calling a `__classFactory` name the plugin did not generate is not a hoist anchor', () => {
+      const input = html`<script>
+        const DEFAULTS = { max: 8 };
+        const gadget__classFactory = () => ({ size: 2 });
+
+        function span(limits = (this.trace.push('default'), DEFAULTS)) {
+          'worklet';
+          const gadget = gadget__classFactory();
+          return limits.max + gadget.size;
+        }
+      </script>`;
+
+      const { code } = runPlugin(input);
+      const worklet = evaluateWorkletCode(code);
+      const trace: Array<string> = [];
+
+      // The suffix is a plain string, so a body statement may take the exact shape of a generated
+      // factory declaration without the plugin having written it. Counting it puts the hoisted
+      // parameter BELOW that statement, and the source runs every parameter expression first.
+      const result = worklet.call({
+        __closure: {
+          DEFAULTS: { max: 8 },
+          gadget__classFactory: () => {
+            trace.push('gadget');
+            return { size: 2 };
+          },
+        },
+        trace,
+      });
+
+      expect(result).toBe(10);
+      expect(trace).toEqual(['default', 'gadget']);
+      expect(code.indexOf('let limits=')).toBeLessThan(
+        code.indexOf('const gadget=')
+      );
+    });
+
+    test('a captured name ending in the class-factory suffix declares no body binding', () => {
+      const input = html`<script>
+        const gadget__classFactory = () => 2;
+
+        function span(gadget, size = gadget * 2) {
+          'worklet';
+          return size + gadget__classFactory();
+        }
+      </script>`;
+
+      const { code } = runPlugin(input);
+
+      // Recovering a constructor name by stripping the suffix off a closure entry invents a
+      // body-scoped `gadget` that no declaration creates, and here the real `gadget` is an
+      // earlier PARAMETER — which parameter scope can legitimately see. The default would then
+      // be hoisted for a reason that does not exist, and a spurious member drags every later
+      // parameter with it and can lose the whole plan to the `var`-redeclaration refusal.
+      expect(code).not.toContain('_workletParameter');
+      expect(code).toContain('size=gadget*2');
     });
   });
 

--- a/packages/react-native-worklets/plugin/index.js
+++ b/packages/react-native-worklets/plugin/index.js
@@ -1677,7 +1677,7 @@ var require_workletStringCode = __commonJS({
       const transformed = (0, transform_1.workletTransformSync)(code, {
         filename: state.file.opts.filename,
         extraPlugins: [
-          getClosurePlugin(closureVariables),
+          getClosurePlugin(closureVariables, parsedClasses),
           ...(_a = state.opts.extraPlugins) !== null && _a !== void 0 ? _a : []
         ],
         extraPresets: state.opts.extraPresets,
@@ -1718,12 +1718,10 @@ var require_workletStringCode = __commonJS({
     function shouldMockSourceMap() {
       return process.env.WORKLETS_JEST_SHOULD_MOCK_SOURCE_MAP === "1";
     }
-    function collectBodyScopeNames(path, closureVariables) {
+    function collectBodyScopeNames(path, closureVariables, workletClassNames) {
       const names = new Set(closureVariables.map((variable) => variable.name));
-      for (const variable of closureVariables) {
-        if (variable.name.endsWith(types_2.workletClassFactorySuffix)) {
-          names.add(variable.name.slice(0, -types_2.workletClassFactorySuffix.length));
-        }
+      for (const className of workletClassNames) {
+        names.add(className);
       }
       if (!(0, types_12.isArrowFunctionExpression)(path.node) && !(0, types_12.isObjectMethod)(path.node) && path.node.id) {
         names.add(path.node.id.name);
@@ -1823,8 +1821,8 @@ var require_workletStringCode = __commonJS({
       }
       return Array.from(planned.values()).sort((left, right) => left.index - right.index);
     }
-    function hoistBodyScopedParameters(path, closureVariables) {
-      const bodyScopeNames = collectBodyScopeNames(path, closureVariables);
+    function hoistBodyScopedParameters(path, closureVariables, workletClassNames) {
+      const bodyScopeNames = collectBodyScopeNames(path, closureVariables, workletClassNames);
       const hoisted = [];
       if (bodyScopeNames.size === 0) {
         return hoisted;
@@ -1855,29 +1853,31 @@ var require_workletStringCode = __commonJS({
       }
       return hoisted;
     }
-    function prependClosure(path, closureVariables, closureDeclaration) {
+    function prependClosure(path, closureVariables, workletClassNames, closureDeclaration) {
       if (!(0, types_12.isProgram)(path.parent) || (0, types_12.isExpression)(path.node.body)) {
         return;
       }
-      const hoisted = hoistBodyScopedParameters(path, closureVariables);
+      const hoisted = hoistBodyScopedParameters(path, closureVariables, workletClassNames);
       const body = path.node.body.body;
-      body.splice(countLeadingClassFactoryDeclarations(body), 0, ...hoisted);
+      body.splice(countLeadingClassFactoryDeclarations(body, workletClassNames), 0, ...hoisted);
       if (closureVariables.length > 0) {
         body.unshift(closureDeclaration);
       }
     }
-    function countLeadingClassFactoryDeclarations(body) {
+    function countLeadingClassFactoryDeclarations(body, workletClassNames) {
+      const remaining = new Set(workletClassNames);
       let count = 0;
-      while (count < body.length) {
+      while (count < body.length && remaining.size > 0) {
         const statement = body[count];
-        if (!(0, types_12.isVariableDeclaration)(statement) || statement.kind !== "const") {
+        if (!(0, types_12.isVariableDeclaration)(statement) || statement.kind !== "const" || statement.declarations.length !== 1) {
           break;
         }
         const [declarator] = statement.declarations;
-        const initializer = declarator === null || declarator === void 0 ? void 0 : declarator.init;
-        if (!(0, types_12.isCallExpression)(initializer) || !(0, types_12.isIdentifier)(initializer.callee) || !initializer.callee.name.endsWith(types_2.workletClassFactorySuffix)) {
+        const initializer = declarator.init;
+        if (!(0, types_12.isIdentifier)(declarator.id) || !remaining.has(declarator.id.name) || !(0, types_12.isCallExpression)(initializer) || initializer.arguments.length > 0 || !(0, types_12.isIdentifier)(initializer.callee) || initializer.callee.name !== declarator.id.name + types_2.workletClassFactorySuffix) {
           break;
         }
+        remaining.delete(declarator.id.name);
         count += 1;
       }
       return count;
@@ -1893,14 +1893,14 @@ var require_workletStringCode = __commonJS({
         }
       }
     }
-    function getClosurePlugin(closureVariables) {
+    function getClosurePlugin(closureVariables, workletClassNames) {
       const closureDeclaration = (0, types_12.variableDeclaration)("const", [
         (0, types_12.variableDeclarator)((0, types_12.objectPattern)(closureVariables.map((variable) => (0, types_12.objectProperty)((0, types_12.identifier)(variable.name), (0, types_12.identifier)(variable.name), false, true))), (0, types_12.memberExpression)((0, types_12.thisExpression)(), (0, types_12.identifier)("__closure")))
       ]);
       return {
         visitor: {
           "FunctionDeclaration|FunctionExpression|ArrowFunctionExpression|ObjectMethod": (path) => {
-            prependClosure(path, closureVariables, closureDeclaration);
+            prependClosure(path, closureVariables, workletClassNames, closureDeclaration);
             prependRecursiveDeclaration(path);
           }
         }

--- a/packages/react-native-worklets/plugin/index.js
+++ b/packages/react-native-worklets/plugin/index.js
@@ -1718,13 +1718,169 @@ var require_workletStringCode = __commonJS({
     function shouldMockSourceMap() {
       return process.env.WORKLETS_JEST_SHOULD_MOCK_SOURCE_MAP === "1";
     }
+    function collectBodyScopeNames(path, closureVariables) {
+      const names = new Set(closureVariables.map((variable) => variable.name));
+      for (const variable of closureVariables) {
+        if (variable.name.endsWith(types_2.workletClassFactorySuffix)) {
+          names.add(variable.name.slice(0, -types_2.workletClassFactorySuffix.length));
+        }
+      }
+      if (!(0, types_12.isArrowFunctionExpression)(path.node) && !(0, types_12.isObjectMethod)(path.node) && path.node.id) {
+        names.add(path.node.id.name);
+      }
+      return names;
+    }
+    function collectBodyRedeclarations(path) {
+      const names = /* @__PURE__ */ new Set();
+      const bodyPath = path.get("body");
+      if (!bodyPath.isBlockStatement()) {
+        return names;
+      }
+      bodyPath.traverse({
+        Function(innerPath) {
+          if (innerPath.isFunctionDeclaration() && innerPath.node.id) {
+            names.add(innerPath.node.id.name);
+          }
+          innerPath.skip();
+        },
+        VariableDeclaration(innerPath) {
+          if (innerPath.node.kind !== "var") {
+            return;
+          }
+          for (const declaration of innerPath.node.declarations) {
+            for (const boundName of Object.keys((0, types_12.getBindingIdentifiers)(declaration.id))) {
+              names.add(boundName);
+            }
+          }
+        }
+      });
+      return names;
+    }
+    function resolveParameterScopeExpression(parameterPath) {
+      const parameter = parameterPath.node;
+      if ((0, types_12.isIdentifier)(parameter) || parameter.type === "VoidPattern") {
+        return void 0;
+      }
+      const restElementNode = (0, types_12.isRestElement)(parameter) ? parameter : void 0;
+      const target = restElementNode ? restElementNode.argument : parameter;
+      if (restElementNode && (0, types_12.isIdentifier)(target)) {
+        return void 0;
+      }
+      return {
+        defaultValue: (0, types_12.isAssignmentPattern)(target) ? target.right : void 0,
+        pattern: (0, types_12.isAssignmentPattern)(target) ? target.left : target,
+        restElementNode
+      };
+    }
+    function readsBodyScopedName(parameterPath, bodyScopeNames) {
+      let reads = false;
+      parameterPath.traverse({
+        Identifier(innerPath) {
+          if (bodyScopeNames.has(innerPath.node.name) && innerPath.isReferencedIdentifier()) {
+            reads = true;
+          }
+        }
+      });
+      return reads;
+    }
+    function resolveHoistReason(readsBodyScope, followsHoistedParameter) {
+      if (readsBodyScope) {
+        return "body-scope";
+      }
+      if (followsHoistedParameter) {
+        return "evaluation-order";
+      }
+      return void 0;
+    }
+    function planHoistedParameters(path, bodyScopeNames) {
+      const names = new Set(bodyScopeNames);
+      const planned = /* @__PURE__ */ new Map();
+      const parameterPaths = path.get("params");
+      let lowestPlannedIndex = Number.POSITIVE_INFINITY;
+      let changed = true;
+      while (changed) {
+        changed = false;
+        parameterPaths.forEach((parameterPath, index) => {
+          if (planned.has(index)) {
+            return;
+          }
+          const scopeExpression = resolveParameterScopeExpression(parameterPath);
+          if (scopeExpression === void 0) {
+            return;
+          }
+          const reason = resolveHoistReason(readsBodyScopedName(parameterPath, names), index > lowestPlannedIndex);
+          if (reason === void 0) {
+            return;
+          }
+          const boundNames = Object.keys((0, types_12.getBindingIdentifiers)(scopeExpression.pattern));
+          planned.set(index, Object.assign(Object.assign({}, scopeExpression), { boundNames, index, reason }));
+          lowestPlannedIndex = Math.min(lowestPlannedIndex, index);
+          for (const boundName of boundNames) {
+            names.add(boundName);
+          }
+          changed = true;
+        });
+      }
+      return Array.from(planned.values()).sort((left, right) => left.index - right.index);
+    }
+    function hoistBodyScopedParameters(path, closureVariables) {
+      const bodyScopeNames = collectBodyScopeNames(path, closureVariables);
+      const hoisted = [];
+      if (bodyScopeNames.size === 0) {
+        return hoisted;
+      }
+      const plan = planHoistedParameters(path, bodyScopeNames);
+      if (plan.length === 0) {
+        return hoisted;
+      }
+      const bodyRedeclarations = collectBodyRedeclarations(path);
+      const blocked = plan.some((entry) => entry.boundNames.some((name) => bodyRedeclarations.has(name)));
+      if (blocked) {
+        return hoisted;
+      }
+      for (const entry of plan) {
+        const placeholder = path.scope.generateUidIdentifier(entry.restElementNode ? "restPattern" : "workletParameter");
+        let initializer = placeholder;
+        if (entry.defaultValue) {
+          initializer = (0, types_12.conditionalExpression)((0, types_12.binaryExpression)("===", (0, types_12.cloneNode)(placeholder), (0, types_12.unaryExpression)("void", (0, types_12.numericLiteral)(0))), entry.defaultValue, (0, types_12.cloneNode)(placeholder));
+        }
+        if (entry.restElementNode) {
+          entry.restElementNode.argument = placeholder;
+        } else {
+          path.node.params[entry.index] = placeholder;
+        }
+        hoisted.push((0, types_12.variableDeclaration)("let", [
+          (0, types_12.variableDeclarator)(entry.pattern, initializer)
+        ]));
+      }
+      return hoisted;
+    }
     function prependClosure(path, closureVariables, closureDeclaration) {
-      if (closureVariables.length === 0 || !(0, types_12.isProgram)(path.parent)) {
+      if (!(0, types_12.isProgram)(path.parent) || (0, types_12.isExpression)(path.node.body)) {
         return;
       }
-      if (!(0, types_12.isExpression)(path.node.body)) {
-        path.node.body.body.unshift(closureDeclaration);
+      const hoisted = hoistBodyScopedParameters(path, closureVariables);
+      const body = path.node.body.body;
+      body.splice(countLeadingClassFactoryDeclarations(body), 0, ...hoisted);
+      if (closureVariables.length > 0) {
+        body.unshift(closureDeclaration);
       }
+    }
+    function countLeadingClassFactoryDeclarations(body) {
+      let count = 0;
+      while (count < body.length) {
+        const statement = body[count];
+        if (!(0, types_12.isVariableDeclaration)(statement) || statement.kind !== "const") {
+          break;
+        }
+        const [declarator] = statement.declarations;
+        const initializer = declarator === null || declarator === void 0 ? void 0 : declarator.init;
+        if (!(0, types_12.isCallExpression)(initializer) || !(0, types_12.isIdentifier)(initializer.callee) || !initializer.callee.name.endsWith(types_2.workletClassFactorySuffix)) {
+          break;
+        }
+        count += 1;
+      }
+      return count;
     }
     function prependRecursiveDeclaration(path) {
       var _a;

--- a/packages/react-native-worklets/plugin/src/workletStringCode.ts
+++ b/packages/react-native-worklets/plugin/src/workletStringCode.ts
@@ -154,7 +154,7 @@ export function buildWorkletString(
   const transformed = workletTransformSync(code, {
     filename: state.file.opts.filename,
     extraPlugins: [
-      getClosurePlugin(closureVariables),
+      getClosurePlugin(closureVariables, parsedClasses),
       ...(state.opts.extraPlugins ?? []),
     ],
     extraPresets: state.opts.extraPresets,
@@ -231,7 +231,8 @@ function shouldMockSourceMap() {
  */
 function collectBodyScopeNames(
   path: NodePath<WorkletizableFunction>,
-  closureVariables: Array<Identifier>
+  closureVariables: Array<Identifier>,
+  workletClassNames: ReadonlySet<string>
 ): Set<string> {
   const names = new Set(closureVariables.map((variable) => variable.name));
 
@@ -239,12 +240,17 @@ function collectBodyScopeNames(
   // `buildWorkletString` replaces `Foo` with `Foo<suffix>` there and prepends
   // `const Foo = Foo<suffix>();` to the body — so the constructor name is
   // body-scoped exactly like a capture, and a default such as `new Foo()`
-  // reads it from parameter scope. Recovering it from the factory name is what
-  // keeps that shape from being the original defect at a new trigger.
-  for (const variable of closureVariables) {
-    if (variable.name.endsWith(workletClassFactorySuffix)) {
-      names.add(variable.name.slice(0, -workletClassFactorySuffix.length));
-    }
+  // reads it from parameter scope. Leaving it out keeps that shape as the
+  // original defect at a new trigger.
+  //
+  // The names come from the census `buildWorkletString` kept while rewriting
+  // rather than from stripping the suffix off a closure entry. The suffix is a
+  // plain string a user may also have typed, so stripping it would declare a
+  // body-scoped `x` for a captured variable named `x__classFactory` that no
+  // declaration ever creates — and hoist a parameter that had no reason to
+  // move.
+  for (const className of workletClassNames) {
+    names.add(className);
   }
 
   // An arrow function and an object method carry no name of their own, so
@@ -511,9 +517,14 @@ function planHoistedParameters(
  */
 function hoistBodyScopedParameters(
   path: NodePath<WorkletizableFunction>,
-  closureVariables: Array<Identifier>
+  closureVariables: Array<Identifier>,
+  workletClassNames: ReadonlySet<string>
 ): Array<VariableDeclaration> {
-  const bodyScopeNames = collectBodyScopeNames(path, closureVariables);
+  const bodyScopeNames = collectBodyScopeNames(
+    path,
+    closureVariables,
+    workletClassNames
+  );
   const hoisted: Array<VariableDeclaration> = [];
 
   if (bodyScopeNames.size === 0) {
@@ -592,6 +603,7 @@ function hoistBodyScopedParameters(
 function prependClosure(
   path: NodePath<WorkletizableFunction>,
   closureVariables: Array<Identifier>,
+  workletClassNames: ReadonlySet<string>,
   closureDeclaration: VariableDeclaration
 ) {
   if (!isProgram(path.parent) || isExpression(path.node.body)) {
@@ -607,14 +619,22 @@ function prependClosure(
   //
   // The hoisted declarations follow the closure destructure, because that is the
   // binding they were moved here to reach.
-  const hoisted = hoistBodyScopedParameters(path, closureVariables);
+  const hoisted = hoistBodyScopedParameters(
+    path,
+    closureVariables,
+    workletClassNames
+  );
   const body = path.node.body.body;
 
   // …and they follow the worklet-class factory calls for the same reason.
   // `buildWorkletString` has already prepended `const Foo = Foo<suffix>();` for
   // every captured class, so a hoisted initializer that constructs one would
   // read `Foo` in its temporal dead zone if it landed above that declaration.
-  body.splice(countLeadingClassFactoryDeclarations(body), 0, ...hoisted);
+  body.splice(
+    countLeadingClassFactoryDeclarations(body, workletClassNames),
+    0,
+    ...hoisted
+  );
 
   if (closureVariables.length > 0) {
     body.unshift(closureDeclaration);
@@ -625,33 +645,48 @@ function prependClosure(
  * How many worklet-class factory declarations `buildWorkletString` has already
  * placed at the top of the body.
  *
- * They are matched by SHAPE — `const <name> = <name><suffix>();` — rather than
- * by counting the captured classes, so a body that carries none is answered
- * with zero and the hoist lands where it did before.
+ * A statement counts only when it is `const <name> = <name><suffix>();` for a
+ * `<name>` in the census of classes this worklet's rewrite actually produced,
+ * and each name counts once — so the answer can never exceed the number of
+ * declarations that were generated, and a body carrying none is answered with
+ * zero. Matching the SHAPE alone would also count a user statement calling any
+ * identifier that happens to end in the suffix, and the hoisted declarations
+ * would then land BELOW a body statement whose side effects the source runs
+ * after every parameter expression.
  */
 function countLeadingClassFactoryDeclarations(
-  body: ReadonlyArray<Statement>
+  body: ReadonlyArray<Statement>,
+  workletClassNames: ReadonlySet<string>
 ): number {
+  const remaining = new Set(workletClassNames);
   let count = 0;
 
-  while (count < body.length) {
+  while (count < body.length && remaining.size > 0) {
     const statement = body[count];
 
-    if (!isVariableDeclaration(statement) || statement.kind !== 'const') {
-      break;
-    }
-
-    const [declarator] = statement.declarations;
-    const initializer = declarator?.init;
-
     if (
-      !isCallExpression(initializer) ||
-      !isIdentifier(initializer.callee) ||
-      !initializer.callee.name.endsWith(workletClassFactorySuffix)
+      !isVariableDeclaration(statement) ||
+      statement.kind !== 'const' ||
+      statement.declarations.length !== 1
     ) {
       break;
     }
 
+    const [declarator] = statement.declarations;
+    const initializer = declarator.init;
+
+    if (
+      !isIdentifier(declarator.id) ||
+      !remaining.has(declarator.id.name) ||
+      !isCallExpression(initializer) ||
+      initializer.arguments.length > 0 ||
+      !isIdentifier(initializer.callee) ||
+      initializer.callee.name !== declarator.id.name + workletClassFactorySuffix
+    ) {
+      break;
+    }
+
+    remaining.delete(declarator.id.name);
     count += 1;
   }
 
@@ -682,7 +717,10 @@ function prependRecursiveDeclaration(path: NodePath<WorkletizableFunction>) {
 }
 
 /** Prepends necessary closure variables to the worklet function. */
-function getClosurePlugin(closureVariables: Array<Identifier>): PluginItem {
+function getClosurePlugin(
+  closureVariables: Array<Identifier>,
+  workletClassNames: ReadonlySet<string>
+): PluginItem {
   const closureDeclaration = variableDeclaration('const', [
     variableDeclarator(
       objectPattern(
@@ -703,7 +741,12 @@ function getClosurePlugin(closureVariables: Array<Identifier>): PluginItem {
     visitor: {
       'FunctionDeclaration|FunctionExpression|ArrowFunctionExpression|ObjectMethod':
         (path: NodePath<WorkletizableFunction>) => {
-          prependClosure(path, closureVariables, closureDeclaration);
+          prependClosure(
+            path,
+            closureVariables,
+            workletClassNames,
+            closureDeclaration
+          );
           prependRecursiveDeclaration(path);
         },
     },

--- a/packages/react-native-worklets/plugin/src/workletStringCode.ts
+++ b/packages/react-native-worklets/plugin/src/workletStringCode.ts
@@ -2,27 +2,41 @@ import type { BabelFileResult, NodePath, PluginItem } from '@babel/core';
 import { traverse } from '@babel/core';
 import generate from '@babel/generator';
 import type {
+  Expression,
   File as BabelFile,
   Identifier,
+  LVal,
+  RestElement,
+  Statement,
   VariableDeclaration,
 } from '@babel/types';
 import {
   assertBlockStatement,
+  binaryExpression,
   callExpression,
+  cloneNode,
+  conditionalExpression,
   functionExpression,
+  getBindingIdentifiers,
   identifier,
   isArrowFunctionExpression,
+  isAssignmentPattern,
   isBlockStatement,
+  isCallExpression,
   isExpression,
   isExpressionStatement,
   isFunctionDeclaration,
   isIdentifier,
   isObjectMethod,
   isProgram,
+  isRestElement,
+  isVariableDeclaration,
   memberExpression,
+  numericLiteral,
   objectPattern,
   objectProperty,
   thisExpression,
+  unaryExpression,
   variableDeclaration,
   variableDeclarator,
 } from '@babel/types';
@@ -199,18 +213,449 @@ function shouldMockSourceMap() {
   return process.env.WORKLETS_JEST_SHOULD_MOCK_SOURCE_MAP === '1';
 }
 
+/**
+ * Names a worklet's BODY resolves and its parameter scope cannot.
+ *
+ * The closure destructure is the bulk of it. The recursion binding is the
+ * other: `prependRecursiveDeclaration` shadows a self-referencing worklet's own
+ * name with `const <name> = this._recur;` inside the body, so a default that
+ * CALLS the worklet resolves, from parameter scope, to the bare function
+ * expression and invokes it with no `this` — and `this.__closure` is the first
+ * thing its body reads.
+ *
+ * The function's own name is added whenever it has one, rather than replicating
+ * `prependRecursiveDeclaration`'s emit condition. Where that declaration is not
+ * emitted the two scopes resolve the name identically, so hoisting is a no-op
+ * there; replicating the condition would only add a second place for the two to
+ * disagree.
+ */
+function collectBodyScopeNames(
+  path: NodePath<WorkletizableFunction>,
+  closureVariables: Array<Identifier>
+): Set<string> {
+  const names = new Set(closureVariables.map((variable) => variable.name));
+
+  // A captured worklet CLASS is not in `closureVariables` under its own name.
+  // `buildWorkletString` replaces `Foo` with `Foo<suffix>` there and prepends
+  // `const Foo = Foo<suffix>();` to the body — so the constructor name is
+  // body-scoped exactly like a capture, and a default such as `new Foo()`
+  // reads it from parameter scope. Recovering it from the factory name is what
+  // keeps that shape from being the original defect at a new trigger.
+  for (const variable of closureVariables) {
+    if (variable.name.endsWith(workletClassFactorySuffix)) {
+      names.add(variable.name.slice(0, -workletClassFactorySuffix.length));
+    }
+  }
+
+  // An arrow function and an object method carry no name of their own, so
+  // `prependRecursiveDeclaration` has nothing to shadow in either.
+  if (
+    !isArrowFunctionExpression(path.node) &&
+    !isObjectMethod(path.node) &&
+    path.node.id
+  ) {
+    names.add(path.node.id.name);
+  }
+
+  return names;
+}
+
+/**
+ * Names the body declares var-scoped.
+ *
+ * `var x` may legally redeclare a parameter and may NOT redeclare a `let`, so
+ * hoisting such a parameter would emit `let x; var x;` — a SyntaxError that
+ * fails on every call rather than only the defaulting one.
+ */
+function collectBodyRedeclarations(
+  path: NodePath<WorkletizableFunction>
+): Set<string> {
+  const names = new Set<string>();
+  const bodyPath = path.get('body');
+
+  if (!bodyPath.isBlockStatement()) {
+    return names;
+  }
+
+  bodyPath.traverse({
+    Function(innerPath) {
+      // A function DECLARATION is var-scoped, so `let x; function x() {}` is the
+      // same SyntaxError. A function EXPRESSION's name binds only inside itself
+      // and redeclares nothing — `let x = 1; const f = function x() {};` is
+      // legal, so counting it here would refuse a hoist that is needed and
+      // silently keep the crash this exists to remove.
+      if (innerPath.isFunctionDeclaration() && innerPath.node.id) {
+        names.add(innerPath.node.id.name);
+      }
+      innerPath.skip();
+    },
+    VariableDeclaration(innerPath) {
+      if (innerPath.node.kind !== 'var') {
+        return;
+      }
+      for (const declaration of innerPath.node.declarations) {
+        for (const boundName of Object.keys(
+          getBindingIdentifiers(declaration.id)
+        )) {
+          names.add(boundName);
+        }
+      }
+    },
+  });
+
+  return names;
+}
+
+/**
+ * Why a parameter cannot stay where it was written. Either reason is sufficient
+ * on its own, and the second is a consequence of the first.
+ *
+ * `body-scope` — the parameter reads a name the body declares, so it sits one
+ * scope away from the binding it needs and throws the first time it evaluates.
+ *
+ * `evaluation-order` — the parameter reads nothing body-scoped, but an EARLIER
+ * parameter has moved. Parameter expressions evaluate left to right and all of
+ * them before the body, so a parameter left behind would now run BEFORE the one
+ * that used to precede it. No value changes; the ORDER of their side effects
+ * does, which is a silent reordering of what the source says.
+ */
+type ParameterHoistReason = 'body-scope' | 'evaluation-order';
+
+/**
+ * One entry of a parameter list, derived from the functions this plugin
+ * rewrites.
+ */
+type WorkletParameterPath = NodePath<WorkletizableFunction['params'][number]>;
+
+/** One parameter the plan moves into the body, and everything the move needs. */
+interface HoistedParameter {
+  readonly boundNames: Array<string>;
+  /** Present iff the parameter carried a default, which becomes a conditional. */
+  readonly defaultValue: Expression | undefined;
+  readonly index: number;
+  readonly pattern: LVal;
+  /** Why this parameter cannot stay in the parameter scope. */
+  readonly reason: ParameterHoistReason;
+  /**
+   * Set iff the parameter is `...[a = CAPTURED]`. The placeholder then replaces
+   * the rest ARGUMENT rather than the parameter, because the rest element
+   * itself has to go on collecting the remaining arguments.
+   */
+  readonly restElementNode: RestElement | undefined;
+}
+
+/** The half of a `HoistedParameter` that the parameter's own shape decides. */
+type ParameterScopeExpression = Pick<
+  HoistedParameter,
+  'defaultValue' | 'pattern' | 'restElementNode'
+>;
+
+/**
+ * What this parameter evaluates in the PARAMETER scope, or `undefined` where it
+ * evaluates nothing there and so can neither fail nor be observed.
+ *
+ * An identifier binds no expression and a void pattern binds nothing at all;
+ * `...rest` binds a plain identifier and cannot carry a default. Every other
+ * shape runs something at call time — a default expression, or the
+ * destructuring itself, which reads properties and drives the iterator
+ * protocol.
+ */
+function resolveParameterScopeExpression(
+  parameterPath: WorkletParameterPath
+): ParameterScopeExpression | undefined {
+  const parameter = parameterPath.node;
+
+  // `VoidPattern` is compared by node TYPE rather than through
+  // `isVoidPattern`, which is a recent `@babel/types` export. This plugin
+  // requires that package at runtime without declaring a range for it, so a
+  // consumer resolving an older copy would get `isVoidPattern is not a
+  // function` and every worklet in the app would fail to compile. A type
+  // comparison needs nothing the package has not always had.
+  if (isIdentifier(parameter) || parameter.type === 'VoidPattern') {
+    return undefined;
+  }
+
+  const restElementNode = isRestElement(parameter) ? parameter : undefined;
+  const target = restElementNode ? restElementNode.argument : parameter;
+
+  if (restElementNode && isIdentifier(target)) {
+    return undefined;
+  }
+
+  return {
+    defaultValue: isAssignmentPattern(target) ? target.right : undefined,
+    pattern: isAssignmentPattern(target) ? target.left : target,
+    restElementNode,
+  };
+}
+
+/**
+ * Whether anything this parameter evaluates reads a name that lives in the
+ * body.
+ */
+function readsBodyScopedName(
+  parameterPath: WorkletParameterPath,
+  bodyScopeNames: ReadonlySet<string>
+): boolean {
+  let reads = false;
+
+  parameterPath.traverse({
+    Identifier(innerPath) {
+      if (
+        bodyScopeNames.has(innerPath.node.name) &&
+        innerPath.isReferencedIdentifier()
+      ) {
+        reads = true;
+      }
+    },
+  });
+
+  return reads;
+}
+
+/** Pure: the two independent reasons, in the order they are reported. */
+function resolveHoistReason(
+  readsBodyScope: boolean,
+  followsHoistedParameter: boolean
+): ParameterHoistReason | undefined {
+  if (readsBodyScope) {
+    return 'body-scope';
+  }
+
+  if (followsHoistedParameter) {
+    return 'evaluation-order';
+  }
+
+  return undefined;
+}
+
+/**
+ * WHICH parameters must move, decided over the WHOLE list before any of them
+ * does.
+ *
+ * The set needs a fixed point because it grows two ways and each feeds the
+ * other. Hoisting a parameter moves its bindings into the body, so a parameter
+ * that READS one of them is newly unable to stay; and hoisting a parameter puts
+ * every LATER one that evaluates anything on the wrong side of it. Deciding
+ * per-parameter while mutating means parameter N commits before N+1 reveals
+ * that it cannot follow, and a parameter left behind reading a name that
+ * already moved is the original defect at a new trigger — on a call that
+ * previously worked.
+ */
+function planHoistedParameters(
+  path: NodePath<WorkletizableFunction>,
+  bodyScopeNames: Set<string>
+): Array<HoistedParameter> {
+  const names = new Set(bodyScopeNames);
+  const planned = new Map<number, HoistedParameter>();
+  const parameterPaths = path.get('params');
+  let lowestPlannedIndex = Number.POSITIVE_INFINITY;
+  let changed = true;
+
+  while (changed) {
+    changed = false;
+    parameterPaths.forEach((parameterPath, index) => {
+      if (planned.has(index)) {
+        return;
+      }
+
+      const scopeExpression = resolveParameterScopeExpression(parameterPath);
+
+      if (scopeExpression === undefined) {
+        return;
+      }
+
+      const reason = resolveHoistReason(
+        readsBodyScopedName(parameterPath, names),
+        index > lowestPlannedIndex
+      );
+
+      if (reason === undefined) {
+        return;
+      }
+
+      const boundNames = Object.keys(
+        getBindingIdentifiers(scopeExpression.pattern)
+      );
+
+      planned.set(index, { ...scopeExpression, boundNames, index, reason });
+      lowestPlannedIndex = Math.min(lowestPlannedIndex, index);
+
+      for (const boundName of boundNames) {
+        names.add(boundName);
+      }
+
+      changed = true;
+    });
+  }
+
+  return Array.from(planned.values()).sort(
+    (left, right) => left.index - right.index
+  );
+}
+
+/**
+ * Move every parameter that reads a body-scoped binding into the body itself.
+ *
+ * A worklet's captured variables are destructured at the top of the BODY, but a
+ * parameter expression — a default value, a destructuring default — is
+ * evaluated in the PARAMETER scope, which by specification cannot see a body
+ * declaration. Such a parameter is therefore emitted exactly one scope away
+ * from the binding it needs, and throws `ReferenceError` the first time a
+ * caller omits that argument. On the UI thread that is an uncaught C++
+ * exception rather than a catchable error.
+ *
+ * A parameter that depends on nothing body-scoped is left exactly as written —
+ * including a default that reads an EARLIER parameter, which parameter scope
+ * can legitimately see.
+ */
+function hoistBodyScopedParameters(
+  path: NodePath<WorkletizableFunction>,
+  closureVariables: Array<Identifier>
+): Array<VariableDeclaration> {
+  const bodyScopeNames = collectBodyScopeNames(path, closureVariables);
+  const hoisted: Array<VariableDeclaration> = [];
+
+  if (bodyScopeNames.size === 0) {
+    return hoisted;
+  }
+
+  const plan = planHoistedParameters(path, bodyScopeNames);
+
+  if (plan.length === 0) {
+    return hoisted;
+  }
+
+  // ALL OR NOTHING. A parameter the body redeclares with `var` cannot become a
+  // `let`, and the rest of the plan depends on it having moved — so hoisting the
+  // others would leave one of them reading a name that is no longer in parameter
+  // scope. Emitting nothing reproduces upstream's output exactly, which keeps
+  // upstream's defect and adds none of its own: the floor for this function is
+  // "no worse than unpatched", never "broken differently".
+  const bodyRedeclarations = collectBodyRedeclarations(path);
+  const blocked = plan.some((entry) =>
+    entry.boundNames.some((name) => bodyRedeclarations.has(name))
+  );
+
+  if (blocked) {
+    return hoisted;
+  }
+
+  for (const entry of plan) {
+    // A generated uid rather than a raw identifier: a raw name collides when the
+    // body already declares it, or when a second hoisted parameter takes the
+    // same one. `generateUid` is what resolves both, by re-suffixing until the
+    // name is free in the whole program.
+    //
+    // The requested name carries no index, because it could not keep one:
+    // `Scope#generateUid` strips trailing digits from its argument before doing
+    // anything else. An index here would be discarded and the digits that DO
+    // appear are the collision counter, so the two disagree — parameter 9 emits
+    // `_workletParameter0`. A name that looks traceable and is not is worse than
+    // one that never claimed to be.
+    const placeholder = path.scope.generateUidIdentifier(
+      entry.restElementNode ? 'restPattern' : 'workletParameter'
+    );
+    let initializer: Expression = placeholder;
+
+    if (entry.defaultValue) {
+      // ES default semantics treat an explicitly-passed `undefined` exactly as
+      // an omitted argument, so the identity check IS the rewrite — against
+      // `void 0`, never a shadowable `undefined`.
+      initializer = conditionalExpression(
+        binaryExpression(
+          '===',
+          cloneNode(placeholder),
+          unaryExpression('void', numericLiteral(0))
+        ),
+        entry.defaultValue,
+        cloneNode(placeholder)
+      );
+    }
+
+    if (entry.restElementNode) {
+      entry.restElementNode.argument = placeholder;
+    } else {
+      path.node.params[entry.index] = placeholder;
+    }
+
+    hoisted.push(
+      variableDeclaration('let', [
+        variableDeclarator(entry.pattern, initializer),
+      ])
+    );
+  }
+
+  return hoisted;
+}
+
 function prependClosure(
   path: NodePath<WorkletizableFunction>,
   closureVariables: Array<Identifier>,
   closureDeclaration: VariableDeclaration
 ) {
-  if (closureVariables.length === 0 || !isProgram(path.parent)) {
+  if (!isProgram(path.parent) || isExpression(path.node.body)) {
     return;
   }
 
-  if (!isExpression(path.node.body)) {
-    path.node.body.body.unshift(closureDeclaration);
+  // The hoist runs whether or not anything was captured.
+  // `prependRecursiveDeclaration` shadows a self-referencing worklet's own name
+  // in the BODY, so a parameter default that reads that name is out of scope of
+  // it even when there is no closure to declare — and gating the hoist on the
+  // closure count made two otherwise-identical worklets differ by one captured
+  // constant.
+  //
+  // The hoisted declarations follow the closure destructure, because that is the
+  // binding they were moved here to reach.
+  const hoisted = hoistBodyScopedParameters(path, closureVariables);
+  const body = path.node.body.body;
+
+  // …and they follow the worklet-class factory calls for the same reason.
+  // `buildWorkletString` has already prepended `const Foo = Foo<suffix>();` for
+  // every captured class, so a hoisted initializer that constructs one would
+  // read `Foo` in its temporal dead zone if it landed above that declaration.
+  body.splice(countLeadingClassFactoryDeclarations(body), 0, ...hoisted);
+
+  if (closureVariables.length > 0) {
+    body.unshift(closureDeclaration);
   }
+}
+
+/**
+ * How many worklet-class factory declarations `buildWorkletString` has already
+ * placed at the top of the body.
+ *
+ * They are matched by SHAPE — `const <name> = <name><suffix>();` — rather than
+ * by counting the captured classes, so a body that carries none is answered
+ * with zero and the hoist lands where it did before.
+ */
+function countLeadingClassFactoryDeclarations(
+  body: ReadonlyArray<Statement>
+): number {
+  let count = 0;
+
+  while (count < body.length) {
+    const statement = body[count];
+
+    if (!isVariableDeclaration(statement) || statement.kind !== 'const') {
+      break;
+    }
+
+    const [declarator] = statement.declarations;
+    const initializer = declarator?.init;
+
+    if (
+      !isCallExpression(initializer) ||
+      !isIdentifier(initializer.callee) ||
+      !initializer.callee.name.endsWith(workletClassFactorySuffix)
+    ) {
+      break;
+    }
+
+    count += 1;
+  }
+
+  return count;
 }
 
 function prependRecursiveDeclaration(path: NodePath<WorkletizableFunction>) {


### PR DESCRIPTION
## Problem

A `'worklet'` whose **parameter list** reads a captured binding is emitted with that binding out of scope at the point it is read:

```js
(function clampScale(scale, limits = DEFAULT_LIMITS) {
  const { DEFAULT_LIMITS } = this.__closure;   // <- one scope too late
  …
})
```

The capture analysis is right — `DEFAULT_LIMITS` reaches `__closure`. Only the placement is wrong: `prependClosure` unshifts the destructure into the body, and a parameter expression evaluates in the parameter scope, which cannot see a body declaration.

It throws the first time a caller omits the argument. **On the UI thread that is not catchable** — it becomes a C++ throw and aborts the process. Measured on an iPad Pro (iOS 26.6.1), release, `EXC_CRASH (SIGABRT)`: pinch-to-zoom killed the app on the first touch move, via `runSyncOnRuntime` → `throwPendingError`.

## Why it isn't caught today

It type-checks, it lints, and passing the argument works. A host-side test cannot see it — importing the module supplies a real lexical binding, the one thing the UI runtime never has. And the plugin's own tests assert emitted **text**; this function parses fine and fails when it is *called*.

## Fix

Move a body-scoped parameter into the body, after the destructure, and leave every other parameter as written.

```js
(function clampScale(scale, _workletParameter) {
  const { DEFAULT_LIMITS } = this.__closure;
  let limits = _workletParameter === void 0 ? DEFAULT_LIMITS : _workletParameter;
  …
})
```

Which parameters move is decided over the whole list first, because the set grows two ways:

- **by name** — hoisting a parameter moves its bindings into the body, so a parameter reading one of them can no longer stay;
- **by position** — parameter expressions all run before the body, left to right, so a parameter left behind would now run *before* the hoisted ones. The bound is what a parameter *evaluates*: a pattern is observable even with no default, a plain identifier is not.

Two refusals keep the floor at "no worse than unpatched": a plan containing a parameter the body redeclares with `var` is refused whole, and the placeholder is a generated uid so it cannot collide.

`Function.prototype.length` rises, because it counts parameters before the first default (measured 1 → 2 for `clamp(value, limits = DEFAULTS)`). `arguments` and the parameter count are unchanged, and nothing in this package reads a worklet's arity. Pinned by a test.

## Tests

18 cases, including the refusals and the negative controls that must **not** move. One of them **evaluates** the emitted worklet in a bare `new Function` scope with only `this.__closure` behind it — the only kind of test that can fail for the reason this defect fails. Every new case is mutation-proved: removing the positional propagation turns 3 red, disabling the hoist turns 14 red.

## Verification

`jest` 234 passed / 201 snapshots · `tsc --noEmit` 0 · `eslint --max-warnings=0 src` 0 · `oxfmt --check` clean.
