### PR TITLE
feat(CSS): support two-argument skew transform strings

### DIFF
--- a/apps/common-app/runtime-tests/reanimated/suites.ts
+++ b/apps/common-app/runtime-tests/reanimated/suites.ts
@@ -5,6 +5,12 @@ type Describe = (name: string, buildSuite: () => void) => void;
 
 export const REANIMATED_TEST_SUITES: RuntimeTestSuite[] = [
   {
+    testSuiteName: 'skew',
+    importTest: () => {
+      require('./tests/props/skew.test');
+    },
+  },
+  {
     testSuiteName: 'animations',
     importTest: () => {
       const { describe } = require('../ReJest/RuntimeTestsApi') as {

--- a/apps/common-app/runtime-tests/reanimated/tests/props/skew.test.tsx
+++ b/apps/common-app/runtime-tests/reanimated/tests/props/skew.test.tsx
@@ -1,0 +1,133 @@
+import React, { useEffect } from 'react';
+import type { MeasuredDimensions } from 'react-native-reanimated';
+import Animated, {
+  measure,
+  useAnimatedRef,
+  useAnimatedStyle,
+  useFrameCallback,
+  useSharedValue,
+} from 'react-native-reanimated';
+
+import {
+  describe,
+  expect,
+  getSharedValue,
+  registerValue,
+  render,
+  test,
+  wait,
+} from '../../../ReJest/RuntimeTestsApi';
+import { ComparisonMode } from '../../../ReJest/types';
+
+type SkewMode = 'static' | 'worklet' | 'css' | 'compound';
+
+function SkewProbe({ mode }: { mode: SkewMode }) {
+  const actualRef = useAnimatedRef();
+  const expectedRef = useAnimatedRef();
+  const actual = useSharedValue<MeasuredDimensions | null>(null);
+  const expected = useSharedValue<MeasuredDimensions | null>(null);
+  registerValue('skewActual', actual);
+  registerValue('skewExpected', expected);
+  const angle = useSharedValue(0);
+  useEffect(() => {
+    angle.value = 30;
+  }, [angle]);
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: `skew(${angle.value}deg, ${angle.value / 2}deg)`,
+  }));
+  useFrameCallback(() => {
+    actual.value = measure(actualRef);
+    expected.value = measure(expectedRef);
+  });
+
+  const box = {
+    position: 'absolute' as const,
+    width: 100,
+    height: 80,
+    left: 80,
+    top: 100,
+    transformOrigin: '0 0',
+  };
+  // A single matrix is accepted by RN and is an independent geometry oracle.
+  const matrix = [
+    1,
+    Math.tan(Math.PI / 12),
+    0,
+    0,
+    Math.tan(Math.PI / 6),
+    1,
+    0,
+    0,
+    0,
+    0,
+    1,
+    0,
+    mode === 'compound' ? 25 : 0,
+    0,
+    0,
+    1,
+  ];
+  return (
+    <>
+      <Animated.View
+        ref={expectedRef}
+        style={[box, { transform: [{ matrix }] }]}
+      />
+      <Animated.View
+        ref={actualRef}
+        style={[
+          box,
+          mode === 'worklet'
+            ? animatedStyle
+            : {
+                transform:
+                  mode === 'css'
+                    ? 'skew(0)'
+                    : `${mode === 'compound' ? 'translateX(25%) ' : ''}skew(30deg, 15deg)`,
+              },
+          mode === 'css'
+            ? {
+                animationName: {
+                  from: { transform: 'skew(0)' },
+                  to: { transform: 'skew(60deg, 30deg)' },
+                },
+                animationDuration: 1000,
+                animationDelay: -500,
+                animationTimingFunction: 'linear',
+                animationPlayState: 'paused',
+                animationFillMode: 'both',
+              }
+            : {},
+        ]}
+      />
+    </>
+  );
+}
+
+describe('Combined CSS skew', () => {
+  test.each<{ mode: SkewMode }>([
+    { mode: 'static' },
+    { mode: 'worklet' },
+    { mode: 'css' },
+    { mode: 'compound' },
+  ])('renders ${mode} skew with CSS geometry', async ({ mode }) => {
+    await render(<SkewProbe mode={mode} />);
+    await wait(500);
+    const actual = (
+      await getSharedValue<MeasuredDimensions | null>('skewActual')
+    ).onUI;
+    const expected = (
+      await getSharedValue<MeasuredDimensions | null>('skewExpected')
+    ).onUI;
+    expect(actual === null).toBe(false);
+    expect(expected === null).toBe(false);
+    if (actual && expected) {
+      // Ensure the measurement includes transforms, so equality cannot pass
+      // just because both views have the same untransformed layout.
+      expect(expected.width > 140).toBe(true);
+      for (const key of ['pageX', 'pageY', 'width', 'height'] as const) {
+        expect(actual[key]).toBe(expected[key], ComparisonMode.PIXEL);
+      }
+    }
+  });
+});

--- a/docs/docs-reanimated/docs/guides/supported-properties.mdx
+++ b/docs/docs-reanimated/docs/guides/supported-properties.mdx
@@ -167,6 +167,12 @@ For animating `react-native-svg` components, see [Animating SVG](/docs/guides/an
 
 ## Remarks
 
+### Transform strings
+
+On native platforms, Reanimated accepts `skew(ax)` and `skew(ax, ay)` in transform strings. Angles can use `deg` or `rad`; unitless `0` is also accepted. The omitted second angle defaults to zero.
+
+For example, `transform: 'skew(30deg, 15deg)'` applies a single CSS skew. Its result differs from `skewX(30deg) skewY(15deg)`. CSS animations and transitions interpolate the two angles independently. The array syntax continues to use React Native's supported transform operations.
+
 ### Style Inheritance
 
 Style inheritance is not supported. Properties that would normally inherit values (e.g., textDecorationColor inheriting from color) must be provided separately, as inheritance is not implemented.

--- a/packages/react-native-reanimated/CHANGELOG.md
+++ b/packages/react-native-reanimated/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### 🐛 Bug fixes
 
-- Reject two-axis `skew()` transform strings that React Native cannot represent instead of rendering incorrect geometry. ([#10519](https://github.com/software-mansion/react-native-reanimated/pull/10519) by [@MatiPl01](https://github.com/MatiPl01))
+- Support two-argument `skew()` transform strings with correct geometry and angle interpolation. ([#10519](https://github.com/software-mansion/react-native-reanimated/pull/10519) by [@MatiPl01](https://github.com/MatiPl01))
 - Fix single-argument `translate()` and `skew()` in transform strings repeating the argument on the Y axis instead of leaving it at zero, so `translate(100px)` no longer also moves the element down. ([#10385](https://github.com/software-mansion/react-native-reanimated/pull/10385) by [@dennytosp](https://github.com/dennytosp))
 - Fix the Metro configuration type import to use the public package export. ([#10454](https://github.com/software-mansion/react-native-reanimated/pull/10454) by [@sneakykiwi](https://github.com/sneakykiwi))
 - Skip the Android mounted-tag correction in Layout Animations when React Native's `enableMountingCoordinatorPullModelAndroid` feature flag is on, since the pull model already guarantees that updates can't outrun a view's first mount. ([#10481](https://github.com/software-mansion/react-native-reanimated/pull/10481) by [@piaskowyk](https://github.com/piaskowyk))

--- a/packages/react-native-reanimated/CHANGELOG.md
+++ b/packages/react-native-reanimated/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### 🐛 Bug fixes
 
+- Reject two-axis `skew()` transform strings that React Native cannot represent instead of rendering incorrect geometry. ([#10519](https://github.com/software-mansion/react-native-reanimated/pull/10519) by [@MatiPl01](https://github.com/MatiPl01))
 - Fix single-argument `translate()` and `skew()` in transform strings repeating the argument on the Y axis instead of leaving it at zero, so `translate(100px)` no longer also moves the element down. ([#10385](https://github.com/software-mansion/react-native-reanimated/pull/10385) by [@dennytosp](https://github.com/dennytosp))
 - Fix the Metro configuration type import to use the public package export. ([#10454](https://github.com/software-mansion/react-native-reanimated/pull/10454) by [@sneakykiwi](https://github.com/sneakykiwi))
 - Skip the Android mounted-tag correction in Layout Animations when React Native's `enableMountingCoordinatorPullModelAndroid` feature flag is on, since the pull model already guarantees that updates can't outrun a view's first mount. ([#10481](https://github.com/software-mansion/react-native-reanimated/pull/10481) by [@piaskowyk](https://github.com/piaskowyk))

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/InterpolatorRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/InterpolatorRegistry.cpp
@@ -151,6 +151,7 @@ const InterpolatorFactoriesRecord STYLE_INTERPOLATORS = {
           {"translateY", transformOp<TranslateYOperation>(0, {RelativeTo::Self, "height"})},
           {"skewX", transformOp<SkewXOperation>("0deg")},
           {"skewY", transformOp<SkewYOperation>("0deg")},
+          {"skew", transformOp<SkewOperation>(SkewAngles{CSSAngle(0.0), CSSAngle(0.0)})},
           {"matrix", transformOp<MatrixOperation>(TransformMatrix2D())}})},
 
     // Filters

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/transforms/TransformOp.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/transforms/TransformOp.cpp
@@ -6,7 +6,7 @@
 
 namespace reanimated::css {
 
-constexpr std::array<const char *, 13> transformOperationStrings = {
+constexpr std::array<const char *, 14> transformOperationStrings = {
     "perspective",
     "rotate",
     "rotateX",
@@ -19,7 +19,8 @@ constexpr std::array<const char *, 13> transformOperationStrings = {
     "translateY",
     "skewX",
     "skewY",
-    "matrix"};
+    "matrix",
+    "skew"};
 
 TransformOp getTransformOperationType(const std::string &property) {
   static const std::unordered_map<std::string, TransformOp> stringToEnumMap = {
@@ -35,7 +36,8 @@ TransformOp getTransformOperationType(const std::string &property) {
       {"translateY", TransformOp::TranslateY},
       {"skewX", TransformOp::SkewX},
       {"skewY", TransformOp::SkewY},
-      {"matrix", TransformOp::Matrix}};
+      {"matrix", TransformOp::Matrix},
+      {"skew", TransformOp::Skew}};
 
   auto it = stringToEnumMap.find(property);
   if (it != stringToEnumMap.end()) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/transforms/TransformOp.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/transforms/TransformOp.h
@@ -18,6 +18,7 @@ enum class TransformOp : uint8_t {
   SkewX,
   SkewY,
   Matrix,
+  Skew,
 };
 
 TransformOp getTransformOperationType(const std::string &property);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSAngle.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSAngle.cpp
@@ -44,7 +44,7 @@ CSSAngle::CSSAngle(const std::string &rotationString) {
   this->value = numericValue * it->second;
 }
 
-CSSAngle::CSSAngle(const char *cstr) : CSSAngle(std::string_view{cstr}) {}
+CSSAngle::CSSAngle(const char *cstr) : CSSAngle(std::string{cstr}) {}
 
 CSSAngle::CSSAngle(jsi::Runtime &rt, const jsi::Value &jsiValue) {
   *this = CSSAngle(jsiValue.asString(rt).utf8(rt));

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformOperation.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformOperation.cpp
@@ -93,6 +93,8 @@ std::shared_ptr<TransformOperation> TransformOperation::fromJSIValue(jsi::Runtim
     }
     case TransformOp::SkewX:
       return std::make_shared<SkewXOperation>(propertyValue.asString(rt).utf8(rt));
+    case TransformOp::Skew:
+      return std::make_shared<SkewOperation>(rt, propertyValue);
     case TransformOp::SkewY:
       return std::make_shared<SkewYOperation>(propertyValue.asString(rt).utf8(rt));
     case TransformOp::Matrix:
@@ -147,6 +149,8 @@ std::shared_ptr<TransformOperation> TransformOperation::fromDynamic(const folly:
     }
     case TransformOp::SkewX:
       return std::make_shared<SkewXOperation>(propertyValue.getString());
+    case TransformOp::Skew:
+      return std::make_shared<SkewOperation>(propertyValue);
     case TransformOp::SkewY:
       return std::make_shared<SkewYOperation>(propertyValue.getString());
     case TransformOp::Matrix:

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformOperationInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformOperationInterpolator.cpp
@@ -208,6 +208,7 @@ template class TransformOperationInterpolator<ScaleYOperation>;
 // Skew operations
 template class TransformOperationInterpolator<SkewXOperation>;
 template class TransformOperationInterpolator<SkewYOperation>;
+template class TransformOperationInterpolator<SkewOperation>;
 
 // Translate operations (resolvable)
 template class TransformOperationInterpolator<TranslateXOperation>;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/operations/skew.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/operations/skew.cpp
@@ -1,8 +1,24 @@
+#include <reanimated/CSS/common/transforms/TransformMatrix2D.h>
+#include <reanimated/CSS/common/transforms/TransformMatrix3D.h>
 #include <reanimated/CSS/interpolation/transforms/operations/skew.h>
+
+#include <algorithm>
+#include <cmath>
+#include <iomanip>
+#include <limits>
+#include <sstream>
 
 #include <string>
 
 namespace reanimated::css {
+
+namespace {
+folly::dynamic preciseAngle(double radians) {
+  std::ostringstream stream;
+  stream << std::fixed << std::setprecision(std::numeric_limits<double>::max_digits10) << radians << "rad";
+  return stream.str();
+}
+} // namespace
 
 template <TransformOp TOperation>
 SkewOperationBase<TOperation>::SkewOperationBase(const std::string &value)
@@ -10,5 +26,76 @@ SkewOperationBase<TOperation>::SkewOperationBase(const std::string &value)
 
 template struct SkewOperationBase<TransformOp::SkewX>;
 template struct SkewOperationBase<TransformOp::SkewY>;
+
+SkewAngles SkewAngles::interpolate(double progress, const SkewAngles &to) const {
+  return {x.interpolate(progress, to.x), y.interpolate(progress, to.y)};
+}
+
+SkewOperation::SkewOperation(SkewAngles angles) : TransformOperation(TransformOp::Skew), value(angles) {}
+
+SkewOperation::SkewOperation(const folly::dynamic &angles)
+    : SkewOperation(SkewAngles{CSSAngle(angles.at(0)), CSSAngle(angles.at(1))}) {}
+
+SkewOperation::SkewOperation(jsi::Runtime &rt, const jsi::Value &angles)
+    : SkewOperation(SkewAngles{
+          CSSAngle(rt, angles.asObject(rt).asArray(rt).getValueAtIndex(rt, 0)),
+          CSSAngle(rt, angles.asObject(rt).asArray(rt).getValueAtIndex(rt, 1))}) {}
+
+TransformMatrix::Shared SkewOperation::toMatrix(bool force3D) const {
+  if (force3D) {
+    auto matrix = std::make_shared<TransformMatrix3D>();
+    (*matrix)[1] = std::tan(value.y.value);
+    (*matrix)[4] = std::tan(value.x.value);
+    return matrix;
+  }
+  auto matrix = std::make_shared<TransformMatrix2D>();
+  (*matrix)[1] = std::tan(value.y.value);
+  (*matrix)[3] = std::tan(value.x.value);
+  return matrix;
+}
+
+folly::dynamic SkewOperation::valueToDynamic() const {
+  return folly::dynamic::array(preciseAngle(value.x.value), preciseAngle(value.y.value));
+}
+
+bool SkewOperation::areValuesEqual(const StyleOperation &other) const {
+  return typeid(*this) == typeid(other) && value == static_cast<const SkewOperation &>(other).value;
+}
+
+std::optional<folly::dynamic> lowerSkewTransforms(const folly::dynamic &transforms) {
+  if (!transforms.isArray() || !std::any_of(transforms.begin(), transforms.end(), [](const auto &operation) {
+        return operation.isObject() && operation.count("skew");
+      })) {
+    return std::nullopt;
+  }
+  folly::dynamic result = folly::dynamic::array;
+  for (const auto &transform : transforms) {
+    if (!transform.isObject() || !transform.count("skew")) {
+      result.push_back(transform);
+      continue;
+    }
+    const SkewOperation skew(transform.at("skew"));
+    const double x = std::tan(skew.value.x.value);
+    const double y = std::tan(skew.value.y.value);
+    const double scaleX = std::hypot(1.0, y);
+    // QR factorization, including zero and negative determinants. No matrix
+    // operation is emitted because Fabric rejects matrices with siblings.
+    result.push_back(folly::dynamic::object("rotate", preciseAngle(std::atan(y))));
+    result.push_back(folly::dynamic::object("scaleX", scaleX));
+    result.push_back(folly::dynamic::object("scaleY", (1 - x * y) / scaleX));
+    result.push_back(folly::dynamic::object("skewX", preciseAngle(std::atan((x + y) / (1 + y * y)))));
+  }
+  return result;
+}
+
+folly::dynamic lowerSkewProps(const folly::dynamic &props) {
+  auto result = props;
+  if (auto transform = result.get_ptr("transform")) {
+    if (auto lowered = lowerSkewTransforms(*transform)) {
+      *transform = std::move(*lowered);
+    }
+  }
+  return result;
+}
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/operations/skew.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/operations/skew.h
@@ -3,6 +3,7 @@
 #include <reanimated/CSS/common/values/CSSAngle.h>
 #include <reanimated/CSS/interpolation/transforms/TransformOperation.h>
 
+#include <optional>
 #include <string>
 
 namespace reanimated::css {
@@ -16,5 +17,31 @@ struct SkewOperationBase : public TransformOperationBase<TOperation, CSSAngle> {
 
 using SkewXOperation = SkewOperationBase<TransformOp::SkewX>;
 using SkewYOperation = SkewOperationBase<TransformOp::SkewY>;
+
+struct SkewAngles {
+  CSSAngle x;
+  CSSAngle y;
+
+  SkewAngles interpolate(double progress, const SkewAngles &to) const;
+  bool operator==(const SkewAngles &other) const = default;
+};
+
+struct SkewOperation : public TransformOperation {
+  const SkewAngles value;
+
+  explicit SkewOperation(SkewAngles angles);
+  explicit SkewOperation(const folly::dynamic &angles);
+  SkewOperation(jsi::Runtime &rt, const jsi::Value &angles);
+  TransformMatrix::Shared toMatrix(bool force3D = false) const override;
+
+ protected:
+  folly::dynamic valueToDynamic() const override;
+  bool areValuesEqual(const StyleOperation &other) const override;
+};
+
+// Convert internal combined skews to RN operations at the rendering boundary.
+// The stored style must retain the original angles for interrupted transitions.
+std::optional<folly::dynamic> lowerSkewTransforms(const folly::dynamic &transforms);
+folly::dynamic lowerSkewProps(const folly::dynamic &props);
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/UpdatesRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/UpdatesRegistry.cpp
@@ -1,3 +1,4 @@
+#include <reanimated/CSS/interpolation/transforms/operations/skew.h>
 #include <reanimated/Fabric/updates/UpdatesRegistry.h>
 
 #include <reanimated/Fabric/updates/PropsLayoutFilter.h>
@@ -184,10 +185,10 @@ void UpdatesRegistry::collectProps(PropsMap &propsMap) {
 
     if (it == propsMap.cend()) {
       auto propsVector = std::vector<RawProps>{};
-      propsVector.emplace_back(RawProps(props));
+      propsVector.emplace_back(RawProps(css::lowerSkewProps(props)));
       propsMap.emplace(shadowNodeFamily, propsVector);
     } else {
-      it->second.push_back(RawProps(props));
+      it->second.push_back(RawProps(css::lowerSkewProps(props)));
     }
   }
 }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/UpdatesRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/UpdatesRegistry.cpp
@@ -6,6 +6,7 @@
 
 #include <react/debug/react_native_assert.h>
 
+#include <jsi/JSIDynamic.h>
 #include <jsi/jsi.h>
 #include <memory>
 #include <string>
@@ -149,6 +150,7 @@ void UpdatesRegistry::addRawPropsToAnimatedPropsBatch(
     const ShadowNodeFamily::Shared &shadowNodeFamily,
     folly::dynamic props) {
   const bool hasLayoutUpdates = hasLayoutProps(props);
+  props = css::lowerSkewProps(props);
   animatedPropsBuilder_.storeDynamic(props);
   addAnimatedPropsToBatch(shadowNodeFamily, animatedPropsBuilder_.get(), hasLayoutUpdates);
 }
@@ -158,6 +160,21 @@ void UpdatesRegistry::addJSIPropsToAnimatedPropsBatch(
     jsi::Runtime &rt,
     jsi::Value &props) {
   const bool hasLayoutUpdates = hasLayoutProps(rt, props);
+  const auto transform = props.asObject(rt).getProperty(rt, "transform");
+  if (transform.isObject() && transform.asObject(rt).isArray(rt)) {
+    const auto operations = transform.asObject(rt).asArray(rt);
+    for (size_t i = 0; i < operations.size(rt); ++i) {
+      const auto operation = operations.getValueAtIndex(rt, i);
+      if (operation.isObject() && operation.asObject(rt).hasProperty(rt, "skew")) {
+        // The animation backend parses typed transforms before creating a
+        // shadow-tree update, so lower our internal operation before that step.
+        auto loweredProps = css::lowerSkewProps(jsi::dynamicFromValue(rt, props));
+        animatedPropsBuilder_.storeDynamic(loweredProps);
+        addAnimatedPropsToBatch(shadowNodeFamily, animatedPropsBuilder_.get(), hasLayoutUpdates);
+        return;
+      }
+    }
+  }
   animatedPropsBuilder_.storeJSI(rt, props);
   addAnimatedPropsToBatch(shadowNodeFamily, animatedPropsBuilder_.get(), hasLayoutUpdates);
 }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/UpdatesRegistryManager.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/UpdatesRegistryManager.cpp
@@ -1,3 +1,4 @@
+#include <reanimated/CSS/interpolation/transforms/operations/skew.h>
 #include <reanimated/Fabric/updates/UpdatesRegistryManager.h>
 #include <reanimated/Tools/FeatureFlags.h>
 
@@ -126,10 +127,10 @@ void UpdatesRegistryManager::addToPropsMap(
 
   if (it == propsMap.cend()) {
     auto propsVector = std::vector<RawProps>{};
-    propsVector.emplace_back(props);
+    propsVector.emplace_back(css::lowerSkewProps(props));
     propsMap.emplace(shadowNodeFamily, propsVector);
   } else {
-    it->second.emplace_back(props);
+    it->second.emplace_back(css::lowerSkewProps(props));
   }
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -9,6 +9,7 @@
 #include <react/renderer/uimanager/primitives.h>
 #include <reanimated/CSS/configs/CSSTransitionConfig.h>
 #include <reanimated/CSS/easing/EasingFunctions.h>
+#include <reanimated/CSS/interpolation/transforms/operations/skew.h>
 #include <reanimated/Compat/WorkletsApi.h>
 #include <reanimated/Events/UIEventHandler.h>
 #include <reanimated/Fabric/updates/PropsLayoutFilter.h>
@@ -1108,7 +1109,7 @@ void ReanimatedModuleProxy::commitUpdates(jsi::Runtime &rt, const UpdatesBatch &
     }
   } else {
     for (auto const &[shadowNodeFamily, props] : updatesBatch) {
-      propsMapBySurface[shadowNodeFamily->getSurfaceId()][shadowNodeFamily].emplace_back(props);
+      propsMapBySurface[shadowNodeFamily->getSurfaceId()][shadowNodeFamily].emplace_back(css::lowerSkewProps(props));
     }
   }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/SynchronousPropsBufferSerializer.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/SynchronousPropsBufferSerializer.cpp
@@ -1,3 +1,4 @@
+#include <reanimated/CSS/interpolation/transforms/operations/skew.h>
 #include <reanimated/NativeModules/SynchronousPropsBufferSerializer.h>
 
 #ifdef ANDROID
@@ -228,10 +229,11 @@ void serializeSynchronousPropsToBuffers(
           }
           break;
 
-        case CMD_START_OF_TRANSFORM:
+        case CMD_START_OF_TRANSFORM: {
           pushInt(command);
           react_native_assert(value.isArray() && "[Reanimated] Transform value must be an array");
-          for (const auto &item : value) {
+          const auto lowered = css::lowerSkewTransforms(value);
+          for (const auto &item : lowered ? *lowered : value) {
             react_native_assert(item.isObject() && "[Reanimated] Transform array item must be an object");
             react_native_assert(
                 item.size() == 1 && "[Reanimated] Transform array item must have exactly one key-value pair");
@@ -299,6 +301,7 @@ void serializeSynchronousPropsToBuffers(
           }
           pushInt(CMD_END_OF_TRANSFORM);
           break;
+        }
 
         default:
           throw std::runtime_error("[Reanimated] Unsupported prop: " + propName);

--- a/packages/react-native-reanimated/src/common/style/processors/__tests__/transform.test.ts
+++ b/packages/react-native-reanimated/src/common/style/processors/__tests__/transform.test.ts
@@ -182,12 +182,12 @@ describe(processTransform, () => {
             output: [{ skewX: '0deg' }, { skewY: '0deg' }],
           },
           {
-            input: 'skew(45deg, 45deg)',
-            output: [{ skewX: '45deg' }, { skewY: '45deg' }],
+            input: 'skew(45deg, 0)',
+            output: [{ skewX: '45deg' }, { skewY: '0deg' }],
           },
           {
-            input: 'skew(1.5rad, 1.5rad)',
-            output: [{ skewX: '1.5rad' }, { skewY: '1.5rad' }],
+            input: 'skew(0rad, 1.5rad)',
+            output: [{ skewX: '0rad' }, { skewY: '1.5rad' }],
           },
           {
             input: 'skew(0, 0)',
@@ -298,14 +298,14 @@ describe(processTransform, () => {
         output: [{ translateX: 25 }, { translateY: 25 }, { scale: 2 }],
       },
       {
-        input: 'translate(50, 50) scale(1.5, 2) skew(30deg, 15deg)',
+        input: 'translate(50, 50) scale(1.5, 2) skew(30deg)',
         output: [
           { translateX: 50 },
           { translateY: 50 },
           { scaleX: 1.5 },
           { scaleY: 2 },
           { skewX: '30deg' },
-          { skewY: '15deg' },
+          { skewY: '0deg' },
         ],
       },
       {
@@ -386,6 +386,14 @@ describe(processTransform, () => {
       {
         input: 'skew(45deg, 90)', // Missing units for second skew value
         errorMessage: ERROR_MESSAGES.invalidTransform('skew(45deg, 90)'),
+      },
+      {
+        input: 'skew(45deg, 30deg)', // Two-axis skew cannot be represented by separate skew operations
+        errorMessage: ERROR_MESSAGES.invalidTransform('skew(45deg, 30deg)'),
+      },
+      {
+        input: 'skew(1.5rad, -0.5rad)', // Two-axis skew cannot be represented by separate skew operations
+        errorMessage: ERROR_MESSAGES.invalidTransform('skew(1.5rad, -0.5rad)'),
       },
       {
         input: 'matrix(1, 2, 3)', // Incorrect number of elements for matrix (should be 6 or 16)

--- a/packages/react-native-reanimated/src/common/style/processors/__tests__/transform.test.ts
+++ b/packages/react-native-reanimated/src/common/style/processors/__tests__/transform.test.ts
@@ -1,6 +1,64 @@
 'use strict';
-import type { TransformsArray } from '../../../types';
-import { ERROR_MESSAGES, processTransform } from '../transform';
+import {
+  ERROR_MESSAGES,
+  processTransform,
+  processTransformForReactNative,
+} from '../transform';
+
+describe(processTransformForReactNative, () => {
+  test.each([
+    [30, 15],
+    [45, 45],
+    [60, 60],
+    [-45, 30],
+    [0, 30],
+    [30, 0],
+    [0, 0],
+    [120, -60],
+  ])('preserves CSS geometry for skew(%sdeg, %sdeg)', (ax, ay) => {
+    const transforms = processTransformForReactNative(
+      `skew(${ax}deg, ${ay}deg)`
+    );
+    // Apply RN operations to basis vectors, rightmost operation first.
+    // CSS skew maps (px, py) to (px + tan(ax) * py, tan(ay) * px + py).
+    for (const [px, py] of [
+      [1, 0],
+      [0, 1],
+      [23, -17],
+    ]) {
+      let x = px;
+      let y = py;
+      for (const operation of [...transforms].reverse()) {
+        if (operation && typeof operation.rotate === 'string') {
+          const angle = parseFloat(operation.rotate);
+          [x, y] = [
+            Math.cos(angle) * x - Math.sin(angle) * y,
+            Math.sin(angle) * x + Math.cos(angle) * y,
+          ];
+        } else if (operation && typeof operation.scaleX === 'number') {
+          x *= operation.scaleX;
+        } else if (operation && typeof operation.scaleY === 'number') {
+          y *= operation.scaleY;
+        } else if (operation && typeof operation.skewX === 'string') {
+          x += Math.tan(parseFloat(operation.skewX)) * y;
+        } else {
+          throw new Error('Unexpected native operation');
+        }
+      }
+      expect(x).toBeCloseTo(px + Math.tan((ax * Math.PI) / 180) * py, 10);
+      expect(y).toBeCloseTo(Math.tan((ay * Math.PI) / 180) * px + py, 10);
+    }
+  });
+
+  test('preserves sibling operations and percentage translations', () => {
+    const result = processTransformForReactNative(
+      'translateX(20%) skew(30deg, 15deg) rotateX(25deg)'
+    );
+    expect(result[0]).toEqual({ translateX: '20%' });
+    expect(result[result.length - 1]).toEqual({ rotateX: '25deg' });
+    expect(result).toHaveLength(6);
+  });
+});
 
 describe(processTransform, () => {
   test('returns the same object if not a string', () => {
@@ -12,7 +70,7 @@ describe(processTransform, () => {
   describe('converts transform string to transform objects', () => {
     const cases: {
       name: string;
-      cases: { input: string; output: TransformsArray }[];
+      cases: { input: string; output: ReturnType<typeof processTransform> }[];
     }[] = [
       {
         name: 'translate',
@@ -175,23 +233,31 @@ describe(processTransform, () => {
           {
             // A single argument leaves the Y axis at zero, it is not repeated.
             input: 'skew(45deg)',
-            output: [{ skewX: '45deg' }, { skewY: '0deg' }],
+            output: [{ skew: ['45deg', '0deg'] }],
           },
           {
             input: 'skew(0)',
-            output: [{ skewX: '0deg' }, { skewY: '0deg' }],
+            output: [{ skew: ['0deg', '0deg'] }],
           },
           {
             input: 'skew(45deg, 0)',
-            output: [{ skewX: '45deg' }, { skewY: '0deg' }],
+            output: [{ skew: ['45deg', '0deg'] }],
           },
           {
             input: 'skew(0rad, 1.5rad)',
-            output: [{ skewX: '0rad' }, { skewY: '1.5rad' }],
+            output: [{ skew: ['0rad', '1.5rad'] }],
           },
           {
             input: 'skew(0, 0)',
-            output: [{ skewX: '0deg' }, { skewY: '0deg' }],
+            output: [{ skew: ['0deg', '0deg'] }],
+          },
+          {
+            input: 'skew(45deg, 30deg)',
+            output: [{ skew: ['45deg', '30deg'] }],
+          },
+          {
+            input: 'skew(1.5rad, -0.5rad)',
+            output: [{ skew: ['1.5rad', '-0.5rad'] }],
           },
         ],
       },
@@ -278,7 +344,7 @@ describe(processTransform, () => {
   describe('converts multiple transforms to the ordered transforms array', () => {
     const cases: {
       input: string;
-      output: TransformsArray;
+      output: ReturnType<typeof processTransform>;
     }[] = [
       {
         input: 'translate(25, 25) scale(2) rotate(45deg)',
@@ -304,8 +370,7 @@ describe(processTransform, () => {
           { translateY: 50 },
           { scaleX: 1.5 },
           { scaleY: 2 },
-          { skewX: '30deg' },
-          { skewY: '0deg' },
+          { skew: ['30deg', '0deg'] },
         ],
       },
       {
@@ -386,14 +451,6 @@ describe(processTransform, () => {
       {
         input: 'skew(45deg, 90)', // Missing units for second skew value
         errorMessage: ERROR_MESSAGES.invalidTransform('skew(45deg, 90)'),
-      },
-      {
-        input: 'skew(45deg, 30deg)', // Two-axis skew cannot be represented by separate skew operations
-        errorMessage: ERROR_MESSAGES.invalidTransform('skew(45deg, 30deg)'),
-      },
-      {
-        input: 'skew(1.5rad, -0.5rad)', // Two-axis skew cannot be represented by separate skew operations
-        errorMessage: ERROR_MESSAGES.invalidTransform('skew(1.5rad, -0.5rad)'),
       },
       {
         input: 'matrix(1, 2, 3)', // Incorrect number of elements for matrix (should be 6 or 16)

--- a/packages/react-native-reanimated/src/common/style/processors/transform.ts
+++ b/packages/react-native-reanimated/src/common/style/processors/transform.ts
@@ -1,6 +1,8 @@
 'use strict';
-import type { TransformsArray, ValueProcessor } from '../../types';
+import type { TransformsArray } from '../../types';
 import { isAngle, isNumber, isNumberArray, isPercentage } from '../../utils';
+
+type InternalTransform = TransformsArray[number] | { skew: [string, string] };
 
 export const ERROR_MESSAGES = {
   invalidTransform: (transform: string) =>
@@ -100,29 +102,26 @@ function parseSkewY(values: (number | string)[]): TransformsArray {
     : [];
 }
 
-function isZeroAngle(value: number | string): boolean {
-  'worklet';
-  return value === 0 || (isAngle(value) && parseFloat(value) === 0);
-}
-
-function parseSkew(values: (number | string)[]): TransformsArray {
+function parseSkew(values: (number | string)[]): InternalTransform[] {
   'worklet';
   if (values.length > 2) {
-    return [];
-  }
-  // React Native exposes skewX and skewY as separate operations. Combining
-  // them changes the matrix when both CSS skew angles are nonzero.
-  if (
-    values.length === 2 &&
-    !isZeroAngle(values[0]) &&
-    !isZeroAngle(values[1])
-  ) {
     return [];
   }
   // skew(ax) leaves ay at zero, same as translate above.
   // https://drafts.csswg.org/css-transforms/#funcdef-transform-skew
   const result = parseSkewX([values[0]]).concat(parseSkewY([values[1] ?? 0]));
-  return result.length === 2 ? result : [];
+  // Keep both angles together so native CSS interpolation interpolates angles,
+  // rather than a decomposition of the resulting matrix.
+  return result.length === 2
+    ? [
+        {
+          skew: [
+            String(values[0] === 0 ? '0deg' : values[0]),
+            String(!values[1] ? '0deg' : values[1]),
+          ],
+        },
+      ]
+    : [];
 }
 
 function parseMatrix(values: (number | string)[]): TransformsArray {
@@ -153,7 +152,9 @@ function parsePerspective(values: (number | string)[]): TransformsArray {
     : [];
 }
 
-const parseTransformProperty = (transform: string): TransformsArray => {
+const parseTransformProperty = (
+  transform: string
+): readonly InternalTransform[] => {
   'worklet';
   const [key, valueString] = transform.split(/\(\s*/);
   const values = parseValues(valueString.replace(/\)$/g, ''));
@@ -191,9 +192,9 @@ const parseTransformProperty = (transform: string): TransformsArray => {
   }
 };
 
-export const processTransform: ValueProcessor<TransformsArray | string> = (
-  value
-) => {
+export const processTransform = (
+  value: readonly InternalTransform[] | string
+): readonly InternalTransform[] => {
   'worklet';
   if (typeof value !== 'string') {
     return value;
@@ -215,3 +216,30 @@ export const processTransform: ValueProcessor<TransformsArray | string> = (
       return parsed;
     });
 };
+
+/** Lower the internal skew operation only when passing transforms to RN. */
+export function processTransformForReactNative(
+  value: readonly InternalTransform[] | string
+): TransformsArray {
+  'worklet';
+  const transforms = processTransform(value);
+  return transforms.flatMap((transform): TransformsArray => {
+    if (!transform || !('skew' in transform)) {
+      return [transform];
+    }
+    const [x, y] = transform.skew.map((angle) => {
+      const radians =
+        parseFloat(angle) * (angle.endsWith('deg') ? Math.PI / 180 : 1);
+      return Math.tan(radians);
+    });
+    // QR factorization of [[1, x], [y, 1]]. Unlike two axis skews,
+    // this also preserves the diagonal and works when the determinant is zero.
+    const scaleX = Math.hypot(1, y);
+    return [
+      { rotate: `${Math.atan(y)}rad` },
+      { scaleX },
+      { scaleY: (1 - x * y) / scaleX },
+      { skewX: `${Math.atan((x + y) / (1 + y * y))}rad` },
+    ];
+  });
+}

--- a/packages/react-native-reanimated/src/common/style/processors/transform.ts
+++ b/packages/react-native-reanimated/src/common/style/processors/transform.ts
@@ -100,9 +100,23 @@ function parseSkewY(values: (number | string)[]): TransformsArray {
     : [];
 }
 
+function isZeroAngle(value: number | string): boolean {
+  'worklet';
+  return value === 0 || (isAngle(value) && parseFloat(value) === 0);
+}
+
 function parseSkew(values: (number | string)[]): TransformsArray {
   'worklet';
   if (values.length > 2) {
+    return [];
+  }
+  // React Native exposes skewX and skewY as separate operations. Combining
+  // them changes the matrix when both CSS skew angles are nonzero.
+  if (
+    values.length === 2 &&
+    !isZeroAngle(values[0]) &&
+    !isZeroAngle(values[1])
+  ) {
     return [];
   }
   // skew(ax) leaves ay at zero, same as translate above.

--- a/packages/react-native-reanimated/src/css/component/AnimatedComponent.native.tsx
+++ b/packages/react-native-reanimated/src/css/component/AnimatedComponent.native.tsx
@@ -191,13 +191,7 @@ export default class AnimatedComponent<
     });
 
     const filteredProps = filterCSSProps(props ?? this.props);
-    const style = StyleSheet.flatten(filteredProps.style);
-    if (hasCombinedSkew(style?.transform)) {
-      filteredProps.style = [
-        filteredProps.style,
-        { transform: processTransformForReactNative(style.transform) },
-      ];
-    }
+    filteredProps.style = processSkewInStyle(filteredProps.style);
     if (hasCombinedSkew(filteredProps.transform)) {
       filteredProps.transform = processTransformForReactNative(
         filteredProps.transform
@@ -223,4 +217,26 @@ function hasCombinedSkew(
     ? /\bskew\s*\(/.test(value)
     : Array.isArray(value) &&
         value.some((operation) => operation && 'skew' in operation);
+}
+
+function processSkewInStyle(
+  style: StyleProp<DefaultStyle>
+): StyleProp<DefaultStyle> {
+  // RN processes every entry, even overridden ones. Replace each raw skew
+  // instead of appending a converted transform at the end of the style array.
+  if (Array.isArray(style)) {
+    return style.map(processSkewInStyle);
+  }
+  if (
+    style &&
+    typeof style === 'object' &&
+    'transform' in style &&
+    hasCombinedSkew(style.transform)
+  ) {
+    return {
+      ...style,
+      transform: processTransformForReactNative(style.transform),
+    };
+  }
+  return style;
 }

--- a/packages/react-native-reanimated/src/css/component/AnimatedComponent.native.tsx
+++ b/packages/react-native-reanimated/src/css/component/AnimatedComponent.native.tsx
@@ -5,6 +5,7 @@ import type { StyleProp } from 'react-native';
 import { Platform, StyleSheet } from 'react-native';
 
 import type { AnyComponent, UnknownRecord } from '../../common';
+import { processTransformForReactNative } from '../../common/style/processors/transform';
 import type { InternalHostInstance } from '../../commonTypes';
 import type {
   AnimatedComponentRef,
@@ -189,9 +190,23 @@ export default class AnimatedComponent<
       default: { collapsable: false },
     });
 
+    const filteredProps = filterCSSProps(props ?? this.props);
+    const style = StyleSheet.flatten(filteredProps.style);
+    if (hasCombinedSkew(style?.transform)) {
+      filteredProps.style = [
+        filteredProps.style,
+        { transform: processTransformForReactNative(style.transform) },
+      ];
+    }
+    if (hasCombinedSkew(filteredProps.transform)) {
+      filteredProps.transform = processTransformForReactNative(
+        filteredProps.transform
+      );
+    }
+
     return (
       <ChildComponent
-        {...filterCSSProps(props ?? this.props)}
+        {...filteredProps}
         {...platformProps}
         // Casting is used here, because ref can be null - in that case it cannot be assigned to HTMLElement.
         // After spending some time trying to figure out what to do with this problem, we decided to leave it this way
@@ -199,4 +214,13 @@ export default class AnimatedComponent<
       />
     );
   }
+}
+
+function hasCombinedSkew(
+  value: unknown
+): value is Parameters<typeof processTransformForReactNative>[0] {
+  return typeof value === 'string'
+    ? /\bskew\s*\(/.test(value)
+    : Array.isArray(value) &&
+        value.some((operation) => operation && 'skew' in operation);
 }


### PR DESCRIPTION
> [!NOTE]
> This pull request was authored by AI on behalf of @MatiPl01.

## Summary

`skew(30deg, 15deg)` previously produced two axis skew operations, which adds an unwanted diagonal term to the resulting matrix. Keep both angles in a combined C++ operation and interpolate them independently. At the React Native rendering boundary, expand the result into an equivalent rotation, scales, and axis skew. This also works with percentage translations and avoids React Native's restriction on matrix operations with siblings.

Handle initial React styles, worklet updates, CSS animations/transitions, settled styles returned to React, synchronous native updates, and the newer animation backend. Native testing also exposed recursive overload resolution in the angle constructor; delegating explicitly through `std::string` fixes it. No upstream React Native changes are required. The public array syntax remains unchanged.

## Test plan

- 655 focused Jest tests pass, including geometry checks for zero, positive, negative, and singular determinants.
- Reanimated native TypeScript check and package build pass.
- All four runtime tests pass on iOS 26.5: static skew, a worklet update, a paused CSS animation midpoint, and composition with a percentage translation. Each compares native measurements with an independent reference matrix, and verifies that measurements include transforms.
- Native iOS build passes for arm64 and x86_64. Android and optional synchronous/animation-backend configurations have not been run locally; the shared runtime suite is available via `--only skew`.

For a manual check, use `transform: 'skew(30deg, 15deg)'`. Compare with a single matrix whose off-diagonal terms are `tan(30deg)` and `tan(15deg)`, with both diagonal terms equal to one. Animate from `skew(0)` to `skew(60deg, 30deg)` with linear timing: the midpoint must match that reference.

## Changelog

- [x] Added an entry under Unpublished and documented transform-string support.
