### PR TITLE
chore: argent CI stuff

### DIFF
--- a/.github/actions/create-rnc-cli-app/action.yml
+++ b/.github/actions/create-rnc-cli-app/action.yml
@@ -79,6 +79,13 @@ runs:
         ruby-version: '3.3'
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
+    # Fixes RNC CLI issue https://github.com/software-mansion/react-native-reanimated/actions/runs/34574250232/job/103183218956?pr=10511
+    - name: Pin json gem below 3.0 (iOS)
+      if: ${{ runner.os == 'macOS' && inputs.integration == 'pods' }}
+      working-directory: ${{ inputs.app-name }}
+      shell: bash
+      run: grep -q "^gem 'json'" Gemfile || echo "gem 'json', '< 3.0'" >> Gemfile
+
     - name: Install Pods (iOS)
       if: ${{ runner.os == 'macOS' && inputs.integration == 'pods' }}
       working-directory: ${{ inputs.app-name }}/ios

--- a/.github/actions/install-sim-remote/action.yml
+++ b/.github/actions/install-sim-remote/action.yml
@@ -5,7 +5,7 @@ inputs:
   release-tag:
     description: Release tag in software-mansion/sim-remote-releases to install
     required: false
-    default: 'softu'
+    default: 'latest'
 
 runs:
   using: 'composite'

--- a/.github/workflows/runtime-tests-ios-argent-pr.yml
+++ b/.github/workflows/runtime-tests-ios-argent-pr.yml
@@ -27,13 +27,45 @@ on:
       - packages/react-native-worklets/Common/**
       - packages/react-native-worklets/bundleMode/**
       - packages/react-native-worklets/src/**
+  pull_request_target:
+    paths:
+      - .github/workflows/runtime-tests-ios-argent.yml
+      - .github/workflows/runtime-tests-ios-argent-pr.yml
+      - .github/actions/install-sim-remote/**
+      - .github/actions/install-pods/**
+      - .github/actions/save-pods/**
+      - .github/actions/setup-ccache/**
+      - .github/actions/save-ccache/**
+      - apps/common-app/runtime-tests/**
+      - apps/fabric-example/package.json
+      - apps/common-app/package.json
+      - apps/fabric-example/scripts/runtime-tests-server.js
+      - apps/fabric-example/scripts/runtime-tests-remote.mjs
+      - apps/fabric-example/scripts/export-runtime-tests-app.js
+      - apps/fabric-example/ios/**
+      - packages/react-native-reanimated/RNReanimated.podspec
+      - packages/react-native-reanimated/scripts/reanimated_utils.rb
+      - packages/react-native-reanimated/apple/**
+      - packages/react-native-reanimated/Common/**
+      - packages/react-native-reanimated/src/**
+      - packages/react-native-worklets/RNWorklets.podspec
+      - packages/react-native-worklets/scripts/worklets_utils.rb
+      - packages/react-native-worklets/apple/**
+      - packages/react-native-worklets/Common/**
+      - packages/react-native-worklets/bundleMode/**
+      - packages/react-native-worklets/src/**
 
 permissions:
   contents: read
 
 jobs:
   ios-argent:
-    if: github.repository == 'software-mansion/react-native-reanimated'
+    if: |
+      github.repository == 'software-mansion/react-native-reanimated' &&
+      (
+        (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) ||
+        (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork)
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -42,6 +74,8 @@ jobs:
     with:
       configuration: ReleaseRuntimeTests
       bundleMode: ${{ matrix.bundleMode }}
+      ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}
+      requireApproval: ${{ github.event_name == 'pull_request_target' }}
     secrets:
       SIM_ROUTER_USERNAME: ${{ secrets.SIM_ROUTER_USERNAME }}
       SIM_ROUTER_API_KEY: ${{ secrets.SIM_ROUTER_API_KEY }}

--- a/.github/workflows/runtime-tests-ios-argent.yml
+++ b/.github/workflows/runtime-tests-ios-argent.yml
@@ -21,6 +21,16 @@ on:
         required: false
         type: string
         default: ''
+      ref:
+        description: Git ref to check out (blank = the default ref of the triggering event)
+        required: false
+        type: string
+        default: ''
+      requireApproval:
+        description: Wait for a maintainer to approve the fork-pr-runtime-tests environment before running
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       bundleMode:
@@ -43,9 +53,19 @@ permissions:
   contents: read
 
 jobs:
+  approve-fork:
+    if: github.repository == 'software-mansion/react-native-reanimated' && inputs.requireApproval
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment: fork-pr-runtime-tests
+    steps:
+      - name: Approved by a maintainer
+        run: echo "Fork PR approved for the Argent Cloud runtime tests"
+
   # Check if we have all must-have credentials before running the workflow.
   preflight:
-    if: github.repository == 'software-mansion/react-native-reanimated'
+    needs: approve-fork
+    if: ${{ !cancelled() && github.repository == 'software-mansion/react-native-reanimated' && (needs.approve-fork.result == 'success' || needs.approve-fork.result == 'skipped') }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
@@ -66,7 +86,7 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 90
     concurrency:
-      group: runtime-tests-ios-argent-${{ github.workflow }}-${{ github.ref }}-${{ matrix.bundleMode }}-${{ matrix.configuration }}
+      group: runtime-tests-ios-argent-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ matrix.bundleMode }}-${{ matrix.configuration }}
       cancel-in-progress: true
     strategy:
       fail-fast: false
@@ -81,6 +101,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
+          ref: ${{ inputs.ref }}
           persist-credentials: false
 
       - name: Restore packaged app from cache
@@ -182,7 +203,7 @@ jobs:
     runs-on: ubuntu-latest # <- the whole point: no macOS, no local simulator
     timeout-minutes: 60
     concurrency:
-      group: runtime-tests-ios-argent-${{ github.workflow }}-${{ github.ref }}-${{ matrix.bundleMode }}-${{ matrix.configuration }}
+      group: runtime-tests-ios-argent-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ matrix.bundleMode }}-${{ matrix.configuration }}
       cancel-in-progress: true
     strategy:
       fail-fast: false
@@ -199,6 +220,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
+          ref: ${{ inputs.ref }}
           persist-credentials: false
 
       - name: Install monorepo node dependencies

--- a/apps/fabric-example/scripts/runtime-tests-remote.mjs
+++ b/apps/fabric-example/scripts/runtime-tests-remote.mjs
@@ -246,11 +246,11 @@ async function install() {
   }
   log(`booting remote simulator ${UDID}`);
   await simRemote(['simctl', 'boot', UDID]).catch(() => {}); // tolerate already-booted
-  await simRemote(['simctl', 'bootstatus', UDID, '-b'], { timeout: 300_000 });
+  await simRemote(['simctl', 'bootstatus', UDID, '-b'], { timeout: 900_000 });
   log(`uploading ${APP_PATH} to the orchestrator (QUIC)`);
   await simRemote(['simctl', 'uninstall', UDID, BUNDLE_ID]).catch(() => {});
   await simRemote(['simctl', 'install', UDID, path.resolve(APP_PATH)], {
-    timeout: 300_000,
+    timeout: 900_000,
   });
   log('install done');
 }


### PR DESCRIPTION
## Summary

1. Fixed timeouts for argents actions and some pod install bugs.
3. Targeted @latest tag for argent actions.

## Test plan

CI

## Changelog

- [x] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.
