### PR TITLE
ci: align native deps with the Expo SDK in the dev client nightly

### DIFF
--- a/.github/workflows/expo-devclient-build-check-nightly.yml
+++ b/.github/workflows/expo-devclient-build-check-nightly.yml
@@ -58,6 +58,9 @@ jobs:
       - name: Install Expo
         working-directory: ${{ env.APP_NAME }}
         run: npm install expo@${{ env.EXPO_TAG }}
+      - name: Align dependencies with the Expo SDK
+        working-directory: ${{ env.APP_NAME }}
+        run: npx expo install --fix
       - name: Setup configuration
         working-directory: ${{ env.APP_NAME }}
         run: node --experimental-strip-types ${{ env.SCRIPT_PATH }} setBundleIdentifier


### PR DESCRIPTION
> [!NOTE]
> This pull request was authored by AI on behalf of @tjzel.

## Summary

The Expo DevClient nightly started failing on Android on 2026-09-11 (https://github.com/software-mansion/react-native-reanimated/actions/runs/34547470600/job/103103098662). `expo@next` moved to `58.0.0-preview.0`, so `expo prebuild` now uses the SDK 58 template with Gradle 9.4.1, while the app kept `react-native@0.86.3` from `create-expo-app`. Gradle 9.4.1 ships Kotlin stdlib 2.3.0 and the RN 0.86 Gradle plugin compiles with Kotlin 2.1.20, which cannot read that metadata. I added an `expo install --fix` step after installing Expo, so React Native and the other bundled packages match the SDK before the Reanimated and Worklets nightlies are installed on top.

## Test plan

The Expo DevClient build check passes on this PR for both platforms.

## Changelog

- [x] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.
