### PR TITLE
fix(CSS): reject unsupported two-axis skew strings

### DIFF
--- a/packages/react-native-reanimated/CHANGELOG.md
+++ b/packages/react-native-reanimated/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### 🐛 Bug fixes
 
+- Reject two-axis `skew()` transform strings that React Native cannot represent instead of rendering incorrect geometry. ([#10518](https://github.com/software-mansion/react-native-reanimated/pull/10518) by [@MatiPl01](https://github.com/MatiPl01))
 - Fix single-argument `translate()` and `skew()` in transform strings repeating the argument on the Y axis instead of leaving it at zero, so `translate(100px)` no longer also moves the element down. ([#10385](https://github.com/software-mansion/react-native-reanimated/pull/10385) by [@dennytosp](https://github.com/dennytosp))
 - Fix the Metro configuration type import to use the public package export. ([#10454](https://github.com/software-mansion/react-native-reanimated/pull/10454) by [@sneakykiwi](https://github.com/sneakykiwi))
 - Skip the Android mounted-tag correction in Layout Animations when React Native's `enableMountingCoordinatorPullModelAndroid` feature flag is on, since the pull model already guarantees that updates can't outrun a view's first mount. ([#10481](https://github.com/software-mansion/react-native-reanimated/pull/10481) by [@piaskowyk](https://github.com/piaskowyk))

--- a/packages/react-native-reanimated/src/common/style/processors/__tests__/transform.test.ts
+++ b/packages/react-native-reanimated/src/common/style/processors/__tests__/transform.test.ts
@@ -182,12 +182,12 @@ describe(processTransform, () => {
             output: [{ skewX: '0deg' }, { skewY: '0deg' }],
           },
           {
-            input: 'skew(45deg, 45deg)',
-            output: [{ skewX: '45deg' }, { skewY: '45deg' }],
+            input: 'skew(45deg, 0)',
+            output: [{ skewX: '45deg' }, { skewY: '0deg' }],
           },
           {
-            input: 'skew(1.5rad, 1.5rad)',
-            output: [{ skewX: '1.5rad' }, { skewY: '1.5rad' }],
+            input: 'skew(0rad, 1.5rad)',
+            output: [{ skewX: '0rad' }, { skewY: '1.5rad' }],
           },
           {
             input: 'skew(0, 0)',
@@ -298,14 +298,14 @@ describe(processTransform, () => {
         output: [{ translateX: 25 }, { translateY: 25 }, { scale: 2 }],
       },
       {
-        input: 'translate(50, 50) scale(1.5, 2) skew(30deg, 15deg)',
+        input: 'translate(50, 50) scale(1.5, 2) skew(30deg)',
         output: [
           { translateX: 50 },
           { translateY: 50 },
           { scaleX: 1.5 },
           { scaleY: 2 },
           { skewX: '30deg' },
-          { skewY: '15deg' },
+          { skewY: '0deg' },
         ],
       },
       {
@@ -386,6 +386,14 @@ describe(processTransform, () => {
       {
         input: 'skew(45deg, 90)', // Missing units for second skew value
         errorMessage: ERROR_MESSAGES.invalidTransform('skew(45deg, 90)'),
+      },
+      {
+        input: 'skew(45deg, 30deg)', // Two-axis skew cannot be represented by separate skew operations
+        errorMessage: ERROR_MESSAGES.invalidTransform('skew(45deg, 30deg)'),
+      },
+      {
+        input: 'skew(1.5rad, -0.5rad)', // Two-axis skew cannot be represented by separate skew operations
+        errorMessage: ERROR_MESSAGES.invalidTransform('skew(1.5rad, -0.5rad)'),
       },
       {
         input: 'matrix(1, 2, 3)', // Incorrect number of elements for matrix (should be 6 or 16)

--- a/packages/react-native-reanimated/src/common/style/processors/transform.ts
+++ b/packages/react-native-reanimated/src/common/style/processors/transform.ts
@@ -100,9 +100,21 @@ function parseSkewY(values: (number | string)[]): TransformsArray {
     : [];
 }
 
+function isZeroAngle(value: number | string): boolean {
+  'worklet';
+  return value === 0 || (isAngle(value) && parseFloat(value) === 0);
+}
+
 function parseSkew(values: (number | string)[]): TransformsArray {
   'worklet';
   if (values.length > 2) {
+    return [];
+  }
+  if (
+    values.length === 2 &&
+    !isZeroAngle(values[0]) &&
+    !isZeroAngle(values[1])
+  ) {
     return [];
   }
   // skew(ax) leaves ay at zero, same as translate above.


### PR DESCRIPTION
> [!NOTE]
> This pull request was authored by AI on behalf of @MatiPl01.

## Summary

`skew(ax, ay)` currently becomes consecutive `skewX(ax)` and `skewY(ay)` operations. When both angles are nonzero, multiplying those operations introduces an extra diagonal matrix term, so the rendered transform differs from CSS `skew(ax, ay)`.

Reject that unsupported case instead of silently rendering different geometry. Forms that are exactly representable through React Native's axis operations remain supported, including `skew(ax)`, `skew(ax, 0)`, and `skew(0, ay)`.

## Test plan

```sh
yarn workspace react-native-reanimated jest src/common/style/processors/__tests__/transform.test.ts --runInBand
```

The focused suite passes 68 tests. It verifies that one-axis-equivalent forms still parse and that two nonzero angles throw the standard invalid-transform error.

ESLint and oxfmt checks pass for both changed TypeScript files.

## Changelog

- [x] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.
