### PR TITLE
chore(worklets): fast path for closure-free worklets

### DIFF
--- a/apps/common-app/runtime-tests/worklets/suites.ts
+++ b/apps/common-app/runtime-tests/worklets/suites.ts
@@ -67,6 +67,7 @@ export const WORKLETS_TEST_SUITES: RuntimeTestSuite[] = [
     testSuiteName: 'babel plugin',
     importTest: () => {
       require('./tests/plugin/closures.test');
+      require('./tests/plugin/closureFree.test');
       require('./tests/plugin/fileWorkletization.test');
       require('./tests/plugin/jsxInWorklets.test');
       require('./tests/plugin/recursion.test');

--- a/apps/common-app/runtime-tests/worklets/tests/plugin/closureFree.test.ts
+++ b/apps/common-app/runtime-tests/worklets/tests/plugin/closureFree.test.ts
@@ -1,0 +1,73 @@
+import type { WorkletFunction } from 'react-native-worklets';
+import {
+  isBundleModeEnabled,
+  runOnRuntimeSync,
+  runOnUISync,
+} from 'react-native-worklets';
+
+import {
+  describe,
+  expect,
+  getWorkletRuntimesFromPool,
+  test,
+} from '../../../ReJest/RuntimeTestsApi';
+
+describe('Closure-free worklets', () => {
+  const [runtime] = getWorkletRuntimesFromPool(1);
+
+  test('deserializes without invoking the worklet and preserves recursion', () => {
+    function factorial(n: number): number {
+      'worklet';
+      if (n === undefined) {
+        throw new Error('Invoked during deserialization');
+      }
+      return n <= 1 ? 1 : n * factorial(n - 1);
+    }
+
+    const worklet = factorial as WorkletFunction<[number], number>;
+    const inspect = (fn: WorkletFunction<[number], number>) => {
+      'worklet';
+      return [typeof fn, '__closure' in fn];
+    };
+
+    expect('__closure' in worklet).toBe(false);
+    expect(runOnUISync(inspect, worklet)).toBe(['function', false]);
+    expect(runOnRuntimeSync(runtime, inspect, worklet)).toBe([
+      'function',
+      false,
+    ]);
+    expect(runOnUISync(worklet, 5)).toBe(120);
+    expect(runOnRuntimeSync(runtime, worklet, 6)).toBe(720);
+  });
+
+  if (isBundleModeEnabled()) {
+    test('serializes nested worklets from UI to a Worker Runtime', () => {
+      function outer(value: string) {
+        'worklet';
+        const captured = () => {
+          'worklet';
+          return value;
+        };
+        const empty = () => {
+          'worklet';
+          return 42;
+        };
+        return [captured, empty] as const;
+      }
+
+      const result = runOnUISync(() => {
+        'worklet';
+        const [captured, empty] = outer('nested');
+        return [
+          '__closure' in outer,
+          '__closure' in captured,
+          '__closure' in empty,
+          runOnRuntimeSync(runtime, captured),
+          runOnRuntimeSync(runtime, empty),
+        ];
+      });
+
+      expect(result).toBe([false, true, false, 'nested', 42]);
+    });
+  }
+});

--- a/docs/docs-worklets/docs/utility/isWorkletFunction.mdx
+++ b/docs/docs-worklets/docs/utility/isWorkletFunction.mdx
@@ -53,7 +53,7 @@ console.log(isNonWorkletFunction); // false
   }
 
   interface WorkletProps {
-    __closure: WorkletClosure;
+    __closure?: WorkletClosure;
     __workletHash: number;
     /** Only in Legacy Eval Mode. */
     __initData?: WorkletInitData;

--- a/packages/react-native-reanimated/CHANGELOG.md
+++ b/packages/react-native-reanimated/CHANGELOG.md
@@ -41,6 +41,7 @@
 
 ### 💡 Others
 
+- Support worklets without closure metadata in handler dependency comparisons and Jest helpers. ([#10517](https://github.com/software-mansion/react-native-reanimated/pull/10517) by [@tshmieldev](https://github.com/tshmieldev))
 - Update hooks for array-based worklet closures and use explicit control points for web Bezier easings instead of inspecting closures. ([#10506](https://github.com/software-mansion/react-native-reanimated/pull/10506) by [@tshmieldev](https://github.com/tshmieldev))
 - Initialize the Layout Animations manager lazily to avoid serializing its worklets during startup. ([#10466](https://github.com/software-mansion/react-native-reanimated/pull/10466) by [@tshmieldev](https://github.com/tshmieldev))
 - Add `fontVariationSettings` to the style properties config, so the package type-checks against React Native 0.88 ([#10239](https://github.com/software-mansion/react-native-reanimated/pull/10239) by [@tjzel](https://github.com/tjzel))

--- a/packages/react-native-reanimated/src/hook/__tests__/useHandler.shared.ts
+++ b/packages/react-native-reanimated/src/hook/__tests__/useHandler.shared.ts
@@ -156,6 +156,16 @@ export function runCommonTests() {
           before: [{ nested: true }],
           after: [{ nested: true }],
         },
+        {
+          name: 'worklet gains a closure',
+          before: undefined,
+          after: [1],
+        },
+        {
+          name: 'worklet loses its closure',
+          before: [1],
+          after: undefined,
+        },
       ])('when $name for same hash', ({ before, after }) => {
         const w = worklet();
         w.__closure = before;
@@ -171,7 +181,7 @@ export function runCommonTests() {
 
     describe('is false', () => {
       test.each([
-        { name: 'no captured values', closure: [] },
+        { name: 'no captured values', closure: undefined },
         { name: 'equal captured values', closure: [1, NaN, 'hello'] },
       ])(
         'when distinct worklets have the same hash and $name',
@@ -182,7 +192,9 @@ export function runCommonTests() {
           const cloned = cloneWorklet(w);
 
           expect(cloned).not.toBe(w);
-          expect(cloned.__closure).not.toBe(w.__closure);
+          if (closure !== undefined) {
+            expect(cloned.__closure).not.toBe(w.__closure);
+          }
 
           rerender({ handlers: { onScroll: cloned } });
 

--- a/packages/react-native-reanimated/src/hook/useHandlerCommon.ts
+++ b/packages/react-native-reanimated/src/hook/useHandlerCommon.ts
@@ -57,7 +57,8 @@ function areWorkletsEqual(
 
   return (
     next.__workletHash === prev.__workletHash &&
-    areWorkletClosuresEqual(next.__closure, prev.__closure)
+    ((next.__closure === undefined && prev.__closure === undefined) ||
+      areWorkletClosuresEqual(next.__closure, prev.__closure))
   );
 }
 

--- a/packages/react-native-reanimated/src/jestUtils/common.ts
+++ b/packages/react-native-reanimated/src/jestUtils/common.ts
@@ -19,7 +19,6 @@ export const worklet = <Args extends unknown[] = [], ReturnValue = void>(
     ReturnValue
   >;
   fn.__workletHash = Math.random();
-  fn.__closure = [];
   return fn;
 };
 
@@ -29,6 +28,8 @@ export const cloneWorklet = <Args extends unknown[] = [], ReturnValue = void>(
 ): WorkletFunction<Args, ReturnValue> => {
   const w = worklet<Args, ReturnValue>();
   w.__workletHash = original.__workletHash;
-  w.__closure = [...original.__closure];
+  if (original.__closure !== undefined) {
+    w.__closure = [...original.__closure];
+  }
   return w;
 };

--- a/packages/react-native-worklets/CHANGELOG.md
+++ b/packages/react-native-worklets/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🛠 Breaking changes
 
+- Omit empty worklet closures and export closure-free worklets directly in Bundle Mode without factory wrappers. ([#10517](https://github.com/software-mansion/react-native-reanimated/pull/10517) by [@tshmieldev](https://github.com/tshmieldev))
 - Store worklet closures as arrays instead of objects. ([#10506](https://github.com/software-mansion/react-native-reanimated/pull/10506) by [@tshmieldev](https://github.com/tshmieldev))
 - Remove the Serializable handle - `SerializableInitializer`, `createSerializableInitializer` and the `__init` clone path are gone. `Serializable::ValueType::HandleType` stays in the Compat Stable API enum for ABI compatibility and `extractSerializable` throws for it. ([#10414](https://github.com/software-mansion/react-native-reanimated/pull/10414) by [@tjzel](https://github.com/tjzel))
 - `makeShareable` now serializes its value eagerly into a retaining Serializable instead of rebuilding it lazily on each runtime through a handle. ([#10412](https://github.com/software-mansion/react-native-reanimated/pull/10412) by [@tjzel](https://github.com/tjzel))

--- a/packages/react-native-worklets/plugin-oxc/src/factory_expression.rs
+++ b/packages/react-native-worklets/plugin-oxc/src/factory_expression.rs
@@ -31,7 +31,11 @@ pub fn build_factory_expression<'a>(
     let (worklet_name, react_name) = (names.worklet_name.as_str(), names.react_name.as_str());
     let pat = closure_binding_pattern(builder, closure_variables);
     let factory_param = builder.plain_formal_parameter(SPAN, pat);
-    let params_vec = builder.vec1(factory_param);
+    let params_vec = if closure_variables.is_empty() {
+        builder.vec()
+    } else {
+        builder.vec1(factory_param)
+    };
     let factory_params =
         builder.formal_parameters(SPAN, FormalParameterKind::FormalParameter, params_vec, NONE);
 
@@ -39,15 +43,17 @@ pub fn build_factory_expression<'a>(
 
     statements.push(build_inner_fn_decl(builder, allocator, react_name, input));
 
-    statements.push(build_member_assign(
-        builder,
-        react_name,
-        "__closure",
-        build_closure_array(
+    if !closure_variables.is_empty() {
+        statements.push(build_member_assign(
             builder,
-            closure_variables.iter().map(|name| (name.as_str(), None)),
-        ),
-    ));
+            react_name,
+            "__closure",
+            build_closure_array(
+                builder,
+                closure_variables.iter().map(|name| (name.as_str(), None)),
+            ),
+        ));
+    }
 
     statements.push(build_member_assign(
         builder,

--- a/packages/react-native-worklets/plugin-oxc/src/worklet_factory.rs
+++ b/packages/react-native-worklets/plugin-oxc/src/worklet_factory.rs
@@ -63,12 +63,23 @@ pub fn make_worklet_factory<'a>(
         allocator,
         filename,
     } = ctx;
-    let names = {
+    let mut names = {
         let n = state.next_worklet_number();
         make_worklet_name(input.self_name, filename, n)
     };
 
     let closure = get_closure(&input, scoping, state, filename);
+
+    // Closure-free worklets share module scope with forwarded imports.
+    if closure.closure_variables.is_empty() {
+        while closure
+            .imports
+            .iter()
+            .any(|import| import.local == names.react_name)
+        {
+            names.react_name.insert(0, '_');
+        }
+    }
 
     let recursive_name = input.recursion_name().and_then(|name| {
         if body_references_name(input.body, name, scoping, input.function_scope_id) {
@@ -199,6 +210,10 @@ fn make_worklet_factory_call<'a>(
         builder.identifier_name(SPAN, "default"),
         false,
     ));
+
+    if closure.is_empty() {
+        return dot_default;
+    }
 
     let mut args = builder.vec_with_capacity(1);
     args.push(Argument::from(build_closure_array(

--- a/packages/react-native-worklets/plugin-oxc/src/worklet_file.rs
+++ b/packages/react-native-worklets/plugin-oxc/src/worklet_file.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+use oxc_allocator::TakeIn;
 use oxc_ast::AstBuilder;
 use oxc_ast::NONE;
 use oxc_ast::ast::{Expression, Statement};
@@ -11,7 +12,7 @@ const GENERATED_WORKLETS_DIR: &str = ".worklets";
 
 pub fn generate_worklet_file<'a>(
     builder: AstBuilder<'a>,
-    factory: Expression<'a>,
+    mut factory: Expression<'a>,
     imports: &[crate::types::ImportInfo],
     filename: &str,
     worklets_package_dir: Option<&str>,
@@ -31,6 +32,16 @@ pub fn generate_worklet_file<'a>(
             rebased.source = p;
         }
         body.push(build_import_declaration(builder, &rebased));
+    }
+    if let Expression::FunctionExpression(function) = &mut factory
+        && function.params.items.is_empty()
+    {
+        let statements = &mut function.body.as_mut().unwrap().statements;
+        let Some(Statement::ReturnStatement(mut returned)) = statements.pop() else {
+            unreachable!("a worklet factory must return its worklet");
+        };
+        body.extend(statements.take_in(builder));
+        factory = returned.argument.take().unwrap();
     }
     let export =
         builder.alloc_export_default_declaration(SPAN, ExportDefaultDeclarationKind::from(factory));

--- a/packages/react-native-worklets/plugin-oxc/test/napi.test.mts
+++ b/packages/react-native-worklets/plugin-oxc/test/napi.test.mts
@@ -140,13 +140,13 @@ test('disableInlineStylesWarning suppresses the warning', () => {
 
 test('to_identifier matches @babel/types on leading digits and unicode', () => {
   const { files: a } = transform(
-    `const w = () => { 'worklet'; return 1; };`,
+    `const value = 1; const w = () => { 'worklet'; return value; };`,
     '/proj/2dExample.js',
     {}
   );
   assert.match(a[0].content, /dExampleJs1Factory/);
   const { files: b } = transform(
-    `const w = function ünïcode(){ 'worklet'; return 1; };`,
+    `const value = 1; const w = function ünïcode(){ 'worklet'; return value; };`,
     'test.js',
     {}
   );
@@ -155,7 +155,7 @@ test('to_identifier matches @babel/types on leading digits and unicode', () => {
 
 test('to_identifier rejects non-ID_Continue numerics', () => {
   const { files } = transform(
-    `export const f = () => { 'worklet'; return 1; };`,
+    `const value = 1; export const f = () => { 'worklet'; return value; };`,
     '/tmp/x².js',
     {}
   );

--- a/packages/react-native-worklets/plugin/__tests__/__snapshots__/plugin-bundleMode.test.ts.snap
+++ b/packages/react-native-worklets/plugin/__tests__/__snapshots__/plugin-bundleMode.test.ts.snap
@@ -2,21 +2,44 @@
 
 exports[`babel plugin in bundleMode bundle mode flag toggle does not flip the flag in unrelated files 1`] = `"globalThis._WORKLETS_BUNDLE_MODE_ENABLED = false;"`;
 
-exports[`babel plugin in bundleMode nested worklets extracts each nested worklet into its own file 1`] = `"const foo = require("react-native-worklets/.worklets/1.js").default([]);"`;
+exports[`babel plugin in bundleMode nested worklets extracts each nested worklet into its own file 1`] = `"const foo = require("react-native-worklets/.worklets/1.js").default;"`;
 
 exports[`babel plugin in bundleMode nested worklets extracts each nested worklet into its own file 2`] = `
-"export default (function testJs2Factory([]) {
-  const testJs2 = function () {
-    "use no memo";
+"const testJs2 = function () {
+  "use no memo";
 
-    const bar = require("react-native-worklets/.worklets/2.js").default([]);
-    return bar();
-  };
-  testJs2.__closure = [];
-  testJs2.__workletHash = 1;
-  testJs2.__pluginVersion = "x.y.z";
-  return testJs2;
-});"
+  const bar = require("react-native-worklets/.worklets/2.js").default;
+  return bar();
+};
+testJs2.__workletHash = 1;
+testJs2.__pluginVersion = "x.y.z";
+export default testJs2;"
+`;
+
+exports[`babel plugin in bundleMode source replacement does not shadow forwarded imports with the closure-free arrow worklet binding 1`] = `
+"import { first as testJs1 } from "some-library";
+import { second as _testJs1 } from "some-library";
+const __testJs1 = function () {
+  "use no memo";
+
+  return [testJs1(), _testJs1()];
+};
+__testJs1.__workletHash = 1;
+__testJs1.__pluginVersion = "x.y.z";
+export default __testJs1;"
+`;
+
+exports[`babel plugin in bundleMode source replacement does not shadow forwarded imports with the closure-free method worklet binding 1`] = `
+"import { first as read } from "some-library";
+import { second as _read } from "some-library";
+const __read = function () {
+  "use no memo";
+
+  return [read(), _read()];
+};
+__read.__workletHash = 1;
+__read.__pluginVersion = "x.y.z";
+export default __read;"
 `;
 
 exports[`babel plugin in bundleMode source replacement packs captures in the same order at the call site and in the factory 1`] = `
@@ -40,7 +63,7 @@ exports[`babel plugin in bundleMode source replacement packs captures in the sam
 });"
 `;
 
-exports[`babel plugin in bundleMode source replacement replaces inline factory with a require to the worklet file 1`] = `"const foo = require("react-native-worklets/.worklets/1.js").default([]);"`;
+exports[`babel plugin in bundleMode source replacement replaces inline factory with a require to the worklet file 1`] = `"const foo = require("react-native-worklets/.worklets/1.js").default;"`;
 
 exports[`babel plugin in bundleMode source replacement still captures closure even with "no-worklet-closure" directive 1`] = `
 "const x = 1;
@@ -68,49 +91,40 @@ exports[`babel plugin in bundleMode worklet file emission captures locally defin
 const renderView = require("react-native-worklets/.worklets/1.js").default([LocalComponent]);"
 `;
 
-exports[`babel plugin in bundleMode worklet file emission does not emit init data 1`] = `"const foo = require("react-native-worklets/.worklets/1.js").default([]);"`;
+exports[`babel plugin in bundleMode worklet file emission does not emit init data 1`] = `"const foo = require("react-native-worklets/.worklets/1.js").default;"`;
 
 exports[`babel plugin in bundleMode worklet file emission does not emit init data 2`] = `
-"export default (function foo_testJs1Factory([]) {
-  const foo = function () {
-    "use no memo";
+"const foo = function () {
+  "use no memo";
 
-    var x = 1;
-  };
-  foo.__closure = [];
-  foo.__workletHash = 1;
-  foo.__pluginVersion = "x.y.z";
-  return foo;
-});"
+  var x = 1;
+};
+foo.__workletHash = 1;
+foo.__pluginVersion = "x.y.z";
+export default foo;"
 `;
 
 exports[`babel plugin in bundleMode worklet file emission does not emit stack-trace machinery 1`] = `
-"export default (function foo_testJs1Factory([]) {
-  const foo = function () {
-    "use no memo";
+"const foo = function () {
+  "use no memo";
 
-    var x = 1;
-  };
-  foo.__closure = [];
-  foo.__workletHash = 1;
-  foo.__pluginVersion = "x.y.z";
-  return foo;
-});"
+  var x = 1;
+};
+foo.__workletHash = 1;
+foo.__pluginVersion = "x.y.z";
+export default foo;"
 `;
 
 exports[`babel plugin in bundleMode worklet file emission does not rebase relative requires from non-workletizable files 1`] = `
-"export default (function baz_fileTs1Factory([]) {
-  const baz = function () {
-    "use no memo";
+"const baz = function () {
+  "use no memo";
 
-    const helper = require("./helper");
-    return helper.foo();
-  };
-  baz.__closure = [];
-  baz.__workletHash = 1;
-  baz.__pluginVersion = "x.y.z";
-  return baz;
-});"
+  const helper = require("./helper");
+  return helper.foo();
+};
+baz.__workletHash = 1;
+baz.__pluginVersion = "x.y.z";
+export default baz;"
 `;
 
 exports[`babel plugin in bundleMode worklet file emission forwards closure variables from source to factory 1`] = `
@@ -135,52 +149,43 @@ exports[`babel plugin in bundleMode worklet file emission forwards closure varia
 
 exports[`babel plugin in bundleMode worklet file emission preserves workletizable library imports in the written worklet file 1`] = `
 "import { foo } from "some-library";
-const bar = require("react-native-worklets/.worklets/1.js").default([]);"
+const bar = require("react-native-worklets/.worklets/1.js").default;"
 `;
 
 exports[`babel plugin in bundleMode worklet file emission preserves workletizable library imports in the written worklet file 2`] = `
 "import { foo } from "some-library";
-export default (function bar_testJs1Factory([]) {
-  const bar = function () {
-    "use no memo";
+const bar = function () {
+  "use no memo";
 
-    return foo();
-  };
-  bar.__closure = [];
-  bar.__workletHash = 1;
-  bar.__pluginVersion = "x.y.z";
-  return bar;
-});"
+  return foo();
+};
+bar.__workletHash = 1;
+bar.__pluginVersion = "x.y.z";
+export default bar;"
 `;
 
 exports[`babel plugin in bundleMode worklet file emission rebases relative requires inside the worklet body against the worklets directory 1`] = `
-"export default (function baz_fileJs1Factory([]) {
-  const baz = function () {
-    "use no memo";
+"const baz = function () {
+  "use no memo";
 
-    const helper = require("../../some-library/helper");
-    return helper.foo();
-  };
-  baz.__closure = [];
-  baz.__workletHash = 1;
-  baz.__pluginVersion = "x.y.z";
-  return baz;
-});"
+  const helper = require("../../some-library/helper");
+  return helper.foo();
+};
+baz.__workletHash = 1;
+baz.__pluginVersion = "x.y.z";
+export default baz;"
 `;
 
-exports[`babel plugin in bundleMode worklet file emission written file content has factory shape 1`] = `
-"export default (function foo_testJs1Factory([]) {
-  const foo = function () {
-    "use no memo";
+exports[`babel plugin in bundleMode worklet file emission written closure-free file exports the worklet directly 1`] = `
+"const foo = function () {
+  "use no memo";
 
-    var x = 1;
-    return x;
-  };
-  foo.__closure = [];
-  foo.__workletHash = 1;
-  foo.__pluginVersion = "x.y.z";
-  return foo;
-});"
+  var x = 1;
+  return x;
+};
+foo.__workletHash = 1;
+foo.__pluginVersion = "x.y.z";
+export default foo;"
 `;
 
-exports[`babel plugin in bundleMode worklet file emission written file path matches the require path 1`] = `"const foo = require("react-native-worklets/.worklets/1.js").default([]);"`;
+exports[`babel plugin in bundleMode worklet file emission written file path matches the require path 1`] = `"const foo = require("react-native-worklets/.worklets/1.js").default;"`;

--- a/packages/react-native-worklets/plugin/__tests__/__snapshots__/plugin-legacy.test.ts.snap
+++ b/packages/react-native-worklets/plugin/__tests__/__snapshots__/plugin-legacy.test.ts.snap
@@ -28,7 +28,6 @@ const foo = function foo_null1Factory([_worklet_1_init_data]) {
     const bar = "worklet"; // prettier-ignore
     const baz = "worklet"; // prettier-ignore
   };
-  foo.__closure = [];
   foo.__workletHash = 1;
   foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_1_init_data;
@@ -51,7 +50,6 @@ const foo = function foo_null1Factory([_worklet_1_init_data]) {
 
     return x + 2;
   };
-  foo.__closure = [];
   foo.__workletHash = 1;
   foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_1_init_data;
@@ -133,7 +131,6 @@ FadeIn.withCallback(function null1Factory([_worklet_1_init_data]) {
 
     console.log("FadeIn with build after");
   };
-  null1.__closure = [];
   null1.__workletHash = 1;
   null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_1_init_data;
@@ -155,7 +152,6 @@ new FadeIn().withCallback(function null1Factory([_worklet_1_init_data]) {
 
     console.log("FadeIn with build after");
   };
-  null1.__closure = [];
   null1.__workletHash = 1;
   null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_1_init_data;
@@ -177,7 +173,6 @@ FadeIn.build().withCallback(function null1Factory([_worklet_1_init_data]) {
 
     console.log("FadeIn with build before");
   };
-  null1.__closure = [];
   null1.__workletHash = 1;
   null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_1_init_data;
@@ -199,7 +194,6 @@ new FadeIn().build().withCallback(function null1Factory([_worklet_1_init_data]) 
 
     console.log("FadeIn with build before");
   };
-  null1.__closure = [];
   null1.__workletHash = 1;
   null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_1_init_data;
@@ -221,7 +215,6 @@ FadeIn.build().duration().withCallback(function null1Factory([_worklet_1_init_da
 
     console.log("FadeIn with build");
   };
-  null1.__closure = [];
   null1.__workletHash = 1;
   null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_1_init_data;
@@ -243,7 +236,6 @@ new FadeIn().build().duration().withCallback(function null1Factory([_worklet_1_i
 
     console.log("FadeIn with build");
   };
-  null1.__closure = [];
   null1.__workletHash = 1;
   null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_1_init_data;
@@ -265,7 +257,6 @@ FadeIn.withCallback(function null1Factory([_worklet_1_init_data]) {
 
     console.log("FadeIn with AmogusIn after");
   };
-  null1.__closure = [];
   null1.__workletHash = 1;
   null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_1_init_data;
@@ -287,7 +278,6 @@ new FadeIn().withCallback(function null1Factory([_worklet_1_init_data]) {
 
     console.log("FadeIn with AmogusIn after");
   };
-  null1.__closure = [];
   null1.__workletHash = 1;
   null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_1_init_data;
@@ -309,7 +299,6 @@ FadeIn.withCallback(function null1Factory([_worklet_1_init_data]) {
 
     console.log("FadeIn");
   };
-  null1.__closure = [];
   null1.__workletHash = 1;
   null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_1_init_data;
@@ -331,7 +320,6 @@ new FadeIn().withCallback(function null1Factory([_worklet_1_init_data]) {
 
     console.log("FadeIn");
   };
-  null1.__closure = [];
   null1.__workletHash = 1;
   null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_1_init_data;
@@ -353,7 +341,6 @@ const foo = function foo_null1Factory([_worklet_1_init_data]) {
 
     await Promise.resolve();
   };
-  foo.__closure = [];
   foo.__workletHash = 1;
   foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_1_init_data;
@@ -375,7 +362,6 @@ const foo = function foo_null1Factory([_worklet_1_init_data]) {
 
     await Promise.resolve();
   };
-  foo.__closure = [];
   foo.__workletHash = 1;
   foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_1_init_data;
@@ -434,7 +420,6 @@ class Foo {
 
       return x + 2;
     };
-    null1.__closure = [];
     null1.__workletHash = 1;
     null1.__pluginVersion = "x.y.z";
     null1.__initData = _worklet_1_init_data;
@@ -458,7 +443,6 @@ class Foo {
 
       return x + 2;
     };
-    bar.__closure = [];
     bar.__workletHash = 1;
     bar.__pluginVersion = "x.y.z";
     bar.__initData = _worklet_1_init_data;
@@ -482,7 +466,6 @@ class Foo {
 
       return x + 2;
     };
-    null1.__closure = [];
     null1.__workletHash = 1;
     null1.__pluginVersion = "x.y.z";
     null1.__initData = _worklet_1_init_data;
@@ -506,7 +489,6 @@ class Foo {
 
       return x + 2;
     };
-    bar.__closure = [];
     bar.__workletHash = 1;
     bar.__pluginVersion = "x.y.z";
     bar.__initData = _worklet_1_init_data;
@@ -557,7 +539,6 @@ const f = function f_null1Factory([_worklet_1_init_data]) {
 
     console.log(arguments);
   };
-  f.__closure = [];
   f.__workletHash = 1;
   f.__pluginVersion = "x.y.z";
   f.__initData = _worklet_1_init_data;
@@ -579,7 +560,6 @@ const f = function f_null1Factory([_worklet_1_init_data]) {
 
     console.log(foo);
   };
-  f.__closure = [];
   f.__workletHash = 1;
   f.__pluginVersion = "x.y.z";
   f.__initData = _worklet_1_init_data;
@@ -649,7 +629,6 @@ const f = function f_null1Factory([_worklet_1_init_data]) {
 
     globalStuff();
   };
-  f.__closure = [];
   f.__workletHash = 1;
   f.__pluginVersion = "x.y.z";
   f.__initData = _worklet_1_init_data;
@@ -693,7 +672,6 @@ const foo = useAnimatedStyle(function null1Factory([_worklet_1_init_data]) {
 
     const x = 1;
   };
-  null1.__closure = [];
   null1.__workletHash = 1;
   null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_1_init_data;
@@ -712,7 +690,6 @@ const foo = useAnimatedStyle(function null1Factory([_worklet_1_init_data]) {
 
     const x = 1;
   };
-  null1.__closure = [];
   null1.__workletHash = 1;
   null1.__initData = _worklet_1_init_data;
   return null1;
@@ -729,7 +706,6 @@ const foo = useAnimatedStyle(function null1Factory([_worklet_1_init_data]) {
 
     const x = 1;
   };
-  null1.__closure = [];
   null1.__workletHash = 1;
   null1.__initData = _worklet_1_init_data;
   return null1;
@@ -748,7 +724,6 @@ const foo = function foo_null1Factory([_worklet_1_init_data]) {
   const foo = function () {
     "use no memo";
   };
-  foo.__closure = [];
   foo.__workletHash = 1;
   foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_1_init_data;
@@ -777,7 +752,6 @@ const foo = function foo_null1Factory([_worklet_1_init_data]) {
   const foo = function () {
     "use no memo";
   };
-  foo.__closure = [];
   foo.__workletHash = 1;
   foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_1_init_data;
@@ -799,7 +773,6 @@ const foo = function foo_null1Factory([_worklet_1_init_data]) {
   const foo = function () {
     "use no memo";
   };
-  foo.__closure = [];
   foo.__workletHash = 1;
   foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_1_init_data;
@@ -821,7 +794,6 @@ const foo = function foo_null1Factory([_worklet_1_init_data]) {
   const foo = function () {
     "use no memo";
   };
-  foo.__closure = [];
   foo.__workletHash = 1;
   foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_1_init_data;
@@ -843,7 +815,6 @@ const foo = function foo_null1Factory([_worklet_1_init_data]) {
   const foo = function () {
     "use no memo";
   };
-  foo.__closure = [];
   foo.__workletHash = 1;
   foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_1_init_data;
@@ -860,7 +831,6 @@ const bar = function bar_null2Factory([_worklet_2_init_data]) {
   const bar = function () {
     "use no memo";
   };
-  bar.__closure = [];
   bar.__workletHash = 2;
   bar.__pluginVersion = "x.y.z";
   bar.__initData = _worklet_2_init_data;
@@ -877,7 +847,6 @@ const baz = function baz_null3Factory([_worklet_3_init_data]) {
   const baz = function () {
     "use no memo";
   };
-  baz.__closure = [];
   baz.__workletHash = 3;
   baz.__pluginVersion = "x.y.z";
   baz.__initData = _worklet_3_init_data;
@@ -894,7 +863,6 @@ const foobar = function foobar_null4Factory([_worklet_4_init_data]) {
   const foobar = function () {
     "use no memo";
   };
-  foobar.__closure = [];
   foobar.__workletHash = 4;
   foobar.__pluginVersion = "x.y.z";
   foobar.__initData = _worklet_4_init_data;
@@ -920,7 +888,6 @@ const foo = function null1Factory([_worklet_1_init_data]) {
 
     return "bar";
   };
-  null1.__closure = [];
   null1.__workletHash = 1;
   null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_1_init_data;
@@ -942,7 +909,6 @@ export default (function null1Factory([_worklet_1_init_data]) {
 
     return "bar";
   };
-  null1.__closure = [];
   null1.__workletHash = 1;
   null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_1_init_data;
@@ -964,7 +930,6 @@ export const foo = function null1Factory([_worklet_1_init_data]) {
 
     return "bar";
   };
-  null1.__closure = [];
   null1.__workletHash = 1;
   null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_1_init_data;
@@ -1012,7 +977,6 @@ const Clazz = function () {
 
       if (!(a instanceof n)) throw new TypeError("Cannot call a class as a function");
     };
-    _classCallCheck.__closure = [];
     _classCallCheck.__workletHash = 1;
     _classCallCheck.__pluginVersion = "x.y.z";
     _classCallCheck.__initData = _worklet_1_init_data;
@@ -1033,7 +997,6 @@ const Clazz = function () {
       }
       return ("string" === r ? String : Number)(t);
     };
-    _toPrimitive.__closure = [];
     _toPrimitive.__workletHash = 2;
     _toPrimitive.__pluginVersion = "x.y.z";
     _toPrimitive.__initData = _worklet_2_init_data;
@@ -1158,7 +1121,6 @@ export default (function () {
 
       if (!(a instanceof n)) throw new TypeError("Cannot call a class as a function");
     };
-    _classCallCheck.__closure = [];
     _classCallCheck.__workletHash = 1;
     _classCallCheck.__pluginVersion = "x.y.z";
     _classCallCheck.__initData = _worklet_1_init_data;
@@ -1179,7 +1141,6 @@ export default (function () {
       }
       return ("string" === r ? String : Number)(t);
     };
-    _toPrimitive.__closure = [];
     _toPrimitive.__workletHash = 2;
     _toPrimitive.__pluginVersion = "x.y.z";
     _toPrimitive.__initData = _worklet_2_init_data;
@@ -1304,7 +1265,6 @@ export const Clazz = function () {
 
       if (!(a instanceof n)) throw new TypeError("Cannot call a class as a function");
     };
-    _classCallCheck.__closure = [];
     _classCallCheck.__workletHash = 1;
     _classCallCheck.__pluginVersion = "x.y.z";
     _classCallCheck.__initData = _worklet_1_init_data;
@@ -1325,7 +1285,6 @@ export const Clazz = function () {
       }
       return ("string" === r ? String : Number)(t);
     };
-    _toPrimitive.__closure = [];
     _toPrimitive.__workletHash = 2;
     _toPrimitive.__pluginVersion = "x.y.z";
     _toPrimitive.__initData = _worklet_2_init_data;
@@ -1424,7 +1383,6 @@ const foo = function foo_null1Factory([_worklet_1_init_data]) {
 
     return "bar";
   };
-  foo.__closure = [];
   foo.__workletHash = 1;
   foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_1_init_data;
@@ -1446,7 +1404,6 @@ export default (function foo_null1Factory([_worklet_1_init_data]) {
 
     return "bar";
   };
-  foo.__closure = [];
   foo.__workletHash = 1;
   foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_1_init_data;
@@ -1468,7 +1425,6 @@ export const foo = function foo_null1Factory([_worklet_1_init_data]) {
 
     return "bar";
   };
-  foo.__closure = [];
   foo.__workletHash = 1;
   foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_1_init_data;
@@ -1490,7 +1446,6 @@ const foo = function null1Factory([_worklet_1_init_data]) {
 
     return "bar";
   };
-  null1.__closure = [];
   null1.__workletHash = 1;
   null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_1_init_data;
@@ -1512,7 +1467,6 @@ export default (function null1Factory([_worklet_1_init_data]) {
 
     return "bar";
   };
-  null1.__closure = [];
   null1.__workletHash = 1;
   null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_1_init_data;
@@ -1534,7 +1488,6 @@ export const foo = function null1Factory([_worklet_1_init_data]) {
 
     return "bar";
   };
-  null1.__closure = [];
   null1.__workletHash = 1;
   null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_1_init_data;
@@ -1557,7 +1510,6 @@ const foo = {
 
       return "bar";
     };
-    bar.__closure = [];
     bar.__workletHash = 1;
     bar.__pluginVersion = "x.y.z";
     bar.__initData = _worklet_1_init_data;
@@ -1581,7 +1533,6 @@ export default {
 
       return "bar";
     };
-    bar.__closure = [];
     bar.__workletHash = 1;
     bar.__pluginVersion = "x.y.z";
     bar.__initData = _worklet_1_init_data;
@@ -1605,7 +1556,6 @@ export const foo = {
 
       return "bar";
     };
-    bar.__closure = [];
     bar.__workletHash = 1;
     bar.__pluginVersion = "x.y.z";
     bar.__initData = _worklet_1_init_data;
@@ -1628,7 +1578,6 @@ const foo = function foo_null1Factory([_worklet_1_init_data]) {
 
     return "bar";
   };
-  foo.__closure = [];
   foo.__workletHash = 1;
   foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_1_init_data;
@@ -1650,7 +1599,6 @@ const foo = function foo_null1Factory([_worklet_1_init_data]) {
 
     return "bar";
   };
-  foo.__closure = [];
   foo.__workletHash = 1;
   foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_1_init_data;
@@ -1669,7 +1617,6 @@ const bar = function null2Factory([_worklet_2_init_data]) {
 
     return "foobar";
   };
-  null2.__closure = [];
   null2.__workletHash = 2;
   null2.__pluginVersion = "x.y.z";
   null2.__initData = _worklet_2_init_data;
@@ -1693,7 +1640,6 @@ const animatedStyle = useAnimatedStyle(function foo_null1Factory([_worklet_1_ini
       width: 50
     };
   };
-  foo.__closure = [];
   foo.__workletHash = 1;
   foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_1_init_data;
@@ -1717,7 +1663,6 @@ const animatedStyle = useAnimatedStyle(function null1Factory([_worklet_1_init_da
       width: 50
     };
   };
-  null1.__closure = [];
   null1.__workletHash = 1;
   null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_1_init_data;
@@ -1742,7 +1687,6 @@ const style = function null1Factory([_worklet_1_init_data]) {
       backgroundColor: "blue"
     };
   };
-  null1.__closure = [];
   null1.__workletHash = 1;
   null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_1_init_data;
@@ -1766,7 +1710,6 @@ const foo = function foo_null1Factory([_worklet_1_init_data]) {
     yield "hello";
     yield "world";
   };
-  foo.__closure = [];
   foo.__workletHash = 1;
   foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_1_init_data;
@@ -1789,7 +1732,6 @@ const foo = function foo_null1Factory([_worklet_1_init_data]) {
     yield "hello";
     yield "world";
   };
-  foo.__closure = [];
   foo.__workletHash = 1;
   foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_1_init_data;
@@ -1870,7 +1812,6 @@ useAnimatedScrollHandler(function null1Factory([_worklet_1_init_data]) {
 
     console.log(event);
   };
-  null1.__closure = [];
   null1.__workletHash = 1;
   null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_1_init_data;
@@ -1911,7 +1852,6 @@ useAnimatedScrollHandler({
     const null1 = function () {
       "use no memo";
     };
-    null1.__closure = [];
     null1.__workletHash = 1;
     null1.__pluginVersion = "x.y.z";
     null1.__initData = _worklet_1_init_data;
@@ -1923,7 +1863,6 @@ useAnimatedScrollHandler({
     const null2 = function () {
       "use no memo";
     };
-    null2.__closure = [];
     null2.__workletHash = 2;
     null2.__pluginVersion = "x.y.z";
     null2.__initData = _worklet_2_init_data;
@@ -1935,7 +1874,6 @@ useAnimatedScrollHandler({
     const null3 = function () {
       "use no memo";
     };
-    null3.__closure = [];
     null3.__workletHash = 3;
     null3.__pluginVersion = "x.y.z";
     null3.__initData = _worklet_3_init_data;
@@ -1947,7 +1885,6 @@ useAnimatedScrollHandler({
     const null4 = function () {
       "use no memo";
     };
-    null4.__closure = [];
     null4.__workletHash = 4;
     null4.__pluginVersion = "x.y.z";
     null4.__initData = _worklet_4_init_data;
@@ -1959,7 +1896,6 @@ useAnimatedScrollHandler({
     const null5 = function () {
       "use no memo";
     };
-    null5.__closure = [];
     null5.__workletHash = 5;
     null5.__pluginVersion = "x.y.z";
     null5.__initData = _worklet_5_init_data;
@@ -1982,7 +1918,6 @@ useAnimatedScrollHandler(function foo_null1Factory([_worklet_1_init_data]) {
 
     console.log(event);
   };
-  foo.__closure = [];
   foo.__workletHash = 1;
   foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_1_init_data;
@@ -2004,7 +1939,6 @@ useAnimatedScrollHandler(function null1Factory([_worklet_1_init_data]) {
 
     console.log(event);
   };
-  null1.__closure = [];
   null1.__workletHash = 1;
   null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_1_init_data;
@@ -2027,7 +1961,6 @@ useAnimatedScrollHandler({
 
       console.log(event);
     };
-    null1.__closure = [];
     null1.__workletHash = 1;
     null1.__pluginVersion = "x.y.z";
     null1.__initData = _worklet_1_init_data;
@@ -2051,7 +1984,6 @@ useAnimatedScrollHandler({
 
       console.log(event);
     };
-    onScroll.__closure = [];
     onScroll.__workletHash = 1;
     onScroll.__pluginVersion = "x.y.z";
     onScroll.__initData = _worklet_1_init_data;
@@ -2075,7 +2007,6 @@ useAnimatedScrollHandler({
 
       console.log(event);
     };
-    onScroll.__closure = [];
     onScroll.__workletHash = 1;
     onScroll.__pluginVersion = "x.y.z";
     onScroll.__initData = _worklet_1_init_data;
@@ -2099,7 +2030,6 @@ useAnimatedScrollHandler({
 
       console.log(event);
     };
-    null1.__closure = [];
     null1.__workletHash = 1;
     null1.__pluginVersion = "x.y.z";
     null1.__initData = _worklet_1_init_data;
@@ -2149,7 +2079,6 @@ const foo = function foo_null1Factory([_worklet_1_init_data]) {
     const bar = [4, 5];
     const baz = [1, ...[2, 3], ...bar];
   };
-  foo.__closure = [];
   foo.__workletHash = 1;
   foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_1_init_data;
@@ -2171,7 +2100,6 @@ const foo = function foo_null1Factory([_worklet_1_init_data]) {
 
     console.log(args);
   };
-  foo.__closure = [];
   foo.__workletHash = 1;
   foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_1_init_data;
@@ -2193,7 +2121,6 @@ const foo = function foo_null1Factory([_worklet_1_init_data]) {
 
     console.log(...arg);
   };
-  foo.__closure = [];
   foo.__workletHash = 1;
   foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_1_init_data;
@@ -2226,7 +2153,6 @@ const foo = function foo_null1Factory([_worklet_1_init_data]) {
       ...bar
     };
   };
-  foo.__closure = [];
   foo.__workletHash = 1;
   foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_1_init_data;
@@ -2260,7 +2186,6 @@ const foo = useTapGesture({
 
       console.log("onBegin");
     };
-    null1.__closure = [];
     null1.__workletHash = 1;
     null1.__pluginVersion = "x.y.z";
     null1.__initData = _worklet_1_init_data;
@@ -2274,7 +2199,6 @@ const foo = useTapGesture({
 
       console.log("onStart");
     };
-    null2.__closure = [];
     null2.__workletHash = 2;
     null2.__pluginVersion = "x.y.z";
     null2.__initData = _worklet_2_init_data;
@@ -2288,7 +2212,6 @@ const foo = useTapGesture({
 
       console.log("onEnd");
     };
-    null3.__closure = [];
     null3.__workletHash = 3;
     null3.__pluginVersion = "x.y.z";
     null3.__initData = _worklet_3_init_data;
@@ -2321,7 +2244,6 @@ const foo = Gesture.Tap().numberOfTaps(2).onBegin(function null1Factory([_workle
 
     console.log("onBegin");
   };
-  null1.__closure = [];
   null1.__workletHash = 1;
   null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_1_init_data;
@@ -2334,7 +2256,6 @@ const foo = Gesture.Tap().numberOfTaps(2).onBegin(function null1Factory([_workle
 
     console.log("onStart");
   };
-  null2.__closure = [];
   null2.__workletHash = 2;
   null2.__pluginVersion = "x.y.z";
   null2.__initData = _worklet_2_init_data;
@@ -2347,7 +2268,6 @@ const foo = Gesture.Tap().numberOfTaps(2).onBegin(function null1Factory([_workle
 
     console.log("onEnd");
   };
-  null3.__closure = [];
   null3.__workletHash = 3;
   null3.__pluginVersion = "x.y.z";
   null3.__initData = _worklet_3_init_data;
@@ -2367,7 +2287,6 @@ const onStart = function null1Factory([_worklet_1_init_data]) {
   const null1 = function () {
     "use no memo";
   };
-  null1.__closure = [];
   null1.__workletHash = 1;
   null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_1_init_data;
@@ -2390,7 +2309,6 @@ const onBegin = function null1Factory([_worklet_1_init_data]) {
 
     console.log("onBegin");
   };
-  null1.__closure = [];
   null1.__workletHash = 1;
   null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_1_init_data;
@@ -2416,7 +2334,6 @@ const onBegin = function null1Factory([_worklet_1_init_data]) {
 
     console.log("onBegin");
   };
-  null1.__closure = [];
   null1.__workletHash = 1;
   null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_1_init_data;
@@ -2443,7 +2360,6 @@ styleFactory = function null1Factory([_worklet_1_init_data]) {
 
     return "AssignmentExpression";
   };
-  null1.__closure = [];
   null1.__workletHash = 1;
   null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_1_init_data;
@@ -2466,7 +2382,6 @@ const styleFactory = function styleFactory_null1Factory([_worklet_1_init_data]) 
 
     return "FunctionDeclaration";
   };
-  styleFactory.__closure = [];
   styleFactory.__workletHash = 1;
   styleFactory.__pluginVersion = "x.y.z";
   styleFactory.__initData = _worklet_1_init_data;
@@ -2491,7 +2406,6 @@ styleFactory = function null1Factory([_worklet_1_init_data]) {
 
     return {};
   };
-  null1.__closure = [];
   null1.__workletHash = 1;
   null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_1_init_data;
@@ -2514,7 +2428,6 @@ let styleFactory = function null1Factory([_worklet_1_init_data]) {
 
     return {};
   };
-  null1.__closure = [];
   null1.__workletHash = 1;
   null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_1_init_data;
@@ -2539,7 +2452,6 @@ styleFactory = function null1Factory([_worklet_1_init_data]) {
 
     return "AssignmentExpression";
   };
-  null1.__closure = [];
   null1.__workletHash = 1;
   null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_1_init_data;
@@ -2562,7 +2474,6 @@ const styleFactory = function styleFactory_null1Factory([_worklet_1_init_data]) 
 
     return {};
   };
-  styleFactory.__closure = [];
   styleFactory.__workletHash = 1;
   styleFactory.__pluginVersion = "x.y.z";
   styleFactory.__initData = _worklet_1_init_data;
@@ -2586,7 +2497,6 @@ styleFactory = function null1Factory([_worklet_1_init_data]) {
 
     return {};
   };
-  null1.__closure = [];
   null1.__workletHash = 1;
   null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_1_init_data;
@@ -2609,7 +2519,6 @@ let styleFactory = function null1Factory([_worklet_1_init_data]) {
 
     return {};
   };
-  null1.__closure = [];
   null1.__workletHash = 1;
   null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_1_init_data;
@@ -2636,7 +2545,6 @@ styleFactory = function null1Factory([_worklet_1_init_data]) {
 
     return "AssignmentExpression";
   };
-  null1.__closure = [];
   null1.__workletHash = 1;
   null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_1_init_data;
@@ -2659,7 +2567,6 @@ handler = {
     const null1 = function () {
       "use no memo";
     };
-    null1.__closure = [];
     null1.__workletHash = 1;
     null1.__pluginVersion = "x.y.z";
     null1.__initData = _worklet_1_init_data;
@@ -2682,7 +2589,6 @@ let handler = {
     const null1 = function () {
       "use no memo";
     };
-    null1.__closure = [];
     null1.__workletHash = 1;
     null1.__pluginVersion = "x.y.z";
     null1.__initData = _worklet_1_init_data;
@@ -2711,7 +2617,6 @@ handler = {
 
       return "AssignmentExpression";
     };
-    null1.__closure = [];
     null1.__workletHash = 1;
     null1.__pluginVersion = "x.y.z";
     null1.__initData = _worklet_1_init_data;
@@ -2737,7 +2642,6 @@ styleFactory = function null1Factory([_worklet_1_init_data]) {
 
     return "AssignmentAfterUse";
   };
-  null1.__closure = [];
   null1.__workletHash = 1;
   null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_1_init_data;
@@ -2759,7 +2663,6 @@ let styleFactory = function null1Factory([_worklet_1_init_data]) {
 
     return {};
   };
-  null1.__closure = [];
   null1.__workletHash = 1;
   null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_1_init_data;
@@ -2783,7 +2686,6 @@ function outerScope() {
 
       return {};
     };
-    null1.__closure = [];
     null1.__workletHash = 1;
     null1.__pluginVersion = "x.y.z";
     null1.__initData = _worklet_1_init_data;
@@ -2809,7 +2711,6 @@ const secondReference = function null1Factory([_worklet_1_init_data]) {
 
     return {};
   };
-  null1.__closure = [];
   null1.__workletHash = 1;
   null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_1_init_data;
@@ -2865,7 +2766,6 @@ function App() {
       const onStart = function () {
         "use no memo";
       };
-      onStart.__closure = [];
       onStart.__workletHash = 1;
       onStart.__pluginVersion = "x.y.z";
       onStart.__initData = _worklet_1_init_data;
@@ -2889,7 +2789,6 @@ function App() {
       const onScroll = function () {
         "use no memo";
       };
-      onScroll.__closure = [];
       onScroll.__workletHash = 1;
       onScroll.__pluginVersion = "x.y.z";
       onScroll.__initData = _worklet_1_init_data;
@@ -2913,7 +2812,6 @@ function App() {
       const onStart = function () {
         "use no memo";
       };
-      onStart.__closure = [];
       onStart.__workletHash = 1;
       onStart.__pluginVersion = "x.y.z";
       onStart.__initData = _worklet_1_init_data;
@@ -3000,7 +2898,6 @@ const foo = function foo_null1Factory([_worklet_1_init_data]) {
 
     var bar = "bar";
   };
-  foo.__closure = [];
   foo.__workletHash = 1;
   foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_1_init_data;
@@ -3010,19 +2907,18 @@ const foo = function foo_null1Factory([_worklet_1_init_data]) {
 `;
 
 exports[`babel plugin for web configuration skips initData when omitNativeOnlyData option is set to true 1`] = `
-"const foo = function foo_null1Factory([]) {
+"const foo = function foo_null1Factory() {
   const _e = [new global.Error(), 1, -27];
   const foo = function () {
     "use no memo";
 
     var foo = "bar";
   };
-  foo.__closure = [];
   foo.__workletHash = 1;
   foo.__pluginVersion = "x.y.z";
   foo.__stackDetails = _e;
   return foo;
-}([]);"
+}();"
 `;
 
 exports[`babel plugin for web configuration substitutes isWeb and shouldBeUseWeb with true when substituteWebPlatformChecks option is set to true 1`] = `
@@ -3069,7 +2965,6 @@ const Clazz = function () {
 
       if (!(a instanceof n)) throw new TypeError("Cannot call a class as a function");
     };
-    _classCallCheck.__closure = [];
     _classCallCheck.__workletHash = 1;
     _classCallCheck.__pluginVersion = "x.y.z";
     _classCallCheck.__initData = _worklet_1_init_data;
@@ -3090,7 +2985,6 @@ const Clazz = function () {
       }
       return ("string" === r ? String : Number)(t);
     };
-    _toPrimitive.__closure = [];
     _toPrimitive.__workletHash = 2;
     _toPrimitive.__pluginVersion = "x.y.z";
     _toPrimitive.__initData = _worklet_2_init_data;
@@ -3215,7 +3109,6 @@ const Clazz = function () {
 
       if (!(a instanceof n)) throw new TypeError("Cannot call a class as a function");
     };
-    _classCallCheck.__closure = [];
     _classCallCheck.__workletHash = 1;
     _classCallCheck.__pluginVersion = "x.y.z";
     _classCallCheck.__initData = _worklet_1_init_data;
@@ -3236,7 +3129,6 @@ const Clazz = function () {
       }
       return ("string" === r ? String : Number)(t);
     };
-    _toPrimitive.__closure = [];
     _toPrimitive.__workletHash = 2;
     _toPrimitive.__pluginVersion = "x.y.z";
     _toPrimitive.__initData = _worklet_2_init_data;
@@ -3413,7 +3305,6 @@ const Clazz = function () {
 
       if (!(a instanceof n)) throw new TypeError("Cannot call a class as a function");
     };
-    _classCallCheck.__closure = [];
     _classCallCheck.__workletHash = 1;
     _classCallCheck.__pluginVersion = "x.y.z";
     _classCallCheck.__initData = _worklet_1_init_data;
@@ -3434,7 +3325,6 @@ const Clazz = function () {
       }
       return ("string" === r ? String : Number)(t);
     };
-    _toPrimitive.__closure = [];
     _toPrimitive.__workletHash = 2;
     _toPrimitive.__pluginVersion = "x.y.z";
     _toPrimitive.__initData = _worklet_2_init_data;
@@ -3601,7 +3491,6 @@ const Clazz = function () {
 
       if (!(a instanceof n)) throw new TypeError("Cannot call a class as a function");
     };
-    _classCallCheck.__closure = [];
     _classCallCheck.__workletHash = 1;
     _classCallCheck.__pluginVersion = "x.y.z";
     _classCallCheck.__initData = _worklet_1_init_data;
@@ -3622,7 +3511,6 @@ const Clazz = function () {
       }
       return ("string" === r ? String : Number)(t);
     };
-    _toPrimitive.__closure = [];
     _toPrimitive.__workletHash = 2;
     _toPrimitive.__pluginVersion = "x.y.z";
     _toPrimitive.__initData = _worklet_2_init_data;
@@ -3747,7 +3635,6 @@ const Clazz = function () {
 
       if (!(a instanceof n)) throw new TypeError("Cannot call a class as a function");
     };
-    _classCallCheck.__closure = [];
     _classCallCheck.__workletHash = 1;
     _classCallCheck.__pluginVersion = "x.y.z";
     _classCallCheck.__initData = _worklet_1_init_data;
@@ -3768,7 +3655,6 @@ const Clazz = function () {
       }
       return ("string" === r ? String : Number)(t);
     };
-    _toPrimitive.__closure = [];
     _toPrimitive.__workletHash = 2;
     _toPrimitive.__pluginVersion = "x.y.z";
     _toPrimitive.__initData = _worklet_2_init_data;
@@ -3893,7 +3779,6 @@ const Clazz = function () {
 
       if (!(a instanceof n)) throw new TypeError("Cannot call a class as a function");
     };
-    _classCallCheck.__closure = [];
     _classCallCheck.__workletHash = 1;
     _classCallCheck.__pluginVersion = "x.y.z";
     _classCallCheck.__initData = _worklet_1_init_data;
@@ -3914,7 +3799,6 @@ const Clazz = function () {
       }
       return ("string" === r ? String : Number)(t);
     };
-    _toPrimitive.__closure = [];
     _toPrimitive.__workletHash = 2;
     _toPrimitive.__pluginVersion = "x.y.z";
     _toPrimitive.__initData = _worklet_2_init_data;
@@ -4012,7 +3896,6 @@ const foo = function foo_sourceJs1Factory([_worklet_1_init_data]) {
 
     return 1;
   };
-  foo.__closure = [];
   foo.__workletHash = 1;
   foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_1_init_data;
@@ -4033,7 +3916,6 @@ const foo = function foo_library_sourceJs1Factory([_worklet_1_init_data]) {
 
     return 1;
   };
-  foo.__closure = [];
   foo.__workletHash = 1;
   foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_1_init_data;
@@ -4054,7 +3936,6 @@ const foo = function foo_SourceJs1Factory([_worklet_1_init_data]) {
 
     return 1;
   };
-  foo.__closure = [];
   foo.__workletHash = 1;
   foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_1_init_data;
@@ -4076,7 +3957,6 @@ const foo = function foo_null1Factory([_worklet_1_init_data]) {
 
     foo(1);
   };
-  foo.__closure = [];
   foo.__workletHash = 1;
   foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_1_init_data;
@@ -4098,7 +3978,6 @@ exports[`babel plugin for worklet names unnamed ArrowFunctionExpression 1`] = `
 
     return 1;
   };
-  null1.__closure = [];
   null1.__workletHash = 1;
   null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_1_init_data;
@@ -4120,7 +3999,6 @@ exports[`babel plugin for worklet names unnamed FunctionExpression 1`] = `
 
     return 1;
   };
-  null1.__closure = [];
   null1.__workletHash = 1;
   null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_1_init_data;
@@ -4136,7 +4014,7 @@ exports[`babel plugin for worklet nesting transpiles nested worklets 1`] = `
   sourceMap: "\\"mock source map\\""
 };
 const _worklet_2_init_data = {
-  code: "(function null2(){const[_worklet_1_init_data]=this.__closure;const bar=function null1Factory([_worklet_1_init_data]){const _e=[new global.Error(),1,-27];const null1=function(){console.log('bar');};null1.__closure=[];null1.__workletHash=15547305016511;null1.__pluginVersion=\\"x.y.z\\";null1.__initData=_worklet_1_init_data;null1.__stackDetails=_e;return null1;}([_worklet_1_init_data]);bar();})",
+  code: "(function null2(){const[_worklet_1_init_data]=this.__closure;const bar=function null1Factory([_worklet_1_init_data]){const _e=[new global.Error(),1,-27];const null1=function(){console.log('bar');};null1.__workletHash=15547305016511;null1.__pluginVersion=\\"x.y.z\\";null1.__initData=_worklet_1_init_data;null1.__stackDetails=_e;return null1;}([_worklet_1_init_data]);bar();})",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
@@ -4152,7 +4030,6 @@ const foo = function null2Factory([_worklet_2_init_data, _worklet_1_init_data]) 
 
         console.log("bar");
       };
-      null1.__closure = [];
       null1.__workletHash = 1;
       null1.__pluginVersion = "x.y.z";
       null1.__initData = _worklet_1_init_data;
@@ -4177,7 +4054,7 @@ exports[`babel plugin for worklet nesting transpiles nested worklets embedded in
   sourceMap: "\\"mock source map\\""
 };
 const _worklet_2_init_data = {
-  code: "(function null2(){const[runOnJS,_worklet_1_init_data]=this.__closure;console.log('Hello from UI thread');runOnJS(function null1Factory([_worklet_1_init_data]){const _e=[new global.Error(),1,-27];const null1=function(){console.log('Hello from JS thread');};null1.__closure=[];null1.__workletHash=11239746781805;null1.__pluginVersion=\\"x.y.z\\";null1.__initData=_worklet_1_init_data;null1.__stackDetails=_e;return null1;}([_worklet_1_init_data]))();})",
+  code: "(function null2(){const[runOnJS,_worklet_1_init_data]=this.__closure;console.log('Hello from UI thread');runOnJS(function null1Factory([_worklet_1_init_data]){const _e=[new global.Error(),1,-27];const null1=function(){console.log('Hello from JS thread');};null1.__workletHash=11239746781805;null1.__pluginVersion=\\"x.y.z\\";null1.__initData=_worklet_1_init_data;null1.__stackDetails=_e;return null1;}([_worklet_1_init_data]))();})",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
@@ -4194,7 +4071,6 @@ runOnUI(function null2Factory([_worklet_2_init_data, runOnJS, _worklet_1_init_da
 
         console.log("Hello from JS thread");
       };
-      null1.__closure = [];
       null1.__workletHash = 1;
       null1.__pluginVersion = "x.y.z";
       null1.__initData = _worklet_1_init_data;
@@ -4218,12 +4094,12 @@ exports[`babel plugin for worklet nesting transpiles nested worklets embedded in
   sourceMap: "\\"mock source map\\""
 };
 const _worklet_2_init_data = {
-  code: "(function null2(){const[runOnUI,_worklet_1_init_data]=this.__closure;console.log('Hello from JS thread');runOnUI(function null1Factory([_worklet_1_init_data]){const _e=[new global.Error(),1,-27];const null1=function(){console.log('Hello from UI thread again');};null1.__closure=[];null1.__workletHash=7548753055656;null1.__pluginVersion=\\"x.y.z\\";null1.__initData=_worklet_1_init_data;null1.__stackDetails=_e;return null1;}([_worklet_1_init_data]))();})",
+  code: "(function null2(){const[runOnUI,_worklet_1_init_data]=this.__closure;console.log('Hello from JS thread');runOnUI(function null1Factory([_worklet_1_init_data]){const _e=[new global.Error(),1,-27];const null1=function(){console.log('Hello from UI thread again');};null1.__workletHash=7548753055656;null1.__pluginVersion=\\"x.y.z\\";null1.__initData=_worklet_1_init_data;null1.__stackDetails=_e;return null1;}([_worklet_1_init_data]))();})",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
 const _worklet_3_init_data = {
-  code: "(function null3(){const[runOnJS,_worklet_2_init_data,runOnUI,_worklet_1_init_data]=this.__closure;console.log('Hello from UI thread');runOnJS(function null2Factory([_worklet_2_init_data,runOnUI,_worklet_1_init_data]){const _e=[new global.Error(),-3,-27];const null2=function(){console.log('Hello from JS thread');runOnUI(function null1Factory([_worklet_1_init_data]){const _e=[new global.Error(),1,-27];const null1=function(){console.log('Hello from UI thread again');};null1.__closure=[];null1.__workletHash=7548753055656;null1.__pluginVersion=\\"x.y.z\\";null1.__initData=_worklet_1_init_data;null1.__stackDetails=_e;return null1;}([_worklet_1_init_data]))();};null2.__closure=[runOnUI,_worklet_1_init_data];null2.__workletHash=5235470675834;null2.__pluginVersion=\\"x.y.z\\";null2.__initData=_worklet_2_init_data;null2.__stackDetails=_e;return null2;}([_worklet_2_init_data,runOnUI,_worklet_1_init_data]))();})",
+  code: "(function null3(){const[runOnJS,_worklet_2_init_data,runOnUI,_worklet_1_init_data]=this.__closure;console.log('Hello from UI thread');runOnJS(function null2Factory([_worklet_2_init_data,runOnUI,_worklet_1_init_data]){const _e=[new global.Error(),-3,-27];const null2=function(){console.log('Hello from JS thread');runOnUI(function null1Factory([_worklet_1_init_data]){const _e=[new global.Error(),1,-27];const null1=function(){console.log('Hello from UI thread again');};null1.__workletHash=7548753055656;null1.__pluginVersion=\\"x.y.z\\";null1.__initData=_worklet_1_init_data;null1.__stackDetails=_e;return null1;}([_worklet_1_init_data]))();};null2.__closure=[runOnUI,_worklet_1_init_data];null2.__workletHash=11543522036047;null2.__pluginVersion=\\"x.y.z\\";null2.__initData=_worklet_2_init_data;null2.__stackDetails=_e;return null2;}([_worklet_2_init_data,runOnUI,_worklet_1_init_data]))();})",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
@@ -4246,7 +4122,6 @@ runOnUI(function null3Factory([_worklet_3_init_data, runOnJS, _worklet_2_init_da
 
             console.log("Hello from UI thread again");
           };
-          null1.__closure = [];
           null1.__workletHash = 1;
           null1.__pluginVersion = "x.y.z";
           null1.__initData = _worklet_1_init_data;
@@ -4278,12 +4153,12 @@ exports[`babel plugin for worklet nesting transpiles nested worklets with depth 
   sourceMap: "\\"mock source map\\""
 };
 const _worklet_2_init_data = {
-  code: "(function null2(){const[_worklet_1_init_data]=this.__closure;const foobar=function null1Factory([_worklet_1_init_data]){const _e=[new global.Error(),1,-27];const null1=function(){console.log('foobar');};null1.__closure=[];null1.__workletHash=7394546508057;null1.__pluginVersion=\\"x.y.z\\";null1.__initData=_worklet_1_init_data;null1.__stackDetails=_e;return null1;}([_worklet_1_init_data]);})",
+  code: "(function null2(){const[_worklet_1_init_data]=this.__closure;const foobar=function null1Factory([_worklet_1_init_data]){const _e=[new global.Error(),1,-27];const null1=function(){console.log('foobar');};null1.__workletHash=7394546508057;null1.__pluginVersion=\\"x.y.z\\";null1.__initData=_worklet_1_init_data;null1.__stackDetails=_e;return null1;}([_worklet_1_init_data]);})",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
 const _worklet_3_init_data = {
-  code: "(function null3(){const[_worklet_2_init_data,_worklet_1_init_data]=this.__closure;const bar=function null2Factory([_worklet_2_init_data,_worklet_1_init_data]){const _e=[new global.Error(),-2,-27];const null2=function(){const foobar=function null1Factory([_worklet_1_init_data]){const _e=[new global.Error(),1,-27];const null1=function(){console.log('foobar');};null1.__closure=[];null1.__workletHash=7394546508057;null1.__pluginVersion=\\"x.y.z\\";null1.__initData=_worklet_1_init_data;null1.__stackDetails=_e;return null1;}([_worklet_1_init_data]);};null2.__closure=[_worklet_1_init_data];null2.__workletHash=39791129959;null2.__pluginVersion=\\"x.y.z\\";null2.__initData=_worklet_2_init_data;null2.__stackDetails=_e;return null2;}([_worklet_2_init_data,_worklet_1_init_data]);bar();})",
+  code: "(function null3(){const[_worklet_2_init_data,_worklet_1_init_data]=this.__closure;const bar=function null2Factory([_worklet_2_init_data,_worklet_1_init_data]){const _e=[new global.Error(),-2,-27];const null2=function(){const foobar=function null1Factory([_worklet_1_init_data]){const _e=[new global.Error(),1,-27];const null1=function(){console.log('foobar');};null1.__workletHash=7394546508057;null1.__pluginVersion=\\"x.y.z\\";null1.__initData=_worklet_1_init_data;null1.__stackDetails=_e;return null1;}([_worklet_1_init_data]);};null2.__closure=[_worklet_1_init_data];null2.__workletHash=5131817430994;null2.__pluginVersion=\\"x.y.z\\";null2.__initData=_worklet_2_init_data;null2.__stackDetails=_e;return null2;}([_worklet_2_init_data,_worklet_1_init_data]);bar();})",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
@@ -4304,7 +4179,6 @@ const foo = function null3Factory([_worklet_3_init_data, _worklet_2_init_data, _
 
             console.log("foobar");
           };
-          null1.__closure = [];
           null1.__workletHash = 1;
           null1.__pluginVersion = "x.y.z";
           null1.__initData = _worklet_1_init_data;
@@ -4342,7 +4216,7 @@ const _worklet_2_init_data = {
   sourceMap: "\\"mock source map\\""
 };
 const _worklet_3_init_data = {
-  code: "(function null3(){const[_worklet_1_init_data,_worklet_2_init_data,runOnJS]=this.__closure;const a=function null1Factory([_worklet_1_init_data]){const _e=[new global.Error(),1,-27];const null1=function(){console.log('Good morning from JS thread!');};null1.__closure=[];null1.__workletHash=10798770476691;null1.__pluginVersion=\\"x.y.z\\";null1.__initData=_worklet_1_init_data;null1.__stackDetails=_e;return null1;}([_worklet_1_init_data]);const b=function null2Factory([_worklet_2_init_data]){const _e=[new global.Error(),1,-27];const null2=function(){console.log('Good afternoon from JS thread');};null2.__closure=[];null2.__workletHash=9016903891659;null2.__pluginVersion=\\"x.y.z\\";null2.__initData=_worklet_2_init_data;null2.__stackDetails=_e;return null2;}([_worklet_2_init_data]);const func=Math.random()<0.5?a:b;runOnJS(func)();})",
+  code: "(function null3(){const[_worklet_1_init_data,_worklet_2_init_data,runOnJS]=this.__closure;const a=function null1Factory([_worklet_1_init_data]){const _e=[new global.Error(),1,-27];const null1=function(){console.log('Good morning from JS thread!');};null1.__workletHash=10798770476691;null1.__pluginVersion=\\"x.y.z\\";null1.__initData=_worklet_1_init_data;null1.__stackDetails=_e;return null1;}([_worklet_1_init_data]);const b=function null2Factory([_worklet_2_init_data]){const _e=[new global.Error(),1,-27];const null2=function(){console.log('Good afternoon from JS thread');};null2.__workletHash=9016903891659;null2.__pluginVersion=\\"x.y.z\\";null2.__initData=_worklet_2_init_data;null2.__stackDetails=_e;return null2;}([_worklet_2_init_data]);const func=Math.random()<0.5?a:b;runOnJS(func)();})",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
@@ -4358,7 +4232,6 @@ runOnUI(function null3Factory([_worklet_3_init_data, _worklet_1_init_data, _work
 
         console.log("Good morning from JS thread!");
       };
-      null1.__closure = [];
       null1.__workletHash = 1;
       null1.__pluginVersion = "x.y.z";
       null1.__initData = _worklet_1_init_data;
@@ -4372,7 +4245,6 @@ runOnUI(function null3Factory([_worklet_3_init_data, _worklet_1_init_data, _work
 
         console.log("Good afternoon from JS thread");
       };
-      null2.__closure = [];
       null2.__workletHash = 2;
       null2.__pluginVersion = "x.y.z";
       null2.__initData = _worklet_2_init_data;
@@ -4404,7 +4276,6 @@ const foo = function foo_nullQuery1Factory([_worklet_1_init_data]) {
 
     var foo = "bar";
   };
-  foo.__closure = [];
   foo.__workletHash = 1;
   foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_1_init_data;
@@ -4426,7 +4297,6 @@ const foo = function foo_nullHash1Factory([_worklet_2_init_data]) {
 
     var foo = "bar";
   };
-  foo.__closure = [];
   foo.__workletHash = 2;
   foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_2_init_data;
@@ -4448,7 +4318,6 @@ const foo = function foo_nullQueryHash1Factory([_worklet_3_init_data]) {
 
     var foo = "bar";
   };
-  foo.__closure = [];
   foo.__workletHash = 3;
   foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_3_init_data;

--- a/packages/react-native-worklets/plugin/__tests__/__snapshots__/plugin-shared.test.ts.snap
+++ b/packages/react-native-worklets/plugin/__tests__/__snapshots__/plugin-shared.test.ts.snap
@@ -3,24 +3,21 @@
 exports[`babel plugin core (bundle mode) autoworkletization workletizes useAnimatedStyle callback 1`] = `
 "import { useAnimatedStyle } from "react-native-reanimated";
 function Box() {
-  const style = useAnimatedStyle(require("react-native-worklets/.worklets/1.js").default([]));
+  const style = useAnimatedStyle(require("react-native-worklets/.worklets/1.js").default);
 }"
 `;
 
 exports[`babel plugin core (bundle mode) autoworkletization workletizes useAnimatedStyle callback 2`] = `
-"export default (function testJs1Factory([]) {
-  const testJs1 = function () {
-    "use no memo";
+"const testJs1 = function () {
+  "use no memo";
 
-    return {
-      width: 100
-    };
+  return {
+    width: 100
   };
-  testJs1.__closure = [];
-  testJs1.__workletHash = 1;
-  testJs1.__pluginVersion = "x.y.z";
-  return testJs1;
-});"
+};
+testJs1.__workletHash = 1;
+testJs1.__pluginVersion = "x.y.z";
+export default testJs1;"
 `;
 
 exports[`babel plugin core (bundle mode) closure handling captures locally bound variables shadowing globals 1`] = `
@@ -52,46 +49,37 @@ exports[`babel plugin core (bundle mode) closure handling captures multiple clos
 `;
 
 exports[`babel plugin core (bundle mode) closure handling does not capture default globals 1`] = `
-"export default (function f_testJs1Factory([]) {
-  const f = function () {
-    "use no memo";
+"const f = function () {
+  "use no memo";
 
-    console.log("hi");
-    return Math.random();
-  };
-  f.__closure = [];
-  f.__workletHash = 1;
-  f.__pluginVersion = "x.y.z";
-  return f;
-});"
+  console.log("hi");
+  return Math.random();
+};
+f.__workletHash = 1;
+f.__pluginVersion = "x.y.z";
+export default f;"
 `;
 
 exports[`babel plugin core (bundle mode) closure handling does not capture navigator 1`] = `
-"export default (function f_testJs1Factory([]) {
-  const f = function () {
-    "use no memo";
+"const f = function () {
+  "use no memo";
 
-    return navigator.gpu;
-  };
-  f.__closure = [];
-  f.__workletHash = 1;
-  f.__pluginVersion = "x.y.z";
-  return f;
-});"
+  return navigator.gpu;
+};
+f.__workletHash = 1;
+f.__pluginVersion = "x.y.z";
+export default f;"
 `;
 
 exports[`babel plugin core (bundle mode) for react-compiler prevents outlining from worklet functions 1`] = `
-"export default (function testJs1Factory([]) {
-  const testJs1 = function () {
-    "use no memo";
+"const testJs1 = function () {
+  "use no memo";
 
-    return [1, 2, 3].map(() => null);
-  };
-  testJs1.__closure = [];
-  testJs1.__workletHash = 1;
-  testJs1.__pluginVersion = "x.y.z";
-  return testJs1;
-});"
+  return [1, 2, 3].map(() => null);
+};
+testJs1.__workletHash = 1;
+testJs1.__pluginVersion = "x.y.z";
+export default testJs1;"
 `;
 
 exports[`babel plugin core (bundle mode) without worklets leaves code untouched and emits no factory 1`] = `
@@ -100,88 +88,73 @@ exports[`babel plugin core (bundle mode) without worklets leaves code untouched 
 }"
 `;
 
-exports[`babel plugin core (bundle mode) worklet shapes workletizes ArrowFunctionExpression 1`] = `"const foo = require("react-native-worklets/.worklets/1.js").default([]);"`;
+exports[`babel plugin core (bundle mode) worklet shapes workletizes ArrowFunctionExpression 1`] = `"const foo = require("react-native-worklets/.worklets/1.js").default;"`;
 
 exports[`babel plugin core (bundle mode) worklet shapes workletizes ArrowFunctionExpression 2`] = `
-"export default (function testJs1Factory([]) {
-  const testJs1 = function (x) {
-    "use no memo";
+"const testJs1 = function (x) {
+  "use no memo";
 
-    return x + 2;
-  };
-  testJs1.__closure = [];
-  testJs1.__workletHash = 1;
-  testJs1.__pluginVersion = "x.y.z";
-  return testJs1;
-});"
+  return x + 2;
+};
+testJs1.__workletHash = 1;
+testJs1.__pluginVersion = "x.y.z";
+export default testJs1;"
 `;
 
-exports[`babel plugin core (bundle mode) worklet shapes workletizes FunctionDeclaration 1`] = `"const foo = require("react-native-worklets/.worklets/1.js").default([]);"`;
+exports[`babel plugin core (bundle mode) worklet shapes workletizes FunctionDeclaration 1`] = `"const foo = require("react-native-worklets/.worklets/1.js").default;"`;
 
 exports[`babel plugin core (bundle mode) worklet shapes workletizes FunctionDeclaration 2`] = `
-"export default (function foo_testJs1Factory([]) {
-  const foo = function (x) {
-    "use no memo";
+"const foo = function (x) {
+  "use no memo";
 
-    return x + 2;
-  };
-  foo.__closure = [];
-  foo.__workletHash = 1;
-  foo.__pluginVersion = "x.y.z";
-  return foo;
-});"
+  return x + 2;
+};
+foo.__workletHash = 1;
+foo.__pluginVersion = "x.y.z";
+export default foo;"
 `;
 
 exports[`babel plugin core (bundle mode) worklet shapes workletizes ObjectMethod 1`] = `
 "const foo = {
-  bar: require("react-native-worklets/.worklets/1.js").default([])
+  bar: require("react-native-worklets/.worklets/1.js").default
 };"
 `;
 
 exports[`babel plugin core (bundle mode) worklet shapes workletizes ObjectMethod 2`] = `
-"export default (function bar_testJs1Factory([]) {
-  const bar = function (x) {
-    "use no memo";
+"const bar = function (x) {
+  "use no memo";
 
-    return x + 2;
-  };
-  bar.__closure = [];
-  bar.__workletHash = 1;
-  bar.__pluginVersion = "x.y.z";
-  return bar;
-});"
+  return x + 2;
+};
+bar.__workletHash = 1;
+bar.__pluginVersion = "x.y.z";
+export default bar;"
 `;
 
-exports[`babel plugin core (bundle mode) worklet shapes workletizes named FunctionExpression 1`] = `"const foo = require("react-native-worklets/.worklets/1.js").default([]);"`;
+exports[`babel plugin core (bundle mode) worklet shapes workletizes named FunctionExpression 1`] = `"const foo = require("react-native-worklets/.worklets/1.js").default;"`;
 
 exports[`babel plugin core (bundle mode) worklet shapes workletizes named FunctionExpression 2`] = `
-"export default (function foo_testJs1Factory([]) {
-  const foo = function (x) {
-    "use no memo";
+"const foo = function (x) {
+  "use no memo";
 
-    return x + 2;
-  };
-  foo.__closure = [];
-  foo.__workletHash = 1;
-  foo.__pluginVersion = "x.y.z";
-  return foo;
-});"
+  return x + 2;
+};
+foo.__workletHash = 1;
+foo.__pluginVersion = "x.y.z";
+export default foo;"
 `;
 
-exports[`babel plugin core (bundle mode) worklet shapes workletizes unnamed FunctionExpression 1`] = `"const foo = require("react-native-worklets/.worklets/1.js").default([]);"`;
+exports[`babel plugin core (bundle mode) worklet shapes workletizes unnamed FunctionExpression 1`] = `"const foo = require("react-native-worklets/.worklets/1.js").default;"`;
 
 exports[`babel plugin core (bundle mode) worklet shapes workletizes unnamed FunctionExpression 2`] = `
-"export default (function testJs1Factory([]) {
-  const testJs1 = function (x) {
-    "use no memo";
+"const testJs1 = function (x) {
+  "use no memo";
 
-    return x + 2;
-  };
-  testJs1.__closure = [];
-  testJs1.__workletHash = 1;
-  testJs1.__pluginVersion = "x.y.z";
-  return testJs1;
-});"
+  return x + 2;
+};
+testJs1.__workletHash = 1;
+testJs1.__pluginVersion = "x.y.z";
+export default testJs1;"
 `;
 
 exports[`babel plugin core (bundleless mode) autoworkletization workletizes useAnimatedStyle callback 1`] = `
@@ -200,7 +173,6 @@ function Box() {
         width: 100
       };
     };
-    testJs1.__closure = [];
     testJs1.__workletHash = 1;
     testJs1.__pluginVersion = "x.y.z";
     testJs1.__initData = _worklet_1_init_data;
@@ -270,7 +242,6 @@ const f = function f_testJs1Factory([_worklet_1_init_data]) {
     console.log("hi");
     return Math.random();
   };
-  f.__closure = [];
   f.__workletHash = 1;
   f.__pluginVersion = "x.y.z";
   f.__initData = _worklet_1_init_data;
@@ -291,7 +262,6 @@ const f = function f_testJs1Factory([_worklet_1_init_data]) {
 
     return navigator.gpu;
   };
-  f.__closure = [];
   f.__workletHash = 1;
   f.__pluginVersion = "x.y.z";
   f.__initData = _worklet_1_init_data;
@@ -317,7 +287,6 @@ const TestComponent = t0 => {
 
         return [1, 2, 3].map(() => null);
       };
-      testJs1.__closure = [];
       testJs1.__workletHash = 1;
       testJs1.__pluginVersion = "x.y.z";
       testJs1.__initData = _worklet_1_init_data;
@@ -351,7 +320,6 @@ const foo = function testJs1Factory([_worklet_1_init_data]) {
 
     return x + 2;
   };
-  testJs1.__closure = [];
   testJs1.__workletHash = 1;
   testJs1.__pluginVersion = "x.y.z";
   testJs1.__initData = _worklet_1_init_data;
@@ -372,7 +340,6 @@ const foo = function foo_testJs1Factory([_worklet_1_init_data]) {
 
     return x + 2;
   };
-  foo.__closure = [];
   foo.__workletHash = 1;
   foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_1_init_data;
@@ -394,7 +361,6 @@ const foo = {
 
       return x + 2;
     };
-    bar.__closure = [];
     bar.__workletHash = 1;
     bar.__pluginVersion = "x.y.z";
     bar.__initData = _worklet_1_init_data;
@@ -416,7 +382,6 @@ const foo = function foo_testJs1Factory([_worklet_1_init_data]) {
 
     return x + 2;
   };
-  foo.__closure = [];
   foo.__workletHash = 1;
   foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_1_init_data;
@@ -437,7 +402,6 @@ const foo = function testJs1Factory([_worklet_1_init_data]) {
 
     return x + 2;
   };
-  testJs1.__closure = [];
   testJs1.__workletHash = 1;
   testJs1.__pluginVersion = "x.y.z";
   testJs1.__initData = _worklet_1_init_data;

--- a/packages/react-native-worklets/plugin/__tests__/plugin-bundleMode.test.ts
+++ b/packages/react-native-worklets/plugin/__tests__/plugin-bundleMode.test.ts
@@ -89,6 +89,26 @@ describe('babel plugin in bundleMode', () => {
   });
 
   describe('source replacement', () => {
+    test.each(['arrow', 'method'])(
+      'does not shadow forwarded imports with the closure-free %s worklet binding',
+      (kind) => {
+        const name = kind === 'arrow' ? 'testJs1' : 'read';
+        const body = `{ 'worklet'; return [${name}(), _${name}()]; }`;
+        const expression =
+          kind === 'arrow' ? `() => ${body}` : `{ read() ${body} }.read`;
+        const { files } = runPlugin(
+          `
+          import { first as ${name}, second as _${name} } from 'some-library';
+          const f = ${expression};
+        `,
+          {},
+          { importForwarding: { moduleNames: ['some-library'] } }
+        );
+        expect(files[0].content).toContain(`const __${name} =`);
+        expect(files[0].content).toMatchSnapshot();
+      }
+    );
+
     test('packs captures in the same order at the call site and in the factory', () => {
       const { code, files } = runPlugin(`
         function make(z, missing, a) {
@@ -101,6 +121,19 @@ describe('babel plugin in bundleMode', () => {
       `);
       expect(code).toMatchSnapshot();
       expect(files[0].content).toMatchSnapshot();
+    });
+
+    test('exports closure-free worklets without a factory call', () => {
+      const { code, files } = runPlugin(`
+        function factorial(n) {
+          'worklet';
+          return n <= 1 ? 1 : n * factorial(n - 1);
+        }
+        module.exports = factorial;
+      `);
+      expect(code).toMatch(/\.default;/);
+      expect(files[0].content).not.toContain('Factory');
+      expect(files[0].content).not.toContain('__closure');
     });
 
     test('replaces inline factory with a require to the worklet file', () => {
@@ -165,7 +198,7 @@ describe('babel plugin in bundleMode', () => {
       expect(code).toMatchSnapshot();
     });
 
-    test('written file content has factory shape', () => {
+    test('written closure-free file exports the worklet directly', () => {
       const input = html`<script>
         function foo() {
           'worklet';

--- a/packages/react-native-worklets/plugin/__tests__/plugin-legacy.test.ts
+++ b/packages/react-native-worklets/plugin/__tests__/plugin-legacy.test.ts
@@ -456,8 +456,8 @@ describe('babel plugin', () => {
           }
         },
       });
-      expect(closureBindings).toEqual([]);
-      expect(code).toContain('f.__closure = []');
+      expect(closureBindings).toBeUndefined();
+      expect(code).not.toContain('__closure');
       expect(code).toMatchSnapshot();
     });
 
@@ -470,7 +470,7 @@ describe('babel plugin', () => {
       </script>`;
 
       const { code } = runPlugin(input, undefined, { globals: ['foo'] });
-      expect(code).toContain('f.__closure = []');
+      expect(code).not.toContain('__closure');
       expect(code).toMatchSnapshot();
     });
 
@@ -498,7 +498,7 @@ describe('babel plugin', () => {
       </script>`;
 
       const { code } = runPlugin(input);
-      expect(code).toContain('f.__closure = []');
+      expect(code).not.toContain('__closure');
       expect(code).toMatchSnapshot();
     });
 

--- a/packages/react-native-worklets/plugin/index.js
+++ b/packages/react-native-worklets/plugin/index.js
@@ -1413,7 +1413,13 @@ var require_generate = __commonJS({
       const filesDirPath = (0, path_1.resolve)((0, path_1.dirname)(require.resolve("react-native-worklets/package.json")), types_2.generatedWorkletsDir);
       const relativeImports = Array.from(relativeBindingsToImport).filter((binding) => binding.path.isImportSpecifier() && binding.path.parentPath.isImportDeclaration()).map((binding) => (0, types_12.importDeclaration)([(0, types_12.cloneNode)(binding.path.node, true)], (0, imports_1.createImportPathLiteral)(binding.path.parentPath.node.source.value, state)));
       const imports = [...libraryImports, ...relativeImports];
-      const newProg = (0, types_12.program)([...imports, (0, types_12.exportDefaultDeclaration)(factory)]);
+      const statements = [...factory.body.body];
+      const returnedWorklet = statements.pop();
+      (0, assert_1.default)((0, types_12.isReturnStatement)(returnedWorklet) && returnedWorklet.argument);
+      const newProg = (0, types_12.program)([
+        ...imports,
+        ...factory.params.length === 0 ? [...statements, (0, types_12.exportDefaultDeclaration)(returnedWorklet.argument)] : [(0, types_12.exportDefaultDeclaration)(factory)]
+      ]);
       const transformedProg = (_a = (0, core_1.transformFromAstSync)(newProg, void 0, {
         filename: state.file.opts.filename,
         presets: [resolvePresetTypescript()],
@@ -1805,7 +1811,14 @@ var require_workletFactory = __commonJS({
       };
       const clone = (0, types_12.cloneNode)(fun.node);
       const funExpression = (0, types_12.isBlockStatement)(clone.body) ? (0, types_12.functionExpression)(null, clone.params, clone.body, clone.generator, clone.async) : clone;
-      const { workletName, reactName } = makeWorkletName(fun, state);
+      const { workletName, reactName: initialReactName } = makeWorkletName(fun, state);
+      let reactName = initialReactName;
+      if (state.opts.bundleMode && closureVariables.length === 0) {
+        const importedNames = new Set([...moduleBindingsToImport, ...relativeBindingsToImport].map((binding) => binding.identifier.name));
+        while (importedNames.has(reactName)) {
+          reactName = `_${reactName}`;
+        }
+      }
       let mutatedClosureVariables;
       if (state.opts.bundleMode) {
         mutatedClosureVariables = closureVariables.map((variable) => (0, types_12.cloneNode)(variable, true));
@@ -1863,7 +1876,9 @@ var require_workletFactory = __commonJS({
         (0, types_12.variableDeclaration)("const", [
           (0, types_12.variableDeclarator)((0, types_12.identifier)(reactName), funExpression)
         ]),
-        (0, types_12.expressionStatement)((0, types_12.assignmentExpression)("=", (0, types_12.memberExpression)((0, types_12.identifier)(reactName), (0, types_12.identifier)("__closure"), false), (0, types_12.arrayExpression)(closureVariables.map((variable) => !state.opts.bundleMode && variable.name.endsWith(types_2.workletClassFactorySuffix) ? (0, types_12.memberExpression)((0, types_12.identifier)(variable.name.slice(0, variable.name.length - types_2.workletClassFactorySuffix.length)), (0, types_12.identifier)(variable.name)) : (0, types_12.cloneNode)(variable, true))))),
+        ...closureVariables.length > 0 ? [
+          (0, types_12.expressionStatement)((0, types_12.assignmentExpression)("=", (0, types_12.memberExpression)((0, types_12.identifier)(reactName), (0, types_12.identifier)("__closure"), false), (0, types_12.arrayExpression)(closureVariables.map((variable) => !state.opts.bundleMode && variable.name.endsWith(types_2.workletClassFactorySuffix) ? (0, types_12.memberExpression)((0, types_12.identifier)(variable.name.slice(0, variable.name.length - types_2.workletClassFactorySuffix.length)), (0, types_12.identifier)(variable.name)) : (0, types_12.cloneNode)(variable, true)))))
+        ] : [],
         (0, types_12.expressionStatement)((0, types_12.assignmentExpression)("=", (0, types_12.memberExpression)((0, types_12.identifier)(reactName), (0, types_12.identifier)("__workletHash"), false), (0, types_12.numericLiteral)(workletHash)))
       ];
       const shouldInjectVersion = !(0, utils_1.isRelease)(state);
@@ -1895,7 +1910,7 @@ var require_workletFactory = __commonJS({
       if (shouldIncludeInitData) {
         factoryParams.unshift((0, types_12.cloneNode)(initDataId, true));
       }
-      const factory = (0, types_12.functionExpression)((0, types_12.identifier)(workletName + "Factory"), [(0, types_12.arrayPattern)(factoryParams.map((param) => (0, types_12.cloneNode)(param, true)))], (0, types_12.blockStatement)(statements));
+      const factory = (0, types_12.functionExpression)((0, types_12.identifier)(workletName + "Factory"), factoryParams.length > 0 ? [(0, types_12.arrayPattern)(factoryParams.map((param) => (0, types_12.cloneNode)(param, true)))] : [], (0, types_12.blockStatement)(statements));
       const factoryCallArgs = factoryParams.map((param) => (0, types_12.cloneNode)(param, true));
       const factoryCallParamPack = (0, types_12.arrayExpression)(factoryCallArgs);
       if (state.opts.bundleMode) {
@@ -1995,11 +2010,16 @@ var require_workletFactoryCall = __commonJS({
       const { factory, factoryCallParamPack, workletHash } = (0, workletFactory_1.makeWorkletFactory)(path, state);
       let factoryCall;
       if (state.opts.bundleMode) {
-        factoryCall = (0, types_12.callExpression)((0, types_12.memberExpression)((0, types_12.callExpression)((0, types_12.identifier)("require"), [
+        const workletModule = (0, types_12.memberExpression)((0, types_12.callExpression)((0, types_12.identifier)("require"), [
           (0, types_12.stringLiteral)(`react-native-worklets/${types_2.generatedWorkletsDir}/${workletHash}.js`)
-        ]), (0, types_12.identifier)("default")), [factoryCallParamPack]);
+        ]), (0, types_12.identifier)("default"));
+        if (factoryCallParamPack.elements.length === 0) {
+          workletModule.loc = path.node.loc;
+          return workletModule;
+        }
+        factoryCall = (0, types_12.callExpression)(workletModule, [factoryCallParamPack]);
       } else {
-        factoryCall = (0, types_12.callExpression)(factory, [factoryCallParamPack]);
+        factoryCall = (0, types_12.callExpression)(factory, factoryCallParamPack.elements.length > 0 ? [factoryCallParamPack] : []);
       }
       addStackTraceDataToWorkletFactory(path, factoryCall);
       const replacement = factoryCall;

--- a/packages/react-native-worklets/plugin/src/generate.ts
+++ b/packages/react-native-worklets/plugin/src/generate.ts
@@ -10,6 +10,7 @@ import {
   cloneNode,
   exportDefaultDeclaration,
   importDeclaration,
+  isReturnStatement,
   program,
   stringLiteral,
 } from '@babel/types';
@@ -68,7 +69,15 @@ export function generateWorkletFile(
 
   const imports = [...libraryImports, ...relativeImports];
 
-  const newProg = program([...imports, exportDefaultDeclaration(factory)]);
+  const statements = [...factory.body.body];
+  const returnedWorklet = statements.pop();
+  assert(isReturnStatement(returnedWorklet) && returnedWorklet.argument);
+  const newProg = program([
+    ...imports,
+    ...(factory.params.length === 0
+      ? [...statements, exportDefaultDeclaration(returnedWorklet.argument)]
+      : [exportDefaultDeclaration(factory)]),
+  ]);
 
   const transformedProg = transformFromAstSync(newProg, undefined, {
     filename: state.file.opts.filename,

--- a/packages/react-native-worklets/plugin/src/utils.ts
+++ b/packages/react-native-worklets/plugin/src/utils.ts
@@ -1,5 +1,5 @@
 import type { NodePath } from '@babel/traverse';
-import type { CallExpression } from '@babel/types';
+import type { CallExpression, MemberExpression } from '@babel/types';
 import {
   identifier,
   isExportNamedDeclaration,
@@ -66,7 +66,7 @@ export function isRelease(state: WorkletsPluginPass) {
 export function replaceWithFactoryCall(
   toReplace: NodePath<unknown>,
   name: string | undefined,
-  factoryCall: CallExpression
+  factoryCall: CallExpression | MemberExpression
 ) {
   if (!name || !needsDeclaration(toReplace)) {
     toReplace.replaceWith(factoryCall);

--- a/packages/react-native-worklets/plugin/src/workletFactory.ts
+++ b/packages/react-native-worklets/plugin/src/workletFactory.ts
@@ -117,7 +117,22 @@ export function makeWorkletFactory(
       )
     : clone;
 
-  const { workletName, reactName } = makeWorkletName(fun, state);
+  const { workletName, reactName: initialReactName } = makeWorkletName(
+    fun,
+    state
+  );
+  let reactName = initialReactName;
+  if (state.opts.bundleMode && closureVariables.length === 0) {
+    // The worklet binding will share module scope with forwarded imports.
+    const importedNames = new Set(
+      [...moduleBindingsToImport, ...relativeBindingsToImport].map(
+        (binding) => binding.identifier.name
+      )
+    );
+    while (importedNames.has(reactName)) {
+      reactName = `_${reactName}`;
+    }
+  }
 
   let mutatedClosureVariables;
   if (state.opts.bundleMode) {
@@ -243,28 +258,37 @@ export function makeWorkletFactory(
     variableDeclaration('const', [
       variableDeclarator(identifier(reactName), funExpression),
     ]),
-    expressionStatement(
-      assignmentExpression(
-        '=',
-        memberExpression(identifier(reactName), identifier('__closure'), false),
-        arrayExpression(
-          closureVariables.map((variable) =>
-            !state.opts.bundleMode &&
-            variable.name.endsWith(workletClassFactorySuffix)
-              ? memberExpression(
-                  identifier(
-                    variable.name.slice(
-                      0,
-                      variable.name.length - workletClassFactorySuffix.length
-                    )
-                  ),
-                  identifier(variable.name)
+    ...(closureVariables.length > 0
+      ? [
+          expressionStatement(
+            assignmentExpression(
+              '=',
+              memberExpression(
+                identifier(reactName),
+                identifier('__closure'),
+                false
+              ),
+              arrayExpression(
+                closureVariables.map((variable) =>
+                  !state.opts.bundleMode &&
+                  variable.name.endsWith(workletClassFactorySuffix)
+                    ? memberExpression(
+                        identifier(
+                          variable.name.slice(
+                            0,
+                            variable.name.length -
+                              workletClassFactorySuffix.length
+                          )
+                        ),
+                        identifier(variable.name)
+                      )
+                    : cloneNode(variable, true)
                 )
-              : cloneNode(variable, true)
-          )
-        )
-      )
-    ),
+              )
+            )
+          ),
+        ]
+      : []),
     expressionStatement(
       assignmentExpression(
         '=',
@@ -363,7 +387,9 @@ export function makeWorkletFactory(
 
   const factory = functionExpression(
     identifier(workletName + 'Factory'),
-    [arrayPattern(factoryParams.map((param) => cloneNode(param, true)))],
+    factoryParams.length > 0
+      ? [arrayPattern(factoryParams.map((param) => cloneNode(param, true)))]
+      : [],
     blockStatement(statements)
   );
 

--- a/packages/react-native-worklets/plugin/src/workletFactoryCall.ts
+++ b/packages/react-native-worklets/plugin/src/workletFactoryCall.ts
@@ -1,5 +1,5 @@
 import type { NodePath } from '@babel/core';
-import type { CallExpression } from '@babel/types';
+import type { CallExpression, MemberExpression } from '@babel/types';
 import {
   callExpression,
   identifier,
@@ -14,7 +14,7 @@ import { makeWorkletFactory } from './workletFactory';
 export function makeWorkletFactoryCall(
   path: NodePath<WorkletizableFunction>,
   state: WorkletsPluginPass
-): CallExpression {
+): CallExpression | MemberExpression {
   const { factory, factoryCallParamPack, workletHash } = makeWorkletFactory(
     path,
     state
@@ -22,20 +22,24 @@ export function makeWorkletFactoryCall(
 
   let factoryCall: CallExpression;
   if (state.opts.bundleMode) {
-    factoryCall = callExpression(
-      memberExpression(
-        callExpression(identifier('require'), [
-          stringLiteral(
-            `react-native-worklets/${generatedWorkletsDir}/${workletHash}.js`
-          ),
-        ]),
-        identifier('default')
-      ),
-
-      [factoryCallParamPack]
+    const workletModule = memberExpression(
+      callExpression(identifier('require'), [
+        stringLiteral(
+          `react-native-worklets/${generatedWorkletsDir}/${workletHash}.js`
+        ),
+      ]),
+      identifier('default')
     );
+    if (factoryCallParamPack.elements.length === 0) {
+      workletModule.loc = path.node.loc;
+      return workletModule;
+    }
+    factoryCall = callExpression(workletModule, [factoryCallParamPack]);
   } else {
-    factoryCall = callExpression(factory, [factoryCallParamPack]);
+    factoryCall = callExpression(
+      factory,
+      factoryCallParamPack.elements.length > 0 ? [factoryCallParamPack] : []
+    );
   }
 
   addStackTraceDataToWorkletFactory(path, factoryCall);

--- a/packages/react-native-worklets/plugin/src/workletSubstitution.ts
+++ b/packages/react-native-worklets/plugin/src/workletSubstitution.ts
@@ -1,5 +1,10 @@
 import type { NodePath } from '@babel/core';
-import type { CallExpression, Directive, ObjectMethod } from '@babel/types';
+import type {
+  CallExpression,
+  Directive,
+  MemberExpression,
+  ObjectMethod,
+} from '@babel/types';
 import {
   isBlockStatement,
   isDirectiveLiteral,
@@ -74,7 +79,7 @@ function hasWorkletDirective(directives: Directive[]): boolean {
 
 function substituteWorkletWithWorkletFactoryCall(
   path: NodePath<WorkletizableFunction>,
-  workletFactoryCall: CallExpression
+  workletFactoryCall: CallExpression | MemberExpression
 ): void {
   if (path.isObjectMethod()) {
     substituteObjectMethodWithObjectProperty(path, workletFactoryCall);
@@ -86,7 +91,7 @@ function substituteWorkletWithWorkletFactoryCall(
 
 export function substituteObjectMethodWithObjectProperty(
   path: NodePath<ObjectMethod>,
-  workletFactoryCall: CallExpression
+  workletFactoryCall: CallExpression | MemberExpression
 ): void {
   const replacement = objectProperty(path.node.key, workletFactoryCall);
   path.replaceWith(replacement);

--- a/packages/react-native-worklets/src/memory/bundleUnpacker.native.ts
+++ b/packages/react-native-worklets/src/memory/bundleUnpacker.native.ts
@@ -18,7 +18,7 @@ export function bundleValueUnpacker(objectToUnpack: ObjectToUnpack): unknown {
 
 function getWorklet(
   workletHash: number,
-  closureVariables: unknown[]
+  closureVariables: unknown[] | undefined
 ): WorkletFunction | undefined {
   let worklet;
   if (__DEV__) {
@@ -39,10 +39,12 @@ const metroRequire = globalThis.__r;
 
 function getWorkletFromMetroRequire(
   workletHash: number,
-  closureVariables: unknown[]
+  closureVariables: unknown[] | undefined
 ): WorkletFunction {
-  const factory = metroRequire(workletHash).default as WorkletFactory;
-  return factory(closureVariables);
+  const exportedWorklet = metroRequire(workletHash).default;
+  return closureVariables === undefined
+    ? (exportedWorklet as WorkletFunction)
+    : (exportedWorklet as WorkletFactory)(closureVariables);
 }
 
 interface ObjectToUnpack extends WorkletFunction {

--- a/packages/react-native-worklets/src/types.ts
+++ b/packages/react-native-worklets/src/types.ts
@@ -69,7 +69,7 @@ interface WorkletInitData {
 }
 
 interface WorkletProps {
-  __closure: WorkletClosure;
+  __closure?: WorkletClosure;
   __workletHash: number;
   /** Only in Legacy Eval Mode. */
   __initData?: WorkletInitData;


### PR DESCRIPTION
## Stack

Depends on #10506 (array-based worklet closures). This PR targets `@tshmieldev/closureArray`; merge the array migration first.

## Summary

- Omit empty `__closure` metadata.
- Export closure-free worklets directly in Bundle Mode, skipping factory wrappers and factory calls in Babel, OXC, and the bundle unpacker.
- Handle forwarded-import name collisions introduced by the direct export.
- Update optional-closure types, handler equality, tests, and snapshots.

## Verification

- Babel plugin: 221 tests and 201 snapshots passed.
- OXC: 3 Rust tests, 19 Node tests, and 44 shared plugin tests passed (14 skipped).
- Worklets: 26 tests passed.
- Reanimated native/web handlers: 56 tests passed.
- Worklets and Reanimated native/web source type checks passed.

No device run or performance benchmark.