### PR TITLE
fix(examples): annotate metro.config.js exports with MetroConfig

### DIFF
--- a/apps/fabric-example/metro.config.js
+++ b/apps/fabric-example/metro.config.js
@@ -35,6 +35,7 @@ config = mergeConfig(defaultConfig, config);
 const { bundleModeMetroConfig } = require('react-native-worklets/bundleMode');
 config = mergeConfig(config, bundleModeMetroConfig);
 
+/** @type {import('@react-native/metro-config').MetroConfig} */
 module.exports = wrapWithReanimatedMetroConfig(
   mergeConfig(defaultConfig, config)
 );

--- a/apps/macos-example/metro.config.js
+++ b/apps/macos-example/metro.config.js
@@ -38,6 +38,7 @@ const config = {
   },
 };
 
+/** @type {import('@react-native/metro-config').MetroConfig} */
 module.exports = wrapWithReanimatedMetroConfig(
   mergeConfig(defaultConfig, config)
 );

--- a/apps/tvos-example/metro.config.js
+++ b/apps/tvos-example/metro.config.js
@@ -31,6 +31,7 @@ let config = {
 const { bundleModeMetroConfig } = require('react-native-worklets/bundleMode');
 config = mergeConfig(config, bundleModeMetroConfig);
 
+/** @type {import('@react-native/metro-config').MetroConfig} */
 module.exports = wrapWithReanimatedMetroConfig(
   mergeConfig(defaultConfig, config)
 );

--- a/apps/web-example/metro.config.js
+++ b/apps/web-example/metro.config.js
@@ -24,4 +24,5 @@ Module._resolveFilename = function resolveReactNativePolyfills(
 
 const defaultConfig = getDefaultConfig(__dirname);
 
+/** @type {import('@react-native/metro-config').MetroConfig} */
 module.exports = wrapWithReanimatedMetroConfig(defaultConfig);


### PR DESCRIPTION
> [!NOTE]
> This pull request was authored by AI on behalf of @tjzel.

## Summary

Since #10454, `Example Typescript check and lint` fails on every PR for `apps/fabric-example` and `apps/tvos-example` with `TS2742` on `module.exports` in `metro.config.js`. `wrapWithReanimatedMetroConfig` now takes its `MetroConfig` type from `metro-config`, and the monorepo has two copies of that package (`0.84.4` hoisted for Expo, `0.87.0` nested under `metro`), so tsc cannot name the inferred export type through a portable module path. The job did not run for #10454 because its path filter does not cover `packages/react-native-reanimated/metro-config`.

I added an explicit `MetroConfig` type annotation on `module.exports` in the four example `metro.config.js` files that use the wrapper.

## Test plan

`yarn type:check` in `apps/fabric-example` and `apps/tvos-example` passes. The pre-existing errors in `apps/web-example` and `apps/macos-example` are unchanged.

## Changelog

- [x] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.