### PR TITLE
fix(ci): refresh bundle-mode metro patches after the MetroConfig annotation

### DIFF
--- a/scripts/patches/fabric-example-metro-config.patch
+++ b/scripts/patches/fabric-example-metro-config.patch
@@ -1,5 +1,5 @@
 diff --git a/apps/fabric-example/metro.config.js b/apps/fabric-example/metro.config.js
-index 84f5db27c9..12f68e3575 100644
+index 51e4b93e4b..2edf2e9b77 100644
 --- a/apps/fabric-example/metro.config.js
 +++ b/apps/fabric-example/metro.config.js
 @@ -32,6 +32,9 @@ let config = {
@@ -9,6 +9,6 @@ index 84f5db27c9..12f68e3575 100644
 +const { bundleModeMetroConfig } = require('react-native-worklets/bundleMode');
 +config = mergeConfig(config, bundleModeMetroConfig);
 +
+ /** @type {import('@react-native/metro-config').MetroConfig} */
  module.exports = wrapWithReanimatedMetroConfig(
    mergeConfig(defaultConfig, config)
- );

--- a/scripts/patches/tvos-example-metro-config.patch
+++ b/scripts/patches/tvos-example-metro-config.patch
@@ -1,5 +1,5 @@
 diff --git a/apps/tvos-example/metro.config.js b/apps/tvos-example/metro.config.js
-index 6f13f57ab4..f9ef69c8c1 100644
+index 11a145633b..d787851a1b 100644
 --- a/apps/tvos-example/metro.config.js
 +++ b/apps/tvos-example/metro.config.js
 @@ -28,6 +28,9 @@ let config = {
@@ -9,6 +9,6 @@ index 6f13f57ab4..f9ef69c8c1 100644
 +const { bundleModeMetroConfig } = require('react-native-worklets/bundleMode');
 +config = mergeConfig(config, bundleModeMetroConfig);
 +
+ /** @type {import('@react-native/metro-config').MetroConfig} */
  module.exports = wrapWithReanimatedMetroConfig(
    mergeConfig(defaultConfig, config)
- );


### PR DESCRIPTION
> [!NOTE]
> This pull request was authored by AI on behalf of @pawicao.

## Summary

#10515 added a `MetroConfig` annotation to `apps/fabric-example/metro.config.js` and `apps/tvos-example/metro.config.js`. The new line sits in the trailing context of the two bundle-mode patches, so `git apply --reverse` no longer matches them.

`scripts/toggle-bundle-mode.sh` needs all five patches to reverse together. Two of them fail, so the script stops with "patches in mixed state" and exits 1. This breaks the `Legacy Eval` job of `Runtime tests Android` on every pull request.

This PR regenerates the two patches against the current file content. It changes no source file.

## Test plan

From the repository root:

1. `yarn toggle-bundle-mode --off` — bundle mode turns off.
2. `yarn toggle-bundle-mode` — bundle mode turns on again.
3. `git status` — the tree is clean.

## Changelog

- [x] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.
