### PR TITLE
fix(plugin): stop reading worklet sources off disk to fill sourcesContent

### DIFF
--- a/packages/react-native-worklets/CHANGELOG.md
+++ b/packages/react-native-worklets/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Stop workletizing getters, setters and constructors. ([#10421](https://github.com/software-mansion/react-native-reanimated/pull/10421) by [@tshmieldev](https://github.com/tshmieldev))
 - Fix a crash when serializing objects with a `__proto__` key. ([#10451](https://github.com/software-mansion/react-native-reanimated/pull/10451) by [@tshmieldev](https://github.com/tshmieldev))
 - Fix `./gradlew app:build` failing on `:lintAnalyzeDebug` with a K2 UAST crash on `.gradle.kts` build scripts - all lint tasks are now skipped, not only `lintVital*`. ([#10448](https://github.com/software-mansion/react-native-reanimated/pull/10448) by [@tshmieldev](https://github.com/tshmieldev))
+- Stop the Babel plugin reading a worklet's sources off disk to fill `sourcesContent` - the field is deleted again before the map is returned, and the unguarded read aborted the whole transform for any source that is not a file. (by [@YevheniiKotyrlo](https://github.com/YevheniiKotyrlo))
 
 ### 💡 Others
 

--- a/packages/react-native-worklets/plugin/__tests__/plugin-legacy.test.ts
+++ b/packages/react-native-worklets/plugin/__tests__/plugin-legacy.test.ts
@@ -171,6 +171,32 @@ describe('babel plugin', () => {
       expect(matches).toHaveLength(2);
     });
 
+    test('a worklet compiles when its file is not on disk', () => {
+      const input = html`<script>
+        function foo() {
+          'worklet';
+          return 1;
+        }
+      </script>`;
+
+      // A filename the caller merely NAMES should not become a filename the plugin insists on
+      // FINDING. Any in-memory transform hands one over: a virtual module specifier, a name that
+      // never existed, a source map carrying paths from an earlier build step.
+      //
+      // The `fs` mock at the top of this file intercepts only `/dev/null`, so this filename
+      // reaches the real `readFileSync` — which is the point. Source maps are left ON for the same
+      // reason: under `disableSourceMaps` the read never happens, so the case would pass whatever
+      // the plugin did with it.
+      const { code } = runPlugin(
+        input,
+        undefined,
+        {},
+        'no-such-directory/no-such-file.js'
+      );
+
+      expect(code).toMatch(/function foo_noSuchFileJs[0-9]+\(\)/gm);
+    });
+
     test('removes comments from worklets', () => {
       const input = html`<script>
         const f = () => {

--- a/packages/react-native-worklets/plugin/index.js
+++ b/packages/react-native-worklets/plugin/index.js
@@ -1622,12 +1622,10 @@ var require_workletStringCode = __commonJS({
     var types_12 = require("@babel/types");
     var assert_1 = require("assert");
     var convertSourceMap = __importStar(require("convert-source-map"));
-    var fs = __importStar(require("fs"));
     var transform_1 = require_transform();
     var types_2 = require_types();
     var utils_1 = require_utils();
     var MOCK_SOURCE_MAP = "mock source map";
-    var querySuffixRE = /[?#].*$/;
     function buildWorkletString(fun, state, closureVariables, workletName, inputMap) {
       var _a;
       restoreRecursiveCalls(fun, workletName);
@@ -1668,12 +1666,6 @@ var require_workletStringCode = __commonJS({
       const code = (0, generator_1.default)(workletFunction).code;
       (0, assert_1.strict)(inputMap, "`inputMap` is undefined.");
       const includeSourceMap = !((0, utils_1.isRelease)(state) || state.opts.disableSourceMaps);
-      if (includeSourceMap) {
-        inputMap.sourcesContent = [];
-        for (const sourceFile of inputMap.sources) {
-          inputMap.sourcesContent.push(fs.readFileSync(sourceFile.replace(querySuffixRE, "")).toString("utf-8"));
-        }
-      }
       const transformed = (0, transform_1.workletTransformSync)(code, {
         filename: state.file.opts.filename,
         extraPlugins: [

--- a/packages/react-native-worklets/plugin/src/workletStringCode.ts
+++ b/packages/react-native-worklets/plugin/src/workletStringCode.ts
@@ -28,7 +28,6 @@ import {
 } from '@babel/types';
 import { strict as assert } from 'assert';
 import * as convertSourceMap from 'convert-source-map';
-import * as fs from 'fs';
 
 import { workletTransformSync } from './transform';
 import type { WorkletizableFunction, WorkletsPluginPass } from './types';
@@ -36,7 +35,6 @@ import { workletClassFactorySuffix } from './types';
 import { isRelease } from './utils';
 
 const MOCK_SOURCE_MAP = 'mock source map';
-const querySuffixRE = /[?#].*$/;
 
 export function buildWorkletString(
   fun: BabelFile,
@@ -125,17 +123,16 @@ export function buildWorkletString(
 
   const includeSourceMap = !(isRelease(state) || state.opts.disableSourceMaps);
 
-  if (includeSourceMap) {
-    // Clear contents array (should be empty anyways)
-    inputMap.sourcesContent = [];
-    // Include source contents in source map, because Flipper/iframe is not
-    // allowed to read files from disk.
-    for (const sourceFile of inputMap.sources) {
-      inputMap.sourcesContent.push(
-        fs.readFileSync(sourceFile.replace(querySuffixRE, '')).toString('utf-8')
-      );
-    }
-  }
+  // `inputMap.sourcesContent` is left unpopulated. Both branches below discard it
+  // — the mocked one replaces the whole map, the real one deletes the field — so
+  // nothing this function returns can carry it, whatever it holds here.
+  //
+  // Filling it would therefore read every source off disk for a value with no
+  // consumer, and a source that is not ON disk would take the whole transform
+  // down rather than being skipped: a virtual module specifier, an in-memory
+  // filename, a map carrying paths from an earlier build step. That failure
+  // surfaces as `[Worklets] Babel plugin exception: ENOENT` naming the path, so
+  // it reads as a missing file rather than as a plugin that insisted on one.
 
   const transformed = workletTransformSync(code, {
     filename: state.file.opts.filename,


### PR DESCRIPTION
## Problem

`buildWorkletString` fills `inputMap.sourcesContent` with an unguarded `readFileSync` over every `inputMap.sources` entry:

```js
inputMap.sourcesContent = [];
for (const sourceFile of inputMap.sources) {
  inputMap.sourcesContent.push(fs.readFileSync(sourceFile.replace(querySuffixRE, '')).toString('utf-8'));
}
```

Any source that is not a file on disk aborts the **entire** Babel transform with `ENOENT`, naming a path the caller never asked to be read. That is a property of the input, not of the platform — a virtual module, a bundler's synthetic entry, a plugin test that compiles a string. I hit it writing an in-memory fixture against this plugin.

## The read is also unnecessary

Forty lines later the outgoing map's `sourcesContent` is deleted:

```js
// sourcesContent field contains a full source code of the file … and is not needed by the
// source map interpreter … Therefore, we remove it to reduce the bandwith
delete sourceMap.sourcesContent;
```

The two comments contradict each other — one says Flipper cannot read files itself, the other says the interpreter does not need the field — and the delete was added later. **Both branches of the `if` discard it**: the mocked one replaces the whole map, the real one deletes the key. Nothing the function returns has ever carried it.

So this is a delete, not a guard: it removes N file reads per worklet and the abort with them.

## Why it isn't caught today

Upstream CI is Linux, where the suite's `MOCK_LOCATION = '/dev/null'` is a real readable empty file. This repo already compensates in the harness — `plugin-legacy.test.ts` carries a `jest.mock('fs')` shim returning an empty buffer for exactly that path. That workaround is what makes the defect invisible; removing the read makes it unnecessary.

## Tests

One case: a worklet whose filename does not exist compiles. It fails with `ENOENT` before this change.

Two things about it are deliberate. It uses a filename the `fs` mock does **not** intercept, so the read reaches the real `readFileSync`. And it leaves source maps **on** — under `disableSourceMaps` the read never happens, so the case would pass whatever the plugin did.

## Verification

`jest` 217 passed / 201 snapshots · `tsc --noEmit` 0 · `eslint --max-warnings=0 src` 0 · `oxfmt --check` clean.

No existing issue tracks this — searched the tracker for `sourcesContent readFileSync`, `plugin ENOENT source`, `babel plugin readFileSync`, `worklet source map sourcesContent` and `makeWorkletName windows`, zero hits.
