### PR TITLE
fix(reanimated): keep hit-testing in sync when a view grows mid-entering

### DIFF
--- a/packages/react-native-reanimated/CHANGELOG.md
+++ b/packages/react-native-reanimated/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix a view that grows during its entering animation keeping the hit-testing geometry of its original size, so content pushed past the original bounds rendered but stopped receiving touches. ([#10526](https://github.com/software-mansion/react-native-reanimated/pull/10526) by [@torsello](https://github.com/torsello))
 - Fix a short `animationDelay` list on web applying no delay to the animations past its end instead of repeating, the way CSS does and the native path already did. ([#10442](https://github.com/software-mansion/react-native-reanimated/pull/10442) by [@dennytosp](https://github.com/dennytosp))
 - Fix `filter` strings using the CSS `hue-rotate()` and `drop-shadow()` spellings being discarded together with every other filter in the same declaration. ([#10383](https://github.com/software-mansion/react-native-reanimated/pull/10383) by [@dennytosp](https://github.com/dennytosp))
 - Fix single-argument `translate()` and `skew()` in transform strings repeating the argument on the Y axis instead of leaving it at zero, so `translate(100px)` no longer also moves the element down. ([#10385](https://github.com/software-mansion/react-native-reanimated/pull/10385) by [@dennytosp](https://github.com/dennytosp))

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
@@ -383,6 +383,13 @@ void LayoutAnimationsProxy_Legacy::handleUpdatesAndEnterings(
           // all entering animations being cancelled when a screen with a header
           // is pushed onto a stack
           // TODO: find a better solution for this problem
+          if (shouldAnimate && (layoutAnimations_.contains(tag) || hasPendingLayoutAnimation(tag))) {
+            // An entering or exiting animation replays its target every frame,
+            // so a layout change that lands mid-animation has to move that
+            // target too. Otherwise the replay restores the old frame and the
+            // view keeps hit-testing against it.
+            updateLayoutAnimationTarget(tag, mutation.newChildShadowView);
+          }
           filteredMutations.push_back(mutation);
           continue;
         } else if (!shouldAnimate) {


### PR DESCRIPTION
> [!NOTE]
> This pull request was authored by AI on behalf of @torsello.

## Summary

Fixes #10161.

`handleUpdatesAndEnterings` forwards an update mutation to the shadow tree when the view has no `LAYOUT` animation config, but it never moves the target of an animation that is already running. `addOngoingAnimations` then replays `layoutAnimation.finalView` on every frame, and since `updateLayoutMetrics` only overwrites the metrics the animation actually drives (`SlideInRight` drives `x`, not `height`), the replay restores the frame captured when the animation started.

A view that grows while its entering animation is in flight therefore renders at the new size but keeps hit-testing against the old one, so descendants pushed past the original bounds are visible and untappable. That is the Bluesky symptom in the issue: a form grows while its screen is entering and the controls in the lower part stop responding.

The mechanism to move the target already exists — `updateLayoutAnimationTarget` updates `finalView` for a running animation — it just is not reached on this path, because the early-return branch is taken whenever there is no `LAYOUT` config. This calls it when a layout change lands on a view with an animation in flight, and leaves the forwarded mutation untouched.

Instrumenting the proxy on the repro below shows the problem and the fix directly (`tag=40` is the `Animated.View`, 80+56+56 → 130+56+56):

```
before   [UPD]     tag=40 shouldAnimate=1 hasLayoutCfg=0 inLayoutAnims=1 oldH=192.0 newH=242.0
         [ONGOING] tag=40 finalH=192.0 emittedH=192.0     ← ×74 frames, overwrites the growth

after    [UPD]     tag=40 ... newH=242.0
         [ONGOING] tag=40 finalH=242.0 emittedH=242.0
```

**Scope:** this is `LayoutAnimationsProxy_Legacy`, the proxy built when `ENABLE_SHARED_ELEMENT_TRANSITIONS` is off — the default, and what the issue reporter hits through Expo Go. `LayoutAnimationsProxy_Experimental` keeps its own light tree and does not share this path; I did not investigate whether it has an equivalent problem.

## Test plan

`apps/fabric-example` builds the Experimental proxy, so reproducing this needs `ENABLE_SHARED_ELEMENT_TRANSITIONS: false` in its `package.json` `reanimated.staticFeatureFlags` plus a `pod install` (the flags are compiler defines). Then run this as the app entry:

```tsx
import React, { useEffect, useState } from 'react';
import { Pressable, StyleSheet, Text, View } from 'react-native';
import Animated, { SlideInRight } from 'react-native-reanimated';

export default function App() {
  const [grown, setGrown] = useState(false);
  const [bottomPresses, setBottomPresses] = useState(0);

  useEffect(() => {
    const t = setTimeout(() => setGrown(true), 300);
    return () => clearTimeout(t);
  }, []);

  return (
    <View style={styles.screen}>
      <Text style={styles.hint}>BOTTOM taps: {bottomPresses}</Text>
      <Animated.View entering={SlideInRight.duration(1200)} style={styles.card}>
        <View style={[styles.spacer, { height: grown ? 130 : 80 }]} />
        <Pressable style={styles.top}><Text>TOP</Text></Pressable>
        <Pressable style={styles.bottom} onPress={() => setBottomPresses((n) => n + 1)}>
          <Text>BOTTOM — pushed past original bounds</Text>
        </Pressable>
      </Animated.View>
    </View>
  );
}

const styles = StyleSheet.create({
  screen: { flex: 1, paddingTop: 80, paddingHorizontal: 16 },
  hint: { fontSize: 16, marginBottom: 12 },
  card: { backgroundColor: '#223', borderRadius: 12 },
  spacer: { backgroundColor: '#446' },
  top: { height: 56, backgroundColor: '#2a7', alignItems: 'center', justifyContent: 'center' },
  bottom: { height: 56, backgroundColor: '#a72', alignItems: 'center', justifyContent: 'center' },
});
```

Wait for the animation to finish, then tap `BOTTOM`.

- **Before:** the counter stays at 0. `TOP`, which sits inside the original bounds, still responds — so the view is rendered and only the lower strip is dead.
- **After:** the counter increments.

Verified on an iPhone 17 Pro simulator (iOS 26.0.1), Debug, New Architecture.

I did not add a runtime test: the suite in `apps/common-app/runtime-tests` asserts native metrics through `toMatchNativeSnapshots`, and the regression here is in hit-testing rather than in the values it records. Happy to add one if you can point me at the right idiom for asserting touch delivery.

## Changelog

- [x] I added an entry to the `Unpublished` section of each changed package's `CHANGELOG.md`, or this PR does not change `react-native-reanimated` or `react-native-worklets`.
